### PR TITLE
[tests] test: add regression test of `tu` modules

### DIFF
--- a/tests/utils/test_padding_on_cpu.py
+++ b/tests/utils/test_padding_on_cpu.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 import torch
 from tensordict import TensorDict
-from verl.workers.utils.padding import embeds_padding_2_no_padding
+
+from verl_omni.workers.utils.padding import embeds_padding_2_no_padding
 
 
 def test_embeds_padding_2_no_padding_varying_lengths():
@@ -77,7 +78,69 @@ def test_embeds_padding_2_no_padding_uniform_length():
         torch.testing.assert_close(embeds_nested[i], prompt_embeds[i])
 
 
+def test_embeds_padding_2_no_padding_nested_tensor_ragged_idx():
+    """test nested tensors from embeds_padding_2_no_padding with _ragged_idx=1"""
+    from verl.utils import tensordict_utils as tu
+
+    batch_size = 4
+    dim = 16
+    valid_lens = [10, 7, 12, 5]
+    max_seq_len = max(valid_lens)
+
+    prompt_embeds = torch.randn(batch_size, max_seq_len, dim)
+    prompt_embeds_mask = torch.zeros(batch_size, max_seq_len, dtype=torch.int32)
+    for i, vlen in enumerate(valid_lens):
+        prompt_embeds_mask[i, :vlen] = 1
+
+    data = TensorDict(
+        {"prompt_embeds": prompt_embeds, "prompt_embeds_mask": prompt_embeds_mask},
+        batch_size=batch_size,
+    )
+    result = embeds_padding_2_no_padding(data)
+
+    # 1. _ragged_idx must be 1 (ragged at seq_len, not at embedding dim).
+    nested_embeds = result["prompt_embeds"]
+    assert nested_embeds.is_nested
+    ragged_idx = getattr(nested_embeds, "_ragged_idx", None)
+    assert ragged_idx == 1, (
+        f"Expected _ragged_idx=1 for (bs, [seq_len], dim) nested tensor, got {ragged_idx}. "
+        "This breaks concat_nested_tensors and chunk_tensordict (fixed in verl commit 5d4bc46f)."
+    )
+
+    # 2. concat_nested_tensors across two identical batches must preserve shapes and values.
+    nested_a = result["prompt_embeds"]
+    nested_b = result["prompt_embeds"]
+    concatenated = tu.concat_nested_tensors([nested_a, nested_b])
+    assert concatenated.is_nested
+    expected_lens = valid_lens + valid_lens
+    for i, exp_len in enumerate(expected_lens):
+        sample = concatenated[i]
+        assert sample.shape == (exp_len, dim), (
+            f"concat sample {i}: expected shape ({exp_len}, {dim}), got {sample.shape}"
+        )
+        orig_i = i % batch_size
+        torch.testing.assert_close(sample, prompt_embeds[orig_i, : valid_lens[orig_i], :])
+
+    # 3. chunk_tensordict must split nested tensors along the batch dim, not embed dim.
+    chunks = tu.chunk_tensordict(result, chunks=2)
+    assert len(chunks) == 2
+    chunk_sizes = [batch_size // 2, batch_size - batch_size // 2]
+    offset = 0
+    for chunk, expected_size in zip(chunks, chunk_sizes, strict=True):
+        chunk_embeds = chunk["prompt_embeds"]
+        assert chunk_embeds.is_nested
+        for j in range(expected_size):
+            orig_i = offset + j
+            sample = chunk_embeds[j]
+            assert sample.shape == (valid_lens[orig_i], dim), (
+                f"chunk sample (orig {orig_i}): expected ({valid_lens[orig_i]}, {dim}), got {sample.shape}"
+            )
+            torch.testing.assert_close(sample, prompt_embeds[orig_i, : valid_lens[orig_i], :])
+        offset += expected_size
+
+
 if __name__ == "__main__":
     test_embeds_padding_2_no_padding_varying_lengths()
     test_embeds_padding_2_no_padding_uniform_length()
+    test_embeds_padding_2_no_padding_nested_tensor_ragged_idx()
     print("All padding tests passed!")

--- a/tests/workers/rollout/rollout_vllm/test_vllm_omni_generate.py
+++ b/tests/workers/rollout/rollout_vllm/test_vllm_omni_generate.py
@@ -141,84 +141,8 @@ def init_server():
 
 
 def test_generate(init_server):
-    """generate() returns a valid DiffusionOutput with CHW image in [0, 1]."""
+    """Concurrent generate() calls covering basic output, logprobs, and multi-request correctness."""
     server = init_server
-    prompt_ids = _tokenize_prompt(
-        "a beautiful sunset over the ocean with vibrant orange and purple clouds "
-        "reflecting on the calm water surface near a rocky coastline"
-    )
-
-    request_id = f"test_{uuid4().hex[:8]}"
-    output = ray.get(
-        server.generate.remote(
-            prompt_ids=prompt_ids,
-            sampling_params={
-                "num_inference_steps": 10,
-                "true_cfg_scale": 4.0,
-                "height": 512,
-                "width": 512,
-            },
-            request_id=request_id,
-        ),
-        timeout=300,
-    )
-
-    assert isinstance(output, DiffusionOutput)
-    assert len(output.diffusion_output) == 3, f"Expected 3 channels (CHW), got {len(output.diffusion_output)}"
-    h, w = len(output.diffusion_output[0]), len(output.diffusion_output[0][0])
-    assert h > 0 and w > 0
-    assert output.stop_reason in ("completed", "aborted", None)
-
-    # spot-check pixel range
-    assert 0.0 <= output.diffusion_output[0][0][0] <= 1.0
-
-    print(f"image: C=3 H={h} W={w}  stop_reason={output.stop_reason}")
-
-
-def test_generate_with_logprobs(init_server):
-    """generate() with logprobs=True returns non-empty log_probs (tensor or sequence)."""
-    server = init_server
-    prompt_ids = _tokenize_prompt(
-        "a futuristic city at night with neon lights glowing on tall glass "
-        "skyscrapers and flying vehicles soaring between the buildings"
-    )
-
-    request_id = f"test_lp_{uuid4().hex[:8]}"
-    output = ray.get(
-        server.generate.remote(
-            prompt_ids=prompt_ids,
-            sampling_params={
-                "num_inference_steps": 10,
-                "true_cfg_scale": 4.0,
-                "height": 512,
-                "width": 512,
-                "logprobs": True,
-            },
-            request_id=request_id,
-        ),
-        timeout=300,
-    )
-
-    assert isinstance(output, DiffusionOutput)
-    assert len(output.diffusion_output) == 3
-    lp = output.log_probs
-    assert lp is not None, "log_probs should be present when logprobs=True"
-    if isinstance(lp, torch.Tensor):
-        assert lp.numel() > 0
-        sample = lp.detach().cpu().flatten()[:3].tolist()
-        n = lp.numel()
-    else:
-        assert len(lp) > 0
-        sample = lp[:3]
-        n = len(lp)
-
-    print(f"log_probs: {n} values, sample: {sample}")
-
-
-def test_generate_concurrent(init_server):
-    """Multiple concurrent generate() calls all return valid DiffusionOutput."""
-    server = init_server
-    n_requests = 4
 
     prompts = [
         "a beautiful sunset over the ocean with vibrant orange and purple clouds "
@@ -232,15 +156,16 @@ def test_generate_concurrent(init_server):
     ]
 
     refs = []
-    for i in range(n_requests):
-        rid = f"concurrent_{i}_{uuid4().hex[:8]}"
+    for i, prompt in enumerate(prompts):
+        rid = f"test_{i}_{uuid4().hex[:8]}"
         ref = server.generate.remote(
-            prompt_ids=_tokenize_prompt(prompts[i]),
+            prompt_ids=_tokenize_prompt(prompt),
             sampling_params={
                 "num_inference_steps": 10,
                 "true_cfg_scale": 4.0,
                 "height": 512,
                 "width": 512,
+                "logprobs": i == 0,  # first request includes logprobs
             },
             request_id=rid,
         )
@@ -248,9 +173,20 @@ def test_generate_concurrent(init_server):
 
     results = ray.get(refs, timeout=600)
 
-    for i, res in enumerate(results):
-        assert isinstance(res, DiffusionOutput), f"Request {i}: expected DiffusionOutput"
-        assert len(res.diffusion_output) == 3, f"Request {i}: expected 3 channels"
-        assert res.stop_reason in ("completed", "aborted", None)
+    for i, output in enumerate(results):
+        assert isinstance(output, DiffusionOutput), f"Request {i}: expected DiffusionOutput"
+        assert len(output.diffusion_output) == 3, f"Request {i}: expected 3 channels (CHW)"
+        h, w = len(output.diffusion_output[0]), len(output.diffusion_output[0][0])
+        assert h > 0 and w > 0, f"Request {i}: image dimensions must be positive"
+        assert output.stop_reason in ("completed", "aborted", None), f"Request {i}: unexpected stop_reason"
+        assert 0.0 <= output.diffusion_output[0][0][0] <= 1.0, f"Request {i}: pixel values must be in [0, 1]"
 
-    print(f"All {n_requests} concurrent requests returned valid DiffusionOutput")
+    # Verify logprobs for the first request
+    lp = results[0].log_probs
+    assert lp is not None, "log_probs should be present when logprobs=True"
+    if isinstance(lp, torch.Tensor):
+        assert lp.numel() > 0
+    else:
+        assert len(lp) > 0
+
+    print(f"All {len(prompts)} concurrent requests returned valid DiffusionOutput")

--- a/tests/workers/test_diffusers_fsdp_engine.py
+++ b/tests/workers/test_diffusers_fsdp_engine.py
@@ -23,12 +23,12 @@ from verl import DataProto
 from verl.single_controller.ray import RayClassWithInitArgs, RayResourcePool, RayWorkerGroup
 from verl.utils import tensordict_utils as tu
 from verl.workers.config import TrainingWorkerConfig
-from verl.workers.utils.padding import embeds_padding_2_no_padding
 
 from verl_omni.pipelines.utils import build_scheduler
 from verl_omni.workers.config import DiffusionModelConfig, FSDPDiffusionActorConfig
 from verl_omni.workers.engine_workers import TrainingWorker
 from verl_omni.workers.utils.losses import diffusion_loss
+from verl_omni.workers.utils.padding import embeds_padding_2_no_padding
 
 
 def create_training_config(model_type, strategy, device_count, model):

--- a/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
+++ b/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
@@ -48,7 +48,6 @@ from verl.utils.import_utils import load_class_from_fqn
 from verl.utils.metric import reduce_metrics
 from verl.utils.py_functional import rename_dict
 from verl.utils.tracking import ValidationGenerationsLogger
-from verl.workers.utils.padding import embeds_padding_2_no_padding
 
 from verl_omni.trainer.diffusion.diffusion_algos import DiffusionAdvantageEstimator, get_diffusion_adv_estimator_fn
 from verl_omni.trainer.diffusion.diffusion_metric_utils import (
@@ -56,6 +55,7 @@ from verl_omni.trainer.diffusion.diffusion_metric_utils import (
     compute_throughput_metrics_diffusion,
     compute_timing_metrics_diffusion,
 )
+from verl_omni.workers.utils.padding import embeds_padding_2_no_padding
 
 
 def compute_advantage(

--- a/verl_omni/workers/utils/padding.py
+++ b/verl_omni/workers/utils/padding.py
@@ -1,0 +1,57 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Padding utilities for diffusion model training."""
+
+import torch
+from tensordict import TensorDict
+
+
+def embeds_padding_2_no_padding(data: TensorDict) -> TensorDict:
+    """
+    Convert TensorDict from prompt embeds with padding to no-padding format.
+    For diffusion model training only.
+
+    Currently we expect the prompt embedding mask to be [1111000...] format,
+    which means the valid tokens are continuous and start from the left.
+
+    Args:
+        data: TensorDict with "prompt_embeds", "prompt_embeds_mask",
+              "negative_prompt_embeds", "negative_prompt_embeds_mask"
+
+    Returns:
+        data: TensorDict with
+        - Tensor includes NestedTensors "prompt_embeds", "prompt_embeds_mask",
+          "negative_prompt_embeds", "negative_prompt_embeds_mask"
+    """
+
+    def _to_nested(embeds: torch.Tensor, mask: torch.Tensor):
+        """Strip padding from (bs, seq_len, dim) embeds using the boolean mask and return nested tensors."""
+        embeds_list, mask_list = [], []
+        for i in range(mask.shape[0]):
+            curr_mask = mask[i].bool()
+            embeds_list.append(embeds[i, curr_mask, :])
+            mask_list.append(curr_mask[curr_mask])
+        return (
+            torch.nested.as_nested_tensor(embeds_list, layout=torch.jagged),
+            torch.nested.as_nested_tensor(mask_list, layout=torch.jagged),
+        )
+
+    data["prompt_embeds"], data["prompt_embeds_mask"] = _to_nested(data["prompt_embeds"], data["prompt_embeds_mask"])
+
+    if isinstance(data.get("negative_prompt_embeds", None), torch.Tensor):
+        data["negative_prompt_embeds"], data["negative_prompt_embeds_mask"] = _to_nested(
+            data["negative_prompt_embeds"], data["negative_prompt_embeds_mask"]
+        )
+
+    return data


### PR DESCRIPTION
### What does this PR do?

1. Move `embeds_padding_2_no_padding` from `verl` to `verl-omni`. It used for diffusion training only.
2. Add regression test of `tu.concat_nested_tensors` and `chunk_tensordict`
3. Simply GPU test for vllm-omni generate

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `vllm_omni`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `diffusion`, `omni`, `tests`, `docker`
  - If this PR involves multiple modules, separate them with `,` like `[diffusion, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][diffusion, fsdp] feat: new rollout scheduler`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update the documentation.
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl-omni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
