### PR TITLE
[ci] chore: change vllm-omni to be a dependency of verl-omni.

### DIFF
--- a/.github/workflows/cpu_unit_tests.yml
+++ b/.github/workflows/cpu_unit_tests.yml
@@ -45,9 +45,10 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install dependencies (CPU-only torch)
+      - name: Install dependencies
         run: |
-          pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
+          pip install --extra-index-url https://download.pytorch.org/whl/cpu "https://github.com/vllm-project/vllm/releases/download/v0.18.0/vllm-0.18.0+cpu-cp38-abi3-manylinux_2_35_x86_64.whl"
+          pip install "vllm-omni==0.18.0"
           pip install --no-deps "verl @ git+https://github.com/verl-project/verl.git@main"
           pip install -r requirements.txt
           pip install -r requirements-test.txt

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -36,7 +36,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install the current repository
         run: |
-          pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
+          pip install --extra-index-url https://download.pytorch.org/whl/cpu "https://github.com/vllm-project/vllm/releases/download/v0.18.0/vllm-0.18.0+cpu-cp38-abi3-manylinux_2_35_x86_64.whl"
+          pip install "vllm-omni==0.18.0"
           pip install --no-deps "verl @ git+https://github.com/verl-project/verl.git@main"
           pip install -r requirements.txt
           pip install -r requirements-test.txt

--- a/.github/workflows/type-coverage-check.yml
+++ b/.github/workflows/type-coverage-check.yml
@@ -33,7 +33,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
+          pip install --extra-index-url https://download.pytorch.org/whl/cpu "https://github.com/vllm-project/vllm/releases/download/v0.18.0/vllm-0.18.0+cpu-cp38-abi3-manylinux_2_35_x86_64.whl"
+          pip install "vllm-omni==0.18.0"
           pip install --no-deps "verl @ git+https://github.com/verl-project/verl.git@main"
           pip install -r requirements.txt
           pip install --no-deps -e .

--- a/tests/agent_loop/conftest.py
+++ b/tests/agent_loop/conftest.py
@@ -11,25 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import pytest
 
 # TODO (mike): to be dropped once `verl` drops its legacy diffusion
 # implementations.
-try:
-    import verl_omni  # noqa: F401
-except ImportError:
-    pass
+import verl_omni  # noqa: F401
 
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "vllm_omni: requires the vllm-omni package")
-
-
-def pytest_collection_modifyitems(config, items):
-    try:
-        import vllm_omni  # noqa: F401
-    except ImportError:
-        skip = pytest.mark.skip(reason="vllm-omni not installed")
-        for item in items:
-            if "vllm_omni" in item.keywords:
-                item.add_marker(skip)

--- a/verl_omni/_patch.py
+++ b/verl_omni/_patch.py
@@ -50,10 +50,7 @@ def _patch_vllm_omni_replica() -> None:
     from verl.workers.rollout.replica import RolloutReplicaRegistry
 
     def _load_vllm_omni():
-        try:
-            from verl_omni.workers.rollout.vllm_rollout.vllm_omni_async_server import vLLMOmniReplica
-        except ImportError as err:
-            raise ImportError("vllm-omni rollout requires vllm-omni to be installed.") from err
+        from verl_omni.workers.rollout.vllm_rollout.vllm_omni_async_server import vLLMOmniReplica
 
         return vLLMOmniReplica
 

--- a/verl_omni/pipelines/qwen_image_flow_grpo/__init__.py
+++ b/verl_omni/pipelines/qwen_image_flow_grpo/__init__.py
@@ -13,14 +13,6 @@
 # limitations under the License.
 
 from .diffusers_training_adapter import QwenImage
+from .vllm_omni_rollout_adapter import QwenImagePipelineWithLogProb
 
-__all__ = ["QwenImage"]
-
-try:
-    from .vllm_omni_rollout_adapter import QwenImagePipelineWithLogProb
-except ImportError:
-    QwenImagePipelineWithLogProb = None
-
-
-if QwenImagePipelineWithLogProb is not None:
-    __all__.append("QwenImagePipelineWithLogProb")
+__all__ = ["QwenImage", "QwenImagePipelineWithLogProb"]

--- a/verl_omni/utils/vllm_omni/utils.py
+++ b/verl_omni/utils/vllm_omni/utils.py
@@ -32,6 +32,8 @@ class OmniTensorLoRARequest(OmniLoRARequest):
 
 
 class VLLMOmniHijack:
+    """Monkey-patches vllm-omni internals to support in-memory LoRA tensors."""
+
     @staticmethod
     def hijack():
         def hijack__load_adapter(self, lora_request: OmniTensorLoRARequest) -> tuple[LoRAModel, PEFTHelper]:


### PR DESCRIPTION
### What does this PR do?
- change vllm-omni to be a dependency of verl-omni.

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `vllm_omni`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `diffusion`, `omni`, `tests`, `docker`
  - If this PR involves multiple modules, separate them with `,` like `[diffusion, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][diffusion, fsdp] feat: new rollout scheduler`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update the documentation.
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl-omni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
