### PR TITLE
[BREAKING][rollout] feat: adapt to verl LLMServerClient refactor

### DIFF
--- a/.github/workflows/cpu_unit_tests.yml
+++ b/.github/workflows/cpu_unit_tests.yml
@@ -53,7 +53,7 @@ jobs:
         run: |
           pip install --extra-index-url https://download.pytorch.org/whl/cpu "https://github.com/vllm-project/vllm/releases/download/v0.18.0/vllm-0.18.0+cpu-cp38-abi3-manylinux_2_35_x86_64.whl"
           pip install "vllm-omni==0.18.0"
-          pip install --no-deps "verl @ git+https://github.com/verl-project/verl.git@a512e90fddcefb64baaa6384e9cf8571b6bfab0b"
+          pip install --no-deps "verl @ git+https://github.com/verl-project/verl.git@a4351480871347092436d17573ad3ccf75b24122"
           pip install -r requirements.txt
           pip install -r requirements-test.txt
           pip install --no-deps -e .

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           pip install --extra-index-url https://download.pytorch.org/whl/cpu "https://github.com/vllm-project/vllm/releases/download/v0.18.0/vllm-0.18.0+cpu-cp38-abi3-manylinux_2_35_x86_64.whl"
           pip install "vllm-omni==0.18.0"
-          pip install --no-deps "verl @ git+https://github.com/verl-project/verl.git@a512e90fddcefb64baaa6384e9cf8571b6bfab0b"
+          pip install --no-deps "verl @ git+https://github.com/verl-project/verl.git@a4351480871347092436d17573ad3ccf75b24122"
           pip install -r requirements.txt
           pip install -r requirements-test.txt
           pip install --no-deps -e .

--- a/.github/workflows/type-coverage-check.yml
+++ b/.github/workflows/type-coverage-check.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           pip install --extra-index-url https://download.pytorch.org/whl/cpu "https://github.com/vllm-project/vllm/releases/download/v0.18.0/vllm-0.18.0+cpu-cp38-abi3-manylinux_2_35_x86_64.whl"
           pip install "vllm-omni==0.18.0"
-          pip install --no-deps "verl @ git+https://github.com/verl-project/verl.git@a512e90fddcefb64baaa6384e9cf8571b6bfab0b"
+          pip install --no-deps "verl @ git+https://github.com/verl-project/verl.git@a4351480871347092436d17573ad3ccf75b24122"
           pip install -r requirements.txt
           pip install --no-deps -e .
       - name: Run type annotation coverage check

--- a/docs/start/install.md
+++ b/docs/start/install.md
@@ -1,6 +1,6 @@
 # Installation
 
-Last updated: 04/23/2026
+Last updated: 04/30/2026
 
 ## Requirements
 
@@ -18,7 +18,7 @@ source .venv/bin/activate
 # Install vllm, vllm-omni, then verl in order
 uv pip install vllm==0.18.0
 uv pip install vllm-omni==0.18
-uv pip install git+https://github.com/verl-project/verl.git@a512e90fddcefb64baaa6384e9cf8571b6bfab0b
+uv pip install git+https://github.com/verl-project/verl.git@a4351480871347092436d17573ad3ccf75b24122
 
 # Install verl-omni from source
 git clone https://github.com/verl-project/verl-omni.git

--- a/tests/agent_loop/test_diffusion_agent_loop.py
+++ b/tests/agent_loop/test_diffusion_agent_loop.py
@@ -110,9 +110,6 @@ def test_single_turn(init_config):
     )
     try:
         AgentLoopManager.agent_loop_workers_class = ray.remote(DiffusionAgentLoopWorker)
-        # Match the new verl#6129 ownership: trainer creates the LLMServerManager and hands a
-        # client to AgentLoopManager. In standalone test mode there is no actor worker_group, so
-        # LLMServerManager spins up its own replicas using nnodes / n_gpus_per_node.
         llm_server_manager = LLMServerManager.create(config=init_config)
         agent_loop_manager = AgentLoopManager.create(
             config=init_config,

--- a/tests/agent_loop/test_diffusion_agent_loop.py
+++ b/tests/agent_loop/test_diffusion_agent_loop.py
@@ -21,6 +21,7 @@ import ray
 from omegaconf import DictConfig
 from verl.experimental.agent_loop.agent_loop import AgentLoopManager
 from verl.protocol import DataProto
+from verl.workers.rollout.llm_server import LLMServerManager
 
 from verl_omni.agent_loop import DiffusionAgentLoopWorker
 
@@ -109,7 +110,14 @@ def test_single_turn(init_config):
     )
     try:
         AgentLoopManager.agent_loop_workers_class = ray.remote(DiffusionAgentLoopWorker)
-        agent_loop_manager = AgentLoopManager.create(init_config)
+        # Match the new verl#6129 ownership: trainer creates the LLMServerManager and hands a
+        # client to AgentLoopManager. In standalone test mode there is no actor worker_group, so
+        # LLMServerManager spins up its own replicas using nnodes / n_gpus_per_node.
+        llm_server_manager = LLMServerManager.create(config=init_config)
+        agent_loop_manager = AgentLoopManager.create(
+            config=init_config,
+            llm_client=llm_server_manager.get_client(),
+        )
 
         system_prompt = (
             "Describe the image by detailing the color, shape, size, texture, quantity, text, "

--- a/verl_omni/agent_loop/diffusion_agent_loop.py
+++ b/verl_omni/agent_loop/diffusion_agent_loop.py
@@ -99,7 +99,7 @@ class DiffusionAgentLoopWorker:
         self,
         config: DictConfig,
         llm_client: LLMServerClient,
-        teacher_client: dict[str, LLMServerClient] = None,
+        teacher_client: dict[str, LLMServerClient] | None = None,
         reward_loop_worker_handles: list[ray.actor.ActorHandle] = None,
     ):
         self.config = config

--- a/verl_omni/agent_loop/diffusion_agent_loop.py
+++ b/verl_omni/agent_loop/diffusion_agent_loop.py
@@ -26,16 +26,15 @@ from tensordict import TensorDict
 from verl.base_config import BaseConfig
 from verl.experimental.agent_loop.agent_loop import (
     AgentLoopMetrics,
-    AsyncLLMServerManager,
     DictConfigWrap,
     _agent_loop_registry,
-    _get_rollout_and_model_config,
 )
 from verl.experimental.agent_loop.utils import resolve_config_path
 from verl.protocol import DataProto
 from verl.utils.config import omega_conf_to_dataclass
 from verl.utils.dataset.rl_dataset import get_dataset_class
 from verl.utils.profiler import simple_timer
+from verl.workers.rollout.llm_server import LLMServerClient
 
 from verl_omni.workers.config import DiffusionModelConfig, DiffusionRolloutConfig
 
@@ -87,33 +86,30 @@ class DiffusionAgentLoopWorker:
 
     Args:
         config (DictConfig): whole config for main entrypoint.
-        servers (list[tuple[str, ray.actor.ActorHandle]]): (address, handle) pairs for each LLM server.
-        load_balancer_handle (ray.actor.ActorHandle): shared global load balancer actor.
-        teacher_servers (list[tuple[str, ray.actor.ActorHandle]]): Not used.
-        teacher_load_balancer_handle (ray.actor.ActorHandle): Not used.
-        reward_loop_worker_handles (List[ray.actor.ActorHandle]): Actor handles for streaming reward computation.
+        llm_client (LLMServerClient): Client for the LLM server replicas, produced by
+            ``LLMServerManager.get_client()`` in the trainer.
+        teacher_client (dict[str, LLMServerClient]): Not used by diffusion training; accepted to
+            keep the constructor signature compatible with verl's ``AgentLoopManager.create()``,
+            which positionally forwards a teacher client argument to each worker.
+        reward_loop_worker_handles (List[ray.actor.ActorHandle]): Actor handles for streaming
+            reward computation.
     """
 
     def __init__(
         self,
         config: DictConfig,
-        servers: list[tuple[str, ray.actor.ActorHandle]],
-        load_balancer_handle: ray.actor.ActorHandle,
-        teacher_servers: list[tuple[str, ray.actor.ActorHandle]] = None,
-        teacher_load_balancer_handle: ray.actor.ActorHandle = None,
+        llm_client: LLMServerClient,
+        teacher_client: dict[str, LLMServerClient] = None,
         reward_loop_worker_handles: list[ray.actor.ActorHandle] = None,
     ):
         self.config = config
-        rollout_config, model_config = _get_rollout_and_model_config(config)
+        rollout_config = config.actor_rollout_ref.rollout
+        model_config = config.actor_rollout_ref.model
         self.rollout_config: DiffusionRolloutConfig = omega_conf_to_dataclass(rollout_config)
         self.model_config: DiffusionModelConfig = omega_conf_to_dataclass(model_config)
 
         if not hasattr(self, "server_manager"):
-            self.server_manager = AsyncLLMServerManager(
-                config,
-                servers,
-                load_balancer_handle=load_balancer_handle,
-            )
+            self.server_manager = llm_client
 
         self.dataset_cls = get_dataset_class(config.data)
         self.reward_loop_worker_handles = reward_loop_worker_handles

--- a/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
+++ b/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
@@ -48,6 +48,7 @@ from verl.utils.import_utils import load_class_from_fqn
 from verl.utils.metric import reduce_metrics
 from verl.utils.py_functional import rename_dict
 from verl.utils.tracking import ValidationGenerationsLogger
+from verl.workers.rollout.llm_server import LLMServerManager
 
 from verl_omni.trainer.config import DiffusionAlgoConfig
 from verl_omni.trainer.diffusion.diffusion_algos import DiffusionAdvantageEstimator, get_diffusion_adv_estimator_fn
@@ -634,10 +635,18 @@ class RayFlowGRPOTrainer:
         # if enable_agent_reward_loop, we directly pass reward_loop_workers to agent loop manager
         # to stream reward computation with actor rollout
         reward_loop_worker_handles = self.reward_loop_manager.reward_loop_workers if enable_agent_reward_loop else None
-        self.async_rollout_manager = AgentLoopManager.create(
+
+        # Server lifecycle (replica launch, load balancer) is owned by LLMServerManager since
+        # verl-project/verl#6129; AgentLoopManager only consumes a client. Replicas are reused by
+        # CheckpointEngineManager for sleep/wake during weight sync.
+        self.llm_server_manager = LLMServerManager.create(
             config=self.config,
             worker_group=self.actor_rollout_wg,
             rollout_resource_pool=actor_rollout_resource_pool,
+        )
+        self.async_rollout_manager = AgentLoopManager.create(
+            config=self.config,
+            llm_client=self.llm_server_manager.get_client(),
             reward_loop_worker_handles=reward_loop_worker_handles,
         )
 
@@ -645,7 +654,7 @@ class RayFlowGRPOTrainer:
         self.checkpoint_manager = CheckpointEngineManager(
             config=checkpoint_engine_config,
             trainer=self.actor_rollout_wg,
-            replicas=self.async_rollout_manager.rollout_replicas,
+            replicas=self.llm_server_manager.get_replicas(),
         )
 
         # sleep all replicas to load checkpoint

--- a/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
+++ b/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
@@ -636,9 +636,6 @@ class RayFlowGRPOTrainer:
         # to stream reward computation with actor rollout
         reward_loop_worker_handles = self.reward_loop_manager.reward_loop_workers if enable_agent_reward_loop else None
 
-        # Server lifecycle (replica launch, load balancer) is owned by LLMServerManager since
-        # verl-project/verl#6129; AgentLoopManager only consumes a client. Replicas are reused by
-        # CheckpointEngineManager for sleep/wake during weight sync.
         self.llm_server_manager = LLMServerManager.create(
             config=self.config,
             worker_group=self.actor_rollout_wg,


### PR DESCRIPTION
Adapt verl-omni's diffusion agent loop and ray trainer to verl-project/verl#6129, which removed AsyncLLMServerManager and made AgentLoopManager / AgentLoopWorker consume an LLMServerClient produced by a separately-owned LLMServerManager.

verl-omni changes:
- DiffusionAgentLoopWorker.__init__ now takes (config, llm_client, teacher_client, reward_loop_worker_handles), matching the positional contract that AgentLoopManager.create() uses when spawning workers. _get_rollout_and_model_config was also dropped upstream, so the config slicing is inlined to keep the diff minimal.
- ray_diffusion_trainer now creates an LLMServerManager first, hands its client to AgentLoopManager.create(), and uses llm_server_manager.get_replicas() (instead of async_rollout_manager.rollout_replicas) to wire the CheckpointEngineManager. This mirrors the new pattern in upstream verl/trainer/ppo/ray_trainer.py.
- tests/agent_loop/test_diffusion_agent_loop.py is updated for the new API; in standalone test mode LLMServerManager spins up its own replicas via rollout.nnodes / n_gpus_per_node.

Pin / docs / CI:
- Bump the pinned verl commit to a4351480 (the merge commit of #5209), which is the first commit that ships verl/experimental/reward_loop/router/ in the wheel AND contains the #6129 refactor that this change adapts to. With this commit, the workaround in PR #51 (clone + editable install) is no longer required.
- Restore the simple `uv pip install git+...@<commit>` install line in docs/start/install.md.
- Bump the same pin in .github/workflows/{cpu_unit_tests,sanity,type-coverage-check}.yml.

This is a BREAKING change because DiffusionAgentLoopWorker.__init__ signature changed. Any downstream code that subclasses or directly instantiates DiffusionAgentLoopWorker must switch from (servers, load_balancer_handle, teacher_servers, teacher_load_balancer_handle) to (llm_client, teacher_client). No public CLI/config surface is affected.

### What does this PR do?

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `vllm_omni`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `diffusion`, `omni`, `tests`, `docker`
  - If this PR involves multiple modules, separate them with `,` like `[diffusion, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][diffusion, fsdp] feat: new rollout scheduler`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update the documentation.
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl-omni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
