### PR TITLE
[ci] fix: drop `ready-for-ci` label if PR is updated.

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -2,7 +2,7 @@ name: check_pr_title
 
 on:
   pull_request:
-    types: [opened, edited, synchronize, labeled]
+    types: [labeled]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/cpu_unit_tests.yml
+++ b/.github/workflows/cpu_unit_tests.yml
@@ -14,7 +14,7 @@ on:
     branches:
       - main
       - v0.*
-    types: [opened, synchronize, reopened, labeled]
+    types: [labeled]
     paths:
       - "verl_omni/**"
       - "tests/**/*_on_cpu.py"

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
     branches:
       - main
-    types: [opened, synchronize, reopened, labeled]
+    types: [labeled]
     paths:
       - "**/*.py"
       - "docs/**"

--- a/.github/workflows/drop-ready-for-ci-label.yml
+++ b/.github/workflows/drop-ready-for-ci-label.yml
@@ -5,7 +5,7 @@ on:
     types: [synchronize, edited, reopened]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/drop-ready-for-ci-label.yml
+++ b/.github/workflows/drop-ready-for-ci-label.yml
@@ -2,7 +2,7 @@ name: drop_ready_for_ci_label
 
 on:
   pull_request_target:
-    types: [synchronize, edited, reopened]
+    types: [synchronize, reopened]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}

--- a/.github/workflows/drop-ready-for-ci-label.yml
+++ b/.github/workflows/drop-ready-for-ci-label.yml
@@ -1,0 +1,28 @@
+name: drop_ready_for_ci_label
+
+on:
+  pull_request_target:
+    types: [synchronize, edited, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  drop_label:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Remove ready-for-ci label
+        run: |
+          if gh api /repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels \
+            --jq '.[].name' | grep -qx 'ready-for-ci'; then
+            gh api --method DELETE \
+              /repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/ready-for-ci
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/drop-ready-for-ci-label.yml
+++ b/.github/workflows/drop-ready-for-ci-label.yml
@@ -11,6 +11,7 @@ concurrency:
 permissions:
   contents: read
   issues: write
+  pull-requests: write
 
 jobs:
   drop_label:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,7 +6,7 @@ on:
   schedule:
     - cron: "0 0 * * 0"
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    types: [labeled]
   push:
     branches:
       - main

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -9,7 +9,7 @@ on:
     branches:
       - main
       - v0.*
-    types: [opened, synchronize, reopened, labeled]
+    types: [labeled]
     paths:
       - "**/*.py"
       - .github/workflows/sanity.yml

--- a/.github/workflows/type-coverage-check.yml
+++ b/.github/workflows/type-coverage-check.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
       - v0.*
-    types: [opened, synchronize, reopened, labeled]
+    types: [labeled]
     paths:
       - "**/*.py"
       - .github/workflows/type-coverage-check.yml


### PR DESCRIPTION
### What does this PR do?
- Drop the `ready-for-ci` label when a PR is updated to avoid overloading the CI flow.

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `vllm_omni`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `diffusion`, `omni`, `tests`, `docker`
  - If this PR involves multiple modules, separate them with `,` like `[diffusion, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][diffusion, fsdp] feat: new rollout scheduler`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update the documentation.
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl-omni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
