### PR TITLE
[misc] fix: Avoid showing the patch warning too many times during GPU tests.

### DIFF
--- a/verl_omni/pipelines/_patch.py
+++ b/verl_omni/pipelines/_patch.py
@@ -43,13 +43,15 @@ def _apply_qwen_image_ulysses_mask_fix() -> None:
         ulysses_degree = cp_config.ulysses_degree if cp_config is not None else 1
 
         if ulysses_degree > 1 and encoder_hidden_states_mask is not None:
-            logger.warning(
-                "verl_omni patch applied: QwenImageTransformer2DModel.forward has been monkey-patched to fix "
-                "the Ulysses SP joint-attention-mask layout bug (diffusers==0.38). "
-                "The joint mask is now built in interleaved [txt_0, img_0, txt_1, img_1, ...] order "
-                "to match the post-all-to-all sequence layout when ulysses_degree > 1. "
-                "Remove this patch once the fix is upstreamed to diffusers."
-            )
+            if not _patched_forward._warned:
+                logger.warning(
+                    "verl_omni patch applied: QwenImageTransformer2DModel.forward has been monkey-patched to fix "
+                    "the Ulysses SP joint-attention-mask layout bug (diffusers==0.38). "
+                    "The joint mask is now built in interleaved [txt_0, img_0, txt_1, img_1, ...] order "
+                    "to match the post-all-to-all sequence layout when ulysses_degree > 1. "
+                    "Remove this patch once the fix is upstreamed to diffusers."
+                )
+                _patched_forward._warned = True
             # Build the joint mask in the interleaved layout that matches the
             # post-all-to-all sequence order: [txt_0, img_0, txt_1, img_1, ...]
             batch_size, image_seq_len = hidden_states.shape[:2]
@@ -70,6 +72,7 @@ def _apply_qwen_image_ulysses_mask_fix() -> None:
         )
 
     _patched_forward._verl_omni_ulysses_mask_patched = True
+    _patched_forward._warned = False
     QwenImageTransformer2DModel.forward = _patched_forward
 
 


### PR DESCRIPTION
### What does this PR do?
- Avoid showing the patch warning too many times during GPU tests.

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `vllm_omni`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `diffusion`, `omni`, `tests`, `docker`
  - If this PR involves multiple modules, separate them with `,` like `[diffusion, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][diffusion, fsdp] feat: new rollout scheduler`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update the documentation.
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl-omni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
