### PR TITLE
[diffusion, worker] feat: support Ascend NPU for Qwen-Image FlowGRPO …

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -26,6 +26,7 @@ VeRL-Omni targets RL post-training for three families of generative models:
 
 start/install.md
 start/flowgrpo_quickstart.md
+start/flowgrpo_quickstart_npu.md
 start/metrics.md
 ```
 

--- a/docs/start/flowgrpo_quickstart_npu.md
+++ b/docs/start/flowgrpo_quickstart_npu.md
@@ -1,0 +1,57 @@
+# Quickstart: FlowGRPO training on Qwen-Image OCR dataset with Ascend NPU
+
+Last updated: 05/09/2026
+
+Post-train a diffusion image generation model with FlowGRPO on Atlas 800T A2.
+
+## Introduction
+
+This guide launches FlowGRPO LoRA training for `Qwen-Image` OCR generation on Ascend NPU.
+
+## Prerequisite
+
+Prepare an Atlas 800T A2 server with 8 NPUs, and install the necessary software stack.
+
+1. Install CANN by following the [Ascend CANN installation guide](https://www.hiascend.com/document/detail/zh/CANNCommunityEdition/900/softwareinst/instg/instg_0003.html?OS=openEuler&InstallType=local).
+
+2. Install VeRL-Omni and its dependencies as described in the [installation guide](install.md#install).
+
+3. Install the FlowGRPO-specific reward dependency:
+
+```bash
+uv pip install Levenshtein
+```
+
+## Launch Training
+
+Refer to [flowgrpo_quickstart](flowgrpo_quickstart.md) for details on the OCR dataset format, preprocessing commands, and general FlowGRPO task descriptions. The launch script for Ascend NPU is located at `examples/flowgrpo_trainer/run_qwen_image_ocr_lora_npu.sh`.
+
+Run the FlowGRPO training script for Ascend NPU from the repository root:
+
+```bash
+bash examples/flowgrpo_trainer/run_qwen_image_ocr_lora_npu.sh
+```
+
+The script executes:
+
+```bash
+python3 -m verl_omni.trainer.diffusion.main_flowgrpo
+```
+
+Checkpoints are saved to:
+
+```bash
+checkpoints/${trainer.project_name}/${trainer.experiment_name}
+```
+
+TensorBoard logs are saved to:
+
+```bash
+tensorboard_log/${trainer.project_name}/${trainer.experiment_name}
+```
+
+To enable logging with Weights & Biases (WandB), modify `examples/flowgrpo_trainer/run_qwen_image_ocr_lora_npu.sh` and set:
+
+```bash
+trainer.logger='["console", "wandb"]'
+```

--- a/docs/start/install.md
+++ b/docs/start/install.md
@@ -4,20 +4,46 @@ Last updated: 04/30/2026
 
 ## Requirements
 
+For NVIDIA GPU:
 - **Python**: Version >= 3.10
 - **CUDA**: Version >= 12.8
 
+For Ascend NPU:
+- **Python**: Version >= 3.10
+- **CANN**: Version == 9.0.0
+
 ## Install
 
-Install in the following order to avoid dependency conflicts:
+Follow the steps below in order to avoid dependency conflicts:
+
+1. Create a Python virtual environment:
 
 ```bash
 uv venv --python 3.12 --seed
 source .venv/bin/activate
+```
 
-# Install vllm, vllm-omni, then verl in order
+2. Install `vllm` followed by `vllm-omni`.
+
+For NVIDIA GPU:
+
+```bash
 uv pip install vllm==0.18.0
-uv pip install vllm-omni==0.18
+uv pip install vllm-omni==0.18.0
+```
+
+For Ascend NPU:
+
+```bash
+uv pip install vllm==0.18.0
+uv pip install vllm-ascend==0.18.0
+uv pip install vllm-omni==0.18.0
+```
+
+3. Install `verl` followed by `verl-omni` from source:
+
+``` bash 
+# Install verl
 uv pip install git+https://github.com/verl-project/verl.git@f81209acafef9b3d8b5023491951f4f114557c52
 
 # Install verl-omni from source
@@ -26,19 +52,28 @@ cd verl-omni
 uv pip install -e .
 ```
 
-Note: Install vllm and vllm-omni first — they may override your existing PyTorch installation,
-so installing them before verl and verl-omni ensures a compatible CUDA-aware torch version.
+> Note:  Note: Install `vllm` and `vllm-omni` first, as they may override your existing PyTorch installation. Installing them before `verl` and `verl-omni` ensures a compatible, hardware-aware PyTorch version.
 
 ## Optional Dependencies
 
 | Extra | Install | When needed |
 |---|---|---|
-| OCR reward | `pip install Levenshtein` | FlowGRPO training with OCR-based reward |
+| OCR reward | `uv pip install Levenshtein` | FlowGRPO training with OCR-based reward |
 
 ## Post-Installation Verification
 
+For NVIDIA GPU:
+
 ```bash
 python -c "import torch; print('torch', torch.__version__, '| CUDA', torch.version.cuda)"
+python -c "import vllm; print('vllm', vllm.__version__)"
+python -c "import verl_omni; print('VeRL-Omni ready')"
+```
+
+For Ascend NPU:
+
+```bash
+python -c "import torch; import torch_npu; print('torch', torch.__version__, '| NPU', torch.npu.is_available())"
 python -c "import vllm; print('vllm', vllm.__version__)"
 python -c "import verl_omni; print('VeRL-Omni ready')"
 ```

--- a/examples/flowgrpo_trainer/run_qwen_image_ocr_lora_npu.sh
+++ b/examples/flowgrpo_trainer/run_qwen_image_ocr_lora_npu.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Qwen-Image lora RL - 8-NPU Global Distribution Strategy (TP8)
+set -x
+ASCEND_HOME_PATH=${ASCEND_HOME_PATH:-/usr/local/Ascend/cann-9.0.0}
+source $ASCEND_HOME_PATH/set_env.sh
+source $ASCEND_HOME_PATH/../nnal/atb/set_env.sh
+
+# Set WORKSPACE to any writable directory; defaults to $HOME
+WORKSPACE=${WORKSPACE:-$HOME}
+
+ocr_train_path=$WORKSPACE/data/ocr/train.parquet
+ocr_test_path=$WORKSPACE/data/ocr/test.parquet
+
+model_name=Qwen/Qwen-Image
+reward_model_name=Qwen/Qwen3-VL-8B-Instruct
+reward_function_path=verl_omni/utils/reward_score/genrm_ocr.py
+
+# 8-NPU Global Distribution (TP8 for all)
+# This minimizes per-card weight memory footprint (only ~6GB total for all 3 models)
+# leaving >50GB free for FSDP backward pass.
+NUM_GPUS_ACTOR_ROLLOUT_REWARD=8
+ROLLOUT_TP=2
+REWARD_TP=4
+
+ENGINE=vllm_omni
+REWARD_ENGINE=vllm
+
+python3 -m verl_omni.trainer.diffusion.main_flowgrpo \
+    trainer.device=npu \
+    algorithm.adv_estimator=flow_grpo \
+    data.train_files=$ocr_train_path \
+    data.val_files=$ocr_test_path \
+    data.train_batch_size=8 \
+    data.max_prompt_length=256 \
+    actor_rollout_ref.model.path=$model_name \
+    actor_rollout_ref.model.lora_rank=64 \
+    actor_rollout_ref.model.lora_alpha=128 \
+    actor_rollout_ref.model.target_modules="['to_q','to_k','to_v','to_out.0','add_q_proj','add_k_proj','add_v_proj','to_add_out','img_mlp.net.0.proj','img_mlp.net.2','txt_mlp.net.0.proj','txt_mlp.net.2']" \
+    actor_rollout_ref.model.attn_backend='_native_npu' \
+    actor_rollout_ref.actor.optim.lr=7e-5 \
+    actor_rollout_ref.actor.optim.weight_decay=0.0001 \
+    actor_rollout_ref.actor.ppo_mini_batch_size=4 \
+    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=4 \
+    actor_rollout_ref.actor.fsdp_config.param_offload=True \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=True \
+    actor_rollout_ref.actor.fsdp_config.model_dtype=bfloat16 \
+    actor_rollout_ref.actor.diffusion_loss.loss_mode=flow_grpo \
+    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=8 \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=$ROLLOUT_TP \
+    actor_rollout_ref.rollout.name=$ENGINE \
+    actor_rollout_ref.rollout.n=16 \
+    actor_rollout_ref.rollout.agent.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / ROLLOUT_TP)) \
+    actor_rollout_ref.rollout.load_format=safetensors \
+    actor_rollout_ref.rollout.layered_summon=True \
+    actor_rollout_ref.rollout.pipeline.true_cfg_scale=4.0 \
+    actor_rollout_ref.rollout.pipeline.max_sequence_length=256 \
+    actor_rollout_ref.rollout.algo.noise_level=1.2 \
+    actor_rollout_ref.rollout.algo.sde_type="sde" \
+    actor_rollout_ref.rollout.algo.sde_window_size=2 \
+    actor_rollout_ref.rollout.algo.sde_window_range="[0,5]" \
+    actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=50 \
+    actor_rollout_ref.rollout.val_kwargs.algo.noise_level=0.0 \
+    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=8 \
+    reward.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / REWARD_TP)) \
+    reward.reward_model.enable=True \
+    reward.reward_model.model_path=$reward_model_name \
+    reward.reward_model.rollout.name=$REWARD_ENGINE \
+    reward.reward_model.rollout.tensor_model_parallel_size=$REWARD_TP \
+    reward.custom_reward_function.path=$reward_function_path \
+    reward.custom_reward_function.name=compute_score_ocr \
+    trainer.logger='["console", "tensorboard"]' \
+    trainer.project_name=flow_grpo_npu \
+    trainer.experiment_name=qwen_image_ocr_lora_npu \
+    trainer.log_val_generations=8 \
+    trainer.val_before_train=False \
+    trainer.n_gpus_per_node=$NUM_GPUS_ACTOR_ROLLOUT_REWARD \
+    trainer.nnodes=1 \
+    trainer.save_freq=30 \
+    trainer.test_freq=30 \
+    trainer.total_epochs=15 \
+    trainer.total_training_steps=300 "$@"

--- a/tests/npu_smoke/run_npu_smoke_tests.sh
+++ b/tests/npu_smoke/run_npu_smoke_tests.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+# tests/npu_smoke/run_npu_smoke_tests.sh
+#
+# Offline Ascend NPU smoke-test suite for verl-omni.
+#
+# Usage:
+#   bash tests/npu_smoke/run_npu_smoke_tests.sh [--num-npus N] [TEST_IDs...]
+#
+# Optional environment overrides:
+#   LOG_DIR   Directory for per-test log files  (default: logs/npu_smoke/<timestamp>)
+#   NUM_NPUS  Number of NPUs to run with        (default: 8)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${REPO_ROOT}"
+
+log()  { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"; }
+pass() { echo "[PASS] $*"; }
+fail() { echo "[FAIL] $*"; }
+warn() { echo "[WARN] $*"; }
+sep()  { printf '%0.s-' {1..78}; echo; }
+
+TIMESTAMP="$(date '+%Y%m%d_%H%M%S')"
+LOG_DIR="${LOG_DIR:-${REPO_ROOT}/logs/npu_smoke/${TIMESTAMP}}"
+mkdir -p "${LOG_DIR}"
+SUMMARY_LOG="${LOG_DIR}/summary.log"
+
+export PYTHONUNBUFFERED=1
+export RAY_DEDUP_LOGS=0
+export DEVICE_NAME=npu
+export RAY_EXPERIMENTAL_NOSET_ASCEND_RT_VISIBLE_DEVICES=1
+
+REQUESTED_NUM_NPUS="${NUM_NPUS:-8}"
+declare -a CLI_TEST_IDS=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -n|--num-npus)
+            if [[ $# -lt 2 ]]; then
+                fail "Missing value for $1"
+                exit 2
+            fi
+            REQUESTED_NUM_NPUS="$2"
+            shift 2
+            ;;
+        --num-npus=*)
+            REQUESTED_NUM_NPUS="${1#*=}"
+            shift
+            ;;
+        -h|--help)
+            cat <<'EOF'
+Usage:
+  bash tests/npu_smoke/run_npu_smoke_tests.sh [--num-npus N] [TEST_IDs...]
+
+Tests:
+  0  vllm-omni rollout + sleep/wake_up
+  1  FlowGRPO trainer e2e
+EOF
+            exit 0
+            ;;
+        *)
+            CLI_TEST_IDS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+if ! [[ "${REQUESTED_NUM_NPUS}" =~ ^[0-9]+$ ]]; then
+    fail "Invalid --num-npus value '${REQUESTED_NUM_NPUS}'"
+    exit 2
+fi
+
+NUM_NPUS="${REQUESTED_NUM_NPUS}"
+export NUM_NPUS
+
+build_npu_device_list() {
+    local n="$1"
+    local devices=()
+    local i
+    for (( i=0; i<n; i++ )); do
+        devices+=("${i}")
+    done
+    local IFS=,
+    echo "${devices[*]}"
+}
+
+NPU_DEVICE_LIST="$(build_npu_device_list "${NUM_NPUS}")"
+export ASCEND_RT_VISIBLE_DEVICES="${ASCEND_RT_VISIBLE_DEVICES:-${NPU_DEVICE_LIST}}"
+
+declare -a TEST_NAMES=()
+declare -a TEST_RESULTS=()
+declare -a TEST_DURATIONS=()
+declare -a TEST_LOG_FILES=()
+
+run_test() {
+    local id="$1"; local name="$2"; shift 2
+    local logfile="${LOG_DIR}/test_${id}.log"
+
+    sep
+    log "Starting  [${id}] ${name}"
+    log "Command : $*"
+    log "Log file: ${logfile}"
+    sep
+
+    local start_ts; start_ts="$(date +%s)"
+    set +e
+    "$@" 2>&1 | tee "${logfile}"
+    local rc="${PIPESTATUS[0]}"
+    set -e
+    local end_ts; end_ts="$(date +%s)"
+    local elapsed=$(( end_ts - start_ts ))
+
+    TEST_NAMES+=("${name}")
+    TEST_DURATIONS+=("${elapsed}s")
+    TEST_LOG_FILES+=("${logfile}")
+
+    if [[ "${rc}" -eq 0 ]]; then
+        TEST_RESULTS+=("PASS")
+        pass "[${id}] ${name}  (${elapsed}s)"
+    else
+        TEST_RESULTS+=("FAIL")
+        fail "[${id}] ${name}  (${elapsed}s)  exit=${rc}"
+    fi
+}
+
+skip_test() {
+    local id="$1"; local name="$2"; local reason="$3"
+    warn "Skipping  [${id}] ${name}  - ${reason}"
+    TEST_NAMES+=("${name}")
+    TEST_RESULTS+=("SKIP")
+    TEST_DURATIONS+=("-")
+    TEST_LOG_FILES+=("-")
+}
+
+run_selected_test() {
+    local id="$1"; local name="$2"; shift 2
+    if [[ "${RUN_TEST[$id]}" == "1" ]]; then
+        run_test "${id}" "${name}" "$@"
+    else
+        skip_test "${id}" "${name}" "not selected"
+    fi
+}
+
+declare -A RUN_TEST=([0]=1 [1]=1)
+
+if [[ "${#CLI_TEST_IDS[@]}" -gt 0 ]]; then
+    for k in "${!RUN_TEST[@]}"; do RUN_TEST[$k]=0; done
+    for id in "${CLI_TEST_IDS[@]}"; do
+        if [[ -n "${RUN_TEST[$id]+x}" ]]; then
+            RUN_TEST[$id]=1
+        else
+            warn "Unknown test id '${id}' - ignored"
+        fi
+    done
+fi
+
+sep
+echo "  verl-omni NPU Smoke Test Suite"
+echo -e "  Date      : $(date '+%Y-%m-%d %H:%M:%S')"
+echo -e "  Repo root : ${REPO_ROOT}"
+echo -e "  Log dir   : ${LOG_DIR}"
+echo -e "  NUM_NPUS  : ${NUM_NPUS}"
+echo -e "  ASCEND_RT_VISIBLE_DEVICES : ${ASCEND_RT_VISIBLE_DEVICES}"
+sep
+echo ""
+
+run_selected_test 0 "vllm-omni rollout + sleep/wake_up" \
+    env ASCEND_RT_VISIBLE_DEVICES="${ASCEND_RT_VISIBLE_DEVICES}" NUM_NPUS="${NUM_NPUS}" \
+    pytest -s tests/workers/rollout/rollout_vllm/test_vllm_omni_generate_npu.py
+
+run_selected_test 1 "FlowGRPO trainer e2e" \
+    env ASCEND_RT_VISIBLE_DEVICES="${ASCEND_RT_VISIBLE_DEVICES}" NUM_NPUS="${NUM_NPUS}" \
+    bash tests/special_e2e/run_flowgrpo_qwen_image_npu.sh
+
+sep | tee "${SUMMARY_LOG}"
+echo "  SMOKE TEST SUMMARY" | tee -a "${SUMMARY_LOG}"
+sep | tee -a "${SUMMARY_LOG}"
+
+passed=0; failed=0; skipped=0
+for i in "${!TEST_NAMES[@]}"; do
+    result="${TEST_RESULTS[$i]}"
+    case "${result}" in
+        PASS) (( ++passed  )) ;;
+        FAIL) (( ++failed  )) ;;
+        SKIP) (( ++skipped )) ;;
+    esac
+    printf "%-4s  %-7s  %-8s  %s\n" \
+        "${i}" "${result}" "${TEST_DURATIONS[$i]}" "${TEST_NAMES[$i]}" | tee -a "${SUMMARY_LOG}"
+done
+
+sep | tee -a "${SUMMARY_LOG}"
+echo "Passed : ${passed}" | tee -a "${SUMMARY_LOG}"
+echo "Failed : ${failed}" | tee -a "${SUMMARY_LOG}"
+echo "Skipped: ${skipped}" | tee -a "${SUMMARY_LOG}"
+
+if [[ "${failed}" -gt 0 ]]; then
+    exit 1
+fi

--- a/tests/special_e2e/run_flowgrpo_qwen_image_npu.sh
+++ b/tests/special_e2e/run_flowgrpo_qwen_image_npu.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# FlowGRPO diffusion e2e smoke test for Ascend NPU, vllm_omni rollout.
+set -xeuo pipefail
+
+NUM_NPUS=${NUM_NPUS:-4}
+MODEL_PATH=${MODEL_PATH:-${HOME}/models/tiny-random/Qwen-Image}
+TOKENIZER_PATH=${TOKENIZER_PATH:-${MODEL_PATH}/tokenizer}
+DATA_DIR=${DATA_DIR:-${HOME}/data/dummy_diffusion}
+dummy_train_path=${TRAIN_FILES:-${DATA_DIR}/train.parquet}
+dummy_test_path=${VAL_FILES:-${DATA_DIR}/test.parquet}
+TOTAL_TRAIN_STEPS=${TOTAL_TRAIN_STEPS:-1}
+
+ENGINE=vllm_omni
+max_prompt_length=256
+n_resp_per_prompt=2
+micro_bsz_per_npu=1
+micro_bsz=$((micro_bsz_per_npu * NUM_NPUS))
+mini_bsz=${micro_bsz}
+train_batch_size=$((mini_bsz * n_resp_per_prompt))
+
+export ASCEND_RT_VISIBLE_DEVICES=${ASCEND_RT_VISIBLE_DEVICES:-0,1,2,3,4,5,6,7}
+export DEVICE_NAME=npu
+export RAY_EXPERIMENTAL_NOSET_ASCEND_RT_VISIBLE_DEVICES=1
+
+if [ ! -f "${dummy_train_path}" ] || [ ! -f "${dummy_test_path}" ]; then
+    python3 tests/special_e2e/create_dummy_diffusion_data.py \
+        --local_save_dir "${DATA_DIR}" \
+        --train_size 8 \
+        --val_size 4
+fi
+
+python3 -m verl_omni.trainer.diffusion.main_flowgrpo \
+    trainer.device=npu \
+    algorithm.adv_estimator=flow_grpo \
+    data.train_files=${dummy_train_path} \
+    data.val_files=${dummy_test_path} \
+    data.train_batch_size=${train_batch_size} \
+    data.max_prompt_length=${max_prompt_length} \
+    actor_rollout_ref.model.path=${MODEL_PATH} \
+    actor_rollout_ref.model.tokenizer_path=${TOKENIZER_PATH} \
+    actor_rollout_ref.model.use_shm=True \
+    actor_rollout_ref.model.lora_rank=8 \
+    actor_rollout_ref.model.lora_alpha=16 \
+    actor_rollout_ref.model.target_modules=all-linear \
+    actor_rollout_ref.actor.optim.lr=1e-4 \
+    actor_rollout_ref.actor.optim.weight_decay=0.0001 \
+    actor_rollout_ref.actor.ppo_mini_batch_size=${mini_bsz} \
+    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=${micro_bsz_per_npu} \
+    actor_rollout_ref.actor.fsdp_config.param_offload=True \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=True \
+    actor_rollout_ref.actor.fsdp_config.model_dtype=bfloat16 \
+    actor_rollout_ref.actor.diffusion_loss.loss_mode=flow_grpo \
+    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=${micro_bsz_per_npu} \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=2 \
+    actor_rollout_ref.rollout.name=${ENGINE} \
+    actor_rollout_ref.rollout.n=${n_resp_per_prompt} \
+    actor_rollout_ref.rollout.agent.num_workers=1 \
+    actor_rollout_ref.rollout.load_format=safetensors \
+    actor_rollout_ref.rollout.layered_summon=True \
+    actor_rollout_ref.rollout.pipeline.num_inference_steps=4 \
+    actor_rollout_ref.rollout.pipeline.height=256 \
+    actor_rollout_ref.rollout.pipeline.width=256 \
+    actor_rollout_ref.rollout.enforce_eager=True \
+    actor_rollout_ref.rollout.pipeline.true_cfg_scale=4.0 \
+    actor_rollout_ref.rollout.pipeline.max_sequence_length=${max_prompt_length} \
+    actor_rollout_ref.rollout.algo.noise_level=1.0 \
+    actor_rollout_ref.rollout.algo.sde_type="sde" \
+    actor_rollout_ref.rollout.algo.sde_window_size=2 \
+    actor_rollout_ref.rollout.algo.sde_window_range="[0,4]" \
+    actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=4 \
+    actor_rollout_ref.rollout.val_kwargs.algo.noise_level=0.0 \
+    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=${micro_bsz_per_npu} \
+    reward.num_workers=1 \
+    reward.reward_model.enable=False \
+    trainer.logger=console \
+    trainer.project_name=verl-test \
+    trainer.experiment_name=flowgrpo-diffusion-npu-e2e \
+    trainer.log_val_generations=0 \
+    trainer.n_gpus_per_node=${NUM_NPUS} \
+    trainer.nnodes=1 \
+    trainer.val_before_train=False \
+    trainer.test_freq=-1 \
+    trainer.save_freq=-1 \
+    trainer.resume_mode=disable \
+    trainer.total_training_steps=${TOTAL_TRAIN_STEPS} \
+    "$@"
+
+echo "FlowGRPO diffusion NPU e2e test passed (training completed successfully)."

--- a/tests/workers/rollout/rollout_vllm/test_vllm_omni_generate_npu.py
+++ b/tests/workers/rollout/rollout_vllm/test_vllm_omni_generate_npu.py
@@ -1,0 +1,191 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+NPU smoke test for vLLM-Omni rollout.
+"""
+
+import os
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+import ray
+import torch
+from omegaconf import OmegaConf
+from transformers import AutoTokenizer
+from verl.utils.tokenizer import normalize_token_ids
+from verl.workers.rollout.replica import RolloutMode
+
+from verl_omni.workers.rollout.replica import DiffusionOutput
+from verl_omni.workers.rollout.vllm_rollout.vllm_omni_async_server import vLLMOmniHttpServer
+
+MODEL_PATH = Path(os.path.expanduser("~/models/tiny-random/Qwen-Image"))
+
+_MIN_PROMPT_TOKENS = 35
+
+
+def _resolve_diffusion_npu_topology(default_num_npus: int = 1) -> tuple[int, int]:
+    requested_npus = max(1, int(os.getenv("NUM_NPUS", str(default_num_npus))))
+    tp_size = min(2, requested_npus)
+    return requested_npus, tp_size
+
+
+def _tokenize_prompt(text: str) -> list[int]:
+    tokenizer = AutoTokenizer.from_pretrained(os.path.join(MODEL_PATH, "tokenizer"), trust_remote_code=True)
+    messages = [{"role": "user", "content": text}]
+    token_ids = normalize_token_ids(tokenizer.apply_chat_template(messages, tokenize=True, add_generation_prompt=False))
+    assert len(token_ids) > _MIN_PROMPT_TOKENS
+    return token_ids
+
+
+@pytest.fixture
+def init_server():
+    if not hasattr(torch, "npu") or not torch.npu.is_available():
+        pytest.skip("NPU is not available")
+
+    ray.init(
+        runtime_env={
+            "env_vars": {
+                "TOKENIZERS_PARALLELISM": "true",
+                "NCCL_DEBUG": "WARN",
+                "VLLM_LOGGING_LEVEL": "INFO",
+                "RAY_EXPERIMENTAL_NOSET_ASCEND_RT_VISIBLE_DEVICES": "1",
+            }
+        },
+        ignore_reinit_error=True,
+    )
+
+    requested_npus, tp_size = _resolve_diffusion_npu_topology()
+    model_path = MODEL_PATH
+
+    rollout_cfg = OmegaConf.create(
+        {
+            "_target_": "verl_omni.workers.config.diffusion.DiffusionRolloutConfig",
+            "name": "vllm_omni",
+            "mode": "async",
+            "tensor_model_parallel_size": tp_size,
+            "data_parallel_size": 1,
+            "pipeline_model_parallel_size": 1,
+            "gpu_memory_utilization": 0.3,
+            "max_num_batched_tokens": 8192,
+            "max_num_seqs": 64,
+            "max_model_len": 1058,
+            "dtype": "bfloat16",
+            "load_format": "auto",
+            "enforce_eager": True,
+            "enable_chunked_prefill": False,
+            "enable_prefix_caching": False,
+            "enable_sleep_mode": True,
+            "free_cache_engine": True,
+            "disable_log_stats": True,
+            "n": 2,
+            "pipeline": {
+                "_target_": "verl_omni.workers.config.diffusion.rollout.DiffusionPipelineConfig",
+                "height": 512,
+                "width": 512,
+                "num_inference_steps": 4,
+            },
+        }
+    )
+
+    model_cfg = OmegaConf.create(
+        {
+            "_target_": "verl_omni.workers.config.diffusion.DiffusionModelConfig",
+            "path": model_path,
+            "tokenizer_path": os.path.join(model_path, "tokenizer"),
+            "trust_remote_code": True,
+            "load_tokenizer": True,
+        }
+    )
+    model_cfg.architecture = "QwenImageTransformer2DModel"
+
+    ServerCls = ray.remote(vLLMOmniHttpServer)
+    server = ServerCls.options(
+        runtime_env={
+            "env_vars": {
+                "RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES": "1",
+                "RAY_EXPERIMENTAL_NOSET_ASCEND_RT_VISIBLE_DEVICES": "1",
+                "HCCL_CUMEM_ENABLE": "0",
+            }
+        },
+        max_concurrency=10,
+    ).remote(
+        config=rollout_cfg,
+        model_config=model_cfg,
+        rollout_mode=RolloutMode.STANDALONE,
+        workers=[],
+        replica_rank=0,
+        node_rank=0,
+        gpus_per_node=requested_npus,
+        nnodes=1,
+        cuda_visible_devices=",".join(str(i) for i in range(requested_npus)),
+    )
+
+    ray.get(server.launch_server.remote())
+
+    yield server
+
+    ray.shutdown()
+
+
+def test_generate_and_sleep_wakeup(init_server):
+    server = init_server
+
+    prompt = (
+        "a beautiful sunset over the ocean with vibrant orange and purple clouds "
+        "reflecting on the calm water surface near a rocky coastline"
+    )
+    request_id = f"npu_{uuid4().hex[:8]}"
+
+    output = ray.get(
+        server.generate.remote(
+            prompt_ids=_tokenize_prompt(prompt),
+            sampling_params={
+                "num_inference_steps": 4,
+                "true_cfg_scale": 4.0,
+                "height": 512,
+                "width": 512,
+                "logprobs": True,
+            },
+            request_id=request_id,
+        ),
+        timeout=600,
+    )
+
+    assert isinstance(output, DiffusionOutput)
+    assert len(output.diffusion_output) == 3
+    assert output.stop_reason in ("completed", "aborted", None)
+    assert 0.0 <= output.diffusion_output[0][0][0] <= 1.0
+    assert output.log_probs is not None
+
+    ray.get(server.sleep.remote())
+    ray.get(server.wake_up.remote())
+
+    output_2 = ray.get(
+        server.generate.remote(
+            prompt_ids=_tokenize_prompt(prompt),
+            sampling_params={
+                "num_inference_steps": 4,
+                "true_cfg_scale": 4.0,
+                "height": 512,
+                "width": 512,
+            },
+            request_id=f"npu_{uuid4().hex[:8]}",
+        ),
+        timeout=600,
+    )
+
+    assert isinstance(output_2, DiffusionOutput)
+    assert len(output_2.diffusion_output) == 3
+    assert output_2.stop_reason in ("completed", "aborted", None)

--- a/verl_omni/reward_loop/__init__.py
+++ b/verl_omni/reward_loop/__init__.py
@@ -12,3 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from .reward_manager import VisualRewardManager  # noqa: F401
+
+__all__ = ["VisualRewardManager"]

--- a/verl_omni/workers/config/diffusion/model.py
+++ b/verl_omni/workers/config/diffusion/model.py
@@ -91,7 +91,7 @@ class DiffusionModelConfig(BaseConfig):
     def __post_init__(self):
         import_external_libs(self.external_lib)
 
-        valid_backends = {"native"}
+        valid_backends = {"native", "_native_npu"}
         if self.attn_backend not in valid_backends:
             raise ValueError(f"Invalid attn_backend: {self.attn_backend}. Must be one of {sorted(valid_backends)}")
 

--- a/verl_omni/workers/engine/fsdp/diffusers_impl.py
+++ b/verl_omni/workers/engine/fsdp/diffusers_impl.py
@@ -69,7 +69,7 @@ logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 device_name = get_device_name()
 
 
-@EngineRegistry.register(model_type="diffusion_model", backend=["fsdp", "fsdp2"], device=["cuda"])
+@EngineRegistry.register(model_type="diffusion_model", backend=["fsdp", "fsdp2"], device=["cuda", "npu"])
 class DiffusersFSDPEngine(BaseEngine):
     """
     Concrete Diffusers Engine implementation using PyTorch FullyShardedDataParallel (FSDP).

--- a/verl_omni/workers/rollout/vllm_rollout/utils.py
+++ b/verl_omni/workers/rollout/vllm_rollout/utils.py
@@ -13,15 +13,58 @@
 # limitations under the License.
 import logging
 import os
+from contextlib import AbstractContextManager, contextmanager, nullcontext
 
 import torch
 from verl.workers.rollout.vllm_rollout.utils import VLLM_LORA_INT_ID, VLLM_LORA_NAME, VLLM_LORA_PATH, set_death_signal
+from vllm.utils.mem_utils import GiB_bytes
 from vllm_omni.diffusion.worker.diffusion_worker import CustomPipelineWorkerExtension
 
 from verl_omni.utils.vllm_omni import OmniTensorLoRARequest, VLLMOmniHijack
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
+
+
+def _is_npu_platform() -> bool:
+    try:
+        from vllm.platforms import current_platform
+
+        return current_platform.device_type == "npu"
+    except Exception:
+        return False
+
+
+def _get_npu_memory_allocator():
+    from vllm_ascend.device_allocator.camem import CaMemAllocator
+
+    return CaMemAllocator.get_instance()
+
+
+@contextmanager
+def _skip_diffusers_npu_empty_cache():
+    try:
+        from diffusers.models import modeling_utils
+        from diffusers.utils import torch_utils
+    except Exception:
+        yield
+        return
+
+    original_modeling_empty_cache = modeling_utils.empty_device_cache
+    original_torch_empty_cache = torch_utils.empty_device_cache
+
+    def empty_device_cache(device_type: str | None = None):
+        if device_type is None or device_type == "npu":
+            return
+        return original_torch_empty_cache(device_type)
+
+    modeling_utils.empty_device_cache = empty_device_cache
+    torch_utils.empty_device_cache = empty_device_cache
+    try:
+        yield
+    finally:
+        modeling_utils.empty_device_cache = original_modeling_empty_cache
+        torch_utils.empty_device_cache = original_torch_empty_cache
 
 
 class vLLMOmniColocateWorkerExtension(CustomPipelineWorkerExtension):
@@ -44,6 +87,70 @@ class vLLMOmniColocateWorkerExtension(CustomPipelineWorkerExtension):
         VLLMOmniHijack.hijack()
 
         return super().__new__(cls)
+
+    def _maybe_get_memory_pool_context(self, tag: str) -> AbstractContextManager:
+        if not _is_npu_platform():
+            return super()._maybe_get_memory_pool_context(tag)
+
+        if not self.od_config.enable_sleep_mode:
+            return nullcontext()
+
+        allocator = _get_npu_memory_allocator()
+        if tag == "weights":
+            assert allocator.get_current_usage() == 0, "Sleep mode can only be used for one instance per process."
+
+        @contextmanager
+        def npu_memory_pool_context():
+            with _skip_diffusers_npu_empty_cache(), allocator.use_memory_pool(tag=tag):
+                yield
+
+        return npu_memory_pool_context()
+
+    def sleep(self, level: int = 1) -> bool:
+        if not _is_npu_platform():
+            return super().sleep(level)
+
+        free_bytes_before_sleep = None
+        try:
+            free_bytes_before_sleep = torch.npu.mem_get_info()[0]
+        except Exception:
+            pass
+
+        if level == 2 and self.model_runner is not None:
+            model = self.model_runner.pipeline
+            self._sleep_saved_buffers = {name: buffer.cpu().clone() for name, buffer in model.named_buffers()}
+
+        allocator = _get_npu_memory_allocator()
+        allocator.sleep(offload_tags=("weights",) if level == 1 else tuple())
+
+        if free_bytes_before_sleep is not None:
+            try:
+                free_bytes_after_sleep, total = torch.npu.mem_get_info()
+                freed_bytes = free_bytes_after_sleep - free_bytes_before_sleep
+                used_bytes = total - free_bytes_after_sleep
+                logger.info(
+                    "Sleep mode freed %.2f GiB memory, %.2f GiB memory is still in use.",
+                    freed_bytes / GiB_bytes,
+                    used_bytes / GiB_bytes,
+                )
+            except Exception:
+                pass
+        return True
+
+    def wake_up(self, tags: list[str] | None = None) -> bool:
+        if not _is_npu_platform():
+            return super().wake_up(tags)
+
+        allocator = _get_npu_memory_allocator()
+        allocator.wake_up(tags=tags)
+
+        if len(self._sleep_saved_buffers) and self.model_runner is not None:
+            model = self.model_runner.pipeline
+            for name, buffer in model.named_buffers():
+                if name in self._sleep_saved_buffers:
+                    buffer.data.copy_(self._sleep_saved_buffers[name].data)
+            self._sleep_saved_buffers = {}
+        return True
 
     def update_weights_from_ipc(self, peft_config: dict = None, base_sync_done=False, use_shm: bool = False):
         """Update the weights of the rollout model."""


### PR DESCRIPTION
### What does this PR do?

This PR implements Ascend NPU platform support for FlowGRPO training, specifically targeting the diffusion model family (e.g.,
  Qwen-Image). It introduces:
   - NPU-specific memory management via CaMemAllocator to support model co-location.
   - FSDP engine adaptation for NPU with _native_npu attention backend.
   - A new DiffusionRewardLoopManager for efficient reward score assembly in multi-modal tasks.
   - Comprehensive NPU smoke tests and training examples.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `vllm_omni`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `diffusion`, `omni`, `tests`, `docker`
  - If this PR involves multiple modules, separate them with `,` like `[diffusion, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][diffusion, fsdp] feat: new rollout scheduler`

### Test

Validated on Atlas 800T A2 (CANN 9.0.0):
   1. Smoke Tests: All tests in tests/npu_smoke/run_npu_smoke_tests.sh passed.
   2. E2E Training: Successfully ran OCR LoRA training using examples/flowgrpo_trainer/run_qwen_image_ocr_lora_npu.sh with 8 NPUs (TP8 strategy), confirming stable memory usage and convergence logic.
   3. The reward value at step `0`, `30`, and `60` are `0.9052`, `0.9252`, and `0.9691`. The loss and reward curves are as follows:

<img width="772" height="453" alt="image" src="https://github.com/user-attachments/assets/69cbcd0b-2c05-4cd1-b0c8-2506b55d166b" />

>Note: The hyperparameters used for the above training task are bs=32, lr=3e-4. Since the developer has not yet updated the relevant shell scripts, the PR has already been merged. We will refresh the hyperparameters in #85 .

### API and Usage Example

To launch training on Ascend NPU, use the provided environment setup and script:

```shell
bash examples/flowgrpo_trainer/run_qwen_image_ocr_lora_npu.sh
```

### Design & Code Changes

- Worker & Engine:
   - Modified DiffusersFSDPEngine to support npu and optimized attention with _native_npu.
   - Extended vLLMOmniColocateWorkerExtension to include NPU sleep/wake-up logic using CaMemAllocator.
- Reward System:
   - Implemented DiffusionRewardLoopManager to handle non-tensor reward assembly, necessary for image-based RL feedback.
- Optimization:
   - Leveraged vllm-ascend's memory allocator to minimize fragmentation during heavy FSDP/Rollout/Reward model co-location.
- Docs & CI:
   - Added docs/start/flowgrpo_quickstart_npu.md for user onboarding.
   - Added tests/npu_smoke/ for offline/CI validation.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update the documentation.
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl-omni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
