### PR TITLE
[rollout, omni] feat: enable batched B=N diffusion rollout in FlowGRPO

### DIFF
--- a/examples/flowgrpo_trainer/run_qwen_image_ocr_lora.sh
+++ b/examples/flowgrpo_trainer/run_qwen_image_ocr_lora.sh
@@ -1,4 +1,13 @@
 # Qwen-Image lora RL, vllm_omni rollout
+#
+# Rollout batching:
+#   actor_rollout_ref.rollout.enable_batched_diffusion (default: True)
+#     When True and rollout.n > 1, the diffusion agent loop submits one
+#     vllm-omni request per prompt with num_outputs_per_prompt = rollout.n
+#     (single B = rollout.n transformer forward) instead of rollout.n
+#     concurrent B = 1 requests that the AsyncOmniDiffusion executor
+#     would otherwise serialize one-by-one. Set to False to fall back to
+#     the legacy per-sample fan-out (useful for A/B comparisons).
 set -x
 
 # Set WORKSPACE to any writable directory; defaults to $HOME
@@ -40,6 +49,7 @@ python3 -m verl_omni.trainer.diffusion.main_flowgrpo \
     actor_rollout_ref.rollout.tensor_model_parallel_size=$ROLLOUT_TP \
     actor_rollout_ref.rollout.name=$ENGINE \
     actor_rollout_ref.rollout.n=16 \
+    actor_rollout_ref.rollout.enable_batched_diffusion=True \
     actor_rollout_ref.rollout.agent.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / ROLLOUT_TP)) \
     actor_rollout_ref.rollout.load_format=safetensors \
     actor_rollout_ref.rollout.layered_summon=True \

--- a/tests/workers/rollout/rollout_vllm/test_vllm_omni_generate_batched.py
+++ b/tests/workers/rollout/rollout_vllm/test_vllm_omni_generate_batched.py
@@ -1,0 +1,267 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+E2E test for vLLMOmniHttpServer.generate_batched (one B=N forward).
+
+Mirrors :mod:`tests.workers.rollout.rollout_vllm.test_vllm_omni_generate`
+but exercises the batched API used by FlowGRPO when
+``actor_rollout_ref.rollout.enable_batched_diffusion=True`` and
+``actor_rollout_ref.rollout.n > 1``: one engine request produces
+``num_outputs_per_prompt`` samples via a single ``QwenImagePipelineWithLogProb``
+forward, and the server splits the result into per-sample
+:class:`DiffusionOutput` records.
+
+Usage:
+    pytest tests/workers/rollout/rollout_vllm/test_vllm_omni_generate_batched.py -v -s
+    python tests/workers/rollout/rollout_vllm/test_vllm_omni_generate_batched.py
+"""
+
+import os
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+import ray
+import torch
+from omegaconf import OmegaConf
+from transformers import AutoTokenizer
+from verl.utils.tokenizer import normalize_token_ids
+from verl.workers.rollout.replica import RolloutMode
+
+from verl_omni.workers.rollout.replica import DiffusionOutput
+from verl_omni.workers.rollout.vllm_rollout.vllm_omni_async_server import vLLMOmniHttpServer
+
+MODEL_PATH = Path(os.path.expanduser("~/models/tiny-random/Qwen-Image"))
+
+_MIN_PROMPT_TOKENS = 35
+
+
+def _tokenize_prompt(text: str) -> list[int]:
+    """Tokenize a text prompt into valid token IDs for the model."""
+    tokenizer = AutoTokenizer.from_pretrained(os.path.join(MODEL_PATH, "tokenizer"), trust_remote_code=True)
+    messages = [{"role": "user", "content": text}]
+    token_ids = normalize_token_ids(tokenizer.apply_chat_template(messages, tokenize=True, add_generation_prompt=False))
+    assert len(token_ids) > _MIN_PROMPT_TOKENS, (
+        f"Prompt too short ({len(token_ids)} tokens, need >{_MIN_PROMPT_TOKENS}). "
+        f"The pipeline drops the first 34 chat-template prefix tokens; "
+        f"use a longer prompt so content tokens remain after the drop."
+    )
+    return token_ids
+
+
+@pytest.fixture
+def init_server():
+    """Create and launch a vLLMOmniHttpServer Ray actor with Qwen/Qwen-Image."""
+    model_path = MODEL_PATH
+
+    ray.init(
+        runtime_env={
+            "env_vars": {
+                "TOKENIZERS_PARALLELISM": "true",
+                "NCCL_DEBUG": "WARN",
+                "VLLM_LOGGING_LEVEL": "INFO",
+            }
+        },
+        ignore_reinit_error=True,
+    )
+
+    rollout_cfg = OmegaConf.create(
+        {
+            "_target_": "verl_omni.workers.config.diffusion.DiffusionRolloutConfig",
+            "name": "vllm_omni",
+            "mode": "async",
+            "tensor_model_parallel_size": 1,
+            "data_parallel_size": 1,
+            "pipeline_model_parallel_size": 1,
+            "gpu_memory_utilization": 0.8,
+            "max_num_batched_tokens": 8192,
+            "max_num_seqs": 256,
+            "max_model_len": 1058,
+            "dtype": "bfloat16",
+            "load_format": "auto",
+            "enforce_eager": True,
+            "enable_chunked_prefill": False,
+            "enable_prefix_caching": False,
+            "enable_sleep_mode": False,
+            "free_cache_engine": True,
+            "disable_log_stats": True,
+            "n": 4,
+            "enable_batched_diffusion": True,
+            "pipeline": {
+                "_target_": "verl_omni.workers.config.diffusion.rollout.DiffusionPipelineConfig",
+                "height": 512,
+                "width": 512,
+                "num_inference_steps": 10,
+            },
+        }
+    )
+
+    model_cfg = OmegaConf.create(
+        {
+            "_target_": "verl_omni.workers.config.diffusion.DiffusionModelConfig",
+            "path": model_path,
+            "tokenizer_path": os.path.join(model_path, "tokenizer"),
+            "trust_remote_code": True,
+            "load_tokenizer": True,
+            "algorithm": "flow_grpo",
+        }
+    )
+
+    ServerCls = ray.remote(vLLMOmniHttpServer)
+    server = ServerCls.options(
+        runtime_env={
+            "env_vars": {
+                "RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES": "1",
+                "RAY_EXPERIMENTAL_NOSET_ASCEND_RT_VISIBLE_DEVICES": "1",
+                "NCCL_CUMEM_ENABLE": "0",
+            }
+        },
+        max_concurrency=10,
+    ).remote(
+        config=rollout_cfg,
+        model_config=model_cfg,
+        rollout_mode=RolloutMode.STANDALONE,
+        workers=[],
+        replica_rank=0,
+        node_rank=0,
+        gpus_per_node=1,
+        nnodes=1,
+        cuda_visible_devices="0",
+    )
+
+    ray.get(server.launch_server.remote())
+
+    yield server
+
+    ray.shutdown()
+
+
+def _assert_valid_diffusion_output(output, *, expect_log_probs: bool, tag: str) -> None:
+    """Shared shape/sanity assertions for a single per-sample DiffusionOutput."""
+    assert isinstance(output, DiffusionOutput), f"{tag}: expected DiffusionOutput, got {type(output)!r}"
+    assert len(output.diffusion_output) == 3, f"{tag}: expected 3 channels (CHW)"
+    h, w = len(output.diffusion_output[0]), len(output.diffusion_output[0][0])
+    assert h > 0 and w > 0, f"{tag}: image dimensions must be positive"
+    assert output.stop_reason in ("completed", "aborted", None), f"{tag}: unexpected stop_reason"
+    assert 0.0 <= output.diffusion_output[0][0][0] <= 1.0, f"{tag}: pixel values must be in [0, 1]"
+    if expect_log_probs:
+        lp = output.log_probs
+        assert lp is not None, f"{tag}: log_probs should be present when logprobs=True"
+        if isinstance(lp, torch.Tensor):
+            assert lp.numel() > 0, f"{tag}: log_probs tensor must be non-empty"
+        else:
+            assert len(lp) > 0, f"{tag}: log_probs sequence must be non-empty"
+
+
+def test_generate_batched(init_server):
+    """A single ``generate_batched`` call returns ``num_outputs_per_prompt`` per-sample outputs.
+
+    This is the exact path used by ``DiffusionAgentLoopWorker`` when
+    ``enable_batched_diffusion=True`` and ``rollout.n > 1``: every prompt
+    group is collapsed into one engine request that runs a single
+    ``B=num_outputs_per_prompt`` transformer forward pass.
+    """
+    server = init_server
+    num_outputs_per_prompt = 4
+
+    prompt_ids = _tokenize_prompt(
+        "a beautiful sunset over the ocean with vibrant orange and purple clouds "
+        "reflecting on the calm water surface near a rocky coastline"
+    )
+
+    outputs = ray.get(
+        server.generate_batched.remote(
+            prompt_ids=prompt_ids,
+            sampling_params={
+                "num_inference_steps": 10,
+                "true_cfg_scale": 4.0,
+                "height": 512,
+                "width": 512,
+                "logprobs": True,
+            },
+            request_id=f"batched_{uuid4().hex[:8]}",
+            num_outputs_per_prompt=num_outputs_per_prompt,
+        ),
+        timeout=600,
+    )
+
+    assert isinstance(outputs, list), f"expected list[DiffusionOutput], got {type(outputs)!r}"
+    assert len(outputs) == num_outputs_per_prompt, f"expected {num_outputs_per_prompt} samples, got {len(outputs)}"
+    for i, out in enumerate(outputs):
+        _assert_valid_diffusion_output(out, expect_log_probs=True, tag=f"sample {i}")
+
+    print(f"generate_batched returned {num_outputs_per_prompt} valid DiffusionOutputs")
+
+
+def test_generate_batched_n1_matches_generate(init_server):
+    """``generate_batched(num_outputs_per_prompt=1)`` returns the same shape as ``generate``.
+
+    Guards the refactor that re-implemented ``generate`` on top of
+    ``_generate_engine_call(num_outputs_per_prompt=1)``.
+    """
+    server = init_server
+    prompt_ids = _tokenize_prompt(
+        "a fluffy orange cat sitting on a wooden windowsill looking outside at "
+        "a garden full of colorful flowers on a bright sunny afternoon"
+    )
+    sampling_params = {
+        "num_inference_steps": 10,
+        "true_cfg_scale": 4.0,
+        "height": 512,
+        "width": 512,
+        "logprobs": True,
+    }
+
+    single = ray.get(
+        server.generate.remote(
+            prompt_ids=prompt_ids,
+            sampling_params=sampling_params,
+            request_id=f"single_{uuid4().hex[:8]}",
+        ),
+        timeout=600,
+    )
+    batched = ray.get(
+        server.generate_batched.remote(
+            prompt_ids=prompt_ids,
+            sampling_params=sampling_params,
+            request_id=f"batched_n1_{uuid4().hex[:8]}",
+            num_outputs_per_prompt=1,
+        ),
+        timeout=600,
+    )
+
+    _assert_valid_diffusion_output(single, expect_log_probs=True, tag="generate")
+    assert isinstance(batched, list) and len(batched) == 1, "generate_batched(n=1) must return a 1-element list"
+    _assert_valid_diffusion_output(batched[0], expect_log_probs=True, tag="generate_batched[0]")
+
+
+def test_generate_batched_invalid_n(init_server):
+    """``num_outputs_per_prompt < 1`` raises ``ValueError`` before touching the engine."""
+    server = init_server
+    prompt_ids = _tokenize_prompt(
+        "a majestic mountain landscape covered with fresh white snow under a "
+        "clear blue sky with pine trees in the foreground and a frozen lake"
+    )
+    with pytest.raises(ray.exceptions.RayTaskError) as exc_info:
+        ray.get(
+            server.generate_batched.remote(
+                prompt_ids=prompt_ids,
+                sampling_params={"num_inference_steps": 10, "height": 512, "width": 512},
+                request_id=f"bad_{uuid4().hex[:8]}",
+                num_outputs_per_prompt=0,
+            ),
+            timeout=60,
+        )
+    assert "num_outputs_per_prompt" in str(exc_info.value)

--- a/verl_omni/agent_loop/diffusion_agent_loop.py
+++ b/verl_omni/agent_loop/diffusion_agent_loop.py
@@ -14,6 +14,7 @@
 import asyncio
 import random
 from typing import Any, Optional
+from uuid import uuid4
 
 import hydra
 import numpy as np
@@ -37,12 +38,48 @@ from verl.utils.profiler import simple_timer
 from verl.workers.rollout.llm_server import LLMServerClient
 
 from verl_omni.workers.config import DiffusionModelConfig, DiffusionRolloutConfig
+from verl_omni.workers.rollout.replica import DiffusionOutput
 
 
 def _config_to_sampling_dict(config: Optional[BaseConfig]) -> dict:
     if config is None:
         return {}
     return {k: v for k, v in config.items() if not k.startswith("_")}
+
+
+async def _server_generate_batched(
+    server_manager: LLMServerClient,
+    *,
+    request_id: str,
+    prompt_ids: list[int],
+    sampling_params: dict[str, Any],
+    num_outputs_per_prompt: int,
+    image_data: Optional[list[Any]] = None,
+    video_data: Optional[list[Any]] = None,
+    negative_prompt_ids: Optional[list[int]] = None,
+) -> list[DiffusionOutput]:
+    """Invoke ``vLLMOmniHttpServer.generate_batched`` via the LLM server load balancer.
+
+    ``LLMServerClient`` in upstream ``verl`` only exposes ``generate``, so this
+    helper acquires a server handle via the existing load-balancer pair and
+    calls the new ``generate_batched`` method directly on the Ray actor. The
+    sticky-session behavior of ``LLMServerClient.generate`` is intentionally
+    bypassed here: each diffusion request is independent and benefits more
+    from least-loaded routing than prefix-cache stickiness.
+    """
+    server_id, server = await server_manager._acquire_server(request_id)
+    try:
+        return await server.generate_batched.remote(
+            request_id=request_id,
+            prompt_ids=prompt_ids,
+            sampling_params=sampling_params,
+            num_outputs_per_prompt=num_outputs_per_prompt,
+            image_data=image_data,
+            video_data=video_data,
+            negative_prompt_ids=negative_prompt_ids,
+        )
+    finally:
+        server_manager._release_server(server_id)
 
 
 class DiffusionAgentLoopOutput(BaseModel):
@@ -171,15 +208,76 @@ class DiffusionAgentLoopWorker:
             default_agent_loop = config.agent.default_agent_loop
             batch.non_tensor_batch["agent_name"] = np.array([default_agent_loop] * len(batch), dtype=object)
 
-        tasks = []
-        for i in range(len(batch)):
-            kwargs = {k: v[i] for k, v in batch.non_tensor_batch.items()}
-            tasks.append(asyncio.create_task(self._run_agent_loop(sampling_params, **kwargs)))
-        outputs = await asyncio.gather(*tasks)
+        rollout_n = self._effective_rollout_n(is_validate)
+        if self._can_use_batched_path(batch, rollout_n):
+            outputs = await self._run_agent_loops_batched(batch, sampling_params, rollout_n)
+        else:
+            tasks = []
+            for i in range(len(batch)):
+                kwargs = {k: v[i] for k, v in batch.non_tensor_batch.items()}
+                tasks.append(asyncio.create_task(self._run_agent_loop(sampling_params, **kwargs)))
+            outputs = await asyncio.gather(*tasks)
 
         output = self._postprocess(outputs, input_non_tensor_batch=batch.non_tensor_batch)
 
         return output
+
+    def _effective_rollout_n(self, is_validate: bool) -> int:
+        """Number of samples generated per prompt for the current call."""
+        if is_validate:
+            return int(getattr(self.rollout_config.val_kwargs, "n", 1) or 1)
+        return int(getattr(self.rollout_config, "n", 1) or 1)
+
+    def _can_use_batched_path(self, batch: DataProto, rollout_n: int) -> bool:
+        """Decide whether ``generate_sequences`` can dispatch via ``generate_batched``.
+
+        The trainer expands each prompt with ``DataProto.repeat(repeat_times=n,
+        interleave=True)`` before calling us, so consecutive groups of
+        ``rollout_n`` rows share the same prompt (and same ``agent_name``).
+        We only collapse a group when (a) the rollout server is ``vllm_omni``,
+        (b) the flag is enabled, (c) ``rollout_n > 1`` and divides the batch
+        cleanly, and (d) every row in the group uses the same ``agent_name``.
+        """
+        if not bool(getattr(self.rollout_config, "enable_batched_diffusion", False)):
+            return False
+        if rollout_n <= 1:
+            return False
+        if getattr(self.rollout_config, "name", None) != "vllm_omni":
+            return False
+        if len(batch) == 0 or len(batch) % rollout_n != 0:
+            return False
+        agent_names = batch.non_tensor_batch.get("agent_name")
+        if agent_names is None:
+            return False
+        for start in range(0, len(batch), rollout_n):
+            group = agent_names[start : start + rollout_n]
+            if not all(name == group[0] for name in group):
+                return False
+        return True
+
+    async def _run_agent_loops_batched(
+        self,
+        batch: DataProto,
+        sampling_params: dict[str, Any],
+        rollout_n: int,
+    ) -> list["_InternalDiffusionAgentLoopOutput"]:
+        """Dispatch one ``generate_batched`` call per prompt group and flatten the results.
+
+        Each group of ``rollout_n`` adjacent rows is collapsed into a single
+        engine request with ``num_outputs_per_prompt = rollout_n``. The
+        returned ``rollout_n`` per-sample :class:`DiffusionOutput` objects are
+        then unpacked into ``rollout_n`` independent agent-loop outputs whose
+        per-row ``kwargs`` (raw prompt, reward model spec, ...) are inherited
+        from the original batch row at the matching position.
+        """
+        tasks: list[asyncio.Task] = []
+        for group_start in range(0, len(batch), rollout_n):
+            row_kwargs_list = [
+                {k: v[group_start + offset] for k, v in batch.non_tensor_batch.items()} for offset in range(rollout_n)
+            ]
+            tasks.append(asyncio.create_task(self._run_agent_loop_batched(sampling_params, rollout_n, row_kwargs_list)))
+        groups = await asyncio.gather(*tasks)
+        return [out for group in groups for out in group]
 
     async def _run_agent_loop(
         self,
@@ -204,6 +302,92 @@ class DiffusionAgentLoopWorker:
         )
         output: DiffusionAgentLoopOutput = await agent_loop.run(sampling_params, **kwargs)
         return await self._agent_loop_postprocess(output, **kwargs)
+
+    async def _run_agent_loop_batched(
+        self,
+        sampling_params: dict[str, Any],
+        num_outputs_per_prompt: int,
+        row_kwargs_list: list[dict[str, Any]],
+    ) -> list[_InternalDiffusionAgentLoopOutput]:
+        """Run a single ``generate_batched`` engine call for one prompt group.
+
+        The first row in ``row_kwargs_list`` is used to tokenize the prompt
+        (all rows in the group are duplicates of the same prompt). The
+        resulting :class:`list[DiffusionOutput]` of length ``num_outputs_per_prompt``
+        is then post-processed per-row so reward / extra-field handling
+        matches the per-row code path.
+        """
+        assert len(row_kwargs_list) == num_outputs_per_prompt, (
+            f"row_kwargs_list size {len(row_kwargs_list)} != num_outputs_per_prompt {num_outputs_per_prompt}"
+        )
+        head_kwargs = row_kwargs_list[0]
+        agent_name = head_kwargs["agent_name"]
+        assert agent_name in _agent_loop_registry, (
+            f"Agent loop {agent_name} not registered, registered agent loops: {_agent_loop_registry.keys()}"
+        )
+
+        # Reuse the registered agent loop just for tokenization / vision-info
+        # extraction so the prompt-prep path stays identical to the per-row path.
+        agent_loop_config = _agent_loop_registry[agent_name]
+        agent_loop = hydra.utils.instantiate(
+            config=agent_loop_config,
+            trainer_config=DictConfigWrap(config=self.config),
+            server_manager=self.server_manager,
+            tokenizer=self.tokenizer,
+            processor=self.processor,
+            dataset_cls=self.dataset_cls,
+            data_config=DictConfigWrap(self.config.data),
+        )
+
+        raw_prompt = head_kwargs["raw_prompt"]
+        raw_negative_prompt = head_kwargs.get("raw_negative_prompt")
+        multi_modal_data = await agent_loop.process_vision_info(raw_prompt)
+        images = multi_modal_data.get("images")
+        videos = multi_modal_data.get("videos")
+        prompt_ids = await agent_loop.apply_chat_template(raw_prompt, images=images, videos=videos)
+        if raw_negative_prompt is not None:
+            negative_prompt_ids = await agent_loop.apply_chat_template(
+                raw_negative_prompt, images=images, videos=videos
+            )
+        else:
+            negative_prompt_ids = None
+
+        metrics: dict[str, Any] = {}
+        with simple_timer("generate_sequences", metrics):
+            diffusion_outputs = await _server_generate_batched(
+                self.server_manager,
+                request_id=uuid4().hex,
+                prompt_ids=prompt_ids,
+                sampling_params=sampling_params,
+                num_outputs_per_prompt=num_outputs_per_prompt,
+                image_data=images,
+                video_data=videos,
+                negative_prompt_ids=negative_prompt_ids,
+            )
+        if len(diffusion_outputs) != num_outputs_per_prompt:
+            raise RuntimeError(
+                f"generate_batched returned {len(diffusion_outputs)} samples, expected {num_outputs_per_prompt}"
+            )
+
+        results: list[_InternalDiffusionAgentLoopOutput] = []
+        for diffusion_output, row_kwargs in zip(diffusion_outputs, row_kwargs_list, strict=True):
+            # Each sample gets its own metrics dict so per-row timings don't alias
+            # the same underlying dict and so num_preempted is per-sample.
+            sample_metrics = dict(metrics)
+            if sample_metrics.get("num_preempted") is None:
+                sample_metrics["num_preempted"] = (
+                    diffusion_output.num_preempted if diffusion_output.num_preempted is not None else -1
+                )
+            agent_output = DiffusionAgentLoopOutput(
+                prompt_ids=prompt_ids,
+                response_diffusion_output=diffusion_output.diffusion_output,
+                response_logprobs=diffusion_output.log_probs,
+                num_turns=2,
+                metrics=sample_metrics,
+                extra_fields=diffusion_output.extra_fields,
+            )
+            results.append(await self._agent_loop_postprocess(agent_output, **row_kwargs))
+        return results
 
     async def _agent_loop_postprocess(self, output, **kwargs) -> _InternalDiffusionAgentLoopOutput:
         """Perform post-processing operations on the output of each individual agent loop."""

--- a/verl_omni/trainer/config/_generated_diffusion_trainer.yaml
+++ b/verl_omni/trainer/config/_generated_diffusion_trainer.yaml
@@ -185,6 +185,7 @@ actor_rollout_ref:
     log_prob_micro_batch_size_per_gpu: null
     disable_log_stats: true
     'n': 1
+    enable_batched_diffusion: true
     multi_turn:
       _target_: verl.workers.config.MultiTurnConfig
       enable: false

--- a/verl_omni/trainer/config/diffusion/rollout/diffusion_rollout.yaml
+++ b/verl_omni/trainer/config/diffusion/rollout/diffusion_rollout.yaml
@@ -94,6 +94,14 @@ disable_log_stats: True
 # number of responses (i.e. num sample times). > 1 for grpo
 n: 1
 
+# When True and ``n > 1``, the diffusion agent loop submits one engine
+# request per *unique* prompt with ``num_outputs_per_prompt = n`` instead of
+# ``n`` concurrent B=1 requests. This lets the pipeline run a single B=n
+# transformer forward and skips ``AsyncOmniDiffusion``'s single-worker
+# request serialization. Only applies to ``vllm_omni`` rollouts.
+# Set to False to fall back to the legacy per-sample request fan-out.
+enable_batched_diffusion: True
+
 # Multi-turn interaction config for tools or chat.
 multi_turn:
 

--- a/verl_omni/workers/config/diffusion/rollout.py
+++ b/verl_omni/workers/config/diffusion/rollout.py
@@ -141,6 +141,16 @@ class DiffusionRolloutConfig(BaseConfig):
 
     enable_sleep_mode: bool = True
 
+    # When True and ``n > 1``, the diffusion agent loop fans out one engine
+    # request per *unique* prompt with ``num_outputs_per_prompt = n`` instead
+    # of ``n`` concurrent ``num_outputs_per_prompt = 1`` requests. This lets
+    # the pipeline run a single ``B = n`` transformer forward (same as
+    # ``diffusers.QwenImagePipeline(num_images_per_prompt = n)``) and skips
+    # ``AsyncOmniDiffusion``'s single-worker request serialization, which
+    # gives a sizeable throughput win for FlowGRPO-style rollouts (e.g.
+    # ``rollout.n = 16``). Only applies to ``vllm_omni`` diffusion rollouts.
+    enable_batched_diffusion: bool = True
+
     mtp: Optional[MtpConfig] = field(default_factory=MtpConfig)
 
     profiler: Optional[ProfilerConfig] = None

--- a/verl_omni/workers/rollout/vllm_rollout/vllm_omni_async_server.py
+++ b/verl_omni/workers/rollout/vllm_rollout/vllm_omni_async_server.py
@@ -151,6 +151,73 @@ class vLLMOmniHttpServer(vLLMHttpServer):
         priority: int = 0,
     ) -> DiffusionOutput:
         """Generate sequence with token-in-image-out."""
+        outputs = await self._generate_engine_call(
+            prompt_ids=prompt_ids,
+            sampling_params=sampling_params,
+            request_id=request_id,
+            num_outputs_per_prompt=1,
+            image_data=image_data,
+            video_data=video_data,
+            negative_prompt_ids=negative_prompt_ids,
+        )
+        return outputs[0]
+
+    async def generate_batched(
+        self,
+        prompt_ids: list[int],
+        sampling_params: dict[str, Any],
+        request_id: str,
+        num_outputs_per_prompt: int,
+        image_data: Optional[list[Any]] = None,
+        video_data: Optional[list[Any]] = None,
+        negative_prompt_ids: Optional[list[int]] = None,
+        priority: int = 0,
+    ) -> list[DiffusionOutput]:
+        """Submit one engine request that produces ``num_outputs_per_prompt`` samples
+        in a single B=N transformer forward pass.
+
+        This bypasses the orchestrator's per-request serialization
+        (``StageDiffusionClient`` runs each ``add_request_async`` through a
+        ``ThreadPoolExecutor(max_workers=1)``) by letting the underlying
+        ``QwenImagePipelineWithLogProb`` forward batch ``N`` latents together,
+        the same way ``diffusers.QwenImagePipeline`` does with
+        ``num_images_per_prompt=N``.
+
+        Returns:
+            list[DiffusionOutput]: One entry per generated sample. Each entry
+            has the same shape as a single :meth:`generate` call would return
+            (``diffusion_output`` is CHW, ``log_probs`` and ``extra_fields[...]``
+            are sliced per-sample).
+        """
+        if num_outputs_per_prompt < 1:
+            raise ValueError(f"num_outputs_per_prompt must be >= 1, got {num_outputs_per_prompt}")
+        return await self._generate_engine_call(
+            prompt_ids=prompt_ids,
+            sampling_params=sampling_params,
+            request_id=request_id,
+            num_outputs_per_prompt=num_outputs_per_prompt,
+            image_data=image_data,
+            video_data=video_data,
+            negative_prompt_ids=negative_prompt_ids,
+        )
+
+    async def _generate_engine_call(
+        self,
+        *,
+        prompt_ids: list[int],
+        sampling_params: dict[str, Any],
+        request_id: str,
+        num_outputs_per_prompt: int,
+        image_data: Optional[list[Any]] = None,
+        video_data: Optional[list[Any]] = None,
+        negative_prompt_ids: Optional[list[int]] = None,
+    ) -> list[DiffusionOutput]:
+        """Shared implementation for :meth:`generate` and :meth:`generate_batched`.
+
+        Builds the ``OmniCustomPrompt`` + ``OmniDiffusionSamplingParams``, calls
+        the async engine once, then slices the resulting ``OmniRequestOutput``
+        into ``num_outputs_per_prompt`` per-sample ``DiffusionOutput`` objects.
+        """
         prompt_ids = normalize_token_ids(prompt_ids)
 
         multi_modal_data = {}
@@ -176,10 +243,14 @@ class vLLMOmniHttpServer(vLLMHttpServer):
         if multi_modal_data:
             custom_prompt["extra_args"] = {"multi_modal_data": multi_modal_data}
 
-        # Build OmniDiffusionSamplingParams from the incoming dict
+        # Build OmniDiffusionSamplingParams from the incoming dict, overriding
+        # num_outputs_per_prompt so the pipeline runs a B=N transformer forward.
+        effective_sp: dict[str, Any] = dict(sampling_params)
+        effective_sp["num_outputs_per_prompt"] = num_outputs_per_prompt
+
         sampling_kwargs: dict[str, Any] = {}
         extra_args: dict[str, Any] = {}
-        for k, v in sampling_params.items():
+        for k, v in effective_sp.items():
             if hasattr(OmniDiffusionSamplingParams, k):
                 sampling_kwargs[k] = v
             else:
@@ -202,16 +273,36 @@ class vLLMOmniHttpServer(vLLMHttpServer):
             final_res = output
         assert final_res is not None
 
-        diffusion_output = self._to_tensor(final_res.images[0]).float() / 255.0
+        if len(final_res.images) < num_outputs_per_prompt:
+            raise RuntimeError(
+                f"Expected {num_outputs_per_prompt} images for request {request_id}, "
+                f"got {len(final_res.images)} from the engine."
+            )
 
-        # Extract extra data from custom_output (populated by DiffusionEngine)
+        return self._unpack_batched_result(
+            final_res=final_res,
+            sampling_params=sampling_params,
+            num_outputs_per_prompt=num_outputs_per_prompt,
+        )
+
+    def _unpack_batched_result(
+        self,
+        *,
+        final_res: OmniRequestOutput,
+        sampling_params: dict[str, Any],
+        num_outputs_per_prompt: int,
+    ) -> list[DiffusionOutput]:
+        """Slice a batched ``OmniRequestOutput`` into per-sample ``DiffusionOutput``s.
+
+        Per-sample tensors in ``custom_output`` are expected to have shape
+        ``(N, ...)`` where ``N == num_outputs_per_prompt``; index ``i`` is
+        used for the *i*-th returned ``DiffusionOutput``.
+        """
         mm_output = final_res.custom_output or {}
 
+        all_log_probs = None
         if sampling_params.get("logprobs", False):
             all_log_probs = mm_output.get("all_log_probs")
-            log_probs = all_log_probs[0] if all_log_probs is not None else None
-        else:
-            log_probs = None
 
         all_latents = mm_output.get("all_latents")
         all_timesteps = mm_output.get("all_timesteps")
@@ -220,19 +311,8 @@ class vLLMOmniHttpServer(vLLMHttpServer):
         negative_prompt_embeds = mm_output.get("negative_prompt_embeds")
         negative_prompt_embeds_mask = mm_output.get("negative_prompt_embeds_mask")
 
-        extra_fields = {
-            "all_latents": all_latents[0] if all_latents is not None else None,
-            "all_timesteps": all_timesteps[0] if all_timesteps is not None else None,
-            "prompt_embeds": prompt_embeds[0] if prompt_embeds is not None else None,
-            "prompt_embeds_mask": prompt_embeds_mask[0] if prompt_embeds_mask is not None else None,
-            "negative_prompt_embeds": negative_prompt_embeds[0] if negative_prompt_embeds is not None else None,
-            "negative_prompt_embeds_mask": negative_prompt_embeds_mask[0]
-            if negative_prompt_embeds_mask is not None
-            else None,
-            "global_steps": self.global_steps,
-        }
-
-        # Determine stop reason from finish_reason
+        # Determine stop reason from finish_reason (shared across all samples
+        # in this batched request).
         if final_res.request_output is not None and hasattr(final_res.request_output, "finish_reason"):
             finish_reason = final_res.request_output.finish_reason or "stop"
         else:
@@ -249,13 +329,32 @@ class vLLMOmniHttpServer(vLLMHttpServer):
         if final_res.request_output is not None and hasattr(final_res.request_output, "num_preempted"):
             num_preempted = final_res.request_output.num_preempted
 
-        return DiffusionOutput(
-            diffusion_output=diffusion_output,
-            log_probs=log_probs,
-            stop_reason=stop_reason,
-            num_preempted=num_preempted,
-            extra_fields=extra_fields,
-        )
+        def _take(tensor, index):
+            return tensor[index] if tensor is not None else None
+
+        outputs: list[DiffusionOutput] = []
+        for i in range(num_outputs_per_prompt):
+            diffusion_output = self._to_tensor(final_res.images[i]).float() / 255.0
+            extra_fields = {
+                "all_latents": _take(all_latents, i),
+                "all_timesteps": _take(all_timesteps, i),
+                "prompt_embeds": _take(prompt_embeds, i),
+                "prompt_embeds_mask": _take(prompt_embeds_mask, i),
+                "negative_prompt_embeds": _take(negative_prompt_embeds, i),
+                "negative_prompt_embeds_mask": _take(negative_prompt_embeds_mask, i),
+                "global_steps": self.global_steps,
+            }
+            outputs.append(
+                DiffusionOutput(
+                    diffusion_output=diffusion_output,
+                    log_probs=_take(all_log_probs, i),
+                    stop_reason=stop_reason,
+                    num_preempted=num_preempted,
+                    extra_fields=extra_fields,
+                )
+            )
+
+        return outputs
 
     async def wait_for_requests_to_drain(self):
         # TODO (mike): implement this once DP is supported.


### PR DESCRIPTION
## Summary

End-to-end FlowGRPO integration for batched (B = N) diffusion rollout, so a single `vllm-omni` request per prompt replaces the existing `rollout.n` concurrent B = 1 requests that `AsyncOmniDiffusion`'s `ThreadPoolExecutor(max_workers=1)` would otherwise serialize. Gated by a single config flag, **default on**.

This PR supersedes the earlier "expose API only" change in #2: same server-side feature, **without** the standalone benchmark script, plus the agent-loop wiring, a config knob, an example doc, and a focused test.

## How to enable in end-to-end FlowGRPO training

The new config knob is:

```
actor_rollout_ref.rollout.enable_batched_diffusion  # default: True
```

- **Default (`True`)**: when `rollout.n > 1`, each prompt group of `rollout.n` interleaved rows is collapsed into one `generate_batched(num_outputs_per_prompt = rollout.n)` engine call, i.e. a single B = `rollout.n` transformer forward.
- **Opt-out (`False`)**: the agent loop falls back to the legacy per-sample fan-out (`rollout.n` concurrent B = 1 requests).

`examples/flowgrpo_trainer/run_qwen_image_ocr_lora.sh` shows the flag inline; the two sibling LoRA scripts (`..._lora_sp2.sh`, `..._lora_async_reward.sh`) automatically pick up the dataclass default.

## Changes

- `verl_omni/workers/rollout/vllm_rollout/vllm_omni_async_server.py`
  - New Ray-callable `generate_batched(num_outputs_per_prompt: int)` returning `list[DiffusionOutput]`.
  - New private `_generate_engine_call` helper shared with `generate`.
  - New `_unpack_batched_result` slices the batched `OmniRequestOutput` (PIL list + batched custom-output tensors: latents / log-probs / prompt-embeds / masks) into per-sample `DiffusionOutput` objects.
  - `generate` is now a thin wrapper around `_generate_engine_call(num_outputs_per_prompt = 1)` → fully backwards compatible.

- `verl_omni/agent_loop/diffusion_agent_loop.py`
  - `generate_sequences` dispatches to `_run_agent_loops_batched` when `_can_use_batched_path` is true.
  - `_can_use_batched_path` activates only when: flag is on, `rollout.name == "vllm_omni"`, `rollout_n > 1`, `len(batch) % rollout_n == 0`, and every group of `rollout_n` rows shares the same `agent_name`.
  - `_run_agent_loop_batched` re-uses the registered agent loop solely for `process_vision_info` / `apply_chat_template`, issues one `generate_batched` call per group, and post-processes each of the N returned samples through the existing `_agent_loop_postprocess` so reward / extra-field handling is unchanged.
  - `_server_generate_batched` is a small module-level helper that goes through `LLMServerClient._acquire_server` / `_release_server` so load balancing keeps working without patching upstream verl.

- `verl_omni/workers/config/diffusion/rollout.py`, `verl_omni/trainer/config/diffusion/rollout/diffusion_rollout.yaml`, `verl_omni/trainer/config/_generated_diffusion_trainer.yaml`
  - New `enable_batched_diffusion: bool = True` field with inline docs. Generated yaml regenerated via `scripts/generate_trainer_config.sh` (pre-commit's `autogen-trainer-cfg` hook passes).

- `examples/flowgrpo_trainer/run_qwen_image_ocr_lora.sh`
  - Header comment explaining the new flag and an explicit `enable_batched_diffusion=True` line for visibility.

- `tests/workers/rollout/rollout_vllm/test_vllm_omni_generate_batched.py` (new)
  - One batched call returns `num_outputs_per_prompt` valid `DiffusionOutput`s (shapes, pixel range, log-probs).
  - `generate_batched(num_outputs_per_prompt = 1)` matches the shape of the legacy `generate`.
  - `num_outputs_per_prompt < 1` raises `ValueError` before touching the engine.

## Why default-on is safe

- `_can_use_batched_path` is conservative: it only triggers when every precondition holds (flag, engine name, divisibility, agent-name uniformity). Any deviation falls back to the legacy path.
- The downstream `DataProto` produced by `_postprocess` is shape-identical to the legacy path; the `repeat(interleave=True)` row layout is preserved sample-by-sample, so reward computation, log-prob handling, and trainer code (`ray_diffusion_trainer.py` lines 931 / 946) require no changes.
- The legacy code path stays in place and is unit-tested by the existing `tests/agent_loop/test_diffusion_agent_loop.py`.

## Compatibility

- No CLI / public-method signature changes for existing call sites. `generate` still returns `DiffusionOutput` and runs as B = 1.
- New config field has a safe default; old configs continue to work.
- No changes to `vllm_omni`, `verl`, trainer, or worker shape contracts.

## Test plan

- [x] `pre-commit run --files <all touched paths>` — all hooks pass (ruff, ruff-format, mypy, license, docstring coverage, doc-time-info, device-api-usage, dataproto-usage, validate-structure, compileall, autogen-trainer-cfg). The pre-existing `check-naming-conventions` failure (its grep excludes `venv` but not `.venv` site-packages installed at the repo root) is unrelated to this PR and was skipped for this commit only.
- [x] AST parse + import sanity for every touched Python file (`python3 -c "import ast; ast.parse(open(p).read())"` for each).
- [ ] `pytest tests/workers/rollout/rollout_vllm/test_vllm_omni_generate_batched.py -v -s` — requires a GPU host with the tiny Qwen-Image fixture (`~/models/tiny-random/Qwen-Image`). Reviewer should run on their workstation before merging.
- [ ] End-to-end smoke run of `examples/flowgrpo_trainer/run_qwen_image_ocr_lora.sh` with `enable_batched_diffusion=True` to confirm trainer parity.

## Benchmarked perf (from PR #2)

Measured Qwen-Image, 512×512, `num_inference_steps=50`, `rollout.n=16`, `num_prompts=2` → 32 images, bf16, FA3 for vllm-omni / TORCH_SDPA for diffusers:

| Mode                                   | Throughput   |
| -------------------------------------- | ------------ |
| vllm-omni concurrent (16 × B=1, legacy)| 0.403 img/s  |
| vllm-omni batched (1 × B=16, **this PR**) | 0.655 img/s  |
| diffusers (1 × B=16)                   | 0.528 img/s  |

vllm-omni in the new batched mode is **+62%** vs the legacy concurrent path and **+24%** vs `diffusers` on this workload.

## Duplicate-work check

Per `AGENTS.md`:

- `gh api search/issues -f q="repo:verl-project/verl-omni is:pr is:open vllm-omni rollout batch"` → 4 hits (#66 BAGEL FlowGRPO, #81 step-wise execution, #77 SD3.5 DPO, #76 z-image FlowGRPO). None of them touch the diffusion server's request-batching API or the FlowGRPO agent-loop dispatch.
- `gh pr list --repo SamitHuang/verl-omni --state open` → only PR #2 (the bench-script counterpart). This PR replaces #2 with the production-grade wiring + tests and no benchmark script, per reviewer request.

## AI assistance disclosure

This change was prepared with AI assistance. The submitter has reviewed every modified line, defends the design end-to-end, and verified the new batched path via the benchmark companion in PR #2.
