### PR TITLE
[vllm_omni, rollout] fix: avoid diffusion MASTER_PORT collisions in parallel Ray rollout

### DIFF
--- a/verl_omni/pipelines/_patch.py
+++ b/verl_omni/pipelines/_patch.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
-import os
 
 import diffusers
 import torch
@@ -77,51 +76,4 @@ def _apply_qwen_image_ulysses_mask_fix() -> None:
     QwenImageTransformer2DModel.forward = _patched_forward
 
 
-def _apply_diffusion_master_port_env_fix() -> None:
-    """Honor MASTER_PORT set by verl-omni rollout servers for diffusion workers.
-
-    vllm-omni's OmniDiffusionConfig.__post_init__ picks a random port in a narrow
-    range (30005 + rand(0, 100)), which collides when multiple Ray vLLMOmniHttpServer
-    actors start in parallel. verl's vLLM reward path avoids this via get_free_port().
-
-    # TODO (long): drop this
-    """
-    try:
-        from vllm_omni.diffusion.data import OmniDiffusionConfig
-    except ImportError:
-        return
-
-    if getattr(OmniDiffusionConfig, "_verl_omni_master_port_patched", False):
-        return
-
-    _orig_post_init = OmniDiffusionConfig.__post_init__
-
-    def _patched_post_init(self) -> None:
-        env_port = os.environ.get("MASTER_PORT")
-        reserved_port: int | None = None
-        if env_port is not None:
-            try:
-                reserved_port = int(env_port)
-            except ValueError:
-                logger.warning("Ignoring invalid MASTER_PORT=%r for diffusion workers", env_port)
-
-        _orig_post_init(self)
-
-        if reserved_port is not None:
-            if not _patched_post_init._warned:
-                logger.warning(
-                    "verl_omni patch applied: OmniDiffusionConfig.__post_init__ now honors "
-                    "MASTER_PORT from the environment (set by vLLMOmniHttpServer) instead of "
-                    "vllm-omni's random port selection. Remove this patch once vllm-omni "
-                    "respects an explicit master_port without adding random jitter."
-                )
-                _patched_post_init._warned = True
-            self.master_port = reserved_port
-
-    _patched_post_init._warned = False
-    OmniDiffusionConfig.__post_init__ = _patched_post_init
-    OmniDiffusionConfig._verl_omni_master_port_patched = True
-
-
 _apply_qwen_image_ulysses_mask_fix()
-_apply_diffusion_master_port_env_fix()

--- a/verl_omni/pipelines/_patch.py
+++ b/verl_omni/pipelines/_patch.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
+import os
 
 import diffusers
 import torch
@@ -76,4 +77,51 @@ def _apply_qwen_image_ulysses_mask_fix() -> None:
     QwenImageTransformer2DModel.forward = _patched_forward
 
 
+def _apply_diffusion_master_port_env_fix() -> None:
+    """Honor MASTER_PORT set by verl-omni rollout servers for diffusion workers.
+
+    vllm-omni's OmniDiffusionConfig.__post_init__ picks a random port in a narrow
+    range (30005 + rand(0, 100)), which collides when multiple Ray vLLMOmniHttpServer
+    actors start in parallel. verl's vLLM reward path avoids this via get_free_port().
+
+    # TODO (long): drop this
+    """
+    try:
+        from vllm_omni.diffusion.data import OmniDiffusionConfig
+    except ImportError:
+        return
+
+    if getattr(OmniDiffusionConfig, "_verl_omni_master_port_patched", False):
+        return
+
+    _orig_post_init = OmniDiffusionConfig.__post_init__
+
+    def _patched_post_init(self) -> None:
+        env_port = os.environ.get("MASTER_PORT")
+        reserved_port: int | None = None
+        if env_port is not None:
+            try:
+                reserved_port = int(env_port)
+            except ValueError:
+                logger.warning("Ignoring invalid MASTER_PORT=%r for diffusion workers", env_port)
+
+        _orig_post_init(self)
+
+        if reserved_port is not None:
+            if not _patched_post_init._warned:
+                logger.warning(
+                    "verl_omni patch applied: OmniDiffusionConfig.__post_init__ now honors "
+                    "MASTER_PORT from the environment (set by vLLMOmniHttpServer) instead of "
+                    "vllm-omni's random port selection. Remove this patch once vllm-omni "
+                    "respects an explicit master_port without adding random jitter."
+                )
+                _patched_post_init._warned = True
+            self.master_port = reserved_port
+
+    _patched_post_init._warned = False
+    OmniDiffusionConfig.__post_init__ = _patched_post_init
+    OmniDiffusionConfig._verl_omni_master_port_patched = True
+
+
 _apply_qwen_image_ulysses_mask_fix()
+_apply_diffusion_master_port_env_fix()

--- a/verl_omni/utils/vllm_omni/utils.py
+++ b/verl_omni/utils/vllm_omni/utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 
+import os
 from typing import cast
 
 import torch
@@ -194,5 +195,47 @@ class VLLMOmniHijack:
 
             return model.eval()
 
+        def hijack_omni_diffusion_config_post_init(self) -> None:
+            """
+            based on vllm_omni.diffusion.data.OmniDiffusionConfig.__post_init__,
+            honor MASTER_PORT reserved by vLLMOmniHttpServer.
+
+            Reason:
+            OmniDiffusionConfig picks master_port via 30005 + random.randint(0, 100)
+            and settle_port(). Multiple Ray vLLMOmniHttpServer actors starting in
+            parallel often collide on the same port, causing torch.distributed
+            init_process_group to fail with EADDRINUSE. verl's vLLM reward rollout
+            avoids this with get_free_port() per actor; diffusion workers need the
+            same via MASTER_PORT in the environment.
+
+            # TODO (long): drop this patch once vllm-omni respects an explicit
+            master_port without adding random jitter.
+            """
+            env_port = os.environ.get("MASTER_PORT")
+            reserved_port: int | None = None
+            if env_port is not None:
+                try:
+                    reserved_port = int(env_port)
+                except ValueError:
+                    logger.warning("Ignoring invalid MASTER_PORT=%r for diffusion workers", env_port)
+
+            _orig_omni_diffusion_config_post_init(self)
+
+            if reserved_port is not None:
+                if not hijack_omni_diffusion_config_post_init._warned:
+                    logger.warning(
+                        "verl_omni hijack applied: OmniDiffusionConfig.__post_init__ honors "
+                        "MASTER_PORT from the environment instead of vllm-omni random port "
+                        "selection. Remove once vllm-omni respects explicit master_port."
+                    )
+                    hijack_omni_diffusion_config_post_init._warned = True
+                self.master_port = reserved_port
+
+        _orig_omni_diffusion_config_post_init = OmniDiffusionConfig.__post_init__
+        hijack_omni_diffusion_config_post_init._warned = False
+
         do_hijack(DiffusionLoRAManager, "_load_adapter", hijack__load_adapter)
         do_hijack(DiffusersPipelineLoader, "load_model", hijack_load_model)
+        if not getattr(OmniDiffusionConfig, "_verl_omni_master_port_hijacked", False):
+            do_hijack(OmniDiffusionConfig, "__post_init__", hijack_omni_diffusion_config_post_init)
+            OmniDiffusionConfig._verl_omni_master_port_hijacked = True

--- a/verl_omni/workers/rollout/vllm_rollout/vllm_omni_async_server.py
+++ b/verl_omni/workers/rollout/vllm_rollout/vllm_omni_async_server.py
@@ -40,6 +40,7 @@ from vllm_omni.lora.request import LoRARequest
 from vllm_omni.outputs import OmniRequestOutput
 
 from verl_omni.pipelines.model_base import VllmOmniPipelineBase
+from verl_omni.utils.vllm_omni import VLLMOmniHijack
 from verl_omni.workers.config import DiffusionModelConfig, DiffusionRolloutConfig
 from verl_omni.workers.rollout.replica import DiffusionOutput
 
@@ -116,6 +117,8 @@ class vLLMOmniHttpServer(vLLMHttpServer):
         os.environ["MASTER_PORT"] = str(diffusion_master_port)
         logger.info("Using MASTER_PORT=%s for vLLM-Omni diffusion workers", os.environ["MASTER_PORT"])
 
+        # Apply before AsyncOmni builds OmniDiffusionConfig in this process.
+        VLLMOmniHijack.hijack()
         engine_client = AsyncOmni(**engine_args)
         app = build_app(args)
         await omni_init_app_state(engine_client, app.state, args)

--- a/verl_omni/workers/rollout/vllm_rollout/vllm_omni_async_server.py
+++ b/verl_omni/workers/rollout/vllm_rollout/vllm_omni_async_server.py
@@ -14,7 +14,6 @@
 import argparse
 import logging
 import os
-import socket
 from dataclasses import asdict
 from typing import Any, Optional
 
@@ -23,6 +22,7 @@ import torchvision.transforms as T
 import vllm_omni.entrypoints.cli.serve
 from verl.utils.config import omega_conf_to_dataclass
 from verl.utils.import_utils import import_external_libs
+from verl.utils.net_utils import get_free_port
 from verl.utils.tokenizer import normalize_token_ids
 from verl.workers.rollout.utils import run_uvicorn
 from verl.workers.rollout.vllm_rollout.utils import (
@@ -45,12 +45,6 @@ from verl_omni.workers.rollout.replica import DiffusionOutput
 
 logger = logging.getLogger(__file__)
 logger.setLevel(logging.INFO)
-
-
-def _get_free_loopback_port() -> int:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        sock.bind(("127.0.0.1", 0))
-        return sock.getsockname()[1]
 
 
 class vLLMOmniHttpServer(vLLMHttpServer):
@@ -115,8 +109,11 @@ class vLLMOmniHttpServer(vLLMHttpServer):
             engine_args["enable_dummy_pipeline"] = True
             engine_args["custom_pipeline_args"] = {"pipeline_class": pipeline_path}
 
+        diffusion_master_port, diffusion_master_sock = get_free_port("127.0.0.1", with_alive_sock=True)
+        diffusion_master_sock.close()
+
         os.environ["MASTER_ADDR"] = "127.0.0.1"
-        os.environ["MASTER_PORT"] = str(_get_free_loopback_port())
+        os.environ["MASTER_PORT"] = str(diffusion_master_port)
         logger.info("Using MASTER_PORT=%s for vLLM-Omni diffusion workers", os.environ["MASTER_PORT"])
 
         engine_client = AsyncOmni(**engine_args)


### PR DESCRIPTION
### What does this PR do?

Fixes a flaky CI failure (`EADDRINUSE` on `MASTER_PORT`, e.g. port 30017) when multiple `vLLMOmniHttpServer` Ray actors start in parallel during FlowGRPO e2e / gpu smoke tests.

**Root cause:** vllm-omni’s `OmniDiffusionConfig.__post_init__` assigns `torch.distributed`’s store port via `30005 + random.randint(0, 100)` plus `settle_port()`. Several rollout agents starting at once often pick the same port; rank-0’s `TCPStore` bind then fails with `address already in use`.

**Why vLLM reward rollout does not hit this:** Pass 2 uses `reward.reward_model.rollout.name=vllm` (`vLLMHttpServer`), which reserves ports per Ray actor with verl’s `get_free_port(..., with_alive_sock=True)` and vLLM’s `data_parallel_master_port` plumbing. That path never uses vllm-omni’s diffusion port selection.

**Ownership:** Primary issue is in **vllm-omni** (random narrow port range, ignores caller `MASTER_PORT` and still adds jitter). This PR fixes the **verl-omni integration** and adds a temporary monkey-patch until vllm-omni respects an explicit `master_port`.

**Changes:**
1. `vllm_omni_async_server.py` — Reserve a unique loopback port per Ray actor with verl’s `get_free_port("127.0.0.1", with_alive_sock=True)`, set `MASTER_ADDR` / `MASTER_PORT`, call `VLLMOmniHijack.hijack()` before `AsyncOmni`, then release the reservation socket so diffusion workers can bind the port.
2. `verl_omni/utils/vllm_omni/utils.py` — Extend `VLLMOmniHijack.hijack()` to wrap `OmniDiffusionConfig.__post_init__` so it honors `MASTER_PORT` from the environment instead of vllm-omni’s random port after `__post_init__` runs (also invoked from worker `__new__` for LoRA-related hijacks).

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here:
  - `gh pr list --repo verl-project/verl-omni --state open --search "MASTER_PORT EADDRINUSE diffusion"`
  - `gh pr list --repo verl-project/verl-omni --state open --search "vllm_omni rollout port"`
  - (No open PR found addressing this specific diffusion port collision at time of writing.)
- [x] Format the PR title as `[{modules}] {type}: {description}` (see suggested title above)

### Test

CI failure context (gpu smoke / FlowGRPO e2e):

```text
torch.distributed.DistNetworkError: ... EADDRINUSE, port: 30017
  at DiffusionWorker.init_device → init_distributed_environment → init_process_group
```

**Test commands run (fill in after local/CI run):**

```bash
# Relevant CI workflow (adjust if your branch uses a different job name)
# .github/workflows — gpu_smoke_tests / run_flowgrpo_qwen_image.sh

bash tests/special_e2e/run_flowgrpo_qwen_image.sh
```

**Results:** _(pending — document pass/fail and link to CI run)_

- [ ] `gpu_smoke_tests` green on PR branch
- [ ] No `EADDRINUSE` on `MASTER_PORT` in vLLMOmniHttpServer / DiffusionWorker logs

### API and Usage Example

No public API change. Behavior is internal to `vLLMOmniHttpServer.run_server()` and the existing `verl_omni.pipelines` import-time patch.

Each Ray rollout actor now logs:

```text
Using MASTER_PORT=<port> for vLLM-Omni diffusion workers
```

### Design & Code Changes

| File | Change |
|------|--------|
| `verl_omni/workers/rollout/vllm_rollout/vllm_omni_async_server.py` | Replace `_get_free_loopback_port()` with `get_free_port("127.0.0.1", with_alive_sock=True)`; set `MASTER_PORT`; call `VLLMOmniHijack.hijack()` before `AsyncOmni(**engine_args)`. |
| `verl_omni/utils/vllm_omni/utils.py` | Add `hijack_omni_diffusion_config_post_init` in `VLLMOmniHijack.hijack()` — after vllm-omni `__post_init__`, restore `self.master_port` from `MASTER_PORT` env so workers do not use the random 30005+rand port. |

**Follow-up (vllm-omni upstream):** Stop adding `random.randint(0, 100)` when `master_port` is explicit; honor `MASTER_PORT` / `OmniDiffusionConfig.master_port` without jitter. Remove verl-omni patch once fixed upstream.

### Accountability (AI-assisted work)

- [x] **AI assistance was used** for investigation and this patch (Cursor / agent).
- [x] A human submitter has reviewed the changed lines and will defend the change in review.
- [x] This is not duplicating an existing open PR (see search links above).

### Checklist Before Submitting

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update the documentation. _(Not required — internal rollout/patch fix.)_
- [ ] Add unit or end-to-end test(s) to CI. _(Existing `run_flowgrpo_qwen_image.sh` / gpu smoke covers the failure mode; no new test file in this PR.)_
