### PR TITLE
[trainer] feat: Support VeOmni as actor engine

### DIFF
--- a/.github/workflows/gpu_smoke.yml
+++ b/.github/workflows/gpu_smoke.yml
@@ -82,6 +82,11 @@ jobs:
           pip3 install -r requirements.txt
           pip3 install -r requirements-test.txt
           pip3 install --no-deps -e .
+          # --no-deps keeps the vllm 0.20.2 / torch stack intact; veomni's [gpu] extra pins
+          # torch 2.9 and would conflict. See docs/start/install.md "Optional engine backends".
+          # TODO: rm --no-deps when VeOmni support torch2.11
+          pip3 install veomni==0.1.11 --no-deps
+          pip3 install torchcodec librosa soundfile av
       - name: Run GPU smoke tests
         run: |
           ray stop --force

--- a/.github/workflows/type-coverage-check.yml
+++ b/.github/workflows/type-coverage-check.yml
@@ -40,6 +40,7 @@ jobs:
           pip install --no-deps "verl @ git+https://github.com/verl-project/verl.git@$(cat .github/verl_pin.txt)"
           pip install -r requirements.txt
           pip install --no-deps -e .
+          pip install --no-deps veomni==0.1.11
       - name: Run type annotation coverage check
         run: python3 tests/special_sanity/type_coverage_check.py
       - name: Run docstring coverage check

--- a/.github/workflows/type-coverage-check.yml
+++ b/.github/workflows/type-coverage-check.yml
@@ -40,7 +40,7 @@ jobs:
           pip install --no-deps "verl @ git+https://github.com/verl-project/verl.git@$(cat .github/verl_pin.txt)"
           pip install -r requirements.txt
           pip install --no-deps -e .
-          pip install --no-deps veomni==0.1.11
+          pip install --no-deps --ignore-requires-python veomni==0.1.11
       - name: Run type annotation coverage check
         run: python3 tests/special_sanity/type_coverage_check.py
       - name: Run docstring coverage check

--- a/docs/algo/performance.md
+++ b/docs/algo/performance.md
@@ -1,7 +1,7 @@
 (performance)=
 # Performance Reference
 
-Last updated: 05/13/2026
+Last updated: 06/04/2026
 
 Below are reference benchmark results for VeRL-Omni training runs.
 
@@ -40,30 +40,62 @@ Evaluated with `trainer.val_before_train=True`:
 
 ## FlowGRPO: non-CFG Full Model Training on Qwen-Image OCR
 
-> Experiments used NVIDIA H200 GPUs, lr 3e-5, clip_ratio 1e-5, optimizer state fp32. The other parameters are consistent with the LoRA setting.
+> lr 3e-5, clip_ratio 1e-5, optimizer state fp32. The other parameters are consistent with the LoRA setting.
 
 > Note that the initial reward is expected to be low for non-CFG full model training.
 
-### Full-Model Experiment Settings and Throughput
+This recipe runs on two interchangeable actor backends. They share the same
+algorithm, data, and hyper-parameters and differ only in the training engine:
 
-| Script | # GPUs | # GPUs for Actor | # GPUs for Rollout | # GPUs for Async Reward | Batch Size | Images per Prompt | LR | Throughput (images/GPU/s) | Time per Step (s) |
-|--------|--------|------------------|--------------------|-------------------------|------------|-------------------|----|-----------------------|-------------------|
-| `run_qwen_image_ocr.sh` | 4 | 4 | 4 | 0 (sync) | 32 | 16 | 3e-5 | 0.510 | 250 |
+- **FSDP1** — `run_qwen_image_ocr.sh`
+- **VeOmni** — `run_qwen_image_ocr_veomni.sh` (see the
+  [install guide](../start/install.md) "Optional engine backends")
 
-### Full-Model Training - Zero Standard Deviation Ratio and Reward Curve
+Use the throughput table to choose a backend.
+
+### Settings and Throughput
+
+| Backend | Script | GPU name | # GPUs | # GPUs for Actor | # GPUs for Rollout | # GPUs for Async Reward | Batch Size | Images per Prompt | LR | Throughput (images/GPU/s) | Time per Step (s) |
+|---------|--------|--------|--------|------------------|--------------------|-------------------------|------------|-------------------|----|-----------------------|-------------------|
+| FSDP1 | `run_qwen_image_ocr.sh` | H200 | 4 | 4 | 4 | 0 (sync) | 32 | 16 | 3e-5 | 0.510 | 250 |
+| VeOmni | `run_qwen_image_ocr_veomni.sh` | H100 | 64 | 64 | 64 | 0 (sync) | 32 | 16 | 3e-5 | 0.079 | 100 |
+
+> **Note**: VeOmni run with `actor_rollout_ref.actor.veomni_config.param_offload=False`, `actor_rollout_ref.actor.veomni_config.optimizer_offload=True` and `SP=1`. 
+
+### FSDP1 Backend — Training Curves
+
+#### Zero Standard Deviation Ratio and Reward Curve
 
 <div align="center">
 <img width="600" alt="Full Model FlowGRPO OCR training zero standard deviation ratio and reward curve" src="https://github.com/user-attachments/assets/ee5db957-f3b0-44e4-8054-b80ddac02bcb" />
 </div>
 
-### Training - Clip Fraction
+#### Clip Fraction
 
 <div align="center">
 <img width="600" alt="Full Model FlowGRPO OCR training Clip Fraction" src="https://github.com/user-attachments/assets/b5d27aae-337b-43bf-8228-1678e71673a5" />
 </div>
 
-### Full-Model Validation Reward Curve
+#### Validation Reward Curve
 
 <div align="center">
 <img width="600" alt="Full Model FlowGRPO OCR validation reward curve" src="https://github.com/user-attachments/assets/5ed8fd76-6f1b-4c80-aa43-af905e58d722" />
 </div>
+
+### VeOmni Backend — Training Curves
+
+#### Zero Standard Deviation Ratio and Reward Curve
+
+<img width="600" alt="image" src="https://github.com/user-attachments/assets/22254cb9-0722-4721-92de-abcb1c30a4aa" />
+
+<img width="600" alt="image" src="https://github.com/user-attachments/assets/232af9b0-ec28-4d2f-abe6-c7d8a34e4533" />
+
+#### Clip Fraction
+
+<img width="600" alt="image" src="https://github.com/user-attachments/assets/7650739b-0c34-4c74-897c-4dbf0746336e" />
+
+#### Validation Reward Curve
+
+<img width="600" alt="image" src="https://github.com/user-attachments/assets/a1ec247b-2b82-47df-8572-5e7a132b7eef" />
+
+

--- a/docs/algo/performance.md
+++ b/docs/algo/performance.md
@@ -70,7 +70,7 @@ Evaluated with `trainer.val_before_train=True`:
 
 ## FlowGRPO non-CFG Full Model: VeOmni vs FSDP1 Backend (same config)
 
-> Apples-to-apples comparison (requested in review): the **VeOmni** and **FSDP1** actor engines run the *same* FlowGRPO recipe — same algorithm, data, and hyper-parameters — on the *same* hardware (64 × NVIDIA H100), differing only in the training engine. lr 3e-5, clip_ratio 1e-5, optimizer state fp32; other parameters match the LoRA setting.
+> Apples-to-apples comparison: the **VeOmni** and **FSDP1** actor engines run the *same* FlowGRPO recipe — same algorithm, data, and hyper-parameters — on the *same* hardware (64 × NVIDIA H100), differing only in the training engine. lr 3e-5, clip_ratio 1e-5, optimizer state fp32; other parameters match the LoRA setting.
 
 - **FSDP1** — `run_qwen_image_ocr.sh`
 - **VeOmni** — `run_qwen_image_ocr_veomni.sh` (see the [install guide](../start/install.md) "Optional engine backends")

--- a/docs/algo/performance.md
+++ b/docs/algo/performance.md
@@ -1,7 +1,7 @@
 (performance)=
 # Performance Reference
 
-Last updated: 06/04/2026
+Last updated: 06/05/2026
 
 Below are reference benchmark results for VeRL-Omni training runs.
 
@@ -40,62 +40,60 @@ Evaluated with `trainer.val_before_train=True`:
 
 ## FlowGRPO: non-CFG Full Model Training on Qwen-Image OCR
 
-> lr 3e-5, clip_ratio 1e-5, optimizer state fp32. The other parameters are consistent with the LoRA setting.
+> Experiments used NVIDIA H200 GPUs, lr 3e-5, clip_ratio 1e-5, optimizer state fp32. The other parameters are consistent with the LoRA setting.
 
 > Note that the initial reward is expected to be low for non-CFG full model training.
 
-This recipe runs on two interchangeable actor backends. They share the same
-algorithm, data, and hyper-parameters and differ only in the training engine:
+### Full-Model Experiment Settings and Throughput
 
-- **FSDP1** — `run_qwen_image_ocr.sh`
-- **VeOmni** — `run_qwen_image_ocr_veomni.sh` (see the
-  [install guide](../start/install.md) "Optional engine backends")
+| Script | # GPUs | # GPUs for Actor | # GPUs for Rollout | # GPUs for Async Reward | Batch Size | Images per Prompt | LR | Throughput (images/GPU/s) | Time per Step (s) |
+|--------|--------|------------------|--------------------|-------------------------|------------|-------------------|----|-----------------------|-------------------|
+| `run_qwen_image_ocr.sh` | 4 | 4 | 4 | 0 (sync) | 32 | 16 | 3e-5 | 0.510 | 250 |
 
-Use the throughput table to choose a backend.
-
-### Settings and Throughput
-
-| Backend | Script | GPU name | # GPUs | # GPUs for Actor | # GPUs for Rollout | # GPUs for Async Reward | Batch Size | Images per Prompt | LR | Throughput (images/GPU/s) | Time per Step (s) |
-|---------|--------|--------|--------|------------------|--------------------|-------------------------|------------|-------------------|----|-----------------------|-------------------|
-| FSDP1 | `run_qwen_image_ocr.sh` | H200 | 4 | 4 | 4 | 0 (sync) | 32 | 16 | 3e-5 | 0.510 | 250 |
-| VeOmni | `run_qwen_image_ocr_veomni.sh` | H100 | 64 | 64 | 64 | 0 (sync) | 32 | 16 | 3e-5 | 0.079 | 100 |
-
-> **Note**: VeOmni run with `actor_rollout_ref.actor.veomni_config.param_offload=False`, `actor_rollout_ref.actor.veomni_config.optimizer_offload=True` and `SP=1`. 
-
-### FSDP1 Backend — Training Curves
-
-#### Zero Standard Deviation Ratio and Reward Curve
+### Full-Model Training - Zero Standard Deviation Ratio and Reward Curve
 
 <div align="center">
 <img width="600" alt="Full Model FlowGRPO OCR training zero standard deviation ratio and reward curve" src="https://github.com/user-attachments/assets/ee5db957-f3b0-44e4-8054-b80ddac02bcb" />
 </div>
 
-#### Clip Fraction
+### Training - Clip Fraction
 
 <div align="center">
 <img width="600" alt="Full Model FlowGRPO OCR training Clip Fraction" src="https://github.com/user-attachments/assets/b5d27aae-337b-43bf-8228-1678e71673a5" />
 </div>
 
-#### Validation Reward Curve
+### Full-Model Validation Reward Curve
 
 <div align="center">
 <img width="600" alt="Full Model FlowGRPO OCR validation reward curve" src="https://github.com/user-attachments/assets/5ed8fd76-6f1b-4c80-aa43-af905e58d722" />
 </div>
 
-### VeOmni Backend — Training Curves
+## FlowGRPO non-CFG Full Model: VeOmni vs FSDP1 Backend (same config)
 
-#### Zero Standard Deviation Ratio and Reward Curve
+> Apples-to-apples comparison (requested in review): the **VeOmni** and **FSDP1** actor engines run the *same* FlowGRPO recipe — same algorithm, data, and hyper-parameters — on the *same* hardware (64 × NVIDIA H100), differing only in the training engine. lr 3e-5, clip_ratio 1e-5, optimizer state fp32; other parameters match the LoRA setting.
 
-<img width="600" alt="image" src="https://github.com/user-attachments/assets/22254cb9-0722-4721-92de-abcb1c30a4aa" />
+- **FSDP1** — `run_qwen_image_ocr.sh`
+- **VeOmni** — `run_qwen_image_ocr_veomni.sh` (see the [install guide](../start/install.md) "Optional engine backends")
 
-<img width="600" alt="image" src="https://github.com/user-attachments/assets/232af9b0-ec28-4d2f-abe6-c7d8a34e4533" />
+### Settings and Throughput
 
-#### Clip Fraction
+| Backend | Script | GPU name | # GPUs | # GPUs for Actor | # GPUs for Rollout | # GPUs for Async Reward | Batch Size | Images per Prompt | LR | Throughput (images/GPU/s) | Time per Step (s) |
+|---------|--------|--------|--------|------------------|--------------------|-------------------------|------------|-------------------|----|-----------------------|-------------------|
+| VeOmni | `run_qwen_image_ocr_veomni.sh` | H100 | 64 | 64 | 64 | 0 (sync) | 32 | 16 | 3e-5 | 0.079 | 100 |
+| FSDP1 | `run_qwen_image_ocr.sh` | H100 | 64 | 64 | 64 | 0 (sync) | 32 | 16 | 3e-5 | 0.077 | 105 |
 
-<img width="600" alt="image" src="https://github.com/user-attachments/assets/7650739b-0c34-4c74-897c-4dbf0746336e" />
+> **Note**: VeOmni and FSDP1 run with `actor_rollout_ref.actor.veomni_config.param_offload=False`, `actor_rollout_ref.actor.veomni_config.optimizer_offload=True`, and `SP=1`.
 
-#### Validation Reward Curve
+### Full-Model Training - Zero Standard Deviation Ratio and Reward Curve
 
-<img width="600" alt="image" src="https://github.com/user-attachments/assets/a1ec247b-2b82-47df-8572-5e7a132b7eef" />
+<img width="1221" height="465" alt="image" src="https://github.com/user-attachments/assets/254ecbde-32eb-4073-b9ea-6025f80a9611" />
 
+<img width="1221" height="465" alt="image" src="https://github.com/user-attachments/assets/468f6022-8333-4b63-ab7d-39355b327d8d" />
 
+### Training - Clip Fraction
+
+<img width="1221" height="465" alt="image" src="https://github.com/user-attachments/assets/9e992ac5-c091-4bba-9aef-736a2fa0ab15" />
+
+### Full-Model Validation Reward Curve
+
+<img width="1221" height="465" alt="image" src="https://github.com/user-attachments/assets/e2fb0d52-2c47-4170-bc0d-d32f0f1da209" />

--- a/docs/contributing/integrating_a_diffusion_model.md
+++ b/docs/contributing/integrating_a_diffusion_model.md
@@ -23,7 +23,8 @@ code is the canonical reference.
 ## TL;DR
 
 A new model needs **three files in one new package** plus **two registry
-hooks**:
+hooks**. The same adapters work with both the default diffusers + FSDP2
+backend and the optional [VeOmni backend](#53-use-the-veomni-backend-optional) — backend selection is purely a configuration concern.
 
 ```
 verl_omni/pipelines/<model>_flow_grpo/
@@ -51,6 +52,8 @@ algorithm** (FlowGRPO) but use **different runtimes**:
 |---|---|---|
 | **Rollout** (sampling trajectories) | vllm-omni | `VllmOmniPipelineBase` subclass — runs the SDE loop and returns latents, log-probs, and prompt embeddings. |
 | **Training** (per-step forward + loss) | FSDP + diffusers | `DiffusionModelBase` subclass — re-runs one denoising step per micro-batch slot to compute fresh log-probs for the policy gradient. |
+
+The trainer runtime can also be VeOmni's FSDP2-based DiT trainer; see [§ 5.3](#53-use-the-veomni-backend-optional). The training-adapter contract (`prepare_model_inputs` / `forward_and_sample_previous_step`) is identical on both backends.
 
 ```text
   ┌─────────────────────────┐                ┌──────────────────────────┐
@@ -330,6 +333,41 @@ The data preprocessor's tokenisation **must match the upstream
 `_encode_prompt` exactly** — same chat template, same special tokens,
 same `enable_thinking` flag, etc. Mismatches here cause silent reward
 collapse.
+
+### 5.3 Use the VeOmni Backend
+
+Backend selection is **orthogonal** to model integration: the adapters you wrote in Steps 3–4 work unchanged regardless of whether the actor runs on the default diffusers + FSDP2 engine or on [VeOmni](https://github.com/ByteDance-Seed/VeOmni). Switching is a configuration concern handled by a few Hydra overrides at launch time.
+
+#### What VeOmni reuses from your model adapter
+
+- `DiffusionModelBase` subclass (Step 3) — used verbatim. The VeOmni engine calls the same `prepare_model_inputs` / `forward_and_sample_previous_step` contract.
+- `VllmOmniPipelineBase` subclass (Step 4) — used verbatim. Rollout always runs in vllm-omni, independent of the actor backend.
+- `FlowMatchSDEDiscreteScheduler` (Step 3.1) — used verbatim.
+
+#### What VeOmni requires that diffusers does not
+
+1. **Upstream support in VeOmni.** Just as diffusers must provide your `<Name>Transformer2DModel`, VeOmni must be able to load your model via its `DiTTrainer` path. If VeOmni does not yet support the architecture, upstream it there first (the diffusers prerequisite from Step 1 still applies for rollout — both upstreams are required).
+2. **`config_path` / `transformer_subfolder`.** The VeOmni engine loads the transformer from `<local_path>/<transformer_subfolder>` and the config from `config_path` (falling back to the weights path). These fields are already on `DiffusionModelConfig` and are shared with the diffusers backend, so no new model-specific fields are needed.
+
+#### Launching with the VeOmni backend
+
+`diffusion/model_engine=veomni_diffusion` switches the entire actor / reference Hydra schema; the other actor-engine fields then live under `actor_rollout_ref.actor.veomni_config.*` and `actor_rollout_ref.ref.veomni_config.*`:
+
+```bash
+python3 -m verl_omni.trainer.main_diffusion \
+    diffusion/model_engine=veomni_diffusion \
+    actor_rollout_ref.actor.strategy=veomni \
+    actor_rollout_ref.actor.veomni_config.strategy=veomni \
+    actor_rollout_ref.ref.veomni_config.strategy=veomni \
+    ...  # everything else identical to your diffusers/FSDP2 recipe
+```
+
+See [`examples/flowgrpo_trainer/run_qwen_image_ocr_veomni.sh`](../../examples/flowgrpo_trainer/run_qwen_image_ocr_veomni.sh) for a complete VeOmni recipe that mirrors [`run_qwen_image_ocr.sh`](../../examples/flowgrpo_trainer/run_qwen_image_ocr.sh) line-for-line — the diff is only the engine-selection fields. Install instructions for VeOmni alongside vLLM 0.20.2 are in [`docs/start/install.md`](../start/install.md#optional-engine-backends).
+
+
+#### Mixing override schemas — don't
+
+`diffusion/model_engine=veomni_diffusion` selects the Hydra schema as a whole. Do **not** mix `actor.fsdp_config.*` and `actor.veomni_config.*` overrides in the same run — the fields for the other engine will be rejected as unknown keys at config-resolution time.
 
 ---
 

--- a/docs/start/install.md
+++ b/docs/start/install.md
@@ -59,6 +59,31 @@ uv pip install -e .
 | Extra | Install | When needed |
 |---|---|---|
 | OCR reward | `uv pip install Levenshtein` | FlowGRPO training with OCR-based reward |
+| VeOmni engine backend | See [Optional engine backends](#optional-engine-backends) | Running the diffusion trainer with VeOmni instead of the default FSDP2 |
+
+## Optional engine backends
+
+VeRL-Omni defaults to **FSDP2** as the training engine for the policy and reference models. The diffusion trainer can alternatively be switched to [**VeOmni**](https://github.com/ByteDance-Seed/VeOmni). The engine is selected at the Hydra command line — see [`examples/flowgrpo_trainer/run_qwen_image_ocr_veomni.sh`](https://github.com/verl-project/verl-omni/blob/main/examples/flowgrpo_trainer/run_qwen_image_ocr_veomni.sh) for a complete recipe.
+
+### Installing VeOmni alongside vLLM 0.20.2
+
+VeOmni 0.1.11's `gpu` extra pins `torch==2.9.1+cu129`, which conflicts with `vllm==0.20.2` (depends on `torch>=2.11`). A plain `uv pip install veomni[gpu,dit]==0.1.11` therefore fails dependency resolution.
+
+VeOmni itself runs correctly on torch 2.11 — only the `[gpu]` extra's pin is too strict. Install it without dependency resolution so the existing torch/vllm stack is preserved, and add the small set of runtime extras that the verl-omni VeOmni engine actually needs:
+
+```bash
+uv pip install veomni==0.1.11 --no-deps
+uv pip install torchcodec librosa soundfile av
+```
+
+Verify the engine is importable:
+
+```bash
+python -c "import veomni; print('veomni', veomni.__version__)"
+python -c "from veomni.distributed.offloading import load_model_to_gpu, load_optimizer, offload_model_to_cpu, offload_optimizer; print('VeOmni offloading helpers OK')"
+```
+
+If you want VeOmni's full `[gpu,dit]` extras (flash-attn variants, liger-kernel, cuda-python, etc.), install them in a separate environment not pinned to vllm 0.20.2; verl-omni does not need them.
 
 ## Post-Installation Verification
 

--- a/examples/flowgrpo_trainer/README.md
+++ b/examples/flowgrpo_trainer/README.md
@@ -110,6 +110,26 @@ An NPU script for Atlas A3 with 16 NPUs is also provided. Before running, set th
 bash examples/flowgrpo_trainer/run_qwen_image_ocr_npu.sh
 ```
 
+### VeOmni engine backend
+
+The diffusion trainer defaults to FSDP2. To use [VeOmni](https://github.com/ByteDance-Seed/VeOmni) as the actor/reference engine instead, first follow the [VeOmni install instructions](../../docs/start/install.md#optional-engine-backends) (vllm 0.20.2 needs torch 2.11, which conflicts with veomni's pinned `[gpu]` extra — the doc covers the workaround), then run the VeOmni counterpart of the full-weight recipe:
+
+```bash
+bash examples/flowgrpo_trainer/run_qwen_image_ocr_veomni.sh
+```
+
+`run_qwen_image_ocr_veomni.sh` is intentionally a line-for-line mirror of `run_qwen_image_ocr.sh` and differs only in the engine-selection overrides:
+
+| Override | FSDP2 (default) | VeOmni |
+|---|---|---|
+| `diffusion/model_engine=` | _(unset; uses `dp_diffusion`)_ | `veomni_diffusion` |
+| `actor_rollout_ref.actor.strategy=` | `fsdp2` | `veomni` |
+| Actor engine config block | `actor.fsdp_config.*` | `actor.veomni_config.*` |
+| Sequence-parallel field | `fsdp_config.ulysses_sequence_parallel_size` | `veomni_config.ulysses_parallel_size` |
+| Ref engine config block | `ref.fsdp_config.*` | `ref.veomni_config.*` |
+
+The two backends are not configured by the same Hydra keys, so do not mix `fsdp_config` and `veomni_config` overrides in a single run — `diffusion/model_engine=...` selects the schema, and overrides for the other engine will be rejected as unknown keys.
+
 ## Performance
 
 > All experiments were conducted on *NVIDIA H800* GPUs using the OCR reward.

--- a/examples/flowgrpo_trainer/run_qwen_image_ocr.sh
+++ b/examples/flowgrpo_trainer/run_qwen_image_ocr.sh
@@ -13,7 +13,7 @@ reward_function_path=verl_omni/utils/reward_score/genrm_ocr.py
 
 NUM_GPUS_ACTOR_ROLLOUT_REWARD=${NUM_GPUS:-4}
 NUM_NODES=${NUM_NODES:-1}
-ACTOR_SP=1
+ACTOR_SP=2
 ROLLOUT_TP=1
 REWARD_TP=4
 IMAGE_RESOLUTION=512

--- a/examples/flowgrpo_trainer/run_qwen_image_ocr.sh
+++ b/examples/flowgrpo_trainer/run_qwen_image_ocr.sh
@@ -13,7 +13,7 @@ reward_function_path=verl_omni/utils/reward_score/genrm_ocr.py
 
 NUM_GPUS_ACTOR_ROLLOUT_REWARD=${NUM_GPUS:-4}
 NUM_NODES=${NUM_NODES:-1}
-ACTOR_SP=2
+ACTOR_SP=1
 ROLLOUT_TP=1
 REWARD_TP=4
 IMAGE_RESOLUTION=512

--- a/examples/flowgrpo_trainer/run_qwen_image_ocr_veomni.sh
+++ b/examples/flowgrpo_trainer/run_qwen_image_ocr_veomni.sh
@@ -25,7 +25,7 @@ reward_function_path=verl_omni/utils/reward_score/genrm_ocr.py
 
 NUM_GPUS_ACTOR_ROLLOUT_REWARD=${NUM_GPUS:-4}
 NUM_NODES=${NUM_NODES:-1}
-ACTOR_SP=2
+ACTOR_SP=1
 ROLLOUT_TP=1
 REWARD_TP=4
 IMAGE_RESOLUTION=512

--- a/examples/flowgrpo_trainer/run_qwen_image_ocr_veomni.sh
+++ b/examples/flowgrpo_trainer/run_qwen_image_ocr_veomni.sh
@@ -1,11 +1,23 @@
-# Qwen-Image full-weight RL, vllm_omni rollout
+# Qwen-Image full-weight RL with the VeOmni engine, vllm_omni rollout.
+#
+# This recipe mirrors run_qwen_image_ocr.sh (full-weight FSDP2 baseline) and
+# differs only in the engine-selection Hydra overrides:
+#
+#   diffusion/model_engine=veomni_diffusion          # switch the Hydra schema
+#   actor_rollout_ref.actor.strategy=veomni          # actor backend = VeOmni
+#   actor_rollout_ref.actor.veomni_config.*          # VeOmni-specific knobs
+#   actor_rollout_ref.ref.veomni_config.strategy=veomni
+#
+# Requires VeOmni installed alongside the verl-omni base environment; see
+# docs/start/install.md "Optional engine backends" for the install workaround
+# (veomni 0.1.11's `[gpu]` extra pins torch 2.9 and conflicts with vllm 0.20.2).
 set -x
 
 # Set WORKSPACE to any writable directory; defaults to $HOME
 WORKSPACE=${WORKSPACE:-$HOME}
 
-ocr_train_path=$WORKSPACE/data/ocr/qwen_image/train.parquet
-ocr_test_path=$WORKSPACE/data/ocr/qwen_image/test.parquet
+ocr_train_path=$WORKSPACE/data/ocr/train.parquet
+ocr_test_path=$WORKSPACE/data/ocr/test.parquet
 
 model_name=Qwen/Qwen-Image
 reward_model_name=Qwen/Qwen3-VL-8B-Instruct
@@ -13,16 +25,18 @@ reward_function_path=verl_omni/utils/reward_score/genrm_ocr.py
 
 NUM_GPUS_ACTOR_ROLLOUT_REWARD=${NUM_GPUS:-4}
 NUM_NODES=${NUM_NODES:-1}
-ACTOR_SP=1
+ACTOR_SP=2
 ROLLOUT_TP=1
 REWARD_TP=4
 IMAGE_RESOLUTION=512
 
 ENGINE=vllm_omni
 REWARD_ENGINE=vllm
+TRAINER_BACKEND=veomni
 
 
 python3 -m verl_omni.trainer.main_diffusion \
+    diffusion/model_engine=veomni_diffusion \
     algorithm.adv_estimator=flow_grpo \
     data.train_files=$ocr_train_path \
     data.val_files=$ocr_test_path \
@@ -33,9 +47,11 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.actor.optim.weight_decay=0.0001 \
     actor_rollout_ref.actor.ppo_mini_batch_size=16 \
     actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=16 \
-    actor_rollout_ref.actor.fsdp_config.param_offload=True \
-    actor_rollout_ref.actor.fsdp_config.ulysses_sequence_parallel_size=$ACTOR_SP \
-    actor_rollout_ref.actor.fsdp_config.optimizer_offload=True \
+    actor_rollout_ref.actor.strategy=$TRAINER_BACKEND \
+    actor_rollout_ref.actor.veomni_config.strategy=$TRAINER_BACKEND \
+    actor_rollout_ref.actor.veomni_config.ulysses_parallel_size=$ACTOR_SP \
+    actor_rollout_ref.actor.veomni_config.param_offload=True \
+    actor_rollout_ref.actor.veomni_config.optimizer_offload=True \
     actor_rollout_ref.actor.diffusion_loss.loss_mode=flow_grpo \
     actor_rollout_ref.actor.diffusion_loss.clip_ratio=1e-5 \
     actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=32 \
@@ -55,6 +71,7 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.rollout.algo.sde_window_range="[0,5]" \
     actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=50 \
     actor_rollout_ref.rollout.val_kwargs.algo.noise_level=0.0 \
+    actor_rollout_ref.ref.veomni_config.strategy=$TRAINER_BACKEND \
     actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=32 \
     reward.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / REWARD_TP)) \
     reward.reward_model.enable=True \
@@ -65,7 +82,7 @@ python3 -m verl_omni.trainer.main_diffusion \
     reward.custom_reward_function.name=compute_score_ocr \
     trainer.logger='["console", "wandb"]' \
     trainer.project_name=flow_grpo \
-    trainer.experiment_name=qwen_image_ocr \
+    trainer.experiment_name=qwen_image_ocr_${TRAINER_BACKEND} \
     trainer.log_val_generations=8 \
     trainer.val_before_train=False \
     trainer.n_gpus_per_node=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / NUM_NODES)) \

--- a/scripts/generate_trainer_config.sh
+++ b/scripts/generate_trainer_config.sh
@@ -5,6 +5,7 @@ set -euox pipefail
 # Define config specifications: "config_name:output_file:config_arg"
 CONFIG_SPECS=(
     "diffusion_trainer:_generated_diffusion_trainer.yaml:--config-name=diffusion_trainer.yaml"
+    "diffusion_trainer:_generated_diffusion_veomni_trainer.yaml:--config-name=diffusion_trainer.yaml diffusion/model_engine=veomni_diffusion"
 )
 
 generate_config() {

--- a/tests/gpu_smoke/run_gpu_smoke_tests.sh
+++ b/tests/gpu_smoke/run_gpu_smoke_tests.sh
@@ -183,7 +183,7 @@ run_selected_test() {
 
 # ── Determine which tests to run ───────────────────────────────────────────────
 declare -A RUN_TEST=(
-    [0]=1 [1]=1 [2]=1 [3]=1 [4]=1 [5]=1 [6]=1
+    [0]=1 [1]=1 [2]=1 [3]=1 [4]=1 [5]=1 [6]=1 [7]=1
 )
 
 # If explicit IDs were passed on the CLI, override to run only those.
@@ -250,6 +250,12 @@ run_selected_test 5 "DiffusionNFT trainer e2e" \
 run_selected_test 6 "SD3.5 offline DPO trainer e2e" \
     env CUDA_VISIBLE_DEVICES=0 NUM_GPUS=1 \
     bash tests/special_e2e/run_sd35_offline_dpo.sh
+
+# ── Test 7: diffusers VeOmni engine ───────────────────────────────────────────
+# Skips itself if the optional `veomni` backend is not installed (importorskip).
+run_selected_test 7 "diffusers VeOmni engine" \
+    env CUDA_VISIBLE_DEVICES="${CUDA_DEVICE_LIST}" \
+    pytest -s tests/workers/test_diffusers_veomni_engine.py
 
 # ══════════════════════════════════════════════════════════════════════════════
 # SUMMARY

--- a/tests/workers/test_diffusers_fsdp_engine.py
+++ b/tests/workers/test_diffusers_fsdp_engine.py
@@ -27,7 +27,7 @@ from verl.utils import tensordict_utils as tu
 from verl.workers.config import TrainingWorkerConfig
 
 from verl_omni.pipelines.utils import build_scheduler
-from verl_omni.workers.config import DiffusionModelConfig, FSDPDiffusionActorConfig
+from verl_omni.workers.config import DiffusionModelConfig, FSDPDiffusionActorConfig, VeOmniDiffusionActorConfig
 from verl_omni.workers.engine_workers import TrainingWorker
 from verl_omni.workers.utils.losses import diffusion_loss
 from verl_omni.workers.utils.padding import embeds_padding_2_no_padding
@@ -66,7 +66,10 @@ def _create_sp_compatible_model(parent_dir, src_model_path, num_attention_heads=
 
 
 def create_training_config(model_type, strategy, device_count, model, policy_state_adapters=None):
-    if device_count == 1:
+    if strategy == "veomni":
+        cp = 1
+        fsdp_size = device_count
+    elif device_count == 1:
         cp = fsdp_size = 1
     else:
         cp = 2 if _diffusers_sp_supported() else 1
@@ -126,6 +129,49 @@ def create_training_config(model_type, strategy, device_count, model, policy_sta
         engine_config = actor_config.engine
         optimizer_config = actor_config.optim
         checkpoint_config = actor_config.checkpoint
+    elif strategy == "veomni":
+        from hydra import compose, initialize_config_dir
+        from verl.utils.config import omega_conf_to_dataclass
+
+        with initialize_config_dir(config_dir=os.path.abspath("verl_omni/trainer/config/diffusion/model")):
+            cfg = compose(
+                config_name="diffusion_model",
+                overrides=[
+                    "path=" + path,
+                    "tokenizer_path=" + tokenizer_path,
+                    "lora_rank=0",
+                    "pipeline.true_cfg_scale=4.0",
+                    "algo.noise_level=1.2",
+                    "algo.sde_type=sde",
+                    "veomni_config_path=" + os.path.join(path, "transformer"),
+                ],
+            )
+        model_config: DiffusionModelConfig = omega_conf_to_dataclass(cfg)
+
+        with initialize_config_dir(config_dir=os.path.abspath("verl_omni/trainer/config/diffusion/actor")):
+            cfg = compose(
+                config_name="veomni_diffusion_actor",
+                overrides=[
+                    "diffusion_loss.clip_ratio=0.0001",
+                    "diffusion_loss.adv_clip_max=5.0",
+                    "ppo_mini_batch_size=4",
+                    "ppo_micro_batch_size_per_gpu=4",
+                    "optim.lr=1e-4",
+                    "optim.weight_decay=0.0001",
+                    "veomni_config.param_offload=False",
+                    "veomni_config.optimizer_offload=False",
+                    "veomni_config.mixed_precision=True",
+                    "veomni_config.forward_only=False",
+                    "veomni_config.fsdp_size=" + str(fsdp_size),
+                    "veomni_config.ulysses_parallel_size=" + str(cp),
+                    "diffusion_loss.loss_mode='flow_grpo'",
+                ],
+            )
+        actor_config: VeOmniDiffusionActorConfig = omega_conf_to_dataclass(cfg)
+
+        engine_config = actor_config.engine
+        optimizer_config = actor_config.optim
+        checkpoint_config = actor_config.checkpoint
     else:
         raise NotImplementedError(f"strategy {strategy} is not supported")
 
@@ -179,7 +225,14 @@ def create_data_samples(num_device: int, model_config: DiffusionModelConfig) -> 
     return data
 
 
-@pytest.mark.parametrize("strategy", ["fsdp", "fsdp2"])
+@pytest.mark.parametrize(
+    "strategy",
+    [
+        "fsdp",
+        "fsdp2",
+        "veomni",
+    ],
+)
 def test_diffusers_fsdp_engine(strategy):
     # Create configs
     ray.init()
@@ -190,7 +243,7 @@ def test_diffusers_fsdp_engine(strategy):
         if device_count > 1 and device_count % 2 != 0:
             pytest.skip(f"Need even GPU count for cp=2/fsdp_size=device_count test, got {device_count}")
 
-        sp_enabled = device_count > 1 and _diffusers_sp_supported()
+        sp_enabled = strategy != "veomni" and device_count > 1 and _diffusers_sp_supported()
         base_model_path = os.path.expanduser("~/models/tiny-random/Qwen-Image")
         if sp_enabled:
             # SP requires num_attention_heads divisible by sp_size (cp=2).

--- a/tests/workers/test_diffusers_veomni_engine.py
+++ b/tests/workers/test_diffusers_veomni_engine.py
@@ -76,6 +76,12 @@ def create_training_config(model_type, device_count, model):
                 "ppo_micro_batch_size_per_gpu=4",
                 "optim.lr=1e-4",
                 "optim.weight_decay=0.0001",
+                # VeOmni's BaseTrainer._build_lr_scheduler reads
+                # ``args.train_steps``, which raises unless ``_train_steps`` has
+                # been set away from the ``-1`` sentinel. In production this is
+                # set by ray_diffusion_trainer (len(dataloader) * total_epochs);
+                # in this unit test we pin a small value explicitly.
+                "optim.total_training_steps=10",
                 "veomni_config.param_offload=False",
                 "veomni_config.optimizer_offload=False",
                 "veomni_config.mixed_precision=True",

--- a/tests/workers/test_diffusers_veomni_engine.py
+++ b/tests/workers/test_diffusers_veomni_engine.py
@@ -41,6 +41,8 @@ from verl_omni.workers.utils.padding import embeds_padding_2_no_padding
 
 from ..utils.gpu_test_topology import resolve_requested_num_gpus
 
+pytest.importorskip("veomni")
+
 
 def create_training_config(model_type, device_count, model):
     cp = 1

--- a/tests/workers/test_diffusers_veomni_engine.py
+++ b/tests/workers/test_diffusers_veomni_engine.py
@@ -12,6 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""End-to-end tests for the VeOmni-backed diffusion FSDP2 actor engine.
+
+Mirrors :mod:`tests.workers.test_diffusers_fsdp_engine` but exercises the
+``veomni`` strategy in isolation so that VeOmni-specific imports and config
+overrides do not bleed into the diffusers FSDP/FSDP2 test surface.
+"""
+
 import os
 import shutil
 import tempfile
@@ -27,7 +34,7 @@ from verl.utils import tensordict_utils as tu
 from verl.workers.config import TrainingWorkerConfig
 
 from verl_omni.pipelines.utils import build_scheduler
-from verl_omni.workers.config import DiffusionModelConfig, FSDPDiffusionActorConfig
+from verl_omni.workers.config import DiffusionModelConfig, VeOmniDiffusionActorConfig
 from verl_omni.workers.engine_workers import TrainingWorker
 from verl_omni.workers.utils.losses import diffusion_loss
 from verl_omni.workers.utils.padding import embeds_padding_2_no_padding
@@ -35,94 +42,50 @@ from verl_omni.workers.utils.padding import embeds_padding_2_no_padding
 from ..utils.gpu_test_topology import resolve_requested_num_gpus
 
 
-def _diffusers_sp_supported() -> bool:
-    """Return True if the installed diffusers version supports ContextParallelConfig (>= 0.38.0)."""
-    import diffusers
-    from packaging import version
-
-    return version.parse(diffusers.__version__) >= version.parse("0.38.0")
-
-
-def _create_sp_compatible_model(parent_dir, src_model_path, num_attention_heads=2):
-    """Create a temporary Qwen-Image model copy compatible with SP."""
-    from diffusers import QwenImageTransformer2DModel
-
-    dst = os.path.join(parent_dir, "Qwen-Image")
-    shutil.copytree(src_model_path, dst)
-
-    transformer = QwenImageTransformer2DModel(
-        num_attention_heads=num_attention_heads,
-        attention_head_dim=32,
-        num_layers=2,
-        in_channels=64,
-        out_channels=16,
-        patch_size=2,
-        joint_attention_dim=32,
-        axes_dims_rope=(8, 12, 12),
-        guidance_embeds=False,
-    )
-    transformer.save_pretrained(os.path.join(dst, "transformer"))
-    return dst
-
-
-def create_training_config(model_type, strategy, device_count, model, policy_state_adapters=None):
-    if strategy not in {"fsdp", "fsdp2"}:
-        raise NotImplementedError(f"strategy {strategy} is not supported")
-
-    if device_count == 1:
-        cp = fsdp_size = 1
-    else:
-        cp = 2 if _diffusers_sp_supported() else 1
-        fsdp_size = device_count
+def create_training_config(model_type, device_count, model):
+    cp = 1
+    fsdp_size = device_count
     path = os.path.expanduser(model)
     tokenizer_path = os.path.join(path, "tokenizer")
 
     from hydra import compose, initialize_config_dir
     from verl.utils.config import omega_conf_to_dataclass
 
-    model_overrides = [
-        "path=" + path,
-        "tokenizer_path=" + tokenizer_path,
-        "lora_rank=8",
-        "lora_alpha=16",
-        "pipeline.true_cfg_scale=4.0",
-        "algo.noise_level=1.2",
-        "algo.sde_type=sde",
-    ]
-    if policy_state_adapters is not None:
-        adapters = ",".join(f'"{adapter}"' for adapter in policy_state_adapters)
-        model_overrides.append(f"policy_state_adapters=[{adapters}]")
-
     with initialize_config_dir(config_dir=os.path.abspath("verl_omni/trainer/config/diffusion/model")):
         cfg = compose(
             config_name="diffusion_model",
-            overrides=model_overrides,
+            overrides=[
+                "path=" + path,
+                "tokenizer_path=" + tokenizer_path,
+                "lora_rank=0",
+                "pipeline.true_cfg_scale=4.0",
+                "algo.noise_level=1.2",
+                "algo.sde_type=sde",
+                "config_path=" + os.path.join(path, "transformer"),
+            ],
         )
     model_config: DiffusionModelConfig = omega_conf_to_dataclass(cfg)
 
     with initialize_config_dir(config_dir=os.path.abspath("verl_omni/trainer/config/diffusion/actor")):
         cfg = compose(
-            config_name="dp_diffusion_actor",
+            config_name="veomni_diffusion_actor",
             overrides=[
-                "strategy=" + strategy,
                 "diffusion_loss.clip_ratio=0.0001",
                 "diffusion_loss.adv_clip_max=5.0",
                 "ppo_mini_batch_size=4",
                 "ppo_micro_batch_size_per_gpu=4",
                 "optim.lr=1e-4",
                 "optim.weight_decay=0.0001",
-                "fsdp_config.param_offload=False",
-                "fsdp_config.optimizer_offload=False",
-                "fsdp_config.model_dtype='bfloat16'",
-                "fsdp_config.dtype='bfloat16'",
-                "+fsdp_config.mixed_precision.param_dtype='bfloat16'",
-                "fsdp_config.forward_only=False",
-                "fsdp_config.fsdp_size=" + str(fsdp_size),
-                "fsdp_config.ulysses_sequence_parallel_size=" + str(cp),
+                "veomni_config.param_offload=False",
+                "veomni_config.optimizer_offload=False",
+                "veomni_config.mixed_precision=True",
+                "veomni_config.forward_only=False",
+                "veomni_config.fsdp_size=" + str(fsdp_size),
+                "veomni_config.ulysses_parallel_size=" + str(cp),
                 "diffusion_loss.loss_mode='flow_grpo'",
             ],
         )
-    actor_config: FSDPDiffusionActorConfig = omega_conf_to_dataclass(cfg)
+    actor_config: VeOmniDiffusionActorConfig = omega_conf_to_dataclass(cfg)
 
     training_config = TrainingWorkerConfig(
         model_type=model_type,
@@ -174,43 +137,27 @@ def create_data_samples(num_device: int, model_config: DiffusionModelConfig) -> 
     return data
 
 
-@pytest.mark.parametrize(
-    "strategy",
-    [
-        "fsdp",
-        "fsdp2",
-    ],
-)
-def test_diffusers_fsdp_engine(strategy):
-    # Create configs
+def test_veomni_fsdp_engine():
     ray.init()
-    tmp_dir = tempfile.mkdtemp(prefix="qwen_image_sp_")
+    tmp_dir = tempfile.mkdtemp(prefix="qwen_image_veomni_")
     try:
         visible_gpus = torch.cuda.device_count()
         device_count = resolve_requested_num_gpus(default_num_gpus=max(1, visible_gpus))
         if device_count > 1 and device_count % 2 != 0:
-            pytest.skip(f"Need even GPU count for cp=2/fsdp_size=device_count test, got {device_count}")
+            pytest.skip(f"Need even GPU count for fsdp_size=device_count test, got {device_count}")
 
-        sp_enabled = device_count > 1 and _diffusers_sp_supported()
-        base_model_path = os.path.expanduser("~/models/tiny-random/Qwen-Image")
-        if sp_enabled:
-            # SP requires num_attention_heads divisible by sp_size (cp=2).
-            model_path = _create_sp_compatible_model(tmp_dir, base_model_path, num_attention_heads=2)
-        else:
-            model_path = base_model_path
+        model_path = os.path.expanduser("~/models/tiny-random/Qwen-Image")
         training_config, actor_config = create_training_config(
             model_type="diffusion_model",
-            strategy=strategy,
             device_count=device_count,
             model=model_path,
         )
-        # init model
+
         ray_cls_with_init = RayClassWithInitArgs(cls=ray.remote(TrainingWorker), config=training_config)
         resource_pool = RayResourcePool(process_on_nodes=[device_count])
-        wg = RayWorkerGroup(resource_pool=resource_pool, ray_cls_with_init=ray_cls_with_init)  # TrainigWorker
+        wg = RayWorkerGroup(resource_pool=resource_pool, ray_cls_with_init=ray_cls_with_init)
         wg.reset()
 
-        # forward only without loss function
         data_td = create_data_samples(device_count, training_config.model_config).to_tensordict()
         data_td = embeds_padding_2_no_padding(data_td)
         tu.assign_non_tensor(
@@ -226,12 +173,9 @@ def test_diffusers_fsdp_engine(strategy):
         for key in ["log_probs", "metrics"]:
             assert key in output_dict
 
-        # forward and backward with loss function
-        # set loss function
         loss_fn = partial(diffusion_loss, config=actor_config)
         wg.set_loss_fn(loss_fn)
 
-        # train batch
         data_td = create_data_samples(device_count, training_config.model_config).to_tensordict()
         data_td = embeds_padding_2_no_padding(data_td)
         ppo_mini_batch_size = 4

--- a/tests/workers/test_diffusers_veomni_engine.py
+++ b/tests/workers/test_diffusers_veomni_engine.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""End-to-end tests for the VeOmni-backed diffusion FSDP2 actor engine.
+"""End-to-end tests for the VeOmni diffusion actor engine.
 
 Mirrors :mod:`tests.workers.test_diffusers_fsdp_engine` but exercises the
-``veomni`` strategy in isolation so that VeOmni-specific imports and config
+``veomni`` backend in isolation so that VeOmni-specific imports and config
 overrides do not bleed into the diffusers FSDP/FSDP2 test surface.
 """
 
@@ -137,7 +137,7 @@ def create_data_samples(num_device: int, model_config: DiffusionModelConfig) -> 
     return data
 
 
-def test_veomni_fsdp_engine():
+def test_diffusers_veomni_engine():
     ray.init()
     tmp_dir = tempfile.mkdtemp(prefix="qwen_image_veomni_")
     try:

--- a/tests/workers/test_diffusers_veomni_engine.py
+++ b/tests/workers/test_diffusers_veomni_engine.py
@@ -20,8 +20,6 @@ overrides do not bleed into the diffusers FSDP/FSDP2 test surface.
 """
 
 import os
-import shutil
-import tempfile
 from functools import partial
 
 import numpy as np
@@ -141,7 +139,6 @@ def create_data_samples(num_device: int, model_config: DiffusionModelConfig) -> 
 
 def test_diffusers_veomni_engine():
     ray.init()
-    tmp_dir = tempfile.mkdtemp(prefix="qwen_image_veomni_")
     try:
         visible_gpus = torch.cuda.device_count()
         device_count = resolve_requested_num_gpus(default_num_gpus=max(1, visible_gpus))
@@ -198,4 +195,3 @@ def test_diffusers_veomni_engine():
         assert "metrics" in output_dict.keys()
     finally:
         ray.shutdown()
-        shutil.rmtree(tmp_dir, ignore_errors=True)

--- a/verl_omni/pipelines/model_base.py
+++ b/verl_omni/pipelines/model_base.py
@@ -186,14 +186,19 @@ class DiffusionModelBase(ABC):
         model_inputs: dict[str, torch.Tensor],
         negative_model_inputs: Optional[dict[str, torch.Tensor]] = None,
     ) -> torch.Tensor:
-        """Run a single model prediction for forward-process objectives.
+        """Run a single model prediction.
 
-        Override this when an algorithm trains by noising clean latents
-        ``x0 -> xt`` (i.e., forward process) and then optimizing model predictions directly, rather
-        than sampling/log-probing the reverse step ``xt -> x_{t-1}``.
-        The default is a plain transformer forward; model adapters only need
-        to override when prediction requires extra handling such as CFG,
-        negative inputs, or output conversion.
+        The default routes through ``module(**model_inputs)`` (rather than calling an
+        inner submodule directly) so FSDP2 / sequence-parallel forward hooks fire and
+        unshard parameters before the linear layers run, then returns the model's first
+        output (the ``(sample,)`` tuple shape used by diffusers transformers). It is
+        backend-agnostic and shared by both the FSDP and VeOmni engines.
+
+        Used both for forward-process objectives (noising clean latents ``x0 -> xt``
+        then optimizing predictions directly) and as the prediction step inside
+        reverse-sampling algorithms (FlowGRPO et al.). Model adapters only need to
+        override this when prediction requires extra handling such as CFG, negative
+        inputs, or output conversion.
         """
         return module(**model_inputs)[0]
 

--- a/verl_omni/pipelines/model_base.py
+++ b/verl_omni/pipelines/model_base.py
@@ -187,13 +187,6 @@ class DiffusionModelBase(ABC):
         negative_model_inputs: Optional[dict[str, torch.Tensor]] = None,
     ) -> torch.Tensor:
         """Run a single model prediction.
-
-        The default routes through ``module(**model_inputs)`` (rather than calling an
-        inner submodule directly) so FSDP2 / sequence-parallel forward hooks fire and
-        unshard parameters before the linear layers run, then returns the model's first
-        output (the ``(sample,)`` tuple shape used by diffusers transformers). It is
-        backend-agnostic and shared by both the FSDP and VeOmni engines.
-
         Used both for forward-process objectives (noising clean latents ``x0 -> xt``
         then optimizing predictions directly) and as the prediction step inside
         reverse-sampling algorithms (FlowGRPO et al.). Model adapters only need to

--- a/verl_omni/pipelines/qwen_image_flow_grpo/diffusers_training_adapter.py
+++ b/verl_omni/pipelines/qwen_image_flow_grpo/diffusers_training_adapter.py
@@ -63,14 +63,11 @@ def _configure_qwen_image_scheduler(
     scheduler.set_timesteps(num_inference_steps, device=device, sigmas=sigmas, mu=mu)
 
 
-def _is_veomni_qwen_image_module(module: QwenImageTransformer2DModel) -> bool:
-    target_module = getattr(module, "_fsdp_wrapped_module", module)
-    return target_module.__class__.__module__.startswith("veomni.models.diffusers.qwen_image")
-
-
 def _forward_qwen_image_prediction(module: QwenImageTransformer2DModel, model_inputs: dict[str, torch.Tensor]):
-    if _is_veomni_qwen_image_module(module):
-        return module(**model_inputs, return_loss=False)[0]
+    # Go through ``module(...)`` so FSDP2 / parallelization forward hooks fire and
+    # unshard parameters before the linear layers run. VeOmni's wrapped model also
+    # implements this entrypoint: with ``training_target`` left unset it falls back to
+    # the diffusers base forward and returns the same ``(sample,)`` tuple shape.
     return module(**model_inputs)[0]
 
 

--- a/verl_omni/pipelines/qwen_image_flow_grpo/diffusers_training_adapter.py
+++ b/verl_omni/pipelines/qwen_image_flow_grpo/diffusers_training_adapter.py
@@ -63,6 +63,17 @@ def _configure_qwen_image_scheduler(
     scheduler.set_timesteps(num_inference_steps, device=device, sigmas=sigmas, mu=mu)
 
 
+def _is_veomni_qwen_image_module(module: QwenImageTransformer2DModel) -> bool:
+    target_module = getattr(module, "_fsdp_wrapped_module", module)
+    return target_module.__class__.__module__.startswith("veomni.models.diffusers.qwen_image")
+
+
+def _forward_qwen_image_prediction(module: QwenImageTransformer2DModel, model_inputs: dict[str, torch.Tensor]):
+    if _is_veomni_qwen_image_module(module):
+        return module(**model_inputs, return_loss=False)[0]
+    return module(**model_inputs)[0]
+
+
 @DiffusionModelBase.register("QwenImagePipeline", algorithm="flow_grpo")
 class QwenImage(DiffusionModelBase):
     """Training adapter for the Qwen-Image diffusion model.
@@ -219,11 +230,11 @@ class QwenImage(DiffusionModelBase):
         latents = scheduler_inputs["all_latents"]
         timesteps = scheduler_inputs["all_timesteps"]
 
-        noise_pred = module(**model_inputs)[0]
+        noise_pred = _forward_qwen_image_prediction(module, model_inputs)
         true_cfg_scale = model_config.pipeline.true_cfg_scale
         if true_cfg_scale > 1.0:
             assert negative_model_inputs is not None
-            neg_noise_pred = module(**negative_model_inputs)[0]
+            neg_noise_pred = _forward_qwen_image_prediction(module, negative_model_inputs)
             noise_pred = apply_true_cfg(noise_pred, neg_noise_pred, true_cfg_scale)
 
         _, log_prob, prev_sample_mean, std_dev_t, sqrt_dt = scheduler.sample_previous_step(

--- a/verl_omni/pipelines/qwen_image_flow_grpo/diffusers_training_adapter.py
+++ b/verl_omni/pipelines/qwen_image_flow_grpo/diffusers_training_adapter.py
@@ -63,14 +63,6 @@ def _configure_qwen_image_scheduler(
     scheduler.set_timesteps(num_inference_steps, device=device, sigmas=sigmas, mu=mu)
 
 
-def _forward_qwen_image_prediction(module: QwenImageTransformer2DModel, model_inputs: dict[str, torch.Tensor]):
-    # Go through ``module(...)`` so FSDP2 / parallelization forward hooks fire and
-    # unshard parameters before the linear layers run. VeOmni's wrapped model also
-    # implements this entrypoint: with ``training_target`` left unset it falls back to
-    # the diffusers base forward and returns the same ``(sample,)`` tuple shape.
-    return module(**model_inputs)[0]
-
-
 @DiffusionModelBase.register("QwenImagePipeline", algorithm="flow_grpo")
 class QwenImage(DiffusionModelBase):
     """Training adapter for the Qwen-Image diffusion model.
@@ -227,11 +219,11 @@ class QwenImage(DiffusionModelBase):
         latents = scheduler_inputs["all_latents"]
         timesteps = scheduler_inputs["all_timesteps"]
 
-        noise_pred = _forward_qwen_image_prediction(module, model_inputs)
+        noise_pred = cls.forward(module, model_config, model_inputs)
         true_cfg_scale = model_config.pipeline.true_cfg_scale
         if true_cfg_scale > 1.0:
             assert negative_model_inputs is not None
-            neg_noise_pred = _forward_qwen_image_prediction(module, negative_model_inputs)
+            neg_noise_pred = cls.forward(module, model_config, negative_model_inputs)
             noise_pred = apply_true_cfg(noise_pred, neg_noise_pred, true_cfg_scale)
 
         _, log_prob, prev_sample_mean, std_dev_t, sqrt_dt = scheduler.sample_previous_step(

--- a/verl_omni/trainer/config/_generated_diffusion_trainer.yaml
+++ b/verl_omni/trainer/config/_generated_diffusion_trainer.yaml
@@ -273,6 +273,8 @@ actor_rollout_ref:
     custom_chat_template: null
     external_lib: null
     enable_gradient_checkpointing: true
+    veomni_config_path: null
+    veomni_transformer_subfolder: transformer
     attn_backend: native
     lora_rank: 0
     lora_alpha: 64

--- a/verl_omni/trainer/config/_generated_diffusion_trainer.yaml
+++ b/verl_omni/trainer/config/_generated_diffusion_trainer.yaml
@@ -273,8 +273,8 @@ actor_rollout_ref:
     custom_chat_template: null
     external_lib: null
     enable_gradient_checkpointing: true
-    veomni_config_path: null
-    veomni_transformer_subfolder: transformer
+    config_path: null
+    transformer_subfolder: transformer
     attn_backend: native
     lora_rank: 0
     lora_alpha: 64

--- a/verl_omni/trainer/config/_generated_diffusion_veomni_trainer.yaml
+++ b/verl_omni/trainer/config/_generated_diffusion_veomni_trainer.yaml
@@ -1,0 +1,540 @@
+# This reference configration yaml is automatically generated via 'scripts/generate_trainer_config.sh'
+# in which it invokes 'python3 scripts/print_cfg.py --cfg job --config-name=diffusion_trainer.yaml diffusion/model_engine=veomni_diffusion' to flatten the 'verl_omni/trainer/config/diffusion_trainer.yaml' config fields into a single file.
+# Do not modify this file directly.
+# The file is usually only for reference and never used.
+
+actor_rollout_ref:
+  actor:
+    optim:
+      _target_: verl_omni.workers.config.diffusion.VeOmniDiffusionOptimizerConfig
+      optimizer: adamw
+      lr: 1.0e-06
+      lr_min: 0.0
+      lr_start: 0.0
+      lr_warmup_steps_ratio: 0.0
+      total_training_steps: -1
+      weight_decay: 0.01
+      betas:
+      - 0.9
+      - 0.999
+      eps: 1.0e-08
+      clip_grad: 1.0
+      lr_scheduler_type: constant
+      lr_decay_ratio: 1.0
+      fused: false
+      lr_warmup_steps: -1
+    veomni_config:
+      _target_: verl_omni.workers.config.diffusion.VeOmniDiffusionEngineConfig
+      param_offload: false
+      optimizer_offload: false
+      fsdp_size: -1
+      ulysses_parallel_size: 1
+      expert_parallel_size: 1
+      init_device: meta
+      reshard_after_forward: true
+      forward_prefetch: true
+      model_dtype: bfloat16
+      mixed_precision: true
+      mixed_precision_param_dtype: bfloat16
+      mixed_precision_reduce_dtype: float32
+      mixed_precision_output_dtype: null
+      mixed_precision_cast_forward_inputs: true
+      enable_reentrant: false
+      enable_activation_offload: false
+      activation_gpu_limit: 0.0
+      strategy: veomni
+      attn_implementation: eager
+      moe_implementation: eager
+      cross_entropy_loss_implementation: eager
+      rms_norm_implementation: eager
+      swiglu_mlp_implementation: eager
+      rotary_pos_emb_implementation: eager
+      load_balancing_loss_implementation: eager
+      rms_norm_gated_implementation: eager
+      causal_conv1d_implementation: eager
+      chunk_gated_delta_rule_implementation: eager
+      forward_only: false
+    profiler:
+      _target_: verl.utils.profiler.ProfilerConfig
+      tool: torch
+      enable: false
+      all_ranks: false
+      ranks: []
+      save_path: ${oc.select:global_profiler.save_path,outputs/profile}
+      tool_config:
+        nsys:
+          _target_: verl.utils.profiler.config.NsightToolConfig
+          discrete: ${oc.select:global_profiler.global_tool_config.nsys.discrete,false}
+          name: nsight
+        torch:
+          _target_: verl.utils.profiler.config.TorchProfilerToolConfig
+          contents: []
+          discrete: false
+          name: torch
+        torch_memory:
+          _target_: verl.utils.profiler.config.TorchMemoryToolConfig
+          trace_alloc_max_entries: ${oc.select:global_profiler.global_tool_config.torch_memory.trace_alloc_max_entries,100000}
+          stack_depth: ${oc.select:global_profiler.global_tool_config.torch_memory.stack_depth,32}
+          name: torch_memory
+    _target_: verl_omni.workers.config.diffusion.VeOmniDiffusionActorConfig
+    rollout_n: ${oc.select:actor_rollout_ref.rollout.n,1}
+    strategy: veomni
+    ppo_mini_batch_size: 256
+    ppo_micro_batch_size_per_gpu: null
+    diffusion_loss:
+      _target_: verl_omni.workers.config.diffusion.DiffusionLossConfig
+      loss_mode: ${oc.select:actor_rollout_ref.model.algorithm,flow_grpo}
+      clip_ratio: 0.0001
+      adv_clip_max: 5.0
+      mix_beta: 0.5
+      ref_kl_coef: 0.0
+      adaptive_weight_min: 1.0e-05
+      dpo_beta: 2000.0
+    rollout_correction:
+      _target_: verl.trainer.config.algorithm.RolloutCorrectionConfig
+      bypass_mode: ${oc.select:algorithm.rollout_correction.bypass_mode,false}
+      loss_type: ${oc.select:algorithm.rollout_correction.loss_type,ppo_clip}
+      rollout_is: ${oc.select:algorithm.rollout_correction.rollout_is,null}
+      rollout_is_threshold: ${oc.select:algorithm.rollout_correction.rollout_is_threshold,2.0}
+      rollout_is_batch_normalize: ${oc.select:algorithm.rollout_correction.rollout_is_batch_normalize,false}
+      rollout_rs: ${oc.select:algorithm.rollout_correction.rollout_rs,null}
+      rollout_rs_threshold: ${oc.select:algorithm.rollout_correction.rollout_rs_threshold,null}
+    loss_scale_factor: null
+    use_kl_loss: false
+    kl_loss_coef: 0.001
+    ppo_epochs: 1
+    shuffle: false
+    data_loader_seed: 42
+    checkpoint:
+      _target_: verl.trainer.config.CheckpointConfig
+      save_contents:
+      - model
+      - optimizer
+      - extra
+      load_contents: ${.save_contents}
+      async_save: false
+      mbridge_config: {}
+  ref:
+    rollout_n: ${oc.select:actor_rollout_ref.rollout.n,1}
+    strategy: veomni
+    log_prob_micro_batch_size_per_gpu: null
+    veomni_config:
+      _target_: verl_omni.workers.config.diffusion.VeOmniDiffusionEngineConfig
+      param_offload: false
+      optimizer_offload: false
+      fsdp_size: -1
+      ulysses_parallel_size: 1
+      expert_parallel_size: 1
+      init_device: meta
+      reshard_after_forward: true
+      forward_prefetch: true
+      model_dtype: bfloat16
+      mixed_precision: true
+      mixed_precision_param_dtype: bfloat16
+      mixed_precision_reduce_dtype: float32
+      mixed_precision_output_dtype: null
+      mixed_precision_cast_forward_inputs: true
+      enable_reentrant: false
+      enable_activation_offload: false
+      activation_gpu_limit: 0.0
+      strategy: veomni
+      attn_implementation: eager
+      moe_implementation: eager
+      cross_entropy_loss_implementation: eager
+      rms_norm_implementation: eager
+      swiglu_mlp_implementation: eager
+      rotary_pos_emb_implementation: eager
+      load_balancing_loss_implementation: eager
+      rms_norm_gated_implementation: eager
+      causal_conv1d_implementation: eager
+      chunk_gated_delta_rule_implementation: eager
+      forward_only: true
+    optim:
+      _target_: verl_omni.workers.config.diffusion.VeOmniDiffusionOptimizerConfig
+      optimizer: adamw
+      lr: 0.001
+      lr_min: 0.0
+      lr_start: 0.0
+      lr_warmup_steps_ratio: 0.0
+      total_training_steps: -1
+      weight_decay: 0.01
+      betas:
+      - 0.9
+      - 0.999
+      eps: 1.0e-08
+      clip_grad: 1.0
+      lr_scheduler_type: constant
+      lr_decay_ratio: 1.0
+      fused: false
+    profiler:
+      _target_: verl.utils.profiler.ProfilerConfig
+      tool: torch
+      enable: false
+      all_ranks: false
+      ranks: []
+      save_path: ${oc.select:global_profiler.save_path,outputs/profile}
+      tool_config:
+        nsys:
+          _target_: verl.utils.profiler.config.NsightToolConfig
+          discrete: ${oc.select:global_profiler.global_tool_config.nsys.discrete,false}
+          name: nsight
+        torch:
+          _target_: verl.utils.profiler.config.TorchProfilerToolConfig
+          contents: []
+          discrete: false
+          name: torch
+        torch_memory:
+          _target_: verl.utils.profiler.config.TorchMemoryToolConfig
+          trace_alloc_max_entries: ${oc.select:global_profiler.global_tool_config.torch_memory.trace_alloc_max_entries,100000}
+          stack_depth: ${oc.select:global_profiler.global_tool_config.torch_memory.stack_depth,32}
+          name: torch_memory
+    _target_: verl_omni.workers.config.diffusion.VeOmniDiffusionActorConfig
+  rollout:
+    profiler:
+      _target_: verl.utils.profiler.ProfilerConfig
+      tool: torch
+      enable: false
+      all_ranks: false
+      ranks: []
+      save_path: ${oc.select:global_profiler.save_path,outputs/profile}
+      tool_config:
+        nsys:
+          _target_: verl.utils.profiler.config.NsightToolConfig
+          discrete: ${oc.select:global_profiler.global_tool_config.nsys.discrete,false}
+          name: nsight
+        torch:
+          _target_: verl.utils.profiler.config.TorchProfilerToolConfig
+          contents: []
+          discrete: false
+          name: torch
+        torch_memory:
+          _target_: verl.utils.profiler.config.TorchMemoryToolConfig
+          trace_alloc_max_entries: ${oc.select:global_profiler.global_tool_config.torch_memory.trace_alloc_max_entries,100000}
+          stack_depth: ${oc.select:global_profiler.global_tool_config.torch_memory.stack_depth,32}
+          name: torch_memory
+    _target_: verl_omni.workers.config.diffusion.DiffusionRolloutConfig
+    name: ???
+    mode: async
+    nnodes: 0
+    n_gpus_per_node: ${oc.select:trainer.n_gpus_per_node,8}
+    prompt_length: ${oc.select:data.max_prompt_length,512}
+    dtype: bfloat16
+    gpu_memory_utilization: 0.5
+    enforce_eager: false
+    cudagraph_capture_sizes: null
+    free_cache_engine: true
+    tensor_model_parallel_size: 2
+    data_parallel_size: 1
+    expert_parallel_size: 1
+    pipeline_model_parallel_size: 1
+    max_num_batched_tokens: 8192
+    max_model_len: null
+    max_num_seqs: 1024
+    enable_chunked_prefill: true
+    enable_prefix_caching: true
+    logprobs_mode: processed_logprobs
+    scheduling_policy: fcfs
+    load_format: dummy
+    layered_summon: false
+    log_prob_micro_batch_size_per_gpu: null
+    disable_log_stats: true
+    'n': 1
+    seed: null
+    multi_turn:
+      _target_: verl.workers.config.MultiTurnConfig
+      enable: false
+    engine_kwargs:
+      vllm_omni: {}
+    val_kwargs:
+      _target_: verl_omni.workers.config.diffusion.DiffusionSamplingConfig
+      'n': 1
+      pipeline:
+        _target_: verl_omni.workers.config.diffusion.DiffusionPipelineConfig
+        height: ${oc.select:actor_rollout_ref.rollout.pipeline.height,512}
+        width: ${oc.select:actor_rollout_ref.rollout.pipeline.width,512}
+        num_inference_steps: 50
+        true_cfg_scale: ${oc.select:actor_rollout_ref.rollout.pipeline.true_cfg_scale,1.0}
+        max_sequence_length: ${oc.select:actor_rollout_ref.rollout.pipeline.max_sequence_length,512}
+        guidance_scale: ${oc.select:actor_rollout_ref.rollout.pipeline.guidance_scale,null}
+        num_frames: ${oc.select:actor_rollout_ref.rollout.pipeline.num_frames,1}
+      algo:
+        _target_: verl_omni.workers.config.diffusion.DiffusionRolloutAlgoConfig
+        noise_level: 0.0
+        sde_type: ${oc.select:actor_rollout_ref.rollout.algo.sde_type,sde}
+        sde_window_size: ${oc.select:actor_rollout_ref.rollout.algo.sde_window_size,null}
+        sde_window_range: ${oc.select:actor_rollout_ref.rollout.algo.sde_window_range,null}
+    algo:
+      _target_: verl_omni.workers.config.diffusion.DiffusionRolloutAlgoConfig
+      noise_level: 1.0
+      sde_type: sde
+      sde_window_size: null
+      sde_window_range: null
+      sample_strategy: random
+      iters_per_group: 1
+      sde_window_seed: 0
+    pipeline:
+      _target_: verl_omni.workers.config.diffusion.DiffusionPipelineConfig
+      height: 512
+      width: 512
+      num_inference_steps: 10
+      true_cfg_scale: 1.0
+      max_sequence_length: 512
+      guidance_scale: null
+      num_frames: 1
+    calculate_log_probs: false
+    rollout_adapter: default
+    agent:
+      _target_: verl.workers.config.AgentLoopConfig
+      num_workers: 8
+      default_agent_loop: diffusion_single_turn_agent
+    checkpoint_engine:
+      _target_: verl.workers.config.CheckpointEngineConfig
+      backend: naive
+      update_weights_bucket_megabytes: 2048
+      engine_kwargs: {}
+      custom_backend_module: null
+    skip_tokenizer_init: true
+    enable_rollout_routing_replay: false
+    prometheus:
+      _target_: verl.workers.config.PrometheusConfig
+      enable: false
+    quantization: null
+    mtp: ${oc.select:actor_rollout_ref.model.mtp, null}
+    external_lib: null
+    disaggregation:
+      _target_: verl.workers.config.DisaggregationConfig
+      enabled: false
+  model:
+    _target_: verl_omni.workers.config.diffusion.DiffusionModelConfig
+    path: ~/models/Qwen/Qwen-Image
+    algorithm: flow_grpo
+    tokenizer_path: null
+    use_shm: false
+    trust_remote_code: false
+    custom_chat_template: null
+    external_lib: null
+    enable_gradient_checkpointing: true
+    config_path: null
+    transformer_subfolder: transformer
+    attn_backend: native
+    lora_rank: 0
+    lora_alpha: 64
+    lora_init_weights: gaussian
+    target_modules: all-linear
+    target_parameters: null
+    exclude_modules: null
+    lora_adapter_path: null
+    policy_state_adapters:
+    - default
+    lora_dtype: null
+    fsdp_layer_prefixes:
+    - transformer_blocks.
+    mtp:
+      _target_: verl.workers.config.MtpConfig
+      enable: false
+    pipeline:
+      _target_: verl_omni.workers.config.diffusion.DiffusionPipelineConfig
+      height: ${oc.select:actor_rollout_ref.rollout.pipeline.height,512}
+      width: ${oc.select:actor_rollout_ref.rollout.pipeline.width,512}
+      num_inference_steps: ${oc.select:actor_rollout_ref.rollout.pipeline.num_inference_steps,10}
+      true_cfg_scale: ${oc.select:actor_rollout_ref.rollout.pipeline.true_cfg_scale,1.0}
+      max_sequence_length: ${oc.select:actor_rollout_ref.rollout.pipeline.max_sequence_length,512}
+      guidance_scale: ${oc.select:actor_rollout_ref.rollout.pipeline.guidance_scale,null}
+      num_frames: ${oc.select:actor_rollout_ref.rollout.pipeline.num_frames,1}
+    algo:
+      _target_: verl_omni.workers.config.diffusion.DiffusionRolloutAlgoConfig
+      noise_level: ${oc.select:actor_rollout_ref.rollout.algo.noise_level,1.0}
+      sde_type: ${oc.select:actor_rollout_ref.rollout.algo.sde_type,sde}
+      sde_window_size: ${oc.select:actor_rollout_ref.rollout.algo.sde_window_size,null}
+      sde_window_range: ${oc.select:actor_rollout_ref.rollout.algo.sde_window_range,null}
+    model_type: diffusion_model
+  hybrid_engine: true
+  nccl_timeout: 600
+data:
+  tokenizer: null
+  use_shm: false
+  train_files: ~/data/rlhf/gsm8k/train.parquet
+  val_files: ~/data/rlhf/gsm8k/test.parquet
+  train_max_samples: -1
+  val_max_samples: -1
+  prompt_key: prompt
+  reward_fn_key: data_source
+  max_prompt_length: 512
+  max_response_length: 512
+  train_batch_size: 1024
+  val_batch_size: null
+  tool_config_path: ${oc.select:actor_rollout_ref.rollout.multi_turn.tool_config_path,
+    null}
+  return_raw_input_ids: false
+  return_raw_chat: true
+  return_full_prompt: false
+  shuffle: true
+  seed: null
+  dataloader_num_workers: 8
+  image_patch_size: 14
+  validation_shuffle: false
+  filter_overlong_prompts: false
+  filter_overlong_prompts_workers: 1
+  truncation: error
+  image_key: images
+  video_key: videos
+  trust_remote_code: false
+  custom_cls:
+    path: null
+    name: null
+    collate_fn: null
+  return_multi_modal_inputs: true
+  sampler:
+    class_path: null
+    class_name: null
+  datagen:
+    path: null
+    name: null
+  apply_chat_template_kwargs: {}
+reward:
+  num_workers: 8
+  custom_reward_function:
+    path: null
+    name: compute_score
+  reward_functions: {}
+  aggregation: weighted_sum
+  reward_manager:
+    _target_: verl.workers.config.reward_model.RewardManagerConfig
+    source: importlib
+    name: VisualRewardManager
+    module:
+      _target_: verl.trainer.config.config.ModuleConfig
+      path: pkg://verl_omni.reward_loop.reward_manager
+  reward_model:
+    enable: false
+    enable_resource_pool: false
+    n_gpus_per_node: 8
+    nnodes: 0
+    model_path: null
+    rollout:
+      _target_: verl.workers.config.RolloutConfig
+      name: ???
+      dtype: bfloat16
+      gpu_memory_utilization: 0.5
+      enforce_eager: true
+      cudagraph_capture_sizes: null
+      free_cache_engine: true
+      data_parallel_size: 1
+      expert_parallel_size: 1
+      tensor_model_parallel_size: 2
+      pipeline_model_parallel_size: 1
+      max_num_batched_tokens: 8192
+      max_model_len: null
+      max_num_seqs: 1024
+      load_format: auto
+      layered_summon: false
+      scheduling_policy: fcfs
+      multi_stage_wake_up: false
+      engine_kwargs: {}
+      limit_images: null
+      enable_chunked_prefill: true
+      enable_prefix_caching: true
+      disable_log_stats: true
+      skip_tokenizer_init: false
+      ignore_eos: false
+      temperature: 1.0
+      top_k: -1
+      top_p: 1
+      do_sample: true
+      'n': 1
+      prompt_length: 2048
+      response_length: 2048
+      quantization: null
+      quantization_config_file: null
+      mtp: null
+      disaggregation:
+        enabled: false
+        prefill_replicas: 1
+        decode_replicas: 1
+        decode_tensor_model_parallel_size: null
+        transfer_backend: nixl
+        bootstrap_port: null
+        ib_device: null
+  sandbox_fusion:
+    url: null
+    max_concurrent: 64
+    memory_limit_mb: 1024
+algorithm:
+  _target_: verl_omni.trainer.config.DiffusionAlgoConfig
+  trainer_type: policy_gradient
+  sample_source: online
+  adv_estimator: ${oc.select:actor_rollout_ref.model.algorithm,flow_grpo}
+  norm_adv_by_std_in_grpo: true
+  global_std: true
+  old_policy_decay_schedule: copy
+  old_policy_decay: null
+  old_policy_update_interval: 1
+  timestep_fraction: 1.0
+  adv_mode: continuous
+  paired_preference: false
+  rollout_correction:
+    _target_: verl.trainer.config.algorithm.RolloutCorrectionConfig
+    bypass_mode: false
+    loss_type: ppo_clip
+    rollout_is: null
+    rollout_is_threshold: 2.0
+    rollout_is_batch_normalize: false
+    rollout_rs: null
+    rollout_rs_threshold: null
+trainer:
+  total_epochs: 30
+  total_training_steps: null
+  project_name: verl_examples
+  experiment_name: ocr
+  logger:
+  - console
+  - wandb
+  log_val_generations: 0
+  rollout_data_dir: null
+  validation_data_dir: null
+  nnodes: 1
+  n_gpus_per_node: 8
+  save_freq: -1
+  esi_redundant_time: 0
+  resume_mode: auto
+  resume_from_path: null
+  val_before_train: true
+  val_only: false
+  test_freq: -1
+  default_hdfs_dir: null
+  del_local_ckpt_after_load: false
+  default_local_dir: checkpoints/${trainer.project_name}/${trainer.experiment_name}
+  max_actor_ckpt_to_keep: null
+  ray_wait_register_center_timeout: 300
+  device: cuda
+global_profiler:
+  _target_: verl.utils.profiler.ProfilerConfig
+  tool: null
+  steps: null
+  profile_continuous_steps: false
+  save_path: outputs/profile
+  global_tool_config:
+    nsys:
+      _target_: verl.utils.profiler.config.NsightToolConfig
+      discrete: false
+      controller_nsight_options:
+        trace: cuda,nvtx,cublas,ucx
+        cuda-memory-usage: 'true'
+        cuda-graph-trace: graph
+      worker_nsight_options:
+        trace: cuda,nvtx,cublas,ucx
+        cuda-memory-usage: 'true'
+        cuda-graph-trace: graph
+        capture-range: cudaProfilerApi
+        capture-range-end: null
+        kill: none
+    torch_memory:
+      trace_alloc_max_entries: 100000
+      stack_depth: 32
+      context: all
+      stacks: all
+      kw_args: {}
+ray_kwargs:
+  ray_init:
+    num_cpus: null
+  timeline_json_file: null

--- a/verl_omni/trainer/config/diffusion/actor/veomni_diffusion_actor.yaml
+++ b/verl_omni/trainer/config/diffusion/actor/veomni_diffusion_actor.yaml
@@ -1,0 +1,29 @@
+# Format checks enforced on CI:
+# 1. Comments must appear above each field.
+# 2. There must be a blank line between each field.
+# 3. Inline comments (after a field on the same line) are not allowed.
+# 4. Indentation level is respected for nested fields.
+
+# defaults specify the default config from each component
+defaults:
+
+  # VeOmni optimizer config
+  - ../../optim@optim: veomni_diffusion
+
+  # VeOmni engine config
+  - ../engine@veomni_config: diffusion_veomni
+
+  # per-role profiler config, inheriting from trainer/config/profiler/profiler.yaml
+  - ../../profiler@profiler: profiler
+
+  # diffusion actor config, inheriting from trainer/config/diffusion/actor/diffusion_actor.yaml
+  - diffusion_actor
+
+  # load the reference default config, then apply the fields in the current yaml
+  - _self_
+
+# Target class for this configuration
+_target_: verl_omni.workers.config.diffusion.VeOmniDiffusionActorConfig
+
+# Training strategy.
+strategy: veomni

--- a/verl_omni/trainer/config/diffusion/engine/diffusion_veomni.yaml
+++ b/verl_omni/trainer/config/diffusion/engine/diffusion_veomni.yaml
@@ -1,0 +1,90 @@
+# Target class for this configuration
+_target_: verl_omni.workers.config.diffusion.VeOmniDiffusionEngineConfig
+
+# Whether to offload model parameters to CPU
+param_offload: false
+
+# Whether to offload optimizer state to CPU
+optimizer_offload: false
+
+# FSDP shard group size. -1 means use all data-parallel ranks.
+fsdp_size: -1
+
+# Qwen-Image VeOmni backend does not support Ulysses SP yet.
+ulysses_parallel_size: 1
+
+# Expert parallel size. Kept for config compatibility; Qwen-Image uses 1.
+expert_parallel_size: 1
+
+# Initialize the model on meta before FSDP2 weight loading.
+init_device: meta
+
+# Reshard parameters after forward.
+reshard_after_forward: true
+
+# Enable FSDP2 manual prefetching.
+forward_prefetch: true
+
+# Model dtype used while loading VeOmni weights. Match the working FSDP
+# Qwen-Image recipe to avoid keeping fp32 actor weights in colocated runs.
+model_dtype: bfloat16
+
+# Whether to use mixed precision in FSDP2.
+mixed_precision: true
+
+# FSDP2 parameter dtype.
+mixed_precision_param_dtype: bfloat16
+
+# FSDP2 gradient reduction dtype.
+mixed_precision_reduce_dtype: float32
+
+# FSDP2 forward output dtype. null keeps the default.
+mixed_precision_output_dtype: null
+
+# Whether FSDP2 casts forward inputs.
+mixed_precision_cast_forward_inputs: true
+
+# Whether to use reentrant activation checkpointing.
+enable_reentrant: false
+
+# Whether to offload activations to CPU.
+enable_activation_offload: false
+
+# Activation GPU memory limit in GB when activation offload is enabled.
+activation_gpu_limit: 0.0
+
+# The backend strategy registered in EngineRegistry.
+strategy: veomni
+
+# Qwen-Image currently uses eager attention in VeOmni.
+attn_implementation: eager
+
+# MoE backend selector.
+moe_implementation: eager
+
+# Cross entropy backend selector.
+cross_entropy_loss_implementation: eager
+
+# RMSNorm backend selector.
+rms_norm_implementation: eager
+
+# SwiGLU backend selector.
+swiglu_mlp_implementation: eager
+
+# Rotary position embedding backend selector.
+rotary_pos_emb_implementation: eager
+
+# Load-balancing loss backend selector.
+load_balancing_loss_implementation: eager
+
+# Gated RMSNorm backend selector.
+rms_norm_gated_implementation: eager
+
+# Causal conv1d backend selector.
+causal_conv1d_implementation: eager
+
+# Chunk gated delta rule backend selector.
+chunk_gated_delta_rule_implementation: eager
+
+# Whether this engine is forward only.
+forward_only: false

--- a/verl_omni/trainer/config/diffusion/model/diffusion_model.yaml
+++ b/verl_omni/trainer/config/diffusion/model/diffusion_model.yaml
@@ -31,6 +31,12 @@ external_lib: null
 # whether to enable gradient checkpointing.
 enable_gradient_checkpointing: True
 
+# Optional VeOmni model config path. If null, VeOmni backend uses <path>/transformer.
+veomni_config_path: null
+
+# Diffusion transformer subfolder for VeOmni backend.
+veomni_transformer_subfolder: transformer
+
 # Diffusers attention backend. Supported: "native"
 attn_backend: native
 

--- a/verl_omni/trainer/config/diffusion/model/diffusion_model.yaml
+++ b/verl_omni/trainer/config/diffusion/model/diffusion_model.yaml
@@ -31,11 +31,11 @@ external_lib: null
 # whether to enable gradient checkpointing.
 enable_gradient_checkpointing: True
 
-# Optional VeOmni model config path. If null, VeOmni backend uses <path>/transformer.
-veomni_config_path: null
+# Optional model config path. If null, backends use <path>/<transformer_subfolder>.
+config_path: null
 
-# Diffusion transformer subfolder for VeOmni backend.
-veomni_transformer_subfolder: transformer
+# Subfolder containing the diffusion transformer weights/config.
+transformer_subfolder: transformer
 
 # Diffusers attention backend. Supported: "native"
 attn_backend: native

--- a/verl_omni/trainer/config/diffusion/model_engine/veomni_diffusion.yaml
+++ b/verl_omni/trainer/config/diffusion/model_engine/veomni_diffusion.yaml
@@ -1,0 +1,2 @@
+# @package _global_
+model_engine: veomni_diffusion

--- a/verl_omni/trainer/config/diffusion/ref/veomni_diffusion_ref.yaml
+++ b/verl_omni/trainer/config/diffusion/ref/veomni_diffusion_ref.yaml
@@ -1,0 +1,29 @@
+# defaults specify the default config from each component
+defaults:
+
+  # diffusion ref config, inheriting from trainer/config/diffusion/ref/diffusion_ref.yaml
+  - diffusion_ref
+
+  # VeOmni engine config
+  - ../engine@veomni_config: diffusion_veomni
+
+  # VeOmni optimizer config
+  - ../../optim@optim: veomni_diffusion
+
+  # per-role profiler config, inheriting from trainer/config/profiler/profiler.yaml
+  - ../../profiler@profiler: profiler
+
+  # load the reference default config, then apply the fields in the current yaml
+  - _self_
+
+# Target class for this configuration
+_target_: verl_omni.workers.config.diffusion.VeOmniDiffusionActorConfig
+
+# Training strategy.
+strategy: veomni
+
+# VeOmni config
+veomni_config:
+
+  # ref model is forward only
+  forward_only: true

--- a/verl_omni/trainer/config/optim/veomni_diffusion.yaml
+++ b/verl_omni/trainer/config/optim/veomni_diffusion.yaml
@@ -1,0 +1,41 @@
+# Target class for this configuration
+_target_: verl_omni.workers.config.diffusion.VeOmniDiffusionOptimizerConfig
+
+# Optimizer type passed to VeOmni.
+optimizer: adamw
+
+# Learning rate
+lr: 1e-3
+
+# Minimum learning rate for cosine decay.
+lr_min: 0.0
+
+# Initial learning rate during warmup.
+lr_start: 0.0
+
+# LR warmup steps ratio
+lr_warmup_steps_ratio: 0.0
+
+# Total training steps
+total_training_steps: -1
+
+# Weight decay
+weight_decay: 0.01
+
+# Betas for Adam optimizer
+betas: [0.9, 0.999]
+
+# Adam epsilon
+eps: 1e-8
+
+# Clip gradient
+clip_grad: 1.0
+
+# LR scheduler type: "constant", "linear", or "cosine"
+lr_scheduler_type: constant
+
+# LR decay ratio
+lr_decay_ratio: 1.0
+
+# Whether to use fused AdamW where supported.
+fused: false

--- a/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
+++ b/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
@@ -362,7 +362,7 @@ class BaseRayDiffusionTrainer(ABC):
         if "wandb" in self.config.trainer.logger:
             import wandb
 
-            outputs = [wandb.Image(image.float(), file_type="jpg") for image in outputs]
+            outputs = [wandb.Image(image.float()) for image in outputs]
         samples = list(zip(inputs, outputs, scores, strict=True))
         samples.sort(key=lambda x: x[0])  # Sort by input text
 

--- a/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
+++ b/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
@@ -362,7 +362,7 @@ class BaseRayDiffusionTrainer(ABC):
         if "wandb" in self.config.trainer.logger:
             import wandb
 
-            outputs = [wandb.Image(image.float()) for image in outputs]
+            outputs = [wandb.Image(image.float(), file_type="jpg") for image in outputs]
         samples = list(zip(inputs, outputs, scores, strict=True))
         samples.sort(key=lambda x: x[0])  # Sort by input text
 

--- a/verl_omni/workers/config/diffusion/actor.py
+++ b/verl_omni/workers/config/diffusion/actor.py
@@ -20,15 +20,18 @@ from verl.base_config import BaseConfig
 from verl.trainer.config import CheckpointConfig
 from verl.trainer.config.algorithm import RolloutCorrectionConfig
 from verl.utils.profiler import ProfilerConfig
-from verl.workers.config.engine import FSDPEngineConfig
+from verl.workers.config.engine import EngineConfig, FSDPEngineConfig
 from verl.workers.config.optimizer import OptimizerConfig
 
 from .model import DiffusionModelConfig
 
 __all__ = [
     "DiffusionLossConfig",
+    "VeOmniDiffusionEngineConfig",
+    "VeOmniDiffusionOptimizerConfig",
     "DiffusionActorConfig",
     "FSDPDiffusionActorConfig",
+    "VeOmniDiffusionActorConfig",
 ]
 
 
@@ -53,6 +56,65 @@ class DiffusionLossConfig(BaseConfig):
             raise ValueError(f"mix_beta must be positive, got {self.mix_beta}.")
         if self.adaptive_weight_min <= 0:
             raise ValueError(f"adaptive_weight_min must be positive, got {self.adaptive_weight_min}.")
+
+
+@dataclass
+class VeOmniDiffusionEngineConfig(EngineConfig):
+    _mutable_fields = EngineConfig._mutable_fields | {"ulysses_parallel_size"}
+
+    # VeOmni diffusion backend only supports FSDP2.
+    strategy: str = "veomni"
+    fsdp_size: int = -1
+    ulysses_parallel_size: int = 1
+    expert_parallel_size: int = 1
+    init_device: str = "meta"
+    reshard_after_forward: bool = True
+    forward_prefetch: bool = True
+    model_dtype: str = "bfloat16"
+    mixed_precision: bool = True
+    mixed_precision_param_dtype: str = "bfloat16"
+    mixed_precision_reduce_dtype: str = "float32"
+    mixed_precision_output_dtype: Optional[str] = None
+    mixed_precision_cast_forward_inputs: bool = True
+    enable_reentrant: bool = False
+    enable_activation_offload: bool = False
+    activation_gpu_limit: float = 0.0
+    attn_implementation: str = "eager"
+    moe_implementation: str = "eager"
+    cross_entropy_loss_implementation: str = "eager"
+    rms_norm_implementation: str = "eager"
+    swiglu_mlp_implementation: str = "eager"
+    rotary_pos_emb_implementation: str = "eager"
+    load_balancing_loss_implementation: str = "eager"
+    rms_norm_gated_implementation: str = "eager"
+    causal_conv1d_implementation: str = "eager"
+    chunk_gated_delta_rule_implementation: str = "eager"
+
+    def __post_init__(self):
+        super().__post_init__()
+        if self.strategy != "veomni":
+            raise ValueError(f"VeOmni diffusion engine requires strategy='veomni', got {self.strategy!r}")
+        if self.ulysses_parallel_size != 1:
+            raise NotImplementedError("VeOmni Qwen-Image diffusion backend does not support Ulysses SP yet.")
+
+
+@dataclass
+class VeOmniDiffusionOptimizerConfig(OptimizerConfig):
+    optimizer: str = "adamw"
+    lr_min: float = 0.0
+    lr_start: float = 0.0
+    lr_decay_ratio: float = 1.0
+    lr_scheduler_type: str = "constant"
+    eps: float = 1e-8
+    fused: bool = False
+
+    def __post_init__(self):
+        super().__post_init__()
+        if self.lr_scheduler_type not in {"constant", "linear", "cosine"}:
+            raise ValueError(
+                f"Invalid VeOmni lr_scheduler_type={self.lr_scheduler_type!r}; "
+                "expected one of ['constant', 'linear', 'cosine']."
+            )
 
 
 @dataclass
@@ -112,3 +174,14 @@ class FSDPDiffusionActorConfig(DiffusionActorConfig):
         # EngineConfig.strategy defaults to None, so without this, engine_workers.py always
         # falls back to FSDP1 even when actor.strategy="fsdp2".
         object.__setattr__(self.engine, "strategy", self.strategy)
+
+
+@dataclass
+class VeOmniDiffusionActorConfig(DiffusionActorConfig):
+    strategy: str = "veomni"
+    veomni_config: VeOmniDiffusionEngineConfig = field(default_factory=VeOmniDiffusionEngineConfig)
+    optim: VeOmniDiffusionOptimizerConfig = field(default_factory=VeOmniDiffusionOptimizerConfig)
+
+    def __post_init__(self):
+        super().__post_init__()
+        self.engine = self.veomni_config

--- a/verl_omni/workers/config/diffusion/model.py
+++ b/verl_omni/workers/config/diffusion/model.py
@@ -104,12 +104,12 @@ class DiffusionModelConfig(BaseConfig):
 
     fsdp_layer_prefixes: list[str] = field(default_factory=lambda: ["transformer_blocks."])
 
-    # Optional VeOmni model config path. If unset, the backend uses
-    # ``<local_path>/<veomni_transformer_subfolder>``.
-    veomni_config_path: Optional[str] = None
+    # Optional model config path. If unset, the backend uses
+    # ``<local_path>/<transformer_subfolder>``.
+    config_path: Optional[str] = None
 
     # Subfolder containing the diffusion transformer weights/config.
-    veomni_transformer_subfolder: str = "transformer"
+    transformer_subfolder: str = "transformer"
 
     def __post_init__(self):
         import_external_libs(self.external_lib)

--- a/verl_omni/workers/config/diffusion/model.py
+++ b/verl_omni/workers/config/diffusion/model.py
@@ -104,6 +104,13 @@ class DiffusionModelConfig(BaseConfig):
 
     fsdp_layer_prefixes: list[str] = field(default_factory=lambda: ["transformer_blocks."])
 
+    # Optional VeOmni model config path. If unset, the backend uses
+    # ``<local_path>/<veomni_transformer_subfolder>``.
+    veomni_config_path: Optional[str] = None
+
+    # Subfolder containing the diffusion transformer weights/config.
+    veomni_transformer_subfolder: str = "transformer"
+
     def __post_init__(self):
         import_external_libs(self.external_lib)
 

--- a/verl_omni/workers/engine/__init__.py
+++ b/verl_omni/workers/engine/__init__.py
@@ -20,7 +20,16 @@ from .fsdp import (  # noqa: F401
 
 try:
     from .veomni import VeOmniDiffusionEngine  # noqa: F401
-except ImportError:
+except ImportError as _veomni_import_err:
+    import warnings
+
+    warnings.warn(
+        f"verl_omni.workers.engine.veomni failed to import; "
+        f"`backend=veomni` will be unavailable. Root cause: "
+        f"{type(_veomni_import_err).__name__}: {_veomni_import_err}",
+        RuntimeWarning,
+        stacklevel=2,
+    )
     VeOmniDiffusionEngine = None
 
 __all__ = [

--- a/verl_omni/workers/engine/__init__.py
+++ b/verl_omni/workers/engine/__init__.py
@@ -20,16 +20,7 @@ from .fsdp import (  # noqa: F401
 
 try:
     from .veomni import VeOmniDiffusionEngine  # noqa: F401
-except ImportError as _veomni_import_err:
-    import warnings
-
-    warnings.warn(
-        f"verl_omni.workers.engine.veomni failed to import; "
-        f"`backend=veomni` will be unavailable. Root cause: "
-        f"{type(_veomni_import_err).__name__}: {_veomni_import_err}",
-        RuntimeWarning,
-        stacklevel=2,
-    )
+except ImportError:
     VeOmniDiffusionEngine = None
 
 __all__ = [

--- a/verl_omni/workers/engine/fsdp/diffusers_impl.py
+++ b/verl_omni/workers/engine/fsdp/diffusers_impl.py
@@ -258,10 +258,10 @@ class DiffusersFSDPEngine(LoRAAdapterMixin, BaseEngine, ABC):
             warnings.simplefilter("ignore")
 
             module = AutoModel.from_pretrained(
-                self.model_config.local_path,
+                self.model_config.config_path or self.model_config.local_path,
                 torch_dtype=torch_dtype,
                 trust_remote_code=self.model_config.trust_remote_code,
-                subfolder="transformer",  # currently we support DiT with transformer backbone only.
+                subfolder="" if self.model_config.config_path else self.model_config.transformer_subfolder,
             )
             module.set_attention_backend(self.model_config.attn_backend)
 

--- a/verl_omni/workers/engine/veomni/__init__.py
+++ b/verl_omni/workers/engine/veomni/__init__.py
@@ -11,22 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from .fsdp import (  # noqa: F401
-    DiffusersFSDPEngine,
-    DPODiffusersFSDPEngine,
-    NFTDiffusersFSDPEngine,
-    PPODiffusersFSDPEngine,
-)
 
-try:
-    from .veomni import VeOmniDiffusionEngine  # noqa: F401
-except ImportError:
-    VeOmniDiffusionEngine = None
+from .diffusion_impl import VeOmniDiffusionEngine
 
-__all__ = [
-    "PPODiffusersFSDPEngine",
-    "DPODiffusersFSDPEngine",
-    "NFTDiffusersFSDPEngine",
-    "DiffusersFSDPEngine",
-    "VeOmniDiffusionEngine",
-]
+__all__ = ["VeOmniDiffusionEngine"]

--- a/verl_omni/workers/engine/veomni/diffusion_impl.py
+++ b/verl_omni/workers/engine/veomni/diffusion_impl.py
@@ -17,28 +17,33 @@ import logging
 import os
 from contextlib import nullcontext
 from dataclasses import fields
-from typing import Optional
+from typing import Callable, Optional
 
 import torch
 import torch.distributed
+from tensordict import TensorDict
 from torch.distributed.tensor import DTensor
 from verl.trainer.config import CheckpointConfig
+from verl.utils import tensordict_utils as tu
 from verl.utils.checkpoint.fsdp_checkpoint_manager import FSDPCheckpointManager
 from verl.utils.device import get_device_id, get_device_name
 from verl.utils.memory_utils import aggressive_empty_cache
 from verl.utils.model import convert_weight_keys
+from verl.utils.py_functional import append_to_dict
 from verl.utils.torch_dtypes import PrecisionType
-from verl.workers.engine.base import EngineRegistry
+from verl.workers.engine.base import BaseEngine, BaseEngineCtx, EngineRegistry
+from verl.workers.engine.utils import enable_full_determinism, prepare_micro_batches
 
+from verl_omni.pipelines.utils import build_scheduler, forward_and_sample_previous_step, prepare_model_inputs
 from verl_omni.workers.config import (
     DiffusionModelConfig,
     VeOmniDiffusionEngineConfig,
     VeOmniDiffusionOptimizerConfig,
 )
-from verl_omni.workers.engine.fsdp.diffusers_impl import DiffusersFSDPEngine
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
+device_name = get_device_name()
 
 
 @torch.no_grad()
@@ -100,7 +105,7 @@ def _load_veomni_optimizer(optimizer, device):
 
 
 @EngineRegistry.register(model_type="diffusion_model", backend=["veomni"], device=["cuda"])
-class VeOmniDiffusionEngine(DiffusersFSDPEngine):
+class VeOmniDiffusionEngine(BaseEngine):
     """VeOmni-backed diffusion training engine for verl-omni RL loops."""
 
     def __init__(
@@ -115,12 +120,31 @@ class VeOmniDiffusionEngine(DiffusersFSDPEngine):
                 "VeOmni diffusion backend does not support LoRA training yet. "
                 "Use the existing fsdp/fsdp2 diffusion backend for LoRA runs."
             )
-        super().__init__(
-            model_config=model_config,
-            engine_config=engine_config,
-            optimizer_config=optimizer_config,
-            checkpoint_config=checkpoint_config,
-        )
+        super().__init__()
+
+        self.model_config = model_config
+        self.engine_config = engine_config
+        self.optimizer_config = optimizer_config
+        self.checkpoint_config = checkpoint_config
+        self.mode = None
+        self.rank = torch.distributed.get_rank()
+
+        self._init_device_mesh()
+
+        if self.engine_config.full_determinism:
+            enable_full_determinism(seed=self.engine_config.seed)
+
+        self._is_offload_param = self.engine_config.param_offload
+        self._is_offload_optimizer = self.engine_config.optimizer_offload
+        self._is_lora = False
+
+    @property
+    def is_param_offload_enabled(self) -> bool:
+        return self._is_offload_param
+
+    @property
+    def is_optimizer_offload_enabled(self) -> bool:
+        return self._is_offload_optimizer
 
     def _init_device_mesh(self):
         from veomni.distributed import parallel_state
@@ -217,6 +241,9 @@ class VeOmniDiffusionEngine(DiffusersFSDPEngine):
             lr_start=self.optimizer_config.lr_start,
         )
 
+    def _build_scheduler(self):
+        return build_scheduler(self.model_config)
+
     def _build_model_optimizer(self):
         from veomni.distributed.offloading import build_activation_offloading_context
         from veomni.distributed.torch_parallelize import build_parallelize_model
@@ -225,6 +252,9 @@ class VeOmniDiffusionEngine(DiffusersFSDPEngine):
         config_path, weights_path = self._get_veomni_model_paths()
         mixed_precision = self._build_mixed_precision_config()
 
+        # Keep this sequence aligned with VeOmni's DiTTrainer._build_model:
+        # build the foundation DiT first, then hand it to VeOmni's parallelizer,
+        # optimizer, scheduler, and training contexts.
         module = build_foundation_model(
             config_path=config_path,
             weights_path=weights_path,
@@ -280,6 +310,12 @@ class VeOmniDiffusionEngine(DiffusersFSDPEngine):
             grad=self._is_offload_param,
         )
 
+    def train_mode(self, **kwargs):
+        return EngineTrainModeCtx(self, **kwargs)
+
+    def eval_mode(self, **kwargs):
+        return EngineEvalModeCtx(self, **kwargs)
+
     def get_data_parallel_rank(self):
         from veomni.distributed import parallel_state
 
@@ -301,6 +337,191 @@ class VeOmniDiffusionEngine(DiffusersFSDPEngine):
         ps = parallel_state.get_parallel_state()
         return ps.sp_rank == 0 if ps.sp_enabled else True
 
+    @staticmethod
+    def _unpad_nested_embeds(embeds: torch.Tensor, mask: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        batch_size = embeds.size(0)
+        max_seq_len = max(embeds.offsets().diff())
+        embed_dim = embeds.size(-1)
+        embeds = torch.nested.to_padded_tensor(embeds, padding=0, output_size=(batch_size, max_seq_len, embed_dim))
+        mask = torch.nested.to_padded_tensor(mask, padding=0, output_size=(batch_size, max_seq_len))
+        return embeds, mask
+
+    @staticmethod
+    def _pad_embeds_for_sp(embeds: torch.Tensor, mask: torch.Tensor, sp_size: int) -> tuple[torch.Tensor, torch.Tensor]:
+        seq_len = embeds.size(1)
+        aligned_seq_len = (seq_len + sp_size - 1) // sp_size * sp_size
+        if aligned_seq_len > seq_len:
+            pad_len = aligned_seq_len - seq_len
+            embeds = torch.nn.functional.pad(embeds, (0, 0, 0, pad_len))
+            mask = torch.nn.functional.pad(mask, (0, pad_len))
+        return embeds, mask
+
+    def prepare_model_inputs(self, micro_batch: TensorDict, step: int):
+        latents = micro_batch["all_latents"]
+        timesteps = micro_batch["all_timesteps"]
+        prompt_embeds = micro_batch["prompt_embeds"]
+        prompt_embeds_mask = micro_batch["prompt_embeds_mask"]
+        negative_prompt_embeds = micro_batch["negative_prompt_embeds"]
+        negative_prompt_embeds_mask = micro_batch["negative_prompt_embeds_mask"]
+        sp_size = self.ulysses_sequence_parallel_size if self.use_ulysses_sp else 1
+
+        if prompt_embeds.is_nested:
+            prompt_embeds, prompt_embeds_mask = self._unpad_nested_embeds(prompt_embeds, prompt_embeds_mask)
+
+        if sp_size > 1:
+            prompt_embeds, prompt_embeds_mask = self._pad_embeds_for_sp(prompt_embeds, prompt_embeds_mask, sp_size)
+
+        if isinstance(negative_prompt_embeds, torch.Tensor) and negative_prompt_embeds.is_nested:
+            negative_prompt_embeds, negative_prompt_embeds_mask = self._unpad_nested_embeds(
+                negative_prompt_embeds, negative_prompt_embeds_mask
+            )
+
+        if isinstance(negative_prompt_embeds, torch.Tensor) and sp_size > 1:
+            negative_prompt_embeds, negative_prompt_embeds_mask = self._pad_embeds_for_sp(
+                negative_prompt_embeds, negative_prompt_embeds_mask, sp_size
+            )
+
+        return prepare_model_inputs(
+            module=self.module,
+            model_config=self.model_config,
+            latents=latents,
+            timesteps=timesteps,
+            prompt_embeds=prompt_embeds,
+            prompt_embeds_mask=prompt_embeds_mask,
+            negative_prompt_embeds=negative_prompt_embeds,
+            negative_prompt_embeds_mask=negative_prompt_embeds_mask,
+            micro_batch=micro_batch,
+            step=step,
+        )
+
+    def prepare_model_outputs(self, output, micro_batch: TensorDict):
+        log_prob, prev_sample_mean, std_dev_t, sqrt_dt = output
+        return {
+            "log_probs": log_prob,
+            "prev_sample_mean": prev_sample_mean,
+            "std_dev_t": std_dev_t,
+            "sqrt_dt": sqrt_dt,
+        }
+
+    def forward_step(self, micro_batch: TensorDict, loss_function, forward_only, step):
+        model_inputs, negative_model_inputs = self.prepare_model_inputs(micro_batch=micro_batch, step=step)
+        raw_output = forward_and_sample_previous_step(
+            module=self.module,
+            scheduler=self.scheduler,
+            model_config=self.model_config,
+            model_inputs=model_inputs,
+            negative_model_inputs=negative_model_inputs,
+            scheduler_inputs=micro_batch,
+            step=step,
+        )
+        model_output = self.prepare_model_outputs(output=raw_output, micro_batch=micro_batch)
+
+        if loss_function is not None:
+            data = tu.get_tensordict(
+                {
+                    "old_log_probs": micro_batch["old_log_probs"][:, step],
+                    "advantages": micro_batch["advantages"][:, step],
+                },
+            )
+            tu.assign_non_tensor(
+                data,
+                gradient_accumulation_steps=tu.get_non_tensor_data(
+                    micro_batch, "gradient_accumulation_steps", default=None
+                ),
+                sp_size=tu.get_non_tensor_data(micro_batch, "sp_size", default=None),
+            )
+
+            if micro_batch.get("ref_log_prob", None) is not None:
+                data["ref_log_prob"] = micro_batch["ref_log_prob"][:, step]
+
+            if micro_batch.get("ref_prev_sample_mean", None) is not None:
+                data["ref_prev_sample_mean"] = micro_batch["ref_prev_sample_mean"][:, step]
+
+            if micro_batch.get("old_prev_sample_mean", None) is not None:
+                data["old_prev_sample_mean"] = micro_batch["old_prev_sample_mean"][:, step]
+
+            loss, metrics = loss_function(model_output=model_output, data=data, dp_group=self.get_data_parallel_group())
+        else:
+            assert forward_only, "forward_only must be True when loss_function is None"
+            loss = torch.tensor(1.0, device=device_name)
+            metrics = {}
+
+        output = {
+            "model_output": model_output,
+            "loss": loss.detach().item(),
+            "metrics": metrics,
+        }
+
+        return loss, output
+
+    def forward_backward_batch(
+        self, data: TensorDict, loss_function: Callable, forward_only: bool = False
+    ) -> list[TensorDict]:
+        num_timesteps = data["all_timesteps"].shape[1]
+        tu.assign_non_tensor(data, sp_size=self.ulysses_sequence_parallel_size)
+        tu.assign_non_tensor(data, use_dynamic_bsz=False)
+
+        micro_batches, indices = prepare_micro_batches(
+            data=data, dp_group=self.get_data_parallel_group(), same_micro_num_in_dp=True
+        )
+
+        gradient_accumulation_steps = len(micro_batches) * num_timesteps
+        output_lst = []
+        ctx = torch.no_grad() if forward_only else nullcontext()
+
+        for micro_batch in micro_batches:
+            micro_batch = micro_batch.to(get_device_id())
+            tu.assign_non_tensor(micro_batch, gradient_accumulation_steps=gradient_accumulation_steps)
+            meta_info_lst = {"model_output": [], "loss": [], "metrics": []}
+            with ctx:
+                for step in range(num_timesteps):
+                    loss, meta_info = self.forward_step(
+                        micro_batch, loss_function=loss_function, forward_only=forward_only, step=step
+                    )
+
+                    if not forward_only:
+                        loss.backward()
+
+                    for key, val in meta_info.items():
+                        meta_info_lst[key].append(val)
+
+            output_lst.append(meta_info_lst)
+
+        return self.postprocess_batch_func(output_lst=output_lst, indices=indices, data=data)
+
+    def postprocess_batch_func(self, output_lst, indices, data: TensorDict):
+        model_output = {}
+        losses = []
+        aggregated_metrics = {}
+
+        for output in output_lst:
+            model_output_lst = {}
+            if "model_output" in output:
+                for model_output_dict in output["model_output"]:
+                    for key, val in model_output_dict.items():
+                        model_output_lst.setdefault(key, []).append(val)
+                for key, val in model_output_lst.items():
+                    model_output.setdefault(key, []).append(torch.stack(val, dim=1))
+
+            if "loss" in output:
+                losses.append(output["loss"])
+
+            if "metrics" in output:
+                for metrics in output["metrics"]:
+                    append_to_dict(aggregated_metrics, metrics)
+
+        for key, val in model_output.items():
+            model_output[key] = torch.concat(val, dim=0)
+
+        return {
+            "model_output": model_output,
+            "loss": losses,
+            "metrics": aggregated_metrics,
+        }
+
+    def optimizer_zero_grad(self):
+        self.optimizer.zero_grad()
+
     def optimizer_step(self):
         assert self.optimizer_config.clip_grad is not None
 
@@ -319,8 +540,12 @@ class VeOmniDiffusionEngine(DiffusersFSDPEngine):
             self.optimizer.step()
         return grad_norm.item()
 
+    def lr_scheduler_step(self):
+        self.lr_scheduler.step()
+        return self.lr_scheduler.get_last_lr()[0]
+
     def to(self, device: str, model: bool = True, optimizer: bool = True, grad: bool = True):
-        super(DiffusersFSDPEngine, self).to(device=device, model=model, optimizer=optimizer, grad=grad)
+        super().to(device=device, model=model, optimizer=optimizer, grad=grad)
 
         device_name = get_device_name()
         assert device in (device_name, "cpu")
@@ -399,3 +624,34 @@ class VeOmniDiffusionEngine(DiffusersFSDPEngine):
 
     def disable_adapter(self):
         return nullcontext()
+
+
+class EngineEvalModeCtx(BaseEngineCtx):
+    def __init__(self, engine: VeOmniDiffusionEngine, **kwargs):
+        super().__init__(engine=engine, mode="eval", **kwargs)
+
+    def __enter__(self):
+        assert isinstance(self.engine, VeOmniDiffusionEngine)
+        super().__enter__()
+        self.engine.module.eval()
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        assert isinstance(self.engine, VeOmniDiffusionEngine)
+        if self.engine.engine_config.fsdp_size > 1 and hasattr(self.engine.module, "reshard"):
+            self.engine.module.reshard()
+        super().__exit__(exc_type, exc_value, traceback)
+
+
+class EngineTrainModeCtx(BaseEngineCtx):
+    def __init__(self, engine: VeOmniDiffusionEngine, **kwargs):
+        super().__init__(engine=engine, mode="train", **kwargs)
+
+    def __enter__(self):
+        assert isinstance(self.engine, VeOmniDiffusionEngine)
+        super().__enter__()
+        self.engine.module.train()
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        assert isinstance(self.engine, VeOmniDiffusionEngine)
+        self.engine.optimizer_zero_grad()
+        super().__exit__(exc_type, exc_value, traceback)

--- a/verl_omni/workers/engine/veomni/diffusion_impl.py
+++ b/verl_omni/workers/engine/veomni/diffusion_impl.py
@@ -1,0 +1,401 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import gc
+import logging
+import os
+from contextlib import nullcontext
+from dataclasses import fields
+from typing import Optional
+
+import torch
+import torch.distributed
+from torch.distributed.tensor import DTensor
+from verl.trainer.config import CheckpointConfig
+from verl.utils.checkpoint.fsdp_checkpoint_manager import FSDPCheckpointManager
+from verl.utils.device import get_device_id, get_device_name
+from verl.utils.memory_utils import aggressive_empty_cache
+from verl.utils.model import convert_weight_keys
+from verl.utils.torch_dtypes import PrecisionType
+from verl.workers.engine.base import EngineRegistry
+
+from verl_omni.workers.config import (
+    DiffusionModelConfig,
+    VeOmniDiffusionEngineConfig,
+    VeOmniDiffusionOptimizerConfig,
+)
+from verl_omni.workers.engine.fsdp.diffusers_impl import DiffusersFSDPEngine
+
+logger = logging.getLogger(__file__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
+
+
+@torch.no_grad()
+def _offload_veomni_model_to_cpu(model, empty_cache: bool = True):
+    from torch.distributed.fsdp._fully_shard._fsdp_common import TrainingState
+    from torch.distributed.fsdp._fully_shard._fsdp_state import _get_module_fsdp_state
+
+    for module in model.modules():
+        state = _get_module_fsdp_state(module)
+        if state is None or state._fsdp_param_group is None:
+            continue
+        state._fsdp_param_group._training_state = TrainingState.IDLE
+
+    model.reshard()
+    model.cpu()
+    if empty_cache:
+        torch.cuda.empty_cache()
+
+
+@torch.no_grad()
+def _load_veomni_model_to_gpu(model):
+    model.to(get_device_id())
+
+
+@torch.no_grad()
+def _iter_optimizers(optimizer):
+    if optimizer is None:
+        return
+    if hasattr(optimizer, "_is_multi_optimizer") and optimizer._is_multi_optimizer:
+        yield from optimizer.optimizers_dict.values()
+    else:
+        yield optimizer
+
+
+@torch.no_grad()
+def _offload_veomni_optimizer(optimizer):
+    for opt in _iter_optimizers(optimizer):
+        if not opt.state:
+            continue
+        for param_group in opt.param_groups:
+            for param in param_group["params"]:
+                state = opt.state[param]
+                for key, value in state.items():
+                    if isinstance(value, torch.Tensor):
+                        state[key] = value.to("cpu", non_blocking=True)
+
+
+@torch.no_grad()
+def _load_veomni_optimizer(optimizer, device):
+    for opt in _iter_optimizers(optimizer):
+        if not opt.state:
+            continue
+        for param_group in opt.param_groups:
+            for param in param_group["params"]:
+                state = opt.state[param]
+                for key, value in state.items():
+                    if isinstance(value, torch.Tensor):
+                        state[key] = value.to(device, non_blocking=True)
+
+
+@EngineRegistry.register(model_type="diffusion_model", backend=["veomni"], device=["cuda"])
+class VeOmniDiffusionEngine(DiffusersFSDPEngine):
+    """VeOmni-backed diffusion training engine for verl-omni RL loops."""
+
+    def __init__(
+        self,
+        model_config: DiffusionModelConfig,
+        engine_config: VeOmniDiffusionEngineConfig,
+        optimizer_config: VeOmniDiffusionOptimizerConfig,
+        checkpoint_config: CheckpointConfig,
+    ):
+        if model_config.lora_rank > 0 or model_config.lora_adapter_path is not None:
+            raise NotImplementedError(
+                "VeOmni diffusion backend does not support LoRA training yet. "
+                "Use the existing fsdp/fsdp2 diffusion backend for LoRA runs."
+            )
+        super().__init__(
+            model_config=model_config,
+            engine_config=engine_config,
+            optimizer_config=optimizer_config,
+            checkpoint_config=checkpoint_config,
+        )
+
+    def _init_device_mesh(self):
+        from veomni.distributed import parallel_state
+
+        if self.engine_config.ulysses_parallel_size != 1:
+            raise NotImplementedError("VeOmni Qwen-Image diffusion backend does not support Ulysses SP yet.")
+
+        world_size = torch.distributed.get_world_size()
+        dp_size = world_size // self.engine_config.ulysses_parallel_size
+        fsdp_size = self.engine_config.fsdp_size
+        if fsdp_size < 0 or fsdp_size >= dp_size:
+            dp_replicate_size = 1
+            dp_shard_size = dp_size
+        else:
+            if dp_size % fsdp_size != 0:
+                raise ValueError(f"Data parallel size ({dp_size}) must be divisible by fsdp_size ({fsdp_size}).")
+            dp_replicate_size = dp_size // fsdp_size
+            dp_shard_size = fsdp_size
+
+        parallel_state.init_parallel_state(
+            dp_size=dp_size,
+            dp_replicate_size=dp_replicate_size,
+            dp_shard_size=dp_shard_size,
+            extra_parallel_sizes=(self.engine_config.expert_parallel_size,),
+            ulysses_size=self.engine_config.ulysses_parallel_size,
+            dp_mode="fsdp2",
+        )
+
+        ps = parallel_state.get_parallel_state()
+        self.device_mesh = ps.device_mesh
+        self.ulysses_device_mesh = None
+        self.ulysses_sequence_parallel_size = self.engine_config.ulysses_parallel_size
+        self.use_ulysses_sp = ps.sp_enabled
+
+    def _build_ops_config(self):
+        from veomni.arguments import OpsImplementationConfig
+
+        ops_fields = {field.name for field in fields(OpsImplementationConfig)}
+        ops_kwargs = {
+            name: getattr(self.engine_config, name) for name in ops_fields if hasattr(self.engine_config, name)
+        }
+        return OpsImplementationConfig(**ops_kwargs)
+
+    def _build_mixed_precision_config(self):
+        from veomni.arguments import MixedPrecisionConfig
+
+        return MixedPrecisionConfig(
+            enable=self.engine_config.mixed_precision,
+            param_dtype=self.engine_config.mixed_precision_param_dtype,
+            reduce_dtype=self.engine_config.mixed_precision_reduce_dtype,
+            output_dtype=self.engine_config.mixed_precision_output_dtype,
+            cast_forward_inputs=self.engine_config.mixed_precision_cast_forward_inputs,
+        )
+
+    def _get_veomni_torch_dtype(self) -> str:
+        dtype = PrecisionType.to_dtype(self.engine_config.model_dtype)
+        if dtype == torch.float32:
+            return "float32"
+        if dtype == torch.float16:
+            return "float16"
+        if dtype == torch.bfloat16:
+            return "bfloat16"
+        raise ValueError(f"Unsupported VeOmni model dtype: {self.engine_config.model_dtype}")
+
+    def _get_veomni_model_paths(self) -> tuple[str, str]:
+        weights_path = os.path.join(self.model_config.local_path, self.model_config.veomni_transformer_subfolder)
+        config_path = self.model_config.veomni_config_path or weights_path
+        return config_path, weights_path
+
+    def _build_optimizer(self, module):
+        from veomni.optim import build_optimizer
+
+        return build_optimizer(
+            module,
+            lr=self.optimizer_config.lr,
+            betas=tuple(self.optimizer_config.betas),
+            eps=self.optimizer_config.eps,
+            weight_decay=self.optimizer_config.weight_decay,
+            fused=self.optimizer_config.fused,
+            optimizer_type=self.optimizer_config.optimizer,
+        )
+
+    def _build_lr_scheduler(self, optimizer):
+        from veomni.optim import build_lr_scheduler
+
+        return build_lr_scheduler(
+            optimizer,
+            train_steps=self.optimizer_config.total_training_steps,
+            lr=self.optimizer_config.lr,
+            lr_min=self.optimizer_config.lr_min,
+            lr_decay_style=self.optimizer_config.lr_scheduler_type,
+            lr_decay_ratio=self.optimizer_config.lr_decay_ratio,
+            lr_warmup_ratio=self.optimizer_config.lr_warmup_steps_ratio,
+            lr_start=self.optimizer_config.lr_start,
+        )
+
+    def _build_model_optimizer(self):
+        from veomni.distributed.offloading import build_activation_offloading_context
+        from veomni.distributed.torch_parallelize import build_parallelize_model
+        from veomni.models.auto import build_foundation_model
+
+        config_path, weights_path = self._get_veomni_model_paths()
+        mixed_precision = self._build_mixed_precision_config()
+
+        module = build_foundation_model(
+            config_path=config_path,
+            weights_path=weights_path,
+            torch_dtype=self._get_veomni_torch_dtype(),
+            init_device=self.engine_config.init_device,
+            ops_implementation=self._build_ops_config(),
+        )
+
+        module = build_parallelize_model(
+            module,
+            init_device=self.engine_config.init_device,
+            weights_path=weights_path,
+            enable_reshard_after_forward=self.engine_config.reshard_after_forward,
+            mixed_precision=mixed_precision,
+            enable_gradient_checkpointing=self.model_config.enable_gradient_checkpointing,
+            basic_modules=list(set(getattr(module, "_no_split_modules", None) or [])),
+            enable_reentrant=self.engine_config.enable_reentrant,
+            enable_forward_prefetch=self.engine_config.forward_prefetch,
+        )
+
+        scheduler = self._build_scheduler()
+        if not self.engine_config.forward_only:
+            optimizer = self._build_optimizer(module)
+            lr_scheduler = self._build_lr_scheduler(optimizer)
+        else:
+            optimizer = None
+            lr_scheduler = None
+
+        self.module = module
+        self.scheduler = scheduler
+        self.optimizer = optimizer
+        self.lr_scheduler = lr_scheduler
+        self.model_fwd_context, self.model_bwd_context = build_activation_offloading_context(
+            self.engine_config.enable_activation_offload,
+            self.model_config.enable_gradient_checkpointing,
+            self.engine_config.activation_gpu_limit,
+        )
+
+    def initialize(self):
+        self._build_model_optimizer()
+        self.checkpoint_manager = FSDPCheckpointManager(
+            model=self.module,
+            optimizer=self.optimizer,
+            lr_scheduler=self.lr_scheduler,
+            processing_class=self.model_config.get_processor(),
+            checkpoint_config=self.checkpoint_config,
+            trust_remote_code=self.model_config.trust_remote_code,
+        )
+        self.to(
+            device="cpu",
+            model=self._is_offload_param,
+            optimizer=self._is_offload_optimizer,
+            grad=self._is_offload_param,
+        )
+
+    def get_data_parallel_rank(self):
+        from veomni.distributed import parallel_state
+
+        return parallel_state.get_parallel_state().dp_rank
+
+    def get_data_parallel_size(self):
+        from veomni.distributed import parallel_state
+
+        return parallel_state.get_parallel_state().dp_size
+
+    def get_data_parallel_group(self):
+        from veomni.distributed import parallel_state
+
+        return parallel_state.get_parallel_state().dp_group
+
+    def is_mp_src_rank_with_outputs(self):
+        from veomni.distributed import parallel_state
+
+        ps = parallel_state.get_parallel_state()
+        return ps.sp_rank == 0 if ps.sp_enabled else True
+
+    def optimizer_step(self):
+        assert self.optimizer_config.clip_grad is not None
+
+        if hasattr(self.module, "clip_grad_norm_"):
+            grad_norm = self.module.clip_grad_norm_(self.optimizer_config.clip_grad)
+        else:
+            grad_norm = torch.nn.utils.clip_grad_norm_(self.module.parameters(), self.optimizer_config.clip_grad)
+
+        if isinstance(grad_norm, DTensor):
+            grad_norm = grad_norm.full_tensor()
+
+        if not torch.isfinite(grad_norm):
+            print(f"WARN: grad_norm is not finite: {grad_norm}")
+            self.optimizer.zero_grad()
+        else:
+            self.optimizer.step()
+        return grad_norm.item()
+
+    def to(self, device: str, model: bool = True, optimizer: bool = True, grad: bool = True):
+        super(DiffusersFSDPEngine, self).to(device=device, model=model, optimizer=optimizer, grad=grad)
+
+        device_name = get_device_name()
+        assert device in (device_name, "cpu")
+        if device == device_name:
+            if model:
+                _load_veomni_model_to_gpu(self.module)
+            if optimizer and self.optimizer is not None:
+                _load_veomni_optimizer(self.optimizer, get_device_id())
+            gc.collect()
+        elif device == "cpu":
+            if model:
+                _offload_veomni_model_to_cpu(self.module)
+            if optimizer and self.optimizer is not None:
+                _offload_veomni_optimizer(self.optimizer)
+
+    def save_checkpoint(
+        self,
+        local_path: str,
+        hdfs_path: Optional[str] = None,
+        global_step: int = 0,
+        max_ckpt_to_keep: Optional[int] = None,
+        **kwargs,
+    ) -> None:
+        origin_module_device = next(self.module.parameters()).device.type
+        if self._is_offload_param or origin_module_device == "cpu":
+            _load_veomni_model_to_gpu(self.module)
+
+        self.checkpoint_manager.save_checkpoint(
+            local_path=local_path, hdfs_path=hdfs_path, global_step=global_step, max_ckpt_to_keep=max_ckpt_to_keep
+        )
+
+        torch.distributed.barrier()
+        if self._is_offload_param:
+            _offload_veomni_model_to_cpu(self.module)
+        gc.collect()
+        aggressive_empty_cache(force_sync=True)
+
+    def load_checkpoint(
+        self, local_path: str, hdfs_path: Optional[str] = None, del_local_after_load: int = True, **kwargs
+    ) -> None:
+        if self._is_offload_param:
+            _load_veomni_model_to_gpu(self.module)
+
+        self.checkpoint_manager.load_checkpoint(
+            local_path=local_path, hdfs_path=hdfs_path, del_local_after_load=del_local_after_load
+        )
+
+        torch.distributed.barrier()
+        if self._is_offload_param:
+            _offload_veomni_model_to_cpu(self.module)
+        if self._is_offload_optimizer:
+            _offload_veomni_optimizer(self.optimizer)
+
+    def get_per_tensor_param(self, **kwargs):
+        if self.model_config.lora_rank > 0 or self.model_config.lora_adapter_path is not None:
+            raise NotImplementedError("VeOmni diffusion backend does not support LoRA weight export yet.")
+
+        _load_veomni_model_to_gpu(self.module)
+        params = self.module.state_dict()
+        params = convert_weight_keys(params, getattr(self.module, "_fsdp_wrapped_module", self.module))
+
+        if self._is_offload_param:
+            _offload_veomni_model_to_cpu(self.module)
+
+        device = get_device_id()
+
+        def param_generator():
+            for name, param in params.items():
+                tensor = param.full_tensor() if isinstance(param, DTensor) else param
+                tensor = tensor.to(device, non_blocking=True)
+                if tensor.is_floating_point() and tensor.dtype == torch.float32:
+                    tensor = tensor.to(torch.bfloat16, non_blocking=True)
+                yield f"transformer.{name}", tensor
+
+        return param_generator(), None
+
+    def disable_adapter(self):
+        return nullcontext()

--- a/verl_omni/workers/engine/veomni/diffusion_impl.py
+++ b/verl_omni/workers/engine/veomni/diffusion_impl.py
@@ -23,6 +23,12 @@ import torch
 import torch.distributed
 from tensordict import TensorDict
 from torch.distributed.tensor import DTensor
+from veomni.distributed.offloading import (
+    load_model_to_gpu,
+    load_optimizer,
+    offload_model_to_cpu,
+    offload_optimizer,
+)
 from verl.trainer.config import CheckpointConfig
 from verl.utils import tensordict_utils as tu
 from verl.utils.checkpoint.fsdp_checkpoint_manager import FSDPCheckpointManager
@@ -44,64 +50,6 @@ from verl_omni.workers.config import (
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 device_name = get_device_name()
-
-
-@torch.no_grad()
-def _offload_veomni_model_to_cpu(model, empty_cache: bool = True):
-    from torch.distributed.fsdp._fully_shard._fsdp_common import TrainingState
-    from torch.distributed.fsdp._fully_shard._fsdp_state import _get_module_fsdp_state
-
-    for module in model.modules():
-        state = _get_module_fsdp_state(module)
-        if state is None or state._fsdp_param_group is None:
-            continue
-        state._fsdp_param_group._training_state = TrainingState.IDLE
-
-    model.reshard()
-    model.cpu()
-    if empty_cache:
-        torch.cuda.empty_cache()
-
-
-@torch.no_grad()
-def _load_veomni_model_to_gpu(model):
-    model.to(get_device_id())
-
-
-@torch.no_grad()
-def _iter_optimizers(optimizer):
-    if optimizer is None:
-        return
-    if hasattr(optimizer, "_is_multi_optimizer") and optimizer._is_multi_optimizer:
-        yield from optimizer.optimizers_dict.values()
-    else:
-        yield optimizer
-
-
-@torch.no_grad()
-def _offload_veomni_optimizer(optimizer):
-    for opt in _iter_optimizers(optimizer):
-        if not opt.state:
-            continue
-        for param_group in opt.param_groups:
-            for param in param_group["params"]:
-                state = opt.state[param]
-                for key, value in state.items():
-                    if isinstance(value, torch.Tensor):
-                        state[key] = value.to("cpu", non_blocking=True)
-
-
-@torch.no_grad()
-def _load_veomni_optimizer(optimizer, device):
-    for opt in _iter_optimizers(optimizer):
-        if not opt.state:
-            continue
-        for param_group in opt.param_groups:
-            for param in param_group["params"]:
-                state = opt.state[param]
-                for key, value in state.items():
-                    if isinstance(value, torch.Tensor):
-                        state[key] = value.to(device, non_blocking=True)
 
 
 @EngineRegistry.register(model_type="diffusion_model", backend=["veomni"], device=["cuda"])
@@ -608,15 +556,15 @@ class VeOmniDiffusionEngine(BaseEngine):
         assert device in (device_name, "cpu")
         if device == device_name:
             if model:
-                _load_veomni_model_to_gpu(self.module)
+                load_model_to_gpu(self.module, get_device_id())
             if optimizer and self.optimizer is not None:
-                _load_veomni_optimizer(self.optimizer, get_device_id())
+                load_optimizer(self.optimizer, get_device_id())
             gc.collect()
         elif device == "cpu":
             if model:
-                _offload_veomni_model_to_cpu(self.module)
+                offload_model_to_cpu(self.module)
             if optimizer and self.optimizer is not None:
-                _offload_veomni_optimizer(self.optimizer)
+                offload_optimizer(self.optimizer)
 
     def save_checkpoint(
         self,
@@ -628,7 +576,7 @@ class VeOmniDiffusionEngine(BaseEngine):
     ) -> None:
         origin_module_device = next(self.module.parameters()).device.type
         if self._is_offload_param or origin_module_device == "cpu":
-            _load_veomni_model_to_gpu(self.module)
+            load_model_to_gpu(self.module, get_device_id())
 
         self.checkpoint_manager.save_checkpoint(
             local_path=local_path, hdfs_path=hdfs_path, global_step=global_step, max_ckpt_to_keep=max_ckpt_to_keep
@@ -636,7 +584,7 @@ class VeOmniDiffusionEngine(BaseEngine):
 
         torch.distributed.barrier()
         if self._is_offload_param:
-            _offload_veomni_model_to_cpu(self.module)
+            offload_model_to_cpu(self.module)
         gc.collect()
         aggressive_empty_cache(force_sync=True)
 
@@ -644,7 +592,7 @@ class VeOmniDiffusionEngine(BaseEngine):
         self, local_path: str, hdfs_path: Optional[str] = None, del_local_after_load: int = True, **kwargs
     ) -> None:
         if self._is_offload_param:
-            _load_veomni_model_to_gpu(self.module)
+            load_model_to_gpu(self.module, get_device_id())
 
         self.checkpoint_manager.load_checkpoint(
             local_path=local_path, hdfs_path=hdfs_path, del_local_after_load=del_local_after_load
@@ -652,20 +600,20 @@ class VeOmniDiffusionEngine(BaseEngine):
 
         torch.distributed.barrier()
         if self._is_offload_param:
-            _offload_veomni_model_to_cpu(self.module)
+            offload_model_to_cpu(self.module)
         if self._is_offload_optimizer:
-            _offload_veomni_optimizer(self.optimizer)
+            offload_optimizer(self.optimizer)
 
     def get_per_tensor_param(self, **kwargs):
         if self.model_config.lora_rank > 0 or self.model_config.lora_adapter_path is not None:
             raise NotImplementedError("VeOmni diffusion backend does not support LoRA weight export yet.")
 
-        _load_veomni_model_to_gpu(self.module)
+        load_model_to_gpu(self.module, get_device_id())
         params = self.module.state_dict()
         params = convert_weight_keys(params, getattr(self.module, "_fsdp_wrapped_module", self.module))
 
         if self._is_offload_param:
-            _offload_veomni_model_to_cpu(self.module)
+            offload_model_to_cpu(self.module)
 
         device = get_device_id()
         export_dtype = PrecisionType.to_dtype(self.engine_config.model_dtype)

--- a/verl_omni/workers/engine/veomni/diffusion_impl.py
+++ b/verl_omni/workers/engine/veomni/diffusion_impl.py
@@ -112,6 +112,10 @@ class VeOmniDiffusionEngine(BaseEngine):
             dp_replicate_size = dp_size // fsdp_size
             dp_shard_size = fsdp_size
 
+        self.dp_size = dp_size
+        self.dp_replicate_size = dp_replicate_size
+        self.dp_shard_size = dp_shard_size
+
         parallel_state.init_parallel_state(
             dp_size=dp_size,
             dp_replicate_size=dp_replicate_size,
@@ -135,27 +139,6 @@ class VeOmniDiffusionEngine(BaseEngine):
             name: getattr(self.engine_config, name) for name in ops_fields if hasattr(self.engine_config, name)
         }
         return OpsImplementationConfig(**ops_kwargs)
-
-    def _build_mixed_precision_config(self):
-        from veomni.arguments import MixedPrecisionConfig
-
-        return MixedPrecisionConfig(
-            enable=self.engine_config.mixed_precision,
-            param_dtype=self.engine_config.mixed_precision_param_dtype,
-            reduce_dtype=self.engine_config.mixed_precision_reduce_dtype,
-            output_dtype=self.engine_config.mixed_precision_output_dtype,
-            cast_forward_inputs=self.engine_config.mixed_precision_cast_forward_inputs,
-        )
-
-    def _get_veomni_torch_dtype(self) -> str:
-        dtype = PrecisionType.to_dtype(self.engine_config.model_dtype)
-        if dtype == torch.float32:
-            return "float32"
-        if dtype == torch.float16:
-            return "float16"
-        if dtype == torch.bfloat16:
-            return "bfloat16"
-        raise ValueError(f"Unsupported VeOmni model dtype: {self.engine_config.model_dtype}")
 
     def _get_veomni_model_paths(self) -> tuple[str, str]:
         weights_path = os.path.join(self.model_config.local_path, self.model_config.transformer_subfolder)
@@ -182,15 +165,9 @@ class VeOmniDiffusionEngine(BaseEngine):
         )
 
         config_path, weights_path = self._get_veomni_model_paths()
-        world_size = torch.distributed.get_world_size()
-        dp_size = world_size // self.engine_config.ulysses_parallel_size
-        fsdp_size = self.engine_config.fsdp_size
-        if fsdp_size < 0 or fsdp_size >= dp_size:
-            dp_replicate_size = 1
-            dp_shard_size = dp_size
-        else:
-            dp_replicate_size = dp_size // fsdp_size
-            dp_shard_size = fsdp_size
+        dp_size = self.dp_size
+        dp_replicate_size = self.dp_replicate_size
+        dp_shard_size = self.dp_shard_size
 
         mixed_precision = MixedPrecisionConfig(
             enable=self.engine_config.mixed_precision,

--- a/verl_omni/workers/engine/veomni/diffusion_impl.py
+++ b/verl_omni/workers/engine/veomni/diffusion_impl.py
@@ -210,8 +210,8 @@ class VeOmniDiffusionEngine(BaseEngine):
         raise ValueError(f"Unsupported VeOmni model dtype: {self.engine_config.model_dtype}")
 
     def _get_veomni_model_paths(self) -> tuple[str, str]:
-        weights_path = os.path.join(self.model_config.local_path, self.model_config.veomni_transformer_subfolder)
-        config_path = self.model_config.veomni_config_path or weights_path
+        weights_path = os.path.join(self.model_config.local_path, self.model_config.transformer_subfolder)
+        config_path = self.model_config.config_path or weights_path
         return config_path, weights_path
 
     def _build_scheduler(self):
@@ -591,7 +591,7 @@ class VeOmniDiffusionEngine(BaseEngine):
             grad_norm = grad_norm.full_tensor()
 
         if not torch.isfinite(grad_norm):
-            print(f"WARN: grad_norm is not finite: {grad_norm}")
+            logger.warning("grad_norm is not finite: %s", grad_norm)
             self.optimizer.zero_grad()
         else:
             self.optimizer.step()
@@ -668,13 +668,14 @@ class VeOmniDiffusionEngine(BaseEngine):
             _offload_veomni_model_to_cpu(self.module)
 
         device = get_device_id()
+        export_dtype = PrecisionType.to_dtype(self.engine_config.model_dtype)
 
         def param_generator():
             for name, param in params.items():
                 tensor = param.full_tensor() if isinstance(param, DTensor) else param
                 tensor = tensor.to(device, non_blocking=True)
-                if tensor.is_floating_point() and tensor.dtype == torch.float32:
-                    tensor = tensor.to(torch.bfloat16, non_blocking=True)
+                if tensor.is_floating_point() and tensor.dtype != export_dtype:
+                    tensor = tensor.to(export_dtype, non_blocking=True)
                 yield f"transformer.{name}", tensor
 
         return param_generator(), None

--- a/verl_omni/workers/engine/veomni/diffusion_impl.py
+++ b/verl_omni/workers/engine/veomni/diffusion_impl.py
@@ -214,84 +214,141 @@ class VeOmniDiffusionEngine(BaseEngine):
         config_path = self.model_config.veomni_config_path or weights_path
         return config_path, weights_path
 
-    def _build_optimizer(self, module):
-        from veomni.optim import build_optimizer
-
-        return build_optimizer(
-            module,
-            lr=self.optimizer_config.lr,
-            betas=tuple(self.optimizer_config.betas),
-            eps=self.optimizer_config.eps,
-            weight_decay=self.optimizer_config.weight_decay,
-            fused=self.optimizer_config.fused,
-            optimizer_type=self.optimizer_config.optimizer,
-        )
-
-    def _build_lr_scheduler(self, optimizer):
-        from veomni.optim import build_lr_scheduler
-
-        return build_lr_scheduler(
-            optimizer,
-            train_steps=self.optimizer_config.total_training_steps,
-            lr=self.optimizer_config.lr,
-            lr_min=self.optimizer_config.lr_min,
-            lr_decay_style=self.optimizer_config.lr_scheduler_type,
-            lr_decay_ratio=self.optimizer_config.lr_decay_ratio,
-            lr_warmup_ratio=self.optimizer_config.lr_warmup_steps_ratio,
-            lr_start=self.optimizer_config.lr_start,
-        )
-
     def _build_scheduler(self):
         return build_scheduler(self.model_config)
 
-    def _build_model_optimizer(self):
-        from veomni.distributed.offloading import build_activation_offloading_context
-        from veomni.distributed.torch_parallelize import build_parallelize_model
-        from veomni.models.auto import build_foundation_model
+    def _build_veomni_dit_args(self):
+        from veomni.arguments import (
+            AcceleratorConfig,
+            FSDPConfig,
+            GradientCheckpointingConfig,
+            MixedPrecisionConfig,
+            OffloadConfig,
+            OptimizerConfig,
+        )
+        from veomni.trainer.dit_trainer import (
+            DiTDataArguments,
+            DiTModelArguments,
+            DiTTrainingArguments,
+            VeOmniDiTArguments,
+        )
 
         config_path, weights_path = self._get_veomni_model_paths()
-        mixed_precision = self._build_mixed_precision_config()
+        world_size = torch.distributed.get_world_size()
+        dp_size = world_size // self.engine_config.ulysses_parallel_size
+        fsdp_size = self.engine_config.fsdp_size
+        if fsdp_size < 0 or fsdp_size >= dp_size:
+            dp_replicate_size = 1
+            dp_shard_size = dp_size
+        else:
+            dp_replicate_size = dp_size // fsdp_size
+            dp_shard_size = fsdp_size
 
-        # Keep this sequence aligned with VeOmni's DiTTrainer._build_model:
-        # build the foundation DiT first, then hand it to VeOmni's parallelizer,
-        # optimizer, scheduler, and training contexts.
-        module = build_foundation_model(
-            config_path=config_path,
-            weights_path=weights_path,
-            torch_dtype=self._get_veomni_torch_dtype(),
-            init_device=self.engine_config.init_device,
-            ops_implementation=self._build_ops_config(),
+        mixed_precision = MixedPrecisionConfig(
+            enable=self.engine_config.mixed_precision,
+            param_dtype=self.engine_config.mixed_precision_param_dtype,
+            reduce_dtype=self.engine_config.mixed_precision_reduce_dtype,
+            output_dtype=self.engine_config.mixed_precision_output_dtype,
+            cast_forward_inputs=self.engine_config.mixed_precision_cast_forward_inputs,
         )
-
-        module = build_parallelize_model(
-            module,
-            init_device=self.engine_config.init_device,
-            weights_path=weights_path,
-            enable_reshard_after_forward=self.engine_config.reshard_after_forward,
+        fsdp_config = FSDPConfig(
+            fsdp_mode="fsdp2",
+            reshard_after_forward=self.engine_config.reshard_after_forward,
+            forward_prefetch=self.engine_config.forward_prefetch,
             mixed_precision=mixed_precision,
-            enable_gradient_checkpointing=self.model_config.enable_gradient_checkpointing,
-            basic_modules=list(set(getattr(module, "_no_split_modules", None) or [])),
-            enable_reentrant=self.engine_config.enable_reentrant,
-            enable_forward_prefetch=self.engine_config.forward_prefetch,
         )
+        accelerator = AcceleratorConfig(
+            dp_replicate_size=dp_replicate_size,
+            dp_shard_size=dp_shard_size,
+            ep_size=self.engine_config.expert_parallel_size,
+            ulysses_size=self.engine_config.ulysses_parallel_size,
+            fsdp_config=fsdp_config,
+            offload_config=OffloadConfig(
+                enable_activation=self.engine_config.enable_activation_offload,
+                activation_gpu_limit=self.engine_config.activation_gpu_limit,
+            ),
+        )
+        optimizer = OptimizerConfig(
+            type=self.optimizer_config.optimizer,
+            lr=self.optimizer_config.lr,
+            lr_min=self.optimizer_config.lr_min,
+            lr_start=self.optimizer_config.lr_start,
+            lr_warmup_ratio=self.optimizer_config.lr_warmup_steps_ratio,
+            lr_decay_style=self.optimizer_config.lr_scheduler_type,
+            lr_decay_ratio=self.optimizer_config.lr_decay_ratio,
+            weight_decay=self.optimizer_config.weight_decay,
+            max_grad_norm=self.optimizer_config.clip_grad,
+        )
+        train_args = DiTTrainingArguments(
+            dyn_bsz=False,
+            micro_batch_size=1,
+            global_batch_size=dp_size,
+            num_train_epochs=1,
+            init_device=self.engine_config.init_device,
+            broadcast_model_weights_from_rank0=True,
+            enable_full_determinism=self.engine_config.full_determinism,
+            seed=self.engine_config.seed,
+            optimizer=optimizer,
+            gradient_checkpointing=GradientCheckpointingConfig(
+                enable=self.model_config.enable_gradient_checkpointing,
+                enable_reentrant=self.engine_config.enable_reentrant,
+            ),
+            accelerator=accelerator,
+            training_task="offline_training",
+        )
+        train_args._train_steps = self.optimizer_config.total_training_steps
 
+        args = VeOmniDiTArguments(
+            model=DiTModelArguments(
+                config_path=config_path,
+                model_path=weights_path,
+                model_config={},
+                tokenizer_path=(
+                    self.model_config.local_tokenizer_path or self.model_config.tokenizer_path or config_path
+                ),
+                basic_modules=[],
+                lora_config={},
+                ops_implementation=self._build_ops_config(),
+            ),
+            data=DiTDataArguments(train_path=self.model_config.local_path, text_keys="messages"),
+            train=train_args,
+        )
+        args._train_steps = self.optimizer_config.total_training_steps
+        return args
+
+    def _build_veomni_dit_trainer(self):
+        from veomni.trainer.base import BaseTrainer
+        from veomni.trainer.dit_trainer import DiTTrainer
+
+        trainer = DiTTrainer.__new__(DiTTrainer)
+        trainer.base = BaseTrainer.__new__(BaseTrainer)
+        trainer.base.args = self._build_veomni_dit_args()
+        trainer.training_task = "offline_training"
+        trainer.base.device = torch.device(device_name)
+        return trainer
+
+    def _build_model_optimizer(self):
+        from veomni.trainer.base import BaseTrainer
+
+        self.veomni_trainer = self._build_veomni_dit_trainer()
+        veomni_base = self.veomni_trainer.base
+        BaseTrainer._build_model(veomni_base)
+        BaseTrainer._build_parallelized_model(veomni_base)
         scheduler = self._build_scheduler()
         if not self.engine_config.forward_only:
-            optimizer = self._build_optimizer(module)
-            lr_scheduler = self._build_lr_scheduler(optimizer)
+            BaseTrainer._build_optimizer(veomni_base)
+            BaseTrainer._build_lr_scheduler(veomni_base)
         else:
-            optimizer = None
-            lr_scheduler = None
+            veomni_base.optimizer = None
+            veomni_base.lr_scheduler = None
+        BaseTrainer._build_training_context(veomni_base)
 
-        self.module = module
+        self.module = veomni_base.model
         self.scheduler = scheduler
-        self.optimizer = optimizer
-        self.lr_scheduler = lr_scheduler
-        self.model_fwd_context, self.model_bwd_context = build_activation_offloading_context(
-            self.engine_config.enable_activation_offload,
-            self.model_config.enable_gradient_checkpointing,
-            self.engine_config.activation_gpu_limit,
-        )
+        self.optimizer = veomni_base.optimizer
+        self.lr_scheduler = veomni_base.lr_scheduler
+        self.model_fwd_context = veomni_base.model_fwd_context
+        self.model_bwd_context = veomni_base.model_bwd_context
 
     def initialize(self):
         self._build_model_optimizer()


### PR DESCRIPTION
### What does this PR do?

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

Support VeOmni as actor engine for Qwen-Image Training.

What this PR do?

1. Support VeOmni as actor backend.
2. Support Qwen-Image flowGRPO with VeOmin but full model only.
3. Adding e2e runnable example shell and relative doc.
4. Compare with native fsdp training and verify the correction.

In Next PR:

1. Support LoRA and e2e LoRA case.
2. Add CI test.
3. Ckpt save/resume workflow verify.
4. Maybe some bugfix for this PR.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `vllm_omni`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `diffusion`, `omni`, `tests`, `docker`
  - If this PR involves multiple modules, separate them with `,` like `[diffusion, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][diffusion, fsdp] feat: new rollout scheduler`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

Run VeOmni example with:
```shell
bash examples/flowgrpo_trainer/run_qwen_image_ocr_veomni.sh
```
Validated on NVIDIA H100 GPUs with the Qwen-Image OCR VeOmni recipe.

Training ran for 120+ steps with batch_size=32, n=16, lr=3e-5, image_resolution=512x512, test_freq=10.

Training reward — critic/rewards/mean (steps 1–120):
<img width="1290" height="690" alt="image" src="https://github.com/user-attachments/assets/7f695986-36f8-4cd0-8c1d-707363514613" />


Validation reward — val-core/flow_grpo/ocr/reward/mean@1 (steps 0–120):
<img width="1290" height="690" alt="image" src="https://github.com/user-attachments/assets/87e37405-affb-4f0d-94d6-13b12f8c863e" />

Qualitative examples (validation generations):

Prompt 1: "A wooden trail marker stands in a dense forest, its surface weathered by time. The words "Hidden Trail" are carved deeply into the wood, surrounded by moss and foliage."

| Step 0 (score: 1.0) | Step 20 (score: 1.0) | Step 40 (score: 0.89) | Step 60 (score: 0.89) | Step 80 (score: 1.0) | Step 100 (score: 1.0) |
| --- | --- | --- | --- | --- | --- |
| <img width="636" height="636" alt="image" src="https://github.com/user-attachments/assets/c50b7163-f9e9-4011-a38f-c214c19d6a3a" /> | <img width="636" height="636" alt="image" src="https://github.com/user-attachments/assets/c86a4c85-5fd7-47bb-b9a1-5beafa9d3c4f" /> | <img width="636" height="636" alt="image" src="https://github.com/user-attachments/assets/d6f2d503-2ea4-4fec-ba12-b7da3c06fdcf" /> | <img width="636" height="636" alt="image" src="https://github.com/user-attachments/assets/0e5670f1-9e78-451c-add7-0fb229718a1b" /> | <img width="636" height="636" alt="image" src="https://github.com/user-attachments/assets/5101e691-732f-49f0-ba8c-a0a1d674480f" /> | <img width="636" height="636" alt="image" src="https://github.com/user-attachments/assets/21fe47bd-1f7e-4d2a-826e-fa465339b345" /> |


Prompt 2: "A birthday card interior with a whimsical, pastel-colored design, featuring the message "Make A Wish" in elegant, cursive handwriting, surrounded by sparkling candles and colorful confetti."

| Step 0 (score: 0.0) | Step 20 (score: 0.19) | Step 40 (score: 0.89) | Step 60 (score: 0.89) | Step 80 (score: 1.0) | Step 100 (score: 1.0) |
| --- | --- | --- | --- | --- | --- |
| <img width="636" height="636" alt="image" src="https://github.com/user-attachments/assets/4bc88c72-1709-4455-9cd5-83dbb2b88d1e" /> | <img width="636" height="636" alt="image" src="https://github.com/user-attachments/assets/f1461ae0-8d01-49f8-9b29-4cd17912acc0" /> | <img width="636" height="636" alt="image" src="https://github.com/user-attachments/assets/a8a4fa6d-0875-4d82-a803-f7271f20ff75" /> | <img width="636" height="636" alt="image" src="https://github.com/user-attachments/assets/71901fb4-7784-40f6-bb0c-09fa2ac3a56a" /> | <img width="636" height="636" alt="image" src="https://github.com/user-attachments/assets/62743946-952d-4ea5-9c93-9d6bb25544e9" /> | <img width="636" height="636" alt="image" src="https://github.com/user-attachments/assets/740039b0-086d-48c6-83d8-ee0edefc62a2" /> |


### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```shell
bash examples/flowgrpo_trainer/run_qwen_image_ocr_veomni.sh
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update the documentation.
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl-omni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
