### PR TITLE
[trainer, rollout] fix: use global row ids for per-rollout seeds

### DIFF
--- a/tests/agent_loop/test_diffusion_rollout_seed_gpu.py
+++ b/tests/agent_loop/test_diffusion_rollout_seed_gpu.py
@@ -135,7 +135,6 @@ def _build_seed_rollout_config(tmp_dir: str, *, default_num_gpus: int, num_worke
 
 @pytest.fixture
 def seed_rollout_config() -> DictConfig:
-    # Single worker avoids chunk-dispatch seed collisions (see xfailed test below).
     with tempfile.TemporaryDirectory() as tmp_dir:
         yield _build_seed_rollout_config(tmp_dir, default_num_gpus=1, num_workers=1)
 
@@ -178,6 +177,7 @@ def test_rollout_seed_reproducible_and_diverse_via_agent_loop(seed_rollout_confi
 
         n = seed_rollout_config.actor_rollout_ref.rollout.n
         batch = _make_prompt_batch(num_prompts=1).repeat(n)
+        batch.non_tensor_batch["_rollout_seed_global_idx"] = np.arange(len(batch), dtype=np.int64)
         batch.meta_info["global_steps"] = 1
         batch.meta_info["rollout_seed"] = 42
 
@@ -200,14 +200,6 @@ def test_rollout_seed_reproducible_and_diverse_via_agent_loop(seed_rollout_confi
         ray.shutdown()
 
 
-@pytest.mark.xfail(
-    reason=(
-        "AgentLoopManager chunks rollouts across workers; each worker derives per-row seeds from "
-        "local indices 0..chunk_size-1, so global rollout indices collide across chunks. "
-        "Fix in a follow-up PR via global rollout index dispatch."
-    ),
-    strict=True,
-)
 def test_rollout_seeds_unique_across_agent_loop_workers(multi_worker_seed_rollout_config):
     """Every expanded rollout row must get a distinct seed when agent.num_workers > 1."""
     ray.init(
@@ -229,6 +221,7 @@ def test_rollout_seeds_unique_across_agent_loop_workers(multi_worker_seed_rollou
 
         n = multi_worker_seed_rollout_config.actor_rollout_ref.rollout.n
         batch = _make_prompt_batch(num_prompts=1).repeat(n)
+        batch.non_tensor_batch["_rollout_seed_global_idx"] = np.arange(len(batch), dtype=np.int64)
         batch.meta_info["global_steps"] = 1
         batch.meta_info["rollout_seed"] = 42
 
@@ -236,8 +229,6 @@ def test_rollout_seeds_unique_across_agent_loop_workers(multi_worker_seed_rollou
         latents = _initial_latents(result)
         assert latents.shape[0] == n
 
-        # With 2 workers each chunk uses local indices 0..1, so global rows 0 and 2
-        # (same prompt, rollout indices 0 and 2) incorrectly share a seed today.
         assert not torch.equal(latents[0], latents[2]), (
             "global rollout rows 0 and 2 must not share the same initial latent"
         )

--- a/tests/agent_loop/test_diffusion_rollout_seed_identity.py
+++ b/tests/agent_loop/test_diffusion_rollout_seed_identity.py
@@ -1,0 +1,70 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+
+def _load_seed_utils():
+    # Keep this CPU unit test independent of package-level diffusion stack auto-registration.
+    utils_path = Path(__file__).resolve().parents[2] / "verl_omni" / "agent_loop" / "utils.py"
+    spec = importlib.util.spec_from_file_location("diffusion_seed_utils", utils_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_seed_utils = _load_seed_utils()
+_derive_rollout_seed = _seed_utils._derive_rollout_seed
+_maybe_per_rollout_seeds = _seed_utils._maybe_per_rollout_seeds
+
+
+def test_per_rollout_seeds_use_explicit_global_row_ids_across_chunks():
+    base_seed = 42
+    first_chunk = _maybe_per_rollout_seeds(
+        {"rollout_seed": base_seed},
+        batch_size=2,
+        global_indices=np.array([0, 1], dtype=np.int64),
+    )
+    second_chunk = _maybe_per_rollout_seeds(
+        {"rollout_seed": base_seed},
+        batch_size=2,
+        global_indices=np.array([2, 3], dtype=np.int64),
+    )
+
+    assert first_chunk == [_derive_rollout_seed(base_seed, 0), _derive_rollout_seed(base_seed, 1)]
+    assert second_chunk == [_derive_rollout_seed(base_seed, 2), _derive_rollout_seed(base_seed, 3)]
+    assert set(first_chunk).isdisjoint(second_chunk)
+
+
+def test_per_rollout_seeds_keep_worker_local_fallback():
+    base_seed = 42
+
+    assert _maybe_per_rollout_seeds({"rollout_seed": base_seed}, batch_size=3) == [
+        _derive_rollout_seed(base_seed, 0),
+        _derive_rollout_seed(base_seed, 1),
+        _derive_rollout_seed(base_seed, 2),
+    ]
+
+
+def test_per_rollout_seeds_disabled_when_rollout_seed_is_unset():
+    assert _maybe_per_rollout_seeds({}, batch_size=2, global_indices=np.array([0, 1], dtype=np.int64)) is None
+
+
+def test_per_rollout_seeds_reject_malformed_global_row_ids():
+    with pytest.raises(ValueError, match="Expected 2 global rollout indices, got 1"):
+        _maybe_per_rollout_seeds({"rollout_seed": 42}, batch_size=2, global_indices=np.array([0], dtype=np.int64))

--- a/verl_omni/agent_loop/diffusion_agent_loop.py
+++ b/verl_omni/agent_loop/diffusion_agent_loop.py
@@ -168,7 +168,10 @@ class DiffusionAgentLoopWorker:
             sampling_params["logprobs"] = False
         else:
             sampling_params["global_steps"] = batch.meta_info["global_steps"]
-            per_rollout_seeds = _maybe_per_rollout_seeds(batch.meta_info, len(batch))
+            global_indices = batch.non_tensor_batch.get("_rollout_seed_global_idx")
+            per_rollout_seeds = _maybe_per_rollout_seeds(
+                batch.meta_info, len(batch), global_indices,
+            )
 
         if "agent_name" not in batch.non_tensor_batch:
             default_agent_loop = config.agent.default_agent_loop
@@ -177,9 +180,8 @@ class DiffusionAgentLoopWorker:
         tasks = []
         for i in range(len(batch)):
             kwargs = {k: v[i] for k, v in batch.non_tensor_batch.items()}
-            task_sampling_params = sampling_params
+            task_sampling_params = sampling_params.copy()
             if per_rollout_seeds is not None:
-                task_sampling_params = sampling_params.copy()
                 task_sampling_params["seed"] = per_rollout_seeds[i]
             tasks.append(asyncio.create_task(self._run_agent_loop(task_sampling_params, **kwargs)))
         outputs = await asyncio.gather(*tasks)

--- a/verl_omni/agent_loop/utils.py
+++ b/verl_omni/agent_loop/utils.py
@@ -22,11 +22,23 @@ def _derive_rollout_seed(base_seed: int, rollout_index: int) -> int:
     return (int(base_seed) * 1_000_003 + int(rollout_index)) % max_seed
 
 
-def _maybe_per_rollout_seeds(meta_info: dict, batch_size: int) -> Optional[list[int]]:
-    """Build one seed per post-repeat rollout row (batch_size == len(batch)).
-    Returns None when meta_info rollout_seed is unset."""
+def _maybe_per_rollout_seeds(meta_info: dict, batch_size: int, global_indices=None) -> Optional[list[int]]:
+    """Build one seed per post-repeat rollout row.
+
+    Explicit global row ids are preferred so dispatched chunks derive seeds
+    from their original expanded-row identity. Worker-local row positions are
+    retained as a compatibility fallback for callers that do not provide the
+    global id column.
+    """
     base = meta_info.get("rollout_seed")
     if base is None:
         return None
     base = int(base)
-    return [_derive_rollout_seed(base, i) for i in range(batch_size)]
+
+    if global_indices is None:
+        return [_derive_rollout_seed(base, i) for i in range(batch_size)]
+
+    if len(global_indices) != batch_size:
+        raise ValueError(f"Expected {batch_size} global rollout indices, got {len(global_indices)}")
+
+    return [_derive_rollout_seed(base, int(idx)) for idx in global_indices]

--- a/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
+++ b/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
@@ -954,7 +954,7 @@ class PolicyGradientRayTrainer(BaseRayDiffusionTrainer):
 
                 gen_batch = self._get_gen_batch(batch)
 
-                # pass global_steps to trace
+                # Pass step metadata to rollout before expansion.
                 gen_batch.meta_info["global_steps"] = self.global_steps
 
                 # Per-step rollout seed for reproducibility
@@ -964,6 +964,9 @@ class PolicyGradientRayTrainer(BaseRayDiffusionTrainer):
 
                 gen_batch_output = gen_batch.repeat(
                     repeat_times=self.config.actor_rollout_ref.rollout.n, interleave=True
+                )
+                gen_batch_output.non_tensor_batch["_rollout_seed_global_idx"] = np.arange(
+                    len(gen_batch_output), dtype=np.int64
                 )
 
                 is_last_step = self.global_steps >= self.total_training_steps


### PR DESCRIPTION
## Context

Follow-up to #60, which added deterministic per-step and per-rollout seeding. That covered the basic seed schedule and made different `rollout.n > 1` group members derive distinct rollout seeds.

One distributed identity gap remained: after `gen_batch.repeat(...)` expands the batch, AgentLoop DP/chunk dispatch can split expanded rows across workers. Worker-local row indices are not globally unique, so using local chunk positions for per-rollout seed identity can collide across chunks.

## What this PR changes

- Assigns `_rollout_seed_global_idx` immediately after `gen_batch.repeat(...)` in `PolicyGradientRayTrainer.fit()`.
- Reads `_rollout_seed_global_idx` from each dispatched chunk in `DiffusionAgentLoopWorker`.
- Makes `_maybe_per_rollout_seeds(...)` derive seeds from explicit global row ids when provided.
- Keeps local-index seed derivation only as a compatibility fallback for older/direct callers.
- Rejects malformed explicit global-index columns whose length does not match the dispatched batch.

## Why this matters

`rollout.n` means each prompt produces multiple stochastic samples. Those samples should keep distinct seed/noise identity even after dispatch chunking. The identity should come from the expanded global row, not from the row’s position inside a worker-local chunk.

Before:

- worker 0 chunk local rows: `0, 1`
- worker 1 chunk local rows: `0, 1`
- seed identity based on local row can collide

After:

- expanded global rows: `0, 1, 2, 3`
- dispatched chunks carry global ids
- seed identity remains unique across workers

## Validation

Main validation was GPU / real-model backed on a dual NVIDIA A100 80GB machine. The evidence below comes from preserved assertion-backed rollout artifacts for this seed/noise identity path.

- Single-GPU real-model rollout: checked same seed/row repeatability, rollout-member diversity, step diversity, and seed-disabled behavior.
- Dispatch DP=2, TP=1: checked global row ids are present, local-index fallback is not used, derived seeds are unique, and initial latent hashes are unique across expanded rows.
- Dispatch-DP stress with larger `rollout.n`: checked the same uniqueness invariants across 8 expanded rows.
- TP=2: checked TP ranks share the same seed/hash for the same expanded row, so TP rank is not part of seed identity.
- Bounded trainer integration: entered `PolicyGradientRayTrainer.fit()`, executed real `gen_batch.repeat(...)`, produced `_rollout_seed_global_idx` in the trainer path, and observed it downstream before stopping before reward/actor update.
- Negative guard: disabling trainer global-row production caused the expected failure, catching missing global ids, local-index fallback use, duplicated seeds, and duplicated latent hashes.

Environment:

- GPU: 2 x NVIDIA A100-SXM4-80GB
- Driver: `580.126.09`
- CUDA runtime reported by PyTorch: `13.0`
- PyTorch: `2.11.0+cu130`
- Python: `3.10.16`
- Model path: Qwen-Image / FlowGRPO rollout through `vllm_omni` and `AgentLoopManager`

Additional local checks on this production-only branch:

- `git diff --check`
- `python -m py_compile` on modified Python files

## Boundaries

- This PR does not claim full deterministic RL training.
- This PR does not claim final image quality or convergence.
- This PR does not claim all distributed topologies.
- This PR does not claim vLLM internal `data_parallel_size=2` semantics.
- This PR only fixes the rollout seed identity path covered by the listed tests.

## Reviewer notes

- This is intentionally small: trainer-side global row id production plus AgentLoop seed consumption.
- The fallback remains for older/direct callers, but the trainer path now carries explicit expanded-row identity.
- The negative guard shows the exact DP/chunk collision mode is detectable.