### PR TITLE
[reward] feat: support deterministic reward inference

### DIFF
--- a/docs/algo/deterministic_post_training.md
+++ b/docs/algo/deterministic_post_training.md
@@ -1,0 +1,143 @@
+# Deterministic Post-Training
+
+Last updated: 08/15/2026.
+
+By default, verl-omni RL training is **not bitwise reproducible**: identical configs run twice can produce different reward curves due to nondeterminism in GPU kernels, batch composition, request routing, and sampling. This page documents the effort to make post-training deterministic across multiple aspects (reward inference, rollout generation, diffusion sampling, and eventually end-to-end bitwise-aligned reward curves).
+
+**Supported: reward inference determinism** (VLM reward-model / GRM scoring). The remaining aspects are tracked as future work — see [Scope](#scope).
+
+## Scope
+
+| Component | Status |
+|---|---|
+| GRM inference — floating-point determinism | ✅ Supported |
+| GRM inference — batch invariance (`VLLM_BATCH_INVARIANT`) | ✅ Supported |
+| GRM inference — deterministic multi-replica routing (`NaiveRouter` crc32) | ✅ Supported |
+| GRM inference — per-request sampling seed | ✅ Supported |
+| Actor-rollout generation determinism | 🚧 Future |
+| Diffusion sampling determinism | 🚧 Future |
+| End-to-end bitwise-aligned reward curves | 🚧 Future |
+
+For the upstream full-determinism feature (actor rollout, FSDP/Megatron, trainer backend), see verl's [`docs/advance/determinism.md`](https://github.com/verl-project/verl/blob/main/docs/advance/determinism.md). verl-omni will adopt those layers incrementally, and a single top-level determinism switch (covering both rollout and reward) will replace the current per-component `full_determinism` flags.
+
+## When to use
+
+- **Debugging** — reproduce a reward-score anomaly exactly.
+- **Regression testing** — verify a code change has no silent effect on GRM scores.
+- **Research** — fair comparison of reward-side algorithmic changes.
+
+Leave determinism off for production training — deterministic kernels are slower, cuDNN benchmarking is disabled, and batch invariance can serialize.
+
+## Enable
+
+Set `reward.reward_model.rollout.full_determinism=true` and a `seed` under the `reward_model.rollout` block:
+
+```yaml
+reward:
+  reward_model:
+    enable: true
+    rollout:
+      name: vllm_omni
+      full_determinism: true
+      seed: 42
+```
+
+Or via Hydra overrides:
+
+```bash
+python -m verl_omni.trainer.main_diffusion \
+  reward.reward_model.enable=true \
+  reward.reward_model.rollout.full_determinism=true \
+  reward.reward_model.rollout.seed=42 \
+  [other config overrides...]
+```
+
+Sampling params (`temperature`, `top_k`, `top_p`) remain user-configured under `reward.reward_model.rollout`; the flag does not override them. Greedy decoding uses `temperature=0`; controlled pseudorandom sampling uses `temperature>0` plus the per-request `seed`. The scorer's own tuned defaults (e.g. genrm_ocr's `temperature=0.7`, `top_p=0.8`) apply unless overridden.
+
+## Configuration Reference
+
+| Parameter | Default | Description |
+|---|---|---|
+| `reward_model.rollout.full_determinism` | `false` | Enables reward inference determinism (all layers below) |
+| `reward_model.rollout.seed` | `42` | Floating-point + per-request sampling seed |
+| `reward_model.rollout.name` | — | Use `vllm_omni` (the server with the `_post_init` determinism hook) |
+| `reward_model.rollout.temperature` | — | User-configured sampling temperature |
+| `reward_model.rollout.top_k` | — | User-configured top-k |
+| `reward_model.rollout.top_p` | — | User-configured top-p |
+
+## How it works
+
+verl-omni's GRM scores images via `/v1/chat/completions` (a VLM such as Qwen3-VL transcribes the image). Reproducibility is enforced at three layers.
+
+### Env export before `ray.init()`
+
+When determinism is requested (currently `reward.reward_model.rollout.full_determinism=true`; a single top-level switch covering rollout + reward is future work — see [Scope](#scope)), `main_diffusion.run_diffusion` calls `_export_full_determinism_env` in the main process **before** `ray.init()` to set the determinism **switch** env vars:
+
+- `VERL_FULL_DETERMINISM=1`, `VLLM_BATCH_INVARIANT=1`, `PYTHONHASHSEED=<seed>`
+
+These are forwarded to every Ray actor via verl's `get_ppo_ray_runtime_env` (the runtime_env forward-list). They must be set before `ray.init()` so actors inherit them — too late if only set inside `_post_init`. The `NaiveRouter` subprocess (a `multiprocessing.Process` forked from an actor) reads `VERL_FULL_DETERMINISM` to activate crc32 routing, and the vLLM server reads `VLLM_BATCH_INVARIANT` to activate batch invariance.
+
+Only switch flags are exported here (mirroring verl's `main_ppo`); the floating-point vars (`CUBLAS_WORKSPACE_CONFIG`, `FLASH_ATTENTION_DETERMINISTIC`, `NCCL_DETERMINISTIC`, `NCCL_ALGO`, `NCCL_PROTO`, `VERL_DISABLE_FLASH_ATTN_CE`) are set inside each actor's `enable_full_determinism()`, so they do not pollute the normal training flow's environment.
+
+### 1. Batch invariance
+
+`VLLM_BATCH_INVARIANT=1` makes a request's output independent of which other requests are co-batched with it. This applies to the generative `/v1/chat/completions` path the GRM uses (unlike vLLM's `/classify` pooling endpoint, which is not covered by batch invariance — that path would require serializing with `max_num_seqs=1`; verl-omni's GRM does not use it).
+
+Coverage is model- and hardware-dependent — see the [vLLM batch invariance docs](https://docs.vllm.ai/en/latest/features/batch_invariance/) (and [tested models](https://docs.vllm.ai/en/latest/features/batch_invariance/#tested-models)). If not covered, set `max_num_seqs=1` to serialize.
+
+### 2. Floating-point determinism
+
+The RM server (`vLLMOmniHttpServer`, reached via `rollout.name=vllm_omni`) applies `enable_full_determinism(seed)` in `_post_init`, before model load:
+
+| Setting | Effect |
+|---|---|
+| `PYTHONHASHSEED` | freezes Python `hash()` / dict ordering |
+| `CUBLAS_WORKSPACE_CONFIG=:16:8` | deterministic cuBLAS |
+| `FLASH_ATTENTION_DETERMINISTIC=1` | deterministic flash-attn |
+| `NCCL_DETERMINISTIC=1` / `NCCL_ALGO=Ring` / `NCCL_PROTO=Simple` | deterministic NCCL |
+| `VERL_DISABLE_FLASH_ATTN_CE=1` | bypass the non-deterministic flash-attn Triton cross-entropy kernel in `logprobs_from_logits` (pure-PyTorch `log_softmax+gather`); not covered by `FLASH_ATTENTION_DETERMINISTIC` (attention backward only) or `torch.use_deterministic_algorithms` (Triton custom ops skip `warn_only`) |
+| `VERL_SEED` | read by rollout worker subprocesses (verl `vllm_rollout/utils.py`) to apply `enable_full_determinism` per worker |
+| seeded `random` / `numpy` / `torch` / `cuda` RNGs | fixed RNG state |
+| `torch.use_deterministic_algorithms(True, warn_only=True)` | deterministic ops |
+| `cudnn.deterministic=True, benchmark=False` | deterministic cuDNN |
+
+`full_determinism`/`seed` live on the `reward_model` block (a non-structured config node), so the trainer propagates them onto `reward_model.rollout` via `OmegaConf.open_dict` — the server process's `self.config` is the rollout config and can read them.
+
+Each RM replica uses the same `seed` (not `replica_rank + seed`), so every replica starts from identical state.
+
+### 3. Deterministic routing
+
+The reward router (verl's `NaiveRouter`) is least-loaded; under `VERL_FULL_DETERMINISM=1` it tie-breaks among equally-loaded replicas with `crc32(request_body) % len(candidates)`, so the same request lands on the same replica across runs. Combined with identical per-replica seeds and batch invariance, the same request yields the same output regardless of which replica serves it.
+
+### 4. Per-request sampling seed
+
+`VisualRewardManager` injects `seed = reward_model.rollout.seed` into each GRM request's `sampling_params`. vLLM's OpenAI-compatible endpoint honors the `seed` field, so the same image + same sampling params + same seed yields the same transcription, and therefore the same reward score. This is **controlled pseudorandom** sampling, not greedy — `temperature`/`top_k`/`top_p` are respected, and the seed makes the randomness reproducible.
+
+`do_sample` is **not** a valid vLLM `SamplingParams` key (silently ignored), so it is not passed. `max_tokens` is always supplied (default `4096`) so generation length is stable.
+
+### VLM scoring path
+
+Enabling the RM requires an explicit `reward.custom_reward_function` — the trainer raises `ValueError` when `reward.reward_model.enable=true` without one. Use the OCR GRM scorer (`verl_omni/utils/reward_score/genrm_ocr.py::compute_score_ocr`) or provide your own scorer via `path`/`name`.
+
+## Side Effects
+
+- **Performance**: deterministic kernels are slower and cuDNN benchmarking is disabled; expect throughput loss.
+- **Recommendation**: enable for debugging, regression testing, or research only.
+
+## Limitations
+
+- **Batch invariance not directly asserted**: `genrm_ocr` sends one image per `/v1/chat/completions` request serially, so requests are not explicitly co-batched and `VLLM_BATCH_INVARIANT` cannot be reliably triggered or observed in the test. Batch invariance is still set by `_post_init` for correctness; its coverage is model/hardware-dependent (see [vLLM batch invariance docs](https://docs.vllm.ai/en/latest/features/batch_invariance/)).
+- **Nondeterministic fallbacks**: some GPU ops have no deterministic implementation. `warn_only=True` emits warnings; these are expected.
+- **Multi-replica routing not asserted**: every replica uses the same seed, so replica outputs are identical regardless of routing, and crc32 routing (gated on `VERL_FULL_DETERMINISM`) cannot be distinguished from least-loaded routing by the assertions. Routing correctness is guaranteed by code, not by the test suite.
+- **Hardware**: deterministic ops and batch invariance require specific hardware — see the [vLLM batch invariance docs](https://docs.vllm.ai/en/latest/features/batch_invariance/). On unsupported hardware, set `max_num_seqs=1`.
+- **Generative GRM only**: this covers the generative VLM reward path. Full E2E determinism (rollout + diffusion sampling) is future work.
+
+## Verify
+
+```bash
+pytest tests/reward_loop/test_visual_reward_manager.py -v -s -k deterministic_reward_reproducibility
+```
+
+Each run spins up its own `RewardLoopManager` (fresh RM server process(es) via `ray.init`/`ray.shutdown`). Floating-point determinism (`enable_full_determinism`), `VERL_SEED`, and `VLLM_BATCH_INVARIANT=1` are all set by the RM server's `_post_init` (gated on `full_determinism=true` in the rollout config, which the test propagates via `OmegaConf.open_dict`), so no determinism env vars are needed in the Ray runtime_env. Two variants cover single replica (`test_deterministic_reward_reproducibility_single_replica`) and multi replica (`test_deterministic_reward_reproducibility_multi_replica`). Each asserts:
+
+- **Same seed → bitwise-aligned**: two independent runs with the same seed produce bitwise-equal `rm_scores` (`torch.equal`) and identical `genrm_response`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -66,6 +66,7 @@ algo/grpo_guard.md
 algo/mixgrpo.md
 algo/diffusion_opd.md
 algo/omni_opd.md
+algo/deterministic_post_training.md
 algo/performance.md
 ```
 

--- a/tests/reward_loop/test_visual_reward_manager.py
+++ b/tests/reward_loop/test_visual_reward_manager.py
@@ -14,6 +14,7 @@
 
 import os
 
+import pytest
 import ray
 import torch
 from hydra import compose, initialize_config_dir
@@ -23,28 +24,32 @@ from verl.utils import hf_tokenizer
 
 from ..utils.gpu_test_topology import resolve_reward_loop_gpu_topology
 
+# Point these at your local model dirs. rollout_model only needs its tokenizer/.
+ROLLOUT_MODEL_PATH = os.path.expanduser("~/models/tiny-random/Qwen-Image")
+REWARD_MODEL_PATH = os.path.expanduser("~/models/tiny-random/qwen3-vl")
 
-def create_data_samples(tokenizer, data_source="ocr") -> DataProto:
-    prompts = ['a photo of displaying "OCR"'] * 3
-    responses = [torch.randint(256, (3, 512, 512), dtype=torch.uint8)] * 3
-    data_source = [data_source] * len(responses)
-    reward_info = [{"ground_truth": "OCR"}] * len(responses)
-    extra_info = [{}] * len(responses)
 
-    responses = torch.stack(responses)
-    prompt_length = 1024
+def _encode_prompts(prompts, tokenizer, prompt_length: int = 1024) -> torch.Tensor:
     pad_token_id = tokenizer.pad_token_id
     prompt_ids = []
     for prompt in prompts:
         prompt_tokens = tokenizer.encode(prompt)
         padded_prompt = [pad_token_id] * (prompt_length - len(prompt_tokens)) + prompt_tokens
         prompt_ids.append(torch.tensor(padded_prompt))
-    prompt_ids = torch.stack(prompt_ids)
+    return torch.stack(prompt_ids)
+
+
+def create_data_samples(tokenizer, data_source="ocr") -> DataProto:
+    prompts = ['a photo of displaying "OCR"'] * 3
+    responses = [torch.randint(0, 256, (3, 512, 512), dtype=torch.uint8) for _ in range(3)]
+    data_source = [data_source] * len(responses)
+    reward_info = [{"ground_truth": "OCR"} for _ in range(len(responses))]
+    extra_info = [{} for _ in range(len(responses))]
 
     data = DataProto.from_dict(
         tensors={
-            "input_ids": prompt_ids,
-            "responses": responses,
+            "input_ids": _encode_prompts(prompts, tokenizer),
+            "responses": torch.stack(responses),
         },
         non_tensors={
             "data_source": data_source,
@@ -65,15 +70,14 @@ def test_reward_model_genrm():
                 "VLLM_USE_V1": "1",
                 "FLASHINFER_DISABLE_VERSION_CHECK": os.environ.get("FLASHINFER_DISABLE_VERSION_CHECK", "1"),
             }
-        },
-        ignore_reinit_error=True,
+        }
     )
     try:
         with initialize_config_dir(config_dir=os.path.abspath("verl_omni/trainer/config")):
             config = compose(config_name="diffusion_trainer")
 
-        rollout_model_name = os.path.expanduser("~/models/tiny-random/Qwen-Image")
-        reward_model_name = os.path.expanduser("~/models/tiny-random/qwen3-vl")
+        rollout_model_name = ROLLOUT_MODEL_PATH
+        reward_model_name = REWARD_MODEL_PATH
         reward_model_gpus, tp_size = resolve_reward_loop_gpu_topology()
 
         config.actor_rollout_ref.model.path = rollout_model_name
@@ -111,6 +115,87 @@ def test_reward_model_genrm():
         ray.shutdown()
 
 
+def _build_deterministic_reward_config(seed: int, num_replicas: int = 1):
+    with initialize_config_dir(config_dir=os.path.abspath("verl_omni/trainer/config")):
+        config = compose(config_name="diffusion_trainer")
+
+    rollout_model_name = ROLLOUT_MODEL_PATH
+    reward_model_name = REWARD_MODEL_PATH
+    reward_model_gpus, tp_size = resolve_reward_loop_gpu_topology()
+    if num_replicas > reward_model_gpus:
+        pytest.skip(f"Need >= {num_replicas} GPUs for {num_replicas} replicas, got {reward_model_gpus}")
+    if num_replicas > 1:
+        tp_size = 1
+        reward_model_gpus = num_replicas
+
+    config.actor_rollout_ref.model.path = rollout_model_name
+    config.actor_rollout_ref.model.tokenizer_path = os.path.join(rollout_model_name, "tokenizer")
+    config.reward.custom_reward_function.path = "verl_omni/utils/reward_score/genrm_ocr.py"
+    config.reward.custom_reward_function.name = "compute_score_ocr"
+    config.reward.reward_model.enable = True
+    config.reward.reward_model.enable_resource_pool = True
+    config.reward.reward_model.n_gpus_per_node = reward_model_gpus
+    config.reward.reward_model.nnodes = 1
+    config.reward.reward_model.model_path = reward_model_name
+    config.reward.reward_model.rollout.name = os.getenv("ROLLOUT_NAME", "vllm")
+    config.reward.reward_model.rollout.gpu_memory_utilization = 0.9
+    config.reward.reward_model.rollout.tensor_model_parallel_size = tp_size
+    config.reward.reward_model.rollout.skip_tokenizer_init = False
+    config.reward.reward_model.rollout.prompt_length = 2048
+    config.reward.reward_model.rollout.response_length = 32
+    config.reward.reward_model.rollout.full_determinism = True
+    config.reward.reward_model.rollout.seed = seed
+    return config
+
+
+_DETERMINISM_RAY_RUNTIME_ENV = {
+    "env_vars": {
+        "TOKENIZERS_PARALLELISM": "true",
+        "NCCL_DEBUG": "WARN",
+        "VLLM_LOGGING_LEVEL": "INFO",
+        "VLLM_USE_V1": "1",
+        "FLASHINFER_DISABLE_VERSION_CHECK": "1",
+    }
+}
+
+
+def _run_rm_with_seed(seed: int, data, num_replicas: int = 1) -> list:
+    """Score ``data`` with a fresh RM server per call so runs are independent."""
+    ray.init(runtime_env=_DETERMINISM_RAY_RUNTIME_ENV)
+    try:
+        manager = RewardLoopManager(_build_deterministic_reward_config(seed=seed, num_replicas=num_replicas))
+        return manager.compute_rm_score(data)
+    finally:
+        ray.shutdown()
+
+
+def _assert_determinism(num_replicas: int):
+    """Same seed across two independent RM runs → bitwise-aligned outputs."""
+    rollout_tokenizer = hf_tokenizer(os.path.join(ROLLOUT_MODEL_PATH, "tokenizer"))
+    torch.manual_seed(42)
+    data = create_data_samples(rollout_tokenizer)
+
+    run1 = _run_rm_with_seed(seed=42, data=data, num_replicas=num_replicas)
+    run2 = _run_rm_with_seed(seed=42, data=data, num_replicas=num_replicas)
+    for idx, (o1, o2) in enumerate(zip(run1, run2, strict=False)):
+        assert torch.equal(o1.batch["rm_scores"], o2.batch["rm_scores"]), (
+            f"[replicas={num_replicas}] same-seed rm_scores[{idx}] differ: "
+            f"{o1.batch['rm_scores']} vs {o2.batch['rm_scores']}"
+        )
+        assert o1.non_tensor_batch["genrm_response"] == o2.non_tensor_batch["genrm_response"], (
+            f"[replicas={num_replicas}] same-seed genrm_response[{idx}] differs: "
+            f"{o1.non_tensor_batch['genrm_response']} vs {o2.non_tensor_batch['genrm_response']}"
+        )
+
+
+def test_deterministic_reward_reproducibility_single_replica():
+    _assert_determinism(num_replicas=1)
+
+
+def test_deterministic_reward_reproducibility_multi_replica():
+    _assert_determinism(num_replicas=2)
+
+
 def test_rule_reward():
     ray.init(
         runtime_env={
@@ -121,14 +206,13 @@ def test_rule_reward():
                 "VLLM_USE_V1": "1",
                 "FLASHINFER_DISABLE_VERSION_CHECK": os.environ.get("FLASHINFER_DISABLE_VERSION_CHECK", "1"),
             }
-        },
-        ignore_reinit_error=True,
+        }
     )
     try:
         with initialize_config_dir(config_dir=os.path.abspath("verl_omni/trainer/config")):
             config = compose(config_name="diffusion_trainer")
 
-        rollout_model_name = os.path.expanduser("~/models/tiny-random/Qwen-Image")
+        rollout_model_name = ROLLOUT_MODEL_PATH
 
         config.actor_rollout_ref.model.path = rollout_model_name
         config.actor_rollout_ref.model.tokenizer_path = os.path.join(rollout_model_name, "tokenizer")

--- a/verl_omni/reward_loop/reward_manager/visual.py
+++ b/verl_omni/reward_loop/reward_manager/visual.py
@@ -73,11 +73,18 @@ class VisualRewardManager(RewardManagerBase):
         extra_info["num_turns"] = num_turns
         extra_info["rollout_reward_scores"] = rollout_reward_scores
 
+        rm_rollout = self.config.reward.reward_model.rollout
+        # Only forward max_tokens and the determinism seed; keep the scorer's own sampling defaults.
+        sampling_params = {"max_tokens": getattr(rm_rollout, "response_length", None) or 4096}
+        if rm_rollout.get("full_determinism", False):
+            sampling_params["seed"] = rm_rollout.get("seed", 42)
+
         extra_reward_kwargs = (
             {
                 "reward_router_address": self.reward_router_address,
                 "reward_model_tokenizer": self.reward_model_tokenizer,
                 "model_name": self.config.reward.reward_model.model_path,
+                "sampling_params": sampling_params,
             }
             if self.reward_router_address is not None
             else {}

--- a/verl_omni/trainer/main_diffusion.py
+++ b/verl_omni/trainer/main_diffusion.py
@@ -70,6 +70,32 @@ def main(config):
     run_diffusion(config)
 
 
+def _determinism_requested(config) -> bool:
+    """Whether reward inference determinism is requested."""
+    rm_rollout = config.reward.reward_model.rollout
+    return bool(config.reward.reward_model.get("enable", False) and rm_rollout.get("full_determinism", False))
+
+
+def _export_full_determinism_env(config) -> None:
+    """Set determinism switch env vars before ray.init() so actors inherit them."""
+    os.environ["VERL_FULL_DETERMINISM"] = "1"
+    os.environ["VLLM_BATCH_INVARIANT"] = "1"
+    os.environ["PYTHONHASHSEED"] = str(config.reward.reward_model.rollout.get("seed", 42))
+
+
+def _validate_grm_reward_function(config) -> None:
+    """Require an explicit reward function when the RM is enabled."""
+    rm_cfg = config.reward.reward_model
+    if not rm_cfg.get("enable", False):
+        return
+    crf = config.reward.custom_reward_function
+    if not crf.get("path"):
+        raise ValueError(
+            "reward.reward_model.enable=true requires reward.custom_reward_function.path. "
+            "For GRM OCR scoring set it to 'verl_omni/utils/reward_score/genrm_ocr.py' with name 'compute_score_ocr'."
+        )
+
+
 def run_diffusion(config, task_runner_class=None) -> None:
     """Initialize Ray and run distributed diffusion training.
 
@@ -82,6 +108,10 @@ def run_diffusion(config, task_runner_class=None) -> None:
     OmegaConf.resolve(config)
     validate_separate_config(config)
     enable_rl_insight(config)
+    _validate_grm_reward_function(config)
+    # Before ray.init() so actors inherit these via runtime_env.
+    if _determinism_requested(config):
+        _export_full_determinism_env(config)
 
     # Check if Ray is not initialized
     if not ray.is_initialized():

--- a/verl_omni/utils/reward_score/genrm_ocr.py
+++ b/verl_omni/utils/reward_score/genrm_ocr.py
@@ -101,6 +101,7 @@ async def compute_score_ocr(
     reward_router_address: str,
     reward_model_tokenizer: PreTrainedTokenizer = None,
     model_name: Optional[str] = None,
+    sampling_params: dict = None,
 ):
     """Compute an image OCR score via a generative reward model (GRM).
 
@@ -120,6 +121,9 @@ async def compute_score_ocr(
             for interface consistency.
         model_name: Name or path of the GRM. Defaults to
             ``DEFAULT_GRM_MODEL_PATH``.
+        sampling_params: Override the defaults from :func:`_sampling_params`.
+            An explicit ``seed`` opts in to reproducible sampling; without one
+            any env-inherited seed is dropped.
 
     Returns:
         dict: ``{"score": float, "genrm_response": str}``.
@@ -182,11 +186,15 @@ async def compute_score_ocr(
                 ],
             },
         ]
-        # TODO: make sampling params configurable
+        params = _sampling_params()
+        if sampling_params is not None:
+            params.update(sampling_params)
+            if "seed" not in sampling_params:
+                params.pop("seed", None)
         chat_complete_request = {
             "messages": messages,
             "model": model_name,
-            **_sampling_params(),
+            **params,
         }
         result = await _chat_complete(
             router_address=reward_router_address,

--- a/verl_omni/workers/rollout/vllm_rollout/vllm_omni_ar_strategy.py
+++ b/verl_omni/workers/rollout/vllm_rollout/vllm_omni_ar_strategy.py
@@ -305,6 +305,8 @@ class ARStrategy(OmniStrategyBase):
         else:
             sampling_params["logprobs"] = None
         sampling_params.setdefault("repetition_penalty", getattr(self.server.config, "repetition_penalty", 1.0))
+        if getattr(self.server.config, "full_determinism", False):
+            sampling_params.setdefault("seed", getattr(self.server.config, "seed", 42))
         policy_params = SamplingParams(max_tokens=max_tokens, **sampling_params)
         if self._rollout_output_modalities is not None:
             default_stage_sampling_params = self.server.engine.default_sampling_params_list

--- a/verl_omni/workers/rollout/vllm_rollout/vllm_omni_async_server.py
+++ b/verl_omni/workers/rollout/vllm_rollout/vllm_omni_async_server.py
@@ -83,6 +83,13 @@ class vLLMOmniHttpServer(vLLMHttpServer):
 
     def _post_init(self, cuda_visible_devices: str) -> None:
         """Run strategy post-init and preserve the replica device list."""
+        if getattr(self.config, "full_determinism", False):
+            from verl.workers.engine.utils import enable_full_determinism
+
+            rollout_seed = getattr(self.config, "seed", 42)
+            enable_full_determinism(seed=rollout_seed)
+            os.environ["VERL_SEED"] = str(rollout_seed)
+            os.environ["VLLM_BATCH_INVARIANT"] = "1"
         # Set before vllm-omni narrows per-stage visible devices; stage workers
         # remap their ZMQ ranks through this replica-level list.
         os.environ["VERL_ZMQ_BASE_VISIBLE_DEVICES"] = cuda_visible_devices


### PR DESCRIPTION
### What does this PR do?

Make VLM reward-model (GRM) inference bitwise-reproducible for identical inputs, reusing verl's full-determinism machinery (`enable_full_determinism`, batch invariance, deterministic routing). Three gaps are addressed:

1. **No floating-point determinism** — flash attention, CUDA matmul, and NCCL all-reduce introduce nondeterminism across RM inference runs.
2. **No batch invariance / routing determinism** — co-batched RM requests and least-loaded router tie-breaking make outputs depend on batch composition and arrival order.
3. **No GenRM seed control** — sampling in the GRM scorer was not reproducible; there was no way to pass a per-request `seed` through to vLLM.

Determinism is opt-in via `reward.reward_model.rollout.full_determinism` (keys already exist in reward.yaml) and enforced at three layers.

### Related Issues

Closes #111

### Test

`test_deterministic_reward_reproducibility_single_replica` and `_multi_replica`. Input: 3 identical image samples (prompt + `torch.randint` uint8 image + ground-truth text "OCR"), scored by the GRM (qwen3-vl transcribes the image; Levenshtein distance vs ground-truth yields `rm_scores ∈ [0,1]` and `genrm_response` text). Each run spins up its own `RewardLoopManager` (fresh RM server process(es) via `ray.init`/`ray.shutdown` in `try/finally`).

Asserts: two runs with `full_determinism=true` + the same seed produce bitwise-equal `rm_scores` (`torch.equal`) and identical `genrm_response`. `rm_scores` is a Levenshtein text-similarity scalar derived from the GRM's generated text — not logits or logprobs — so text equality ⟺ score equality. Multi-replica skips unless enough GPUs are available.

Batch invariance and multi-replica crc32 routing are exercised by the code path but not separately asserted: `genrm_ocr` sends one image per request serially (no explicit co-batching → `VLLM_BATCH_INVARIANT` not reliably triggerable), and every replica uses the same seed (routing differences are output-preserving).

### API and Usage Example

```yaml
reward:
  custom_reward_function:
    path: verl_omni/utils/reward_score/genrm_ocr.py
    name: compute_score_ocr
  reward_model:
    enable: True
    model_path: ~/models/qwen3-vl
    rollout:
      name: vllm_omni       # RM server whose _post_init applies determinism
      full_determinism: true
      seed: 42              # floating-point + per-request sampling seed
      tensor_model_parallel_size: 2
```

`reward.custom_reward_function` is required when the RM is enabled — the trainer raises `ValueError` otherwise (genrm must name its scorer explicitly).

### Design & Propagation Chain

```
reward.reward_model.rollout.full_determinism / seed (existing keys in reward.yaml)
  → main_diffusion.run_diffusion()
      ├─ _validate_grm_reward_function: RM enabled without custom_reward_function.path → ValueError
      └─ if _determinism_requested(config):   # rollout.full_determinism + RM enabled
            _export_full_determinism_env
            export switch flags VERL_FULL_DETERMINISM / VLLM_BATCH_INVARIANT / PYTHONHASHSEED
            → forwarded to every Ray actor via runtime_env (get_ppo_ray_runtime_env);
            floating-point vars (CUBLAS/FLASH/NCCL_*) are NOT exported here — they are
            set inside each actor's enable_full_determinism(), as in verl's main_ppo
  → NaiveRouter (multiprocessing.Process)
      └─ reads VERL_FULL_DETERMINISM=1 → crc32(request) tie-break among equally-loaded replicas
  → vLLMOmniHttpServer._post_init  (rollout.name=vllm_omni)
      └─ if config.full_determinism: enable_full_determinism(seed)
            + set VERL_SEED (read by rollout worker subprocesses) / VLLM_BATCH_INVARIANT
  → vLLMOmniARStrategy.preprocess_input
      └─ if config.full_determinism: inject per-request seed into SamplingParams
  → VisualRewardManager
      └─ if full_determinism: sampling_params = {max_tokens, seed} → compute_score_ocr
          → HTTP /v1/chat/completions request carries the seed
```

**1. Batch invariance** — the RM server sets `VLLM_BATCH_INVARIANT=1`, making a request's output independent of which other requests are co-batched. This applies to the generative `/v1/chat/completions` path the GRM uses (verl-omni's GRM does not use vLLM's `/classify` pooling endpoint, which batch invariance does not cover).

**2. Floating-point determinism** — `enable_full_determinism(seed)` is applied in `vLLMOmniHttpServer._post_init`, covering PYTHONHASHSEED, CUBLAS, flash-attn, NCCL (`NCCL_DETERMINISTIC`/`NCCL_ALGO=Ring`/`NCCL_PROTO=Simple`), all RNGs, `torch.use_deterministic_algorithms`, cuDNN config, and `VERL_DISABLE_FLASH_ATTN_CE=1` (which routes `logprobs_from_logits` through the pure-PyTorch `log_softmax+gather` path, bypassing the non-deterministic flash-attn Triton cross-entropy kernel). As in verl's `main_ppo`, only the switch flags are exported before `ray.init()` (they must be in the runtime env forward-list so actors and the router subprocess inherit them); the floating-point vars are set inside each actor's `enable_full_determinism()`, not in the main process.

**3. Per-request sampling seed** — `VisualRewardManager` forwards only `max_tokens` (response-length cap) plus, under determinism, the `seed` into each GRM request's `sampling_params`; vLLM's OpenAI-compatible endpoint honors it. The scorer keeps its own tuned sampling defaults (`genrm_ocr`: `temperature=0.7`, `top_p=0.8`, overridable via `GENRM_OCR_*` env vars), and an explicit `seed` opts in to reproducible sampling — without one, any env-inherited seed is dropped, so nondeterministic sampling remains the default.

### Files

| File | Change |
|---|---|
| `verl_omni/trainer/main_diffusion.py` | `_determinism_requested` gate + `_export_full_determinism_env` (switch flags before `ray.init()`) + `_validate_grm_reward_function` (require scorer when RM enabled) |
| `verl_omni/workers/rollout/vllm_rollout/vllm_omni_async_server.py` | `vLLMOmniHttpServer._post_init` determinism hook |
| `verl_omni/workers/rollout/vllm_rollout/vllm_omni_ar_strategy.py` | Per-request seed injection in `preprocess_input` |
| `verl_omni/reward_loop/reward_manager/visual.py` | Pass `sampling_params` (`max_tokens` + determinism `seed`) to the scorer |
| `verl_omni/utils/reward_score/genrm_ocr.py` | Accept `sampling_params` kwarg; seed opt-in semantics |
| `tests/reward_loop/test_visual_reward_manager.py` | Same-seed bitwise-reproducibility tests (single/multi replica); GPU-count skip; `try/finally` around `ray.init` |
| `docs/algo/deterministic_post_training.md` + `docs/index.md` | New doc on enabling and verifying reward determinism; toctree entry |
