### PR TITLE
[reward] feat: add HTTP reward service adapter for external scorer services

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -27,6 +27,7 @@ VeRL-Omni targets RL post-training for three families of generative models:
 start/install.md
 start/flowgrpo_quickstart.md
 start/flowgrpo_quickstart_npu.md
+start/http_scorer.md
 start/metrics.md
 ```
 

--- a/docs/start/http_scorer.md
+++ b/docs/start/http_scorer.md
@@ -1,0 +1,116 @@
+(http_scorer)=
+# Using an External HTTP Scorer Service
+
+Last updated: 05/28/2026
+
+VeRL-Omni ships a generic HTTP reward client (`verl_omni.utils.reward_score.http_scorer_client`) that sends generated images to an external scorer service over HTTP and returns the score. This is useful when your reward model is too large to co-locate with training, needs a different runtime (e.g., a separate GPU pool), or is shared across multiple experiments.
+
+## How it works
+
+```text
+┌──────────────┐        pickle payload        ┌──────────────────┐
+│  VeRL-Omni   │  ──── POST (bytes) ────────► │  Scorer Service  │
+│  (training)  │                               │  (Flask/Gunicorn)│
+│              │  ◄─── pickle response ──────  │                  │
+└──────────────┘                               └──────────────────┘
+```
+
+1. During reward computation, the client converts the generated image tensor to JPEG bytes (offloaded to a thread pool to avoid blocking the async event loop).
+2. The JPEG bytes and prompt are packed into a pickle payload and sent via HTTP POST.
+3. The scorer service runs inference and returns scores in a pickle response.
+
+Since `compute_score` is an `async` function and `RewardLoopWorker.compute_score_batch` uses `asyncio.gather`, all samples in a batch hit the server concurrently — no serial bottleneck.
+
+## Scorer service protocol
+
+The HTTP scorer client (`http_scorer_client.py`) communicates with external reward services using a pickle-based protocol, following the interface defined in [flow_grpo](https://github.com/yifan123/flow_grpo#3-reward-preparation). A reference implementation is available at [deepgen_rl/ocr_scorer_service](https://github.com/deepgenteam/deepgen_rl/tree/main/rewards_services/api_services/ocr_scorer_service).
+
+### Request
+
+The client sends a **POST** request with body = `pickle.dumps(payload)` where:
+
+```python
+payload = {
+    "images": [bytes, ...],   # List of JPEG-encoded image bytes
+    "prompts": [str, ...],    # List of prompt strings (same length as images)
+    "metadata": {},           # Reserved for future use
+}
+```
+
+### Response
+
+The service must return `pickle.dumps(response)` where:
+
+```python
+# Success (HTTP 200):
+response = {"scores": [float, ...]}  # One score per image, typically in [0, 1]
+
+# Error (HTTP 200 with error key, or HTTP 5xx):
+response = {"error": "description of what went wrong"}
+```
+
+Any service that implements this interface can be used as a reward function — PaddleOCR, HPSv3, aesthetic scorers, CLIP-based scorers, etc. The service runs independently and can use any framework (PaddlePaddle, PyTorch, ONNX, etc.) without conflicting with the training environment.
+
+## Setting up a scorer service
+
+A reference implementation is available at [deepgen_rl/ocr_scorer_service](https://github.com/deepgenteam/deepgen_rl/tree/main/rewards_services/api_services/ocr_scorer_service). Each service follows the same Flask + Gunicorn pattern:
+
+```bash
+# Clone and start the OCR scorer service
+cd rewards_services/api_services/ocr_scorer_service
+pip install -r requirements.txt
+gunicorn -c gunicorn.conf.py 'app:create_app()'
+```
+
+The default port is configured in each service's `gunicorn.conf.py`. You can also write your own service — just implement the pickle-based protocol above (see [flow_grpo reward preparation](https://github.com/yifan123/flow_grpo#3-reward-preparation) for the specification).
+
+## Configuring VeRL-Omni to use the HTTP scorer
+
+In your training launch script, configure the reward function to point to `http_scorer_client` and pass the `server_url`:
+
+```bash
+python3 -m verl_omni.trainer.main_diffusion \
+    ...
+    "+reward.reward_functions.my_reward.path=pkg://verl_omni.utils.reward_score.http_scorer_client" \
+    '+reward.reward_functions.my_reward.name=compute_score' \
+    '+reward.reward_functions.my_reward.weight=1.0' \
+    "+reward.reward_functions.my_reward.server_url=http://<scorer-host>:<port>" \
+    ...
+```
+
+Key points:
+
+- **`path`**: Module path using the `pkg://` prefix.
+- **`name`**: The async function to call (`compute_score`).
+- **`weight`**: Reward weight when combining multiple reward functions.
+- **`server_url`**: Full URL of your scorer service (no trailing slash).
+
+Any extra key-value pairs added under the same reward function config are forwarded as `**kwargs` to `compute_score`.
+
+## Full example
+
+See the example script: `examples/flowgrpo_trainer/run_qwen_image_ocr_reward_server.sh`
+
+This script trains Qwen-Image with FlowGRPO using an external OCR reward server.
+
+```bash
+# 1. Start external OCR reward server (separate process/machine)
+# See: https://github.com/deepgenteam/deepgen_rl/tree/main/rewards_services/api_services/ocr_scorer_service
+# The service interface follows: https://github.com/yifan123/flow_grpo#3-reward-preparation
+cd rewards_services/api_services/ocr_scorer_service
+bash run.sh  # Starts on port 19082
+
+# 2. Prepare data (stores full prompt as ground_truth for HTTP service)
+python examples/flowgrpo_trainer/data_process/qwenimage_ocr_http_service.py \
+    --input_dir ~/dataset/ocr/ --output_dir ~/data/ocr_http
+
+# 3. Run training
+OCR_REWARD_SERVER_URL=http://<server-ip>:19082 \
+    bash examples/flowgrpo_trainer/run_qwen_image_ocr_reward_server.sh
+```
+
+## Notes
+
+- The HTTP client reuses a single `aiohttp.ClientSession` across calls to avoid per-request connection overhead.
+- Image serialization (tensor to PIL to JPEG) is offloaded to a thread pool via `asyncio.loop.run_in_executor` so it does not block the reward manager's async event loop.
+- The default request timeout is 120 seconds. If your scorer model is slow, consider scaling the service with Gunicorn workers or increasing the timeout in the client code.

--- a/examples/flowgrpo_trainer/data_process/qwenimage_ocr_http_service.py
+++ b/examples/flowgrpo_trainer/data_process/qwenimage_ocr_http_service.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """
 Preprocess the OCR dataset to parquet format for HTTP scorer service training.
 
@@ -13,11 +27,12 @@ import os
 
 import datasets
 
-
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--input_dir", default="~/dataset/ocr/", help="Path to the raw OCR dataset directory.")
-    parser.add_argument("--output_dir", default="~/data/ocr_http", help="Directory to save the preprocessed parquet files.")
+    parser.add_argument(
+        "--output_dir", default="~/data/ocr_http", help="Directory to save the preprocessed parquet files."
+    )
     args = parser.parse_args()
 
     local_dataset_path = os.path.expanduser(args.input_dir)
@@ -48,6 +63,7 @@ if __name__ == "__main__":
                 "extra_info": {"split": split, "index": idx},
             }
             return data
+
         return process_fn
 
     train_dataset = dataset["train"].map(function=make_map_fn("train"), with_indices=True)

--- a/examples/flowgrpo_trainer/data_process/qwenimage_ocr_http_service.py
+++ b/examples/flowgrpo_trainer/data_process/qwenimage_ocr_http_service.py
@@ -1,0 +1,60 @@
+"""
+Preprocess the OCR dataset to parquet format for HTTP scorer service training.
+
+Unlike qwenimage_ocr.py which extracts bare text as ground_truth, this script
+stores the full prompt (containing quoted target text) as ground_truth so that
+the HTTP scorer service can parse it directly.
+
+Raw dataset: https://github.com/yifan123/flow_grpo/tree/main/dataset/ocr
+"""
+
+import argparse
+import os
+
+import datasets
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input_dir", default="~/dataset/ocr/", help="Path to the raw OCR dataset directory.")
+    parser.add_argument("--output_dir", default="~/data/ocr_http", help="Directory to save the preprocessed parquet files.")
+    args = parser.parse_args()
+
+    local_dataset_path = os.path.expanduser(args.input_dir)
+    dataset = datasets.load_dataset(local_dataset_path)
+
+    data_source = "flow_grpo/ocr"
+    system_prompt = (
+        "Describe the image by detailing the color, shape, size, "
+        "texture, quantity, text, spatial relationships of the objects and background:"
+    )
+    negative_user_prompt = " "
+
+    def make_map_fn(split):
+        def process_fn(example, idx):
+            text = example.pop("text")
+            data = {
+                "data_source": data_source,
+                "prompt": [
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": text},
+                ],
+                "negative_prompt": [
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": negative_user_prompt},
+                ],
+                "ability": "ocr",
+                "reward_model": {"style": "model", "ground_truth": text},
+                "extra_info": {"split": split, "index": idx},
+            }
+            return data
+        return process_fn
+
+    train_dataset = dataset["train"].map(function=make_map_fn("train"), with_indices=True)
+    test_dataset = dataset["test"].map(function=make_map_fn("test"), with_indices=True)
+
+    local_save_dir = os.path.expanduser(args.output_dir)
+    os.makedirs(local_save_dir, exist_ok=True)
+    train_dataset.to_parquet(os.path.join(local_save_dir, "train.parquet"))
+    test_dataset.to_parquet(os.path.join(local_save_dir, "test.parquet"))
+    print(f"Saved to {local_save_dir}")

--- a/examples/flowgrpo_trainer/run_qwen_image_ocr_reward_server.sh
+++ b/examples/flowgrpo_trainer/run_qwen_image_ocr_reward_server.sh
@@ -93,7 +93,6 @@ python3 -m verl_omni.trainer.main_diffusion \
     trainer.val_before_train=False \
     trainer.n_gpus_per_node=$NUM_GPUS_ACTOR_ROLLOUT \
     trainer.nnodes=1 \
-    +trainer.ray_master_port_range="[45000,45100]" \
     trainer.save_freq=30 \
     trainer.test_freq=10 \
     trainer.total_epochs=15 \

--- a/examples/flowgrpo_trainer/run_qwen_image_ocr_reward_server.sh
+++ b/examples/flowgrpo_trainer/run_qwen_image_ocr_reward_server.sh
@@ -1,0 +1,100 @@
+# Qwen-Image full-weight RL with external OCR reward server, vllm_omni rollout
+# use examples/flowgrpo_trainer/data_process/qwenimage_ocr_http_service.py to prepare data
+set -x
+
+# Set WORKSPACE to any writable directory; defaults to $HOME
+WORKSPACE=${WORKSPACE:-$HOME}
+export RAY_DEDUP_LOGS=0
+
+ocr_train_path=$WORKSPACE/data/ocr_http/train.parquet
+ocr_test_path=$WORKSPACE/data/ocr_http/test.parquet
+
+model_name=${MODEL_PATH:-$HOME/huggingface/Qwen-Image}
+
+# External OCR reward server URL (must be running before training starts)
+OCR_REWARD_SERVER_URL=${OCR_REWARD_SERVER_URL:-http://localhost:19082}
+
+NUM_GPUS_ACTOR_ROLLOUT=4
+ACTOR_SP=1
+ROLLOUT_TP=1
+IMAGE_RESOLUTION=512
+
+ENGINE=vllm_omni
+
+script_path=$(readlink -f "$0")
+script_name=$(basename "$script_path" .sh)
+repo_root=$(dirname "$script_path")
+while [[ "$repo_root" != "/" && ! -f "$repo_root/LICENSE" ]]; do
+    repo_root=$(dirname "$repo_root")
+done
+if [[ ! -f "$repo_root/LICENSE" ]]; then
+    echo "Unable to locate repo root from $script_path: no LICENSE found" >&2
+    exit 1
+fi
+
+output_dir=$repo_root/outputs/$script_name
+checkpoint_dir=$output_dir/checkpoints
+run_timestamp=$(date +"%Y%m%d_%H%M")
+log_file=$output_dir/logs/$run_timestamp/${NODE_RANK:-0}.log
+rollout_data_dir=$output_dir/logs/$run_timestamp/rollout_images
+mkdir -p "$checkpoint_dir" "$(dirname "$log_file")"
+exec > >(tee -a "$log_file") 2>&1
+echo "Logging to $log_file"
+
+python3 -m verl_omni.trainer.main_diffusion \
+    algorithm.adv_estimator=flow_grpo \
+    data.train_files=$ocr_train_path \
+    data.val_files=$ocr_test_path \
+    data.train_batch_size=32 \
+    data.max_prompt_length=256 \
+    actor_rollout_ref.model.path=$model_name \
+    actor_rollout_ref.actor.optim.lr=3e-5 \
+    actor_rollout_ref.actor.optim.weight_decay=0.0001 \
+    actor_rollout_ref.actor.ppo_mini_batch_size=16 \
+    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=16 \
+    actor_rollout_ref.actor.fsdp_config.param_offload=True \
+    actor_rollout_ref.actor.fsdp_config.ulysses_sequence_parallel_size=$ACTOR_SP \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=True \
+    actor_rollout_ref.actor.diffusion_loss.loss_mode=flow_grpo \
+    actor_rollout_ref.actor.diffusion_loss.clip_ratio=1e-5 \
+    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=32 \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=$ROLLOUT_TP \
+    actor_rollout_ref.rollout.name=$ENGINE \
+    actor_rollout_ref.rollout.n=16 \
+    actor_rollout_ref.rollout.agent.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT / ROLLOUT_TP)) \
+    actor_rollout_ref.rollout.load_format=safetensors \
+    actor_rollout_ref.rollout.layered_summon=True \
+    actor_rollout_ref.rollout.pipeline.true_cfg_scale=1.0 \
+    actor_rollout_ref.rollout.pipeline.height=$IMAGE_RESOLUTION \
+    actor_rollout_ref.rollout.pipeline.width=$IMAGE_RESOLUTION \
+    actor_rollout_ref.rollout.pipeline.max_sequence_length=256 \
+    actor_rollout_ref.rollout.algo.noise_level=1.2 \
+    actor_rollout_ref.rollout.algo.sde_type="sde" \
+    actor_rollout_ref.rollout.algo.sde_window_size=2 \
+    actor_rollout_ref.rollout.algo.sde_window_range="[0,5]" \
+    actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=50 \
+    actor_rollout_ref.rollout.val_kwargs.algo.noise_level=0.0 \
+    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=32 \
+    reward.reward_model.enable=False \
+    reward.custom_reward_function.path=pkg://verl_omni.reward_loop.reward_manager.multi \
+    reward.custom_reward_function.name=_multi_reward_placeholder \
+    reward.reward_manager.name=MultiVisualRewardManager \
+    reward.reward_manager.module.path=pkg://verl_omni.reward_loop.reward_manager \
+    "+reward.reward_functions.ocr.path=pkg://verl_omni.utils.reward_score.http_scorer_client" \
+    '+reward.reward_functions.ocr.name=compute_score' \
+    '+reward.reward_functions.ocr.weight=1.0' \
+    "+reward.reward_functions.ocr.server_url=$OCR_REWARD_SERVER_URL" \
+    trainer.logger='["console", "wandb"]' \
+    trainer.project_name=flow_grpo \
+    trainer.experiment_name=qwen_image_ocr_reward_server \
+    trainer.default_local_dir=$checkpoint_dir \
+    +trainer.rollout_data_dir=$rollout_data_dir \
+    trainer.log_val_generations=8 \
+    trainer.val_before_train=False \
+    trainer.n_gpus_per_node=$NUM_GPUS_ACTOR_ROLLOUT \
+    trainer.nnodes=1 \
+    +trainer.ray_master_port_range="[45000,45100]" \
+    trainer.save_freq=30 \
+    trainer.test_freq=10 \
+    trainer.total_epochs=15 \
+    trainer.total_training_steps=300 "$@"

--- a/verl_omni/reward_loop/reward_manager/multi.py
+++ b/verl_omni/reward_loop/reward_manager/multi.py
@@ -68,11 +68,15 @@ class MultiVisualRewardManager(VisualRewardManager):
 
         self._sub_rewards = []
         total_weight = 0.0
+        _reserved_keys = {"path", "name", "weight"}
         for key, entry in reward_functions_cfg.items():
             path = entry["path"]
             name = entry["name"]
             weight = float(entry.get("weight", 1.0))
             total_weight += weight
+
+            # Collect extra config fields (beyond path/name/weight) to pass to compute_score
+            extra_args = {k: v for k, v in entry.items() if k not in _reserved_keys}
 
             fn = load_extern_object(path, name)
             sig = inspect.signature(fn)
@@ -85,6 +89,7 @@ class MultiVisualRewardManager(VisualRewardManager):
                     "weight": weight,
                     "sig": sig,
                     "is_async": is_async,
+                    "extra_args": extra_args,
                 }
             )
             logger.info(f"Loaded sub-reward '{key}': {path}:{name} (weight={weight}, async={is_async})")
@@ -139,8 +144,11 @@ class MultiVisualRewardManager(VisualRewardManager):
             weight = sub["weight"]
             sig = sub["sig"]
             is_async = sub["is_async"]
+            extra_args = sub["extra_args"]
 
-            filtered_kwargs = _filter_kwargs(all_kwargs, sig)
+            # Merge per-reward extra config fields into kwargs
+            sub_kwargs = {**all_kwargs, **extra_args}
+            filtered_kwargs = _filter_kwargs(sub_kwargs, sig)
 
             try:
                 if is_async:

--- a/verl_omni/utils/reward_score/http_scorer_client.py
+++ b/verl_omni/utils/reward_score/http_scorer_client.py
@@ -21,6 +21,7 @@ rewards_services/api_services/ that accept the standard payload format:
     Response: pickle-serialized {"scores": List[float]}
 """
 
+import asyncio
 import io
 import logging
 import pickle
@@ -51,6 +52,12 @@ def _serialize_image(pil_image: Image.Image) -> bytes:
     return buf.getvalue()
 
 
+def _prepare_image_bytes(image: torch.Tensor) -> bytes:
+    """Convert image tensor to JPEG bytes (CPU-heavy, run in thread pool)."""
+    pil_image = _tensor_to_pil(image)
+    return _serialize_image(pil_image)
+
+
 async def compute_score(
     solution_image: torch.Tensor,
     ground_truth: str,
@@ -67,8 +74,8 @@ async def compute_score(
     Returns:
         dict with "score" key.
     """
-    pil_image = _tensor_to_pil(solution_image)
-    image_bytes = _serialize_image(pil_image)
+    loop = asyncio.get_event_loop()
+    image_bytes = await loop.run_in_executor(None, _prepare_image_bytes, solution_image)
 
     payload = pickle.dumps(
         {

--- a/verl_omni/utils/reward_score/http_scorer_client.py
+++ b/verl_omni/utils/reward_score/http_scorer_client.py
@@ -78,14 +78,17 @@ async def compute_score(
         }
     )
 
-    timeout = aiohttp.ClientTimeout(total=120)
-    async with aiohttp.ClientSession(timeout=timeout) as session:
-        async with session.post(server_url, data=payload) as resp:
-            if resp.status != 200:
-                error_text = await resp.text()
-                logger.error(f"Scorer server returned {resp.status}: {error_text}")
-                return {"score": 0.0}
-            response_data = pickle.loads(await resp.read())
+    if not hasattr(compute_score, "_session") or compute_score._session.closed:
+        timeout = aiohttp.ClientTimeout(total=120)
+        compute_score._session = aiohttp.ClientSession(timeout=timeout)
+
+    session = compute_score._session
+    async with session.post(server_url, data=payload) as resp:
+        if resp.status != 200:
+            error_text = await resp.text()
+            logger.error(f"Scorer server returned {resp.status}: {error_text}")
+            return {"score": 0.0}
+        response_data = pickle.loads(await resp.read())
 
     if "error" in response_data:
         logger.error(f"Scorer server error: {response_data['error']}")

--- a/verl_omni/utils/reward_score/http_scorer_client.py
+++ b/verl_omni/utils/reward_score/http_scorer_client.py
@@ -1,0 +1,82 @@
+"""Generic HTTP reward client for external scorer services.
+
+Sends generated images to an external HTTP scorer service using pickle protocol
+and returns the score. Compatible with all scorer services under
+rewards_services/api_services/ that accept the standard payload format:
+    POST with pickle-serialized {"images": List[bytes], "prompts": List[str], "metadata": dict}
+    Response: pickle-serialized {"scores": List[float]}
+"""
+
+import io
+import logging
+import pickle
+
+import aiohttp
+import numpy as np
+import torch
+from PIL import Image
+
+logger = logging.getLogger(__name__)
+
+
+def _tensor_to_pil(image: torch.Tensor) -> Image.Image:
+    """Convert a CHW float tensor in [0, 1] to a uint8 RGB PIL image."""
+    if image.ndim == 4:
+        image = image[0]
+    image = image.float().permute(1, 2, 0).cpu().numpy()
+    image = (image * 255).round().clip(0, 255).astype(np.uint8)
+    return Image.fromarray(image)
+
+
+def _serialize_image(pil_image: Image.Image) -> bytes:
+    """Serialize a PIL image to JPEG bytes."""
+    if pil_image.mode != "RGB":
+        pil_image = pil_image.convert("RGB")
+    buf = io.BytesIO()
+    pil_image.save(buf, format="JPEG")
+    return buf.getvalue()
+
+
+async def compute_score(
+    solution_image: torch.Tensor,
+    ground_truth: str,
+    server_url: str,
+    **kwargs,
+) -> dict:
+    """Compute reward by calling an external HTTP scorer service.
+
+    Args:
+        solution_image: Generated image tensor (C, H, W) or (N, C, H, W).
+        ground_truth: Prompt string passed directly to the scorer service.
+        server_url: Full URL of the scorer service (e.g., "http://localhost:19082").
+
+    Returns:
+        dict with "score" key.
+    """
+    pil_image = _tensor_to_pil(solution_image)
+    image_bytes = _serialize_image(pil_image)
+
+    payload = pickle.dumps(
+        {
+            "images": [image_bytes],
+            "prompts": [ground_truth],
+            "metadata": {},
+        }
+    )
+
+    timeout = aiohttp.ClientTimeout(total=120)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        async with session.post(server_url, data=payload) as resp:
+            if resp.status != 200:
+                error_text = await resp.text()
+                logger.error(f"Scorer server returned {resp.status}: {error_text}")
+                return {"score": 0.0}
+            response_data = pickle.loads(await resp.read())
+
+    if "error" in response_data:
+        logger.error(f"Scorer server error: {response_data['error']}")
+        return {"score": 0.0}
+
+    scores = response_data["scores"]
+    score = float(scores[0]) if scores else 0.0
+    return {"score": score}

--- a/verl_omni/utils/reward_score/http_scorer_client.py
+++ b/verl_omni/utils/reward_score/http_scorer_client.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Generic HTTP reward client for external scorer services.
 
 Sends generated images to an external HTTP scorer service using pickle protocol


### PR DESCRIPTION
### What does this PR do?

Adds support for using external HTTP reward services (e.g., PaddleOCR-based scorer) as reward functions in RL training. This enables developers to deploy custom reward models as standalone HTTP services and connect them to verl-omni without modifying any framework code.

Key changes:
1. **`MultiVisualRewardManager` now passes extra config fields to reward functions** — any field beyond `path`/`name`/`weight` in `reward.reward_functions.<key>.*` is forwarded to the corresponding `compute_score` function via kwargs filtering. This is a generic mechanism that enables per-reward custom configuration (e.g., `server_url`, `timeout`).
2. **New generic HTTP scorer client** (`http_scorer_client.py`) — an async `compute_score` adapter that sends images to any HTTP scorer service using the pickle-based protocol.
3. **New data preprocessing script** (`qwenimage_ocr_http_service.py`) — prepares OCR data in a format compatible with the HTTP scorer service (full prompt as ground_truth instead of bare text).
4. **Example training script** (`run_qwen_image_ocr_reward_server.sh`) — demonstrates training with an external OCR reward server, no internal reward model required.

### Motivation

This addresses the RFC discussion in #103 about supporting custom reward models. The implementation follows **Option A (Custom Reward Function via Adapter)** with several modifications purposed by me:
- Users deploy their own HTTP reward server externally
- A `compute_score` adapter calls the endpoint
- The adapter plugs into the existing `MultiVisualRewardManager` path with no framework changes beyond the extra_args forwarding

This approach:
- Requires **zero GPU resources** for reward computation in the training cluster (reward runs on a separate service)
- Supports **any reward model backend** (PaddleOCR, HPSv3, aesthetic models, etc.) as long as it exposes the pickle-based HTTP interface
- Is **fully concurrent** — since `compute_score` is async and `RewardLoopWorker.compute_score_batch` uses `asyncio.gather`, all samples in a batch hit the server concurrently

### Checklist Before Starting

- [x] Search for similar PRs: https://github.com/verl-project/verl-omni/pulls?q=is%3Apr+reward+service
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

Validated on 4x NVIDIA B300 GPUs with the Qwen-Image OCR FlowGRPO recipe using an external PaddleOCR reward server (separate GPU).

Training ran for 180+ steps with `batch_size=32`, `n=16`, `lr=3e-5`, `image_resolution=512x512`, `test_freq=10`.

**Results (training reward — `critic/rewards/mean`):**

| Step | 10 | 30 | 50 | 70 | 100 | 130 | 150 | 180 |
|------|----|----|----|----|-----|-----|-----|-----|
| reward | 0.06 | 0.10 | 0.31 | 0.54 | 0.62 | 0.77 | 0.79 | 0.67 |

**Validation reward (`val-core/flow_grpo/ocr/reward/mean@1`):**

| Step | 10 | 30 | 50 | 70 | 100 | 130 | 150 | 180 |
|------|----|----|----|----|-----|-----|-----|-----|
| reward | 0.31 | 0.42 | 0.66 | 0.77 | 0.81 | 0.89 | 0.86 | 0.81 |

Peak validation reward: **0.886** at step 130.

**Training curve (`critic/rewards/mean`):**

<img width="606" height="317" alt="image" src="https://github.com/user-attachments/assets/fc2ab5ba-7233-454d-a70c-2174933c5fd6" />

**Validation curve (`val-core/flow_grpo/ocr/reward/mean@1`):**

<img width="806" height="478" alt="image" src="https://github.com/user-attachments/assets/68b44dca-95be-425d-bc5b-671c2bbe5264" />

The model rapidly improves OCR accuracy from ~0.06 to ~0.8 within 100 steps and maintains high performance. The slight drop after step 150 is expected variance from the stochastic reward evaluation.

**Qualitative examples (validation generations):**

Prompt 1: *"A wooden trail marker stands in a dense forest, its surface weathered by time. The words **"Hidden Trail"** are carved deeply into the wood, surrounded by moss and foliage."*

| Step 10 (score: 0.0) | Step 30 (score: 0.0) | Step 50 (score: 0.0) | Step 70 (score: 1.0) | Step 100 (score: 1.0) |
|---|---|---|---|---|
| <img width="512" height="512" alt="image" src="https://github.com/user-attachments/assets/3f4ecf28-b362-4f8a-9fea-cd7263c6baf0" /> | <img width="512" height="512" alt="image" src="https://github.com/user-attachments/assets/74c71e57-36b1-44f7-bf49-e83939edc281" /> | <img width="512" height="512" alt="image" src="https://github.com/user-attachments/assets/84e9da43-9876-4485-a924-bdf920c8472f" /> | <img width="512" height="512" alt="image" src="https://github.com/user-attachments/assets/cc36ee47-59fc-4b7e-a360-0985f846d386" /> | <img width="512" height="512" alt="image" src="https://github.com/user-attachments/assets/b2d70062-54ae-4a18-a261-1de4191e7724" /> |

Prompt 2: *"A birthday card interior with a whimsical, pastel-colored design, featuring the message **"Make A Wish"** in elegant, cursive handwriting, surrounded by sparkling candles and colorful confetti."*

| Step 10 (score: 0.33) | Step 30 (score: 0.67) | Step 50 (score: 1.0) | Step 70 (score: 0.89) | Step 100 (score: 1.0) |
|---|---|---|---|---|
| <img width="512" height="512" alt="image" src="https://github.com/user-attachments/assets/665ef158-1535-4f7b-8751-b1949a9e69d5" /> | <img width="512" height="512" alt="image" src="https://github.com/user-attachments/assets/6217ab64-f5f1-4e8b-b6ff-d2cc8ebcd7be" /> | <img width="512" height="512" alt="image" src="https://github.com/user-attachments/assets/f2f8a74b-8f37-4488-a9dd-3134661dba2d" /> | <img width="512" height="512" alt="image" src="https://github.com/user-attachments/assets/9da631f4-7372-4a05-9c82-3d28275b7b9f" /> | <img width="512" height="512" alt="image" src="https://github.com/user-attachments/assets/2aeb8123-3174-4bca-ad78-549ec79c3d5f" /> |

Key observations:
- The model learns to render accurate text by step 50-100, going from illegible or missing text to perfect OCR scores.
- Image composition and scene detail remain high quality throughout — the reward service focuses purely on text accuracy without degrading visual quality.
- The HTTP reward server introduces negligible latency: `timing_s/reward` is essentially 0, confirming that async concurrent calls to the server are efficient.

### API and Usage Example

```bash
# 1. Start external OCR reward server (separate process/machine)
# See: https://github.com/deepgenteam/deepgen_rl/tree/main/rewards_services/api_services/ocr_scorer_service
# The service interface format follows: https://github.com/yifan123/flow_grpo#3-reward-preparation
cd rewards_services/api_services/ocr_scorer_service
bash run.sh  # Starts on port 19082

# 2. Prepare data (stores full prompt as ground_truth for HTTP service)
python examples/flowgrpo_trainer/data_process/qwenimage_ocr_http_service.py \
    --input_dir ~/dataset/ocr/ --output_dir ~/data/ocr_http

# 3. Run training
OCR_REWARD_SERVER_URL=http://<server-ip>:19082 \
    bash examples/flowgrpo_trainer/run_qwen_image_ocr_reward_server.sh
```

The key config pattern for HTTP reward services:

```bash
reward.reward_model.enable=False \
reward.reward_manager.name=MultiVisualRewardManager \
"+reward.reward_functions.ocr.path=pkg://verl_omni.utils.reward_score.http_scorer_client" \
'+reward.reward_functions.ocr.name=compute_score' \
'+reward.reward_functions.ocr.weight=1.0' \
"+reward.reward_functions.ocr.server_url=http://localhost:19082"
```

The `server_url` field is passed directly to `compute_score` via the new extra_args mechanism in `MultiVisualRewardManager`. Any custom field can be added this way — the framework uses signature-based filtering to pass only declared parameters.

### Reward Service Interface

The HTTP scorer client (`http_scorer_client.py`) communicates with external reward services using a pickle-based protocol, following the interface defined in [flow_grpo](https://github.com/yifan123/flow_grpo#3-reward-preparation). A reference implementation is available at [deepgen_rl/ocr_scorer_service](https://github.com/deepgenteam/deepgen_rl/tree/main/rewards_services/api_services/ocr_scorer_service).

**Request** (POST, body is `pickle.dumps(payload)`):

```python
{
    "images": List[bytes],    # JPEG-encoded image bytes
    "prompts": List[str],     # prompt/ground_truth strings
    "metadata": dict          # optional metadata (currently empty)
}
```

**Response** (body is `pickle.dumps(response)`):

```python
{
    "scores": List[float]     # one score per image, typically in [0, 1]
}
```

Any service that implements this interface can be used as a reward function — PaddleOCR, HPSv3, aesthetic scorers, CLIP-based scorers, etc. The service runs independently and can use any framework (PaddlePaddle, PyTorch, ONNX, etc.) without conflicting with the training environment.

### Design & Code Changes

#### High-level architecture

```
┌──────────────────────────────────────────────────────────────────┐
│               External HTTP Reward Server                         │
│  (e.g., PaddleOCR scorer on separate GPU/machine)                │
│  POST / → pickle({images, prompts, metadata})                    │
│  Response → pickle({scores: List[float]})                        │
└──────────────────────────────────┬───────────────────────────────┘
                                   │ HTTP (async, concurrent)
                                   │
┌──────────────────────────────────┼───────────────────────────────┐
│  MultiVisualRewardManager        │                               │
│                                  ▼                               │
│  run_single(data):                                               │
│    all_kwargs = {solution_image, ground_truth, ...}              │
│    sub_kwargs = {**all_kwargs, **extra_args}  ← NEW: server_url  │
│    filtered_kwargs = _filter_kwargs(sub_kwargs, sig)             │
│    score = await compute_score(**filtered_kwargs)                │
└──────────────────────────────────────────────────────────────────┘
                                   │
┌──────────────────────────────────┼───────────────────────────────┐
│  http_scorer_client.compute_score(solution_image, ground_truth,  │
│                                   server_url, **kwargs)          │
│    1. tensor → PIL → JPEG bytes                                  │
│    2. pickle.dumps({images: [bytes], prompts: [gt], metadata})   │
│    3. aiohttp.post(server_url, data=payload)                     │
│    4. pickle.loads(response) → {"score": float}                  │
└──────────────────────────────────────────────────────────────────┘
```

#### Design decisions

1. **Extra args via config (not env vars):** Each reward function receives its own config fields (e.g., `server_url`) through the `reward.reward_functions.<key>.*` namespace. This is more declarative than env vars and naturally supports multiple HTTP reward services with different endpoints.

2. **Generic client, not OCR-specific:** `http_scorer_client.py` works with any scorer service that implements the pickle-based protocol (`{images, prompts, metadata} → {scores}`). The same client can be reused for HPS, aesthetic, or any future HTTP scorer.

3. **No framework plumbing needed:** By extending `MultiVisualRewardManager` to forward extra config fields, we avoid adding new config schemas or wiring code. The change is 6 lines in `multi.py`.

4. **Async by design:** The `compute_score` function is `async` using `aiohttp`, which means all samples in a batch hit the server concurrently via `asyncio.gather` in `RewardLoopWorker.compute_score_batch`. No serial bottleneck.

5. **Separate data preprocessing:** The HTTP scorer service expects the full prompt (with quoted text) as ground_truth, while the GenRM-based scorer expects bare text. A separate data preprocessing script (`qwenimage_ocr_http_service.py`) handles this difference cleanly.

#### File-by-file changes

| File | Change |
|------|--------|
| `verl_omni/reward_loop/reward_manager/multi.py` | Collect extra config fields per reward function entry and merge them into kwargs before filtering. (+9 lines) |
| `verl_omni/utils/reward_score/http_scorer_client.py` | New. Generic async HTTP scorer client implementing the `compute_score` interface. |
| `examples/flowgrpo_trainer/data_process/qwenimage_ocr_http_service.py` | New. Data preprocessing for HTTP scorer service format. |
| `examples/flowgrpo_trainer/run_qwen_image_ocr_reward_server.sh` | New. Example training script using external OCR reward server. |

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md).
- [x] Apply pre-commit checks.
- [x] Backward compatible — existing configs work unchanged (extra_args defaults to empty dict).
- [x] Validated with end-to-end training experiment (180+ steps, 4xB300).
- [x] No internal reward model GPU resources required for this configuration.
