### PR TITLE
[diffusion] feat: add multi-node Flow-GRPO reference script for Qwen-Image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,9 @@ logs
 log
 outputs
 .history
+
+# editor / assistant workspace artifacts
+.cursor/
+.cursorindexingignore
+.specstory/
+.run_logs/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,7 +58,7 @@ repos:
 
       - id: check-naming-conventions
         name: Check naming conventions
-        entry: sh -c 'fail=0; if grep -rIn --exclude-dir=.git --exclude-dir=.github --exclude-dir=venv --exclude-dir=.venv --exclude-dir=__pycache__ --exclude=.pre-commit-config.yaml "veRL" .; then echo "Please use verl instead of veRL"; fail=1; fi; if grep -rIn --exclude-dir=.git --exclude-dir=.github --exclude-dir=venv --exclude-dir=.venv --exclude-dir=__pycache__ --exclude=ascend_sglang_best_practices.rst --exclude=.pre-commit-config.yaml -E "Sglang|sgLang|sglAng|sglaNg|sglanG" .; then echo "Please use SGLang or sglang"; fail=1; fi; exit $fail'
+        entry: sh -c 'fail=0; if grep -rIn --exclude-dir=.git --exclude-dir=.github --exclude-dir=venv --exclude-dir=.venv --exclude-dir=__pycache__ --exclude-dir=.cursor --exclude-dir=.specstory --exclude-dir=.run_logs --exclude=.pre-commit-config.yaml "veRL" .; then echo "Please use verl instead of veRL"; fail=1; fi; if grep -rIn --exclude-dir=.git --exclude-dir=.github --exclude-dir=venv --exclude-dir=.venv --exclude-dir=__pycache__ --exclude-dir=.cursor --exclude-dir=.specstory --exclude-dir=.run_logs --exclude=ascend_sglang_best_practices.rst --exclude=.pre-commit-config.yaml -E "Sglang|sgLang|sglAng|sglaNg|sglanG" .; then echo "Please use SGLang or sglang"; fail=1; fi; exit $fail'
         language: system
         pass_filenames: false
 

--- a/examples/flowgrpo_trainer/README.md
+++ b/examples/flowgrpo_trainer/README.md
@@ -104,6 +104,22 @@ We have provided a script to enable non-cfg full-weight Qwen-Image OCR training.
 bash examples/flowgrpo_trainer/run_qwen_image_ocr.sh
 ```
 
+### Multi-node training (replica-level load balancing)
+
+For scaling Flow-GRPO beyond a single node, a multi-node reference script is provided that follows the design in [RFC #117](https://github.com/verl-project/verl-omni/issues/117): rollout `tensor_model_parallel_size=1` / `data_parallel_size=1` so each GPU becomes an independent `vLLMOmniReplica`, with verl's `GlobalRequestLoadBalancer` dispatching prompts via least-connection routing. Weight sync stays strictly intra-node via ZMQ IPC.
+
+```bash
+# On head node:
+ray start --head --port=6379 --num-gpus=8 \
+    --node-ip-address=$HEAD_IP --dashboard-host=0.0.0.0
+# On each worker node:
+ray start --address=$HEAD_IP:6379 --num-gpus=8
+# Then on the head node:
+NNODES=2 GPUS_PER_NODE=8 bash examples/flowgrpo_trainer/run_qwen_image_ocr_lora_multinode.sh
+```
+
+The script is parameterized via `NNODES` and `GPUS_PER_NODE`, defaulting to `2 x 8 = 16` GPUs. Batch sizes are scaled linearly from the 4-GPU baseline. For NCCL cross-node setup (`NCCL_SOCKET_IFNAME`, IB/RoCE), see the script header.
+
 
 ## Performance
 

--- a/examples/flowgrpo_trainer/run_qwen_image_ocr_lora_multinode.sh
+++ b/examples/flowgrpo_trainer/run_qwen_image_ocr_lora_multinode.sh
@@ -1,0 +1,133 @@
+# Qwen-Image LoRA Flow-GRPO, vllm_omni rollout
+# Multi-node training (2 nodes x 8 GPUs = 16 GPUs) using replica-level
+# load balancing, as proposed in RFC verl-project/verl-omni#117.
+#
+# Design (per RFC #117):
+#   - Actor: FSDP sharded across all 16 GPUs (cross-node NCCL).
+#   - Rollout (vllm-omni): TP=DP=1 -> 16 fully-independent single-GPU replicas.
+#     Each replica satisfies nnodes=1, so launch goes through `run_server`
+#     (NOT `run_headless`), bypassing the NotImplementedError in
+#     verl_omni/workers/rollout/vllm_rollout/vllm_omni_async_server.py.
+#   - ZMQ IPC weight sync stays strictly intra-node:
+#     ipc:///tmp/rl-colocate-zmq-{job_id}-replica-{rank}-rank-{local_rank}.sock
+#     Sender (ServerAdapter) and receiver (vLLMOmniColocateWorkerExtension)
+#     agree on (replica_rank, local_rank); since both live on the same GPU,
+#     no cross-node IPC routing is needed.
+#   - verl's GlobalRequestLoadBalancer + AgentLoopWorker form a decentralized
+#     gateway: only request_ids are routed, payloads (prompts, embed images)
+#     go directly from the local AgentLoopWorker to the assigned local HTTP
+#     server, maximizing cluster bandwidth.
+#
+# How to launch (typical Ray cluster setup):
+#   On head node (this script runs HERE):
+#     ray start --head --port=6379 --num-gpus=8 \
+#       --node-ip-address=$HEAD_IP \
+#       --dashboard-host=0.0.0.0
+#   On the second worker node:
+#     ray start --address=$HEAD_IP:6379 --num-gpus=8
+#   Then on the head node:
+#     bash examples/flowgrpo_trainer/run_qwen_image_ocr_lora_multinode.sh
+#
+# Make sure NCCL can reach the right NICs across nodes, e.g.:
+#   export NCCL_SOCKET_IFNAME=bond0   # or your inter-node NIC
+#   export GLOO_SOCKET_IFNAME=bond0
+#   export NCCL_IB_DISABLE=0          # enable IB / RoCE if available
+#   export NCCL_DEBUG=WARN
+#
+# Validates the 16-GPU scale-up scenario from the RFC's validation plan.
+
+set -x
+
+# Set WORKSPACE to any writable directory; defaults to $HOME
+WORKSPACE=${WORKSPACE:-$HOME}
+
+ocr_train_path=$WORKSPACE/data/ocr/train.parquet
+ocr_test_path=$WORKSPACE/data/ocr/test.parquet
+
+model_name=Qwen/Qwen-Image
+reward_model_name=Qwen/Qwen3-VL-8B-Instruct
+reward_function_path=verl_omni/utils/reward_score/genrm_ocr.py
+
+# ---- Cluster topology --------------------------------------------------------
+NNODES=${NNODES:-2}
+GPUS_PER_NODE=${GPUS_PER_NODE:-8}
+TOTAL_GPUS=$((NNODES * GPUS_PER_NODE))     # 16
+
+# ---- Parallelism -------------------------------------------------------------
+# Rollout: TP=1, DP=1 -> 16 independent vLLMOmniReplica instances (one per GPU).
+# Each replica's nnodes = (TP*DP)/GPUS_PER_NODE = 1, so run_headless is bypassed.
+ROLLOUT_TP=1
+# Reward: keep TP=4 so one reward server fits on 4 GPUs on a single node.
+# With TOTAL_GPUS=16 this yields 4 reward replicas (2 per node).
+REWARD_TP=4
+
+ENGINE=vllm_omni
+REWARD_ENGINE=vllm
+
+# ---- Batch sizing ------------------------------------------------------------
+# Single-node baseline (run_qwen_image_ocr_lora.sh): 4 GPUs, train_batch=32,
+# ppo_mini=16. Linearly scale by TOTAL_GPUS/4 = 4x to keep per-GPU work the
+# same while increasing global batch size, matching the RFC's "scale-up"
+# validation goal (equivalent per-GPU throughput, larger global batch).
+TRAIN_BATCH_SIZE=$((32 * TOTAL_GPUS / 4))   # 128
+PPO_MINI_BATCH_SIZE=$((16 * TOTAL_GPUS / 4)) # 64
+PPO_MICRO_BATCH_PER_GPU=16                   # unchanged
+
+# Number of AgentLoopWorker actors that fan out prompts in parallel and call
+# the HTTP servers. Following the existing convention (one client per
+# rollout replica): TOTAL_GPUS / ROLLOUT_TP. NOTE: this knob controls the
+# *clients*, not the number of replicas (replicas = total_gpus / TP / DP).
+ROLLOUT_NUM_WORKERS=$((TOTAL_GPUS / ROLLOUT_TP))   # 16
+
+python3 -m verl_omni.trainer.main_diffusion \
+    data.train_files=$ocr_train_path \
+    data.val_files=$ocr_test_path \
+    data.train_batch_size=$TRAIN_BATCH_SIZE \
+    data.max_prompt_length=256 \
+    actor_rollout_ref.model.algorithm=flow_grpo \
+    actor_rollout_ref.model.path=$model_name \
+    actor_rollout_ref.model.lora_rank=64 \
+    actor_rollout_ref.model.lora_alpha=128 \
+    actor_rollout_ref.model.target_modules="['to_q','to_k','to_v','to_out.0','add_q_proj','add_k_proj','add_v_proj','to_add_out','img_mlp.net.0.proj','img_mlp.net.2','txt_mlp.net.0.proj','txt_mlp.net.2']" \
+    actor_rollout_ref.actor.optim.lr=3e-4 \
+    actor_rollout_ref.actor.optim.weight_decay=0.0001 \
+    actor_rollout_ref.actor.ppo_mini_batch_size=$PPO_MINI_BATCH_SIZE \
+    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=$PPO_MICRO_BATCH_PER_GPU \
+    actor_rollout_ref.actor.fsdp_config.param_offload=True \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=True \
+    actor_rollout_ref.actor.fsdp_config.model_dtype=bfloat16 \
+    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=32 \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=$ROLLOUT_TP \
+    actor_rollout_ref.rollout.data_parallel_size=1 \
+    actor_rollout_ref.rollout.name=$ENGINE \
+    actor_rollout_ref.rollout.n=16 \
+    actor_rollout_ref.rollout.agent.num_workers=$ROLLOUT_NUM_WORKERS \
+    actor_rollout_ref.rollout.load_format=safetensors \
+    actor_rollout_ref.rollout.layered_summon=True \
+    actor_rollout_ref.rollout.pipeline.true_cfg_scale=4.0 \
+    actor_rollout_ref.rollout.pipeline.max_sequence_length=256 \
+    actor_rollout_ref.rollout.algo.noise_level=1.2 \
+    actor_rollout_ref.rollout.algo.sde_type="sde" \
+    actor_rollout_ref.rollout.algo.sde_window_size=2 \
+    actor_rollout_ref.rollout.algo.sde_window_range="[0,5]" \
+    actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=50 \
+    actor_rollout_ref.rollout.val_kwargs.algo.noise_level=0.0 \
+    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=32 \
+    reward.num_workers=$((TOTAL_GPUS / REWARD_TP)) \
+    reward.reward_model.enable=True \
+    reward.reward_model.model_path=$reward_model_name \
+    reward.reward_model.rollout.name=$REWARD_ENGINE \
+    reward.reward_model.rollout.tensor_model_parallel_size=$REWARD_TP \
+    reward.custom_reward_function.path=$reward_function_path \
+    reward.custom_reward_function.name=compute_score_ocr \
+    trainer.logger='["console", "wandb"]' \
+    trainer.project_name=flow_grpo \
+    trainer.experiment_name=qwen_image_ocr_lora_multinode_${NNODES}x${GPUS_PER_NODE} \
+    trainer.log_val_generations=8 \
+    trainer.val_before_train=False \
+    trainer.n_gpus_per_node=$GPUS_PER_NODE \
+    trainer.nnodes=$NNODES \
+    trainer.save_freq=30 \
+    trainer.test_freq=30 \
+    trainer.total_epochs=15 \
+    trainer.total_training_steps=300 "$@"


### PR DESCRIPTION
### What does this PR do?


Adds the first deliverable from [RFC #117](https://github.com/verl-project/verl-omni/issues/117) — a reference shell script for running Qwen-Image Flow-GRPO LoRA training across multiple nodes, using replica-level load balancing instead of vllm-omni's native DP.

**Configuration only — zero code changes** to `verl-omni` or `vllm-omni`. The design works by exploiting the existing degrees of freedom in `LLMServerManager` and `vLLMOmniReplica`:

- `rollout.tensor_model_parallel_size=1`, `rollout.data_parallel_size=1` → each GPU becomes an independent `vLLMOmniReplica` with `nnodes_per_replica=1`, taking the `run_server` branch and bypassing the unimplemented `run_headless` in `verl_omni/workers/rollout/vllm_rollout/vllm_omni_async_server.py`.
- verl's `GlobalRequestLoadBalancer` (least-connection + sticky LRU) routes only `server_id` strings across nodes; payloads stay node-local via `AgentLoopWorker` → local HTTP server. This avoids the master-NIC bottleneck of native DP, which is especially impactful for image-conditioned diffusion where per-prompt payloads are large.
- ZMQ IPC weight sync stays strictly intra-node: each actor/rollout pair shares a GPU, and the IPC handle keyed by `(job_id, replica_rank, local_rank)` matches automatically (see `verl/workers/rollout/vllm_rollout/vllm_rollout.py:108` ↔ `verl_omni/workers/rollout/vllm_rollout/utils.py:98`).


### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `vllm_omni`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `diffusion`, `omni`, `tests`, `docker`
  - If this PR involves multiple modules, separate them with `,` like `[diffusion, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][diffusion, fsdp] feat: new rollout scheduler`

### Test plan

Run on this PR so far:
- `bash -n examples/flowgrpo_trainer/run_qwen_image_ocr_lora_multinode.sh` — syntax check: PASS.
- `pre-commit run --all-files` on the staged diff — PASS.
- Source-traced the relevant code paths in `verl` and `verl_omni`:
  - `LLMServerManager._initialize_llm_servers` correctly derives `num_replicas = world_size_total / (TP·DP·PP)` for `TP=DP=PP=1` → 16 replicas on 16 GPUs.
  - `vLLMOmniReplica.launch_server` takes the `node_rank == 0 → run_server` branch when `nnodes_per_replica == 1`.
  - ZMQ handle keying matches between sender (`ServerAdapter`) and receiver (`vLLMOmniColocateWorkerExtension`).

Not yet run (this is why the PR is draft):
- [ ] End-to-end on a real 2-node × 8-GPU cluster (≥30 steps).
- [ ] A/B reward curve vs the 4-GPU single-node baseline.
- [ ] Throughput measurement (samples/GPU/s) for the linear-scaling claim.


### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update the documentation.
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl-omni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
