### PR TITLE
[tests] test: add CPU coverage for MixGRPO and GRPO-Guard

### DIFF
--- a/tests/pipelines/test_qwen_image_mix_grpo_on_cpu.py
+++ b/tests/pipelines/test_qwen_image_mix_grpo_on_cpu.py
@@ -1,0 +1,171 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU tests for MixGRPO pipeline registration and SDE window positioning."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+import verl_omni.pipelines  # noqa: F401 — trigger pipeline registration
+from verl_omni.pipelines.model_base import DiffusionModelBase, VllmOmniPipelineBase
+from verl_omni.pipelines.qwen_image_mix_grpo.diffusers_training_adapter import QwenImageMixGRPO
+from verl_omni.pipelines.qwen_image_mix_grpo.vllm_omni_rollout_adapter import (
+    QwenImageMixGRPOPipelineWithLogProb,
+)
+from verl_omni.workers.config.diffusion.model import DiffusionModelConfig
+
+
+def _make_model_config(algorithm: str = "mix_grpo") -> DiffusionModelConfig:
+    cfg = object.__new__(DiffusionModelConfig)
+    object.__setattr__(cfg, "architecture", "QwenImagePipeline")
+    object.__setattr__(cfg, "algorithm", algorithm)
+    object.__setattr__(cfg, "external_lib", None)
+    return cfg
+
+
+def _make_request(extra_args: dict) -> SimpleNamespace:
+    return SimpleNamespace(sampling_params=SimpleNamespace(extra_args=extra_args))
+
+
+class TestMixGRPORegistry:
+    def test_vllm_omni_rollout_pipeline_registered(self):
+        pipeline_cls = VllmOmniPipelineBase.get_class("QwenImagePipeline", "mix_grpo")
+        assert pipeline_cls is QwenImageMixGRPOPipelineWithLogProb
+
+    def test_training_adapter_registered(self):
+        model_config = _make_model_config()
+        assert DiffusionModelBase.get_class(model_config) is QwenImageMixGRPO
+
+
+class TestMixGRPOWindowPositioning:
+    def test_random_without_seed_is_noop(self):
+        extra = {
+            "sample_strategy": "random",
+            "sde_window_size": 2,
+            "sde_window_range": [0, 5],
+            "global_steps": 3,
+        }
+        req = _make_request(extra)
+        QwenImageMixGRPOPipelineWithLogProb._maybe_make_progressive_window(req, {})
+        assert extra["sde_window_range"] == [0, 5]
+
+    def test_random_with_seed_pins_window(self):
+        extra = {
+            "sample_strategy": "random",
+            "sde_window_seed": 42,
+            "sde_window_size": 2,
+            "sde_window_range": [0, 5],
+            "global_steps": 7,
+        }
+        req = _make_request(extra)
+        QwenImageMixGRPOPipelineWithLogProb._maybe_make_progressive_window(req, {})
+
+        start, end = extra["sde_window_range"]
+        assert end - start == 2
+        assert 0 <= start <= 3
+
+        # Same seed + global_steps must be deterministic across calls.
+        extra_copy = dict(extra)
+        req_copy = _make_request(extra_copy)
+        QwenImageMixGRPOPipelineWithLogProb._maybe_make_progressive_window(req_copy, {})
+        assert extra_copy["sde_window_range"] == extra["sde_window_range"]
+
+    def test_random_seed_changes_with_global_steps(self):
+        def pinned_start(global_steps: int) -> int:
+            extra = {
+                "sample_strategy": "random",
+                "sde_window_seed": 99,
+                "sde_window_size": 2,
+                "sde_window_range": [0, 10],
+                "global_steps": global_steps,
+            }
+            req = _make_request(extra)
+            QwenImageMixGRPOPipelineWithLogProb._maybe_make_progressive_window(req, {})
+            return extra["sde_window_range"][0]
+
+        assert pinned_start(0) != pinned_start(1)
+
+    def test_progressive_slides_window(self):
+        extra = {
+            "sample_strategy": "progressive",
+            "sde_window_size": 2,
+            "sde_window_range": [0, 8],
+            "iters_per_group": 2,
+            "global_steps": 4,
+        }
+        req = _make_request(extra)
+        QwenImageMixGRPOPipelineWithLogProb._maybe_make_progressive_window(req, {})
+        assert extra["sde_window_range"] == [4, 6]
+
+    def test_progressive_clamps_at_envelope_end(self):
+        extra = {
+            "sample_strategy": "progressive",
+            "sde_window_size": 2,
+            "sde_window_range": [0, 5],
+            "iters_per_group": 1,
+            "global_steps": 100,
+        }
+        req = _make_request(extra)
+        QwenImageMixGRPOPipelineWithLogProb._maybe_make_progressive_window(req, {})
+        assert extra["sde_window_range"] == [3, 5]
+
+    def test_progressive_without_window_size_is_noop(self):
+        extra = {
+            "sample_strategy": "progressive",
+            "sde_window_range": [0, 5],
+            "global_steps": 10,
+        }
+        req = _make_request(extra)
+        QwenImageMixGRPOPipelineWithLogProb._maybe_make_progressive_window(req, {})
+        assert extra["sde_window_range"] == [0, 5]
+
+    def test_unknown_strategy_is_noop(self):
+        extra = {
+            "sample_strategy": "fixed",
+            "sde_window_size": 2,
+            "sde_window_range": [0, 5],
+            "global_steps": 3,
+        }
+        req = _make_request(extra)
+        QwenImageMixGRPOPipelineWithLogProb._maybe_make_progressive_window(req, {})
+        assert extra["sde_window_range"] == [0, 5]
+
+    def test_window_size_from_kwargs(self):
+        extra = {
+            "sample_strategy": "progressive",
+            "sde_window_range": [0, 6],
+            "iters_per_group": 1,
+            "global_steps": 2,
+        }
+        req = _make_request(extra)
+        QwenImageMixGRPOPipelineWithLogProb._maybe_make_progressive_window(
+            req, {"sde_window_size": 2, "sde_window_range": [0, 6]}
+        )
+        assert extra["sde_window_range"] == [4, 6]
+
+    @pytest.mark.parametrize("strategy", ["random", "progressive"])
+    def test_invalid_window_raises(self, strategy: str):
+        extra = {
+            "sample_strategy": strategy,
+            "sde_window_size": 6,
+            "sde_window_range": [0, 5],
+            "global_steps": 0,
+        }
+        if strategy == "random":
+            extra["sde_window_seed"] = 1
+        req = _make_request(extra)
+        with pytest.raises(ValueError, match="does not fit"):
+            QwenImageMixGRPOPipelineWithLogProb._maybe_make_progressive_window(req, {})

--- a/tests/trainer/diffusion/test_diffusion_registry_on_cpu.py
+++ b/tests/trainer/diffusion/test_diffusion_registry_on_cpu.py
@@ -108,11 +108,18 @@ class TestDiffusionLossRegistry(unittest.TestCase):
     def test_builtin_flow_grpo_registered(self):
         assert "flow_grpo" in DIFFUSION_LOSS_REGISTRY
 
+    def test_builtin_grpo_guard_registered(self):
+        assert "grpo_guard" in DIFFUSION_LOSS_REGISTRY
+
     def test_builtin_kl_registered(self):
         assert "kl" in DIFFUSION_LOSS_REGISTRY
 
     def test_get_existing_loss_fn(self):
         fn = get_diffusion_loss_fn("flow_grpo")
+        assert callable(fn)
+
+    def test_get_grpo_guard_loss_fn(self):
+        fn = get_diffusion_loss_fn("grpo_guard")
         assert callable(fn)
 
     def test_get_unknown_loss_fn_raises(self):

--- a/tests/trainer/diffusion/test_rollout_correction_on_cpu.py
+++ b/tests/trainer/diffusion/test_rollout_correction_on_cpu.py
@@ -353,6 +353,118 @@ class TestLossIntegration:
             assert key in metrics, f"Missing metric: {key}"
 
 
+def _grpo_guard_tensors(batch_size: int) -> dict:
+    old_prev_sample_mean = torch.randn((batch_size, 4, 4, 4), dtype=torch.float32)
+    return {
+        "old_prev_sample_mean": old_prev_sample_mean,
+        "prev_sample_mean": old_prev_sample_mean + 0.01 * torch.randn_like(old_prev_sample_mean),
+        "std_dev_t": torch.full((batch_size, 1, 1, 1), 0.5, dtype=torch.float32),
+        "sqrt_dt": torch.full((batch_size,), 0.3, dtype=torch.float32),
+    }
+
+
+class TestGRPOGuardLossIntegration:
+    """Tests that rollout_is_weights affect the grpo_guard loss correctly."""
+
+    @pytest.fixture(scope="class")
+    def actor_config(self):
+        from hydra import compose, initialize_config_dir
+        from verl.utils.config import omega_conf_to_dataclass
+
+        config_dir = os.path.abspath("verl_omni/trainer/config/diffusion/actor")
+        with initialize_config_dir(config_dir=config_dir, version_base=None):
+            cfg = compose(
+                config_name="dp_diffusion_actor",
+                overrides=[
+                    "strategy=fsdp",
+                    "diffusion_loss.loss_mode=grpo_guard",
+                    "diffusion_loss.clip_ratio=2e-6",
+                    "diffusion_loss.adv_clip_max=5.0",
+                ],
+            )
+        return omega_conf_to_dataclass(cfg)
+
+    def test_rollout_is_weights_rejected_samples_zero_loss(self, actor_config):
+        batch_size = 8
+        old_log_prob = torch.randn(batch_size)
+        log_prob = torch.randn(batch_size)
+        advantages = torch.ones(batch_size)
+        rollout_is_weights = torch.cat(
+            [
+                torch.zeros(batch_size // 2),
+                torch.ones(batch_size // 2),
+            ]
+        )
+        guard_tensors = _grpo_guard_tensors(batch_size)
+
+        loss_fn = diffusion_algos.get_diffusion_loss_fn("grpo_guard")
+        loss, _ = loss_fn.compute_loss(
+            old_log_prob=old_log_prob,
+            log_prob=log_prob,
+            advantages=advantages,
+            config=actor_config,
+            rollout_is_weights=rollout_is_weights,
+            **guard_tensors,
+        )
+        loss_no_weights, _ = loss_fn.compute_loss(
+            old_log_prob=old_log_prob,
+            log_prob=log_prob,
+            advantages=advantages,
+            config=actor_config,
+            rollout_is_weights=None,
+            **guard_tensors,
+        )
+
+        assert loss.shape == ()
+        assert isinstance(loss.item(), float)
+        assert not torch.allclose(loss, loss_no_weights)
+
+    def test_all_rejected_gives_zero_loss(self, actor_config):
+        batch_size = 4
+        old_log_prob = torch.randn(batch_size)
+        log_prob = torch.randn(batch_size)
+        advantages = torch.ones(batch_size)
+        rollout_is_weights = torch.zeros(batch_size)
+        guard_tensors = _grpo_guard_tensors(batch_size)
+
+        loss_fn = diffusion_algos.get_diffusion_loss_fn("grpo_guard")
+        loss, _ = loss_fn.compute_loss(
+            old_log_prob=old_log_prob,
+            log_prob=log_prob,
+            advantages=advantages,
+            config=actor_config,
+            rollout_is_weights=rollout_is_weights,
+            **guard_tensors,
+        )
+
+        assert loss.item() == 0.0
+
+    def test_pg_metrics_present(self, actor_config):
+        batch_size = 8
+        old_log_prob = torch.randn(batch_size)
+        log_prob = torch.randn(batch_size)
+        advantages = torch.randn(batch_size)
+        guard_tensors = _grpo_guard_tensors(batch_size)
+
+        loss_fn = diffusion_algos.get_diffusion_loss_fn("grpo_guard")
+        _, metrics = loss_fn.compute_loss(
+            old_log_prob=old_log_prob,
+            log_prob=log_prob,
+            advantages=advantages,
+            config=actor_config,
+            rollout_is_weights=torch.ones(batch_size),
+            **guard_tensors,
+        )
+
+        for key in (
+            "actor/ppo_kl",
+            "actor/pg_clipfrac",
+            "actor/ratio_mean",
+            "actor/ratio_std",
+        ):
+            assert key in metrics, f"Missing metric: {key}"
+
+
 # ---------------------------------------------------------------------------
 # Config helpers
 # ---------------------------------------------------------------------------

--- a/tests/workers/config/test_diffusion_config_on_cpu.py
+++ b/tests/workers/config/test_diffusion_config_on_cpu.py
@@ -42,6 +42,11 @@ class TestDiffusionLossConfig:
         assert cfg.clip_ratio == pytest.approx(0.01)
         assert cfg.adv_clip_max == pytest.approx(10.0)
 
+    def test_grpo_guard_loss_mode_accepted(self):
+        cfg = DiffusionLossConfig(loss_mode="grpo_guard", clip_ratio=2e-6)
+        assert cfg.loss_mode == "grpo_guard"
+        assert cfg.clip_ratio == pytest.approx(2e-6)
+
     def test_invalid_loss_mode_raises(self):
         with pytest.raises(ValueError, match="Invalid diffusion loss_mode"):
             DiffusionLossConfig(loss_mode="not_a_valid_mode")


### PR DESCRIPTION


### What does this PR do?

Add cheap CPU unit tests for MixGRPO window positioning/registry dispatch and extend GRPO-Guard coverage (loss registry, config validation, rollout correction integration) without expensive end-to-end runs.


### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `vllm_omni`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `diffusion`, `omni`, `tests`, `docker`
  - If this PR involves multiple modules, separate them with `,` like `[diffusion, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][diffusion, fsdp] feat: new rollout scheduler`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update the documentation.
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl-omni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
