### PR TITLE
[recipe, doc] feat: add mixgrpo/grpoguard and full-weight flowgrpo fo…

### DIFF
--- a/docs/start/install.md
+++ b/docs/start/install.md
@@ -1,6 +1,6 @@
 # Installation
 
-Last updated: 05/14/2026
+Last updated: 06/03/2026
 
 ## Requirements
 
@@ -10,7 +10,7 @@ For NVIDIA GPU:
 
 For Ascend NPU:
 - **Python**: Version >= 3.10
-- **CANN**: Version == 9.0.0
+- **CANN**: Version >= 8.5.0
 
 ## Install
 
@@ -35,7 +35,7 @@ uv pip install "vllm-omni @ git+https://github.com/vllm-project/vllm-omni.git@c7
 For Ascend NPU:
 
 ```bash
-uv pip install vllm==0.20.2
+uv pip install "vllm @ git+https://github.com/vllm-project/vllm.git@releases/v0.20.2"
 uv pip install "vllm-ascend @ git+https://github.com/vllm-project/vllm-ascend.git@07f6fec2aa4404e1283c4cd6c0981aa878bc5be9"
 uv pip install "vllm-omni @ git+https://github.com/vllm-project/vllm-omni.git@c7178d89bb7a70817f239febc84c3b21a714dae7"
 ```

--- a/examples/flowgrpo_trainer/README.md
+++ b/examples/flowgrpo_trainer/README.md
@@ -104,6 +104,11 @@ We have provided a script to enable non-cfg full-weight Qwen-Image OCR training.
 bash examples/flowgrpo_trainer/run_qwen_image_ocr.sh
 ```
 
+An NPU script for Atlas A3 with 16 NPUs is also provided. Before running, set the `ASCEND_HOME_PATH` environment variable (defaults to `/usr/local/Ascend/cann-9.0.0`).
+
+```bash
+bash examples/flowgrpo_trainer/run_qwen_image_ocr_npu.sh
+```
 
 ## Performance
 

--- a/examples/flowgrpo_trainer/run_qwen_image_ocr_npu.sh
+++ b/examples/flowgrpo_trainer/run_qwen_image_ocr_npu.sh
@@ -1,0 +1,81 @@
+# Qwen-Image full-weight RL, vllm_omni rollout
+set -x
+ASCEND_HOME_PATH=${ASCEND_HOME_PATH:-/usr/local/Ascend/cann-9.0.0}
+source $ASCEND_HOME_PATH/set_env.sh
+source $ASCEND_HOME_PATH/../nnal/atb/set_env.sh
+
+export RAY_memory_usage_threshold=0.98
+
+# Set WORKSPACE to any writable directory; defaults to $HOME
+WORKSPACE=${WORKSPACE:-$HOME}
+
+ocr_train_path=$WORKSPACE/data/ocr/qwen_image/train.parquet
+ocr_test_path=$WORKSPACE/data/ocr/qwen_image/test.parquet
+
+model_name=Qwen/Qwen-Image
+reward_model_name=Qwen/Qwen3-VL-8B-Instruct
+reward_function_path=verl_omni/utils/reward_score/genrm_ocr.py
+
+# use Atlas A3 16-NPU for this large experiment
+NUM_GPUS_ACTOR_ROLLOUT_REWARD=16
+ROLLOUT_TP=2
+REWARD_TP=4
+IMAGE_RESOLUTION=512
+
+ENGINE=vllm_omni
+REWARD_ENGINE=vllm
+
+
+python3 -m verl_omni.trainer.main_diffusion \
+    trainer.device=npu \
+    algorithm.adv_estimator=flow_grpo \
+    data.train_files=$ocr_train_path \
+    data.val_files=$ocr_test_path \
+    data.train_batch_size=32 \
+    data.max_prompt_length=256 \
+    actor_rollout_ref.model.path=$model_name \
+    actor_rollout_ref.model.attn_backend='_native_npu' \
+    actor_rollout_ref.actor.optim.lr=3e-5 \
+    actor_rollout_ref.actor.optim.weight_decay=0.0001 \
+    actor_rollout_ref.actor.ppo_mini_batch_size=16 \
+    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=4 \
+    actor_rollout_ref.actor.fsdp_config.param_offload=True \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=True \
+    actor_rollout_ref.actor.diffusion_loss.loss_mode=flow_grpo \
+    actor_rollout_ref.actor.diffusion_loss.clip_ratio=1e-5 \
+    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=32 \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=$ROLLOUT_TP \
+    actor_rollout_ref.rollout.name=$ENGINE \
+    actor_rollout_ref.rollout.n=16 \
+    actor_rollout_ref.rollout.agent.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / ROLLOUT_TP)) \
+    actor_rollout_ref.rollout.load_format=safetensors \
+    actor_rollout_ref.rollout.layered_summon=True \
+    actor_rollout_ref.rollout.pipeline.true_cfg_scale=1.0 \
+    actor_rollout_ref.rollout.pipeline.height=$IMAGE_RESOLUTION \
+    actor_rollout_ref.rollout.pipeline.width=$IMAGE_RESOLUTION \
+    actor_rollout_ref.rollout.pipeline.max_sequence_length=256 \
+    actor_rollout_ref.rollout.algo.noise_level=1.2 \
+    actor_rollout_ref.rollout.algo.sde_type="sde" \
+    actor_rollout_ref.rollout.algo.sde_window_size=2 \
+    actor_rollout_ref.rollout.algo.sde_window_range="[0,5]" \
+    actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=50 \
+    actor_rollout_ref.rollout.val_kwargs.algo.noise_level=0.0 \
+    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=32 \
+    reward.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / REWARD_TP)) \
+    reward.reward_model.enable=True \
+    reward.reward_model.model_path=$reward_model_name \
+    reward.reward_model.rollout.name=$REWARD_ENGINE \
+    reward.reward_model.rollout.tensor_model_parallel_size=$REWARD_TP \
+    reward.custom_reward_function.path=$reward_function_path \
+    reward.custom_reward_function.name=compute_score_ocr \
+    trainer.logger='["console", "wandb"]' \
+    trainer.project_name=flow_grpo \
+    trainer.experiment_name=qwen_image_ocr \
+    trainer.log_val_generations=8 \
+    trainer.val_before_train=False \
+    trainer.n_gpus_per_node=$NUM_GPUS_ACTOR_ROLLOUT_REWARD \
+    trainer.nnodes=1 \
+    trainer.save_freq=30 \
+    trainer.test_freq=30 \
+    trainer.total_epochs=15 \
+    trainer.total_training_steps=300 "$@"

--- a/examples/grpoguard_trainer/README.md
+++ b/examples/grpoguard_trainer/README.md
@@ -12,7 +12,7 @@ Follow the [installation guide](../../docs/start/install.md) to set up the base 
 pip install Levenshtein
 ```
 
-The provided script is configured for a single node with `4` GPUs.
+The provided GPU script is configured for a single node with `4` GPUs. An NPU script for Ascend 800T A2 with `8` NPUs is also available (see [Run training](#run-training) below).
 
 ## Prepare the dataset
 
@@ -43,11 +43,21 @@ This produces:
 
 Launch the example from the repository root:
 
+**GPU (4 GPUs):**
+
 ```bash
 bash examples/grpoguard_trainer/run_qwen_image_ocr_lora.sh
 ```
 
-The script runs `python3 -m verl_omni.trainer.main_diffusion` with:
+**NPU (8 NPUs, Atlas 800T A2):**
+
+The NPU script requires the CANN software stack. Before running, set the `ASCEND_HOME_PATH` environment variable (defaults to `/usr/local/Ascend/cann-9.0.0`).
+
+```bash
+bash examples/grpoguard_trainer/run_qwen_image_ocr_lora_npu.sh
+```
+
+The scripts run `python3 -m verl_omni.trainer.main_diffusion` with:
 
 - `algorithm.adv_estimator=flow_grpo`
 - `actor_rollout_ref.model.path=Qwen/Qwen-Image`
@@ -58,7 +68,16 @@ The script runs `python3 -m verl_omni.trainer.main_diffusion` with:
 - `actor_rollout_ref.actor.diffusion_loss.clip_ratio=2e-6`
 - `actor_rollout_ref.rollout.algo.sde_type=sde`
 - `reward.custom_reward_function.name=compute_score_ocr`
-- `trainer.n_gpus_per_node=4`
+
+Due to differences in memory capacity, the NPU and GPU configurations differ as follows:
+
+| Parameter | GPU | NPU |
+|---|---|---|
+| `trainer.device` | gpu (default) | `npu` |
+| `actor_rollout_ref.model.attn_backend` | default | `_native_npu` |
+| `trainer.n_gpus_per_node` | 4 | 8 |
+| `actor_rollout_ref.rollout.tensor_model_parallel_size` | 1 | 2 |
+| `actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu` | 16 | 4 |
 
 ## Logging
 

--- a/examples/grpoguard_trainer/run_qwen_image_ocr_lora_npu.sh
+++ b/examples/grpoguard_trainer/run_qwen_image_ocr_lora_npu.sh
@@ -1,0 +1,80 @@
+# Qwen-Image lora RL with GRPO-Guard (https://arxiv.org/abs/2510.22319), vllm_omni rollout
+set -x
+ASCEND_HOME_PATH=${ASCEND_HOME_PATH:-/usr/local/Ascend/cann-9.0.0}
+source $ASCEND_HOME_PATH/set_env.sh
+source $ASCEND_HOME_PATH/../nnal/atb/set_env.sh
+
+# Set WORKSPACE to any writable directory; defaults to $HOME
+WORKSPACE=${WORKSPACE:-$HOME}
+
+ocr_train_path=$WORKSPACE/data/ocr/qwen_image/train.parquet
+ocr_test_path=$WORKSPACE/data/ocr/qwen_image/test.parquet
+
+model_name=Qwen/Qwen-Image
+reward_model_name=Qwen/Qwen3-VL-8B-Instruct
+reward_function_path=verl_omni/utils/reward_score/genrm_ocr.py
+
+NUM_GPUS_ACTOR_ROLLOUT_REWARD=8
+ROLLOUT_TP=2
+REWARD_TP=4
+
+ENGINE=vllm_omni
+REWARD_ENGINE=vllm
+
+
+python3 -m verl_omni.trainer.main_diffusion \
+    trainer.device=npu \
+    algorithm.adv_estimator=flow_grpo \
+    data.train_files=$ocr_train_path \
+    data.val_files=$ocr_test_path \
+    data.train_batch_size=32 \
+    data.max_prompt_length=256 \
+    actor_rollout_ref.model.path=$model_name \
+    actor_rollout_ref.model.lora_rank=64 \
+    actor_rollout_ref.model.lora_alpha=128 \
+    actor_rollout_ref.model.target_modules="['to_q','to_k','to_v','to_out.0','add_q_proj','add_k_proj','add_v_proj','to_add_out','img_mlp.net.0.proj','img_mlp.net.2','txt_mlp.net.0.proj','txt_mlp.net.2']" \
+    actor_rollout_ref.model.attn_backend='_native_npu' \
+    actor_rollout_ref.actor.optim.lr=3e-4 \
+    actor_rollout_ref.actor.optim.weight_decay=0.0001 \
+    actor_rollout_ref.actor.ppo_mini_batch_size=16 \
+    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=4 \
+    actor_rollout_ref.actor.fsdp_config.param_offload=True \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=True \
+    actor_rollout_ref.actor.fsdp_config.model_dtype=bfloat16 \
+    actor_rollout_ref.actor.diffusion_loss.loss_mode=grpo_guard \
+    actor_rollout_ref.actor.diffusion_loss.clip_ratio=2e-6 \
+    actor_rollout_ref.actor.diffusion_loss.adv_clip_max=5.0 \
+    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=32 \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=$ROLLOUT_TP \
+    actor_rollout_ref.rollout.name=$ENGINE \
+    actor_rollout_ref.rollout.n=16 \
+    actor_rollout_ref.rollout.agent.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / ROLLOUT_TP)) \
+    actor_rollout_ref.rollout.load_format=safetensors \
+    actor_rollout_ref.rollout.layered_summon=True \
+    actor_rollout_ref.rollout.pipeline.true_cfg_scale=4.0 \
+    actor_rollout_ref.rollout.pipeline.max_sequence_length=256 \
+    actor_rollout_ref.rollout.algo.noise_level=1.2 \
+    actor_rollout_ref.rollout.algo.sde_type="sde" \
+    actor_rollout_ref.rollout.algo.sde_window_size=2 \
+    actor_rollout_ref.rollout.algo.sde_window_range="[0,5]" \
+    actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=50 \
+    actor_rollout_ref.rollout.val_kwargs.algo.noise_level=0.0 \
+    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=32 \
+    reward.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / REWARD_TP)) \
+    reward.reward_model.enable=True \
+    reward.reward_model.model_path=$reward_model_name \
+    reward.reward_model.rollout.name=$REWARD_ENGINE \
+    reward.reward_model.rollout.tensor_model_parallel_size=$REWARD_TP \
+    reward.custom_reward_function.path=$reward_function_path \
+    reward.custom_reward_function.name=compute_score_ocr \
+    trainer.logger='["console", "wandb"]' \
+    trainer.project_name=grpo_guard \
+    trainer.experiment_name=qwen_image_ocr_lora \
+    trainer.log_val_generations=8 \
+    trainer.val_before_train=False \
+    trainer.n_gpus_per_node=$NUM_GPUS_ACTOR_ROLLOUT_REWARD \
+    trainer.nnodes=1 \
+    trainer.save_freq=30 \
+    trainer.test_freq=30 \
+    trainer.total_epochs=15 \
+    trainer.total_training_steps=300 "$@"

--- a/examples/mixgrpo_trainer/README.md
+++ b/examples/mixgrpo_trainer/README.md
@@ -14,7 +14,7 @@ Follow the [installation guide](../../docs/start/install.md) to set up the base 
 pip install Levenshtein
 ```
 
-The provided script is configured for a single node with `4` GPUs.
+The provided GPU script is configured for a single node with `4` GPUs. An NPU script for Ascend 800T A2 with `8` NPUs is also available (see [Run training](#run-training) below).
 
 ## Prepare the dataset
 
@@ -45,8 +45,18 @@ This produces:
 
 Launch the example from the repository root:
 
+**GPU (4 GPUs):**
+
 ```bash
 bash examples/mixgrpo_trainer/run_qwen_image_ocr_lora_mixgrpo.sh
+```
+
+**NPU (8 NPUs, Atlas 800T A2):**
+
+The NPU script requires the CANN software stack. Before running, set the `ASCEND_HOME_PATH` environment variable (defaults to `/usr/local/Ascend/cann-9.0.0`).
+
+```bash
+bash examples/mixgrpo_trainer/run_qwen_image_ocr_lora_mixgrpo_npu.sh
 ```
 
 ### MixGRPO Tuning

--- a/examples/mixgrpo_trainer/run_qwen_image_ocr_lora_mixgrpo_npu.sh
+++ b/examples/mixgrpo_trainer/run_qwen_image_ocr_lora_mixgrpo_npu.sh
@@ -1,0 +1,85 @@
+# Qwen-Image LoRA RL with MixGRPO sliding-window SDE training (vllm_omni rollout)
+#
+# Reference: MixGRPO (Tencent-Hunyuan), https://arxiv.org/abs/2507.21802
+#            https://github.com/Tencent-Hunyuan/MixGRPO
+#
+set -x
+ASCEND_HOME_PATH=${ASCEND_HOME_PATH:-/usr/local/Ascend/cann-9.0.0}
+source $ASCEND_HOME_PATH/set_env.sh
+source $ASCEND_HOME_PATH/../nnal/atb/set_env.sh
+
+# Set WORKSPACE to any writable directory; defaults to $HOME
+WORKSPACE=${WORKSPACE:-$HOME}
+
+ocr_train_path=$WORKSPACE/data/ocr/qwen_image/train.parquet
+ocr_test_path=$WORKSPACE/data/ocr/qwen_image/test.parquet
+
+model_name=Qwen/Qwen-Image
+reward_model_name=Qwen/Qwen3-VL-8B-Instruct
+reward_function_path=verl_omni/utils/reward_score/genrm_ocr.py
+
+NUM_GPUS_ACTOR_ROLLOUT_REWARD=8
+ROLLOUT_TP=2
+REWARD_TP=4
+
+ENGINE=vllm_omni
+REWARD_ENGINE=vllm
+
+
+python3 -m verl_omni.trainer.main_diffusion \
+    trainer.device=npu \
+    algorithm.adv_estimator=flow_grpo \
+    data.train_files=$ocr_train_path \
+    data.val_files=$ocr_test_path \
+    data.train_batch_size=32 \
+    data.max_prompt_length=256 \
+    actor_rollout_ref.model.algorithm=mix_grpo \
+    actor_rollout_ref.model.path=$model_name \
+    actor_rollout_ref.model.lora_rank=64 \
+    actor_rollout_ref.model.lora_alpha=128 \
+    actor_rollout_ref.model.target_modules="['to_q','to_k','to_v','to_out.0','add_q_proj','add_k_proj','add_v_proj','to_add_out','img_mlp.net.0.proj','img_mlp.net.2','txt_mlp.net.0.proj','txt_mlp.net.2']" \
+    actor_rollout_ref.model.attn_backend='_native_npu' \
+    actor_rollout_ref.actor.optim.lr=3e-4 \
+    actor_rollout_ref.actor.optim.weight_decay=0.0001 \
+    actor_rollout_ref.actor.ppo_mini_batch_size=16 \
+    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=4 \
+    actor_rollout_ref.actor.fsdp_config.param_offload=True \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=True \
+    actor_rollout_ref.actor.fsdp_config.model_dtype=bfloat16 \
+    actor_rollout_ref.actor.diffusion_loss.loss_mode=flow_grpo \
+    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=32 \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=$ROLLOUT_TP \
+    actor_rollout_ref.rollout.name=$ENGINE \
+    actor_rollout_ref.rollout.n=16 \
+    actor_rollout_ref.rollout.agent.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / ROLLOUT_TP)) \
+    actor_rollout_ref.rollout.load_format=safetensors \
+    actor_rollout_ref.rollout.layered_summon=True \
+    actor_rollout_ref.rollout.pipeline.true_cfg_scale=4.0 \
+    actor_rollout_ref.rollout.pipeline.max_sequence_length=256 \
+    actor_rollout_ref.rollout.algo.sample_strategy=random \
+    actor_rollout_ref.rollout.algo.sde_window_seed=42 \
+    actor_rollout_ref.rollout.algo.sde_window_size=2 \
+    actor_rollout_ref.rollout.algo.sde_window_range="[0,5]" \
+    actor_rollout_ref.rollout.algo.noise_level=1.2 \
+    actor_rollout_ref.rollout.algo.sde_type="sde" \
+    actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=50 \
+    actor_rollout_ref.rollout.val_kwargs.algo.noise_level=0.0 \
+    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=32 \
+    reward.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / REWARD_TP)) \
+    reward.reward_model.enable=True \
+    reward.reward_model.model_path=$reward_model_name \
+    reward.reward_model.rollout.name=$REWARD_ENGINE \
+    reward.reward_model.rollout.tensor_model_parallel_size=$REWARD_TP \
+    reward.custom_reward_function.path=$reward_function_path \
+    reward.custom_reward_function.name=compute_score_ocr \
+    trainer.logger='["console", "wandb"]' \
+    trainer.project_name=mix_grpo \
+    trainer.experiment_name=qwen_image_ocr_lora \
+    trainer.log_val_generations=8 \
+    trainer.val_before_train=False \
+    trainer.n_gpus_per_node=$NUM_GPUS_ACTOR_ROLLOUT_REWARD \
+    trainer.nnodes=1 \
+    trainer.save_freq=30 \
+    trainer.test_freq=30 \
+    trainer.total_epochs=15 \
+    trainer.total_training_steps=150 "$@"


### PR DESCRIPTION
…r Qwen-Image with npu bakcend

### What does this PR do?

Add npu training scripts for Qwen-Image model, including: 1. mixgrpo, 2. grpoguard, 3. full-weight Qwen-Image flowgrpo.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `vllm_omni`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `diffusion`, `omni`, `tests`, `docker`
  - If this PR involves multiple modules, separate them with `,` like `[diffusion, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][diffusion, fsdp] feat: new rollout scheduler`

### Test
1. result of mixgrpo validated on Atlas 800T A2 (CANN 9.0.0)
The reward value at step 0, 30, 60, 90 are 0.8999, 0.9074, 0.9306, and 0.9323, and the loss and reward curves are as follow:

actor
<img width="1686" height="908" alt="image" src="https://github.com/user-attachments/assets/92d6f96e-b5dd-45cf-b823-b0adb16cf81d" />

critic
<img width="1684" height="426" alt="image" src="https://github.com/user-attachments/assets/ad3cfc12-42c4-4f1e-94f9-f539e6ed7602" />

2. result of grpoguard validated on Atlas 800T A2 (CANN 9.0.0)
The reward value at step 0, 30, 60, 90 are 0.9013, 0.9173, 0.9524, and the loss and reward curves are as follow:

actor
<img width="1680" height="856" alt="image" src="https://github.com/user-attachments/assets/62661da4-a5bd-4a8a-87a9-fb66d593ea5d" />

critic
<img width="1678" height="426" alt="image" src="https://github.com/user-attachments/assets/20676822-107e-4ba9-b7c4-38c92871a3c0" />

val
<img width="410" height="422" alt="image" src="https://github.com/user-attachments/assets/6bbfbc2e-cd84-4660-ad03-57c3fd423f4f" />

3. result of full-weight flowgrpo validated  on Atlas 800T A3 (CANN 9.0.0) with 16 cards
The reward value at step 30, 60, 90, 120 are 0.5186, 0.6985, 0.88, and 0.9232, and the loss and reward curves are as follow:

actor
<img width="1682" height="906" alt="image" src="https://github.com/user-attachments/assets/8ac7adc0-921c-463b-8e56-3377b12c5e92" />

critic
<img width="1674" height="360" alt="image" src="https://github.com/user-attachments/assets/a4101b0c-730f-400d-81c5-b29f5a113111" />

val
<img width="402" height="352" alt="image" src="https://github.com/user-attachments/assets/4b0eaae9-a199-4fb4-9a27-f2ab417f761a" />

### API and Usage Example
```bash
bash examples/mixgrpo_trainer/run_qwen_image_ocr_lora_mixgrpo_npu.sh
```
```bash
bash examples/grpoguard_trainer/run_qwen_image_ocr_lora_npu.sh
```
```bash
bash examples/flowgrpo_trainer/run_qwen_image_ocr_npu.sh
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update the documentation.
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl-omni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
