### PR TITLE
[tests] test: add guard for null-seed rollout 

### DIFF
--- a/tests/agent_loop/test_diffusion_rollout_seed_gpu.py
+++ b/tests/agent_loop/test_diffusion_rollout_seed_gpu.py
@@ -200,6 +200,55 @@ def test_rollout_seed_reproducible_and_diverse_via_agent_loop(seed_rollout_confi
         ray.shutdown()
 
 
+def test_rollout_without_seed_produces_different_initial_latents(seed_rollout_config):
+    """When ``rollout_seed`` is not provided, initial latents must differ across reruns.
+
+    This is the default training behaviour when the rollout config does not set a seed.
+    """
+    ray.init(
+        runtime_env={
+            "env_vars": {
+                "TOKENIZERS_PARALLELISM": "true",
+                "NCCL_DEBUG": "WARN",
+                "VLLM_LOGGING_LEVEL": "INFO",
+            }
+        }
+    )
+    try:
+        AgentLoopManager.agent_loop_workers_class = ray.remote(DiffusionAgentLoopWorker)
+        llm_server_manager = LLMServerManager.create(config=seed_rollout_config)
+        agent_loop_manager = AgentLoopManager.create(
+            config=seed_rollout_config,
+            llm_client=llm_server_manager.get_client(),
+        )
+
+        n = seed_rollout_config.actor_rollout_ref.rollout.n
+        batch = _make_prompt_batch(num_prompts=1).repeat(n)
+        batch.meta_info["global_steps"] = 1
+
+        # Pin the global RNG so the first run is deterministic and the second
+        # run inevitably uses a different RNG state, avoiding a flaky pass.
+        torch.manual_seed(0)
+
+        first = agent_loop_manager.generate_sequences(prompts=batch)
+        second = agent_loop_manager.generate_sequences(prompts=batch)
+
+        latents_first = _initial_latents(first)
+        latents_second = _initial_latents(second)
+        assert latents_first.shape[0] == n
+        assert not torch.equal(latents_first, latents_second), (
+            "identical batch without rollout_seed must produce different initial latents across reruns"
+        )
+
+        for i in range(n):
+            for j in range(i + 1, n):
+                assert not torch.equal(latents_first[i], latents_first[j]), (
+                    f"rollout indices {i} and {j} must not share the same initial latent"
+                )
+    finally:
+        ray.shutdown()
+
+
 @pytest.mark.xfail(
     reason=(
         "AgentLoopManager chunks rollouts across workers; each worker derives per-row seeds from "

--- a/tests/agent_loop/test_diffusion_rollout_seed_gpu.py
+++ b/tests/agent_loop/test_diffusion_rollout_seed_gpu.py
@@ -225,10 +225,7 @@ def test_rollout_without_seed_produces_different_initial_latents(seed_rollout_co
         n = seed_rollout_config.actor_rollout_ref.rollout.n
         batch = _make_prompt_batch(num_prompts=1).repeat(n)
         batch.meta_info["global_steps"] = 1
-
-        # Pin the global RNG so the first run is deterministic and the second
-        # run inevitably uses a different RNG state, avoiding a flaky pass.
-        torch.manual_seed(0)
+        # Deliberately omit rollout_seed — the default behaviour.
 
         first = agent_loop_manager.generate_sequences(prompts=batch)
         second = agent_loop_manager.generate_sequences(prompts=batch)

--- a/tests/agent_loop/test_diffusion_rollout_seed_gpu.py
+++ b/tests/agent_loop/test_diffusion_rollout_seed_gpu.py
@@ -200,18 +200,12 @@ def test_rollout_seed_reproducible_and_diverse_via_agent_loop(seed_rollout_confi
         ray.shutdown()
 
 
-@pytest.mark.parametrize(
-    "rollout_config_fixture",
-    ["seed_rollout_config", "multi_worker_seed_rollout_config"],
-)
-def test_rollout_without_seed_produces_different_initial_latents(request, rollout_config_fixture):
+def test_rollout_without_seed_produces_different_initial_latents(multi_worker_seed_rollout_config):
     """When ``rollout_seed`` is not provided, initial latents must differ across reruns.
 
     This is the default training behaviour when the rollout config does not set a seed.
-    Verified for both single-worker and multi-worker agent loop setups.
+    Uses a multi-worker setup which also covers the single-worker path.
     """
-    rollout_config = request.getfixturevalue(rollout_config_fixture)
-
     ray.init(
         runtime_env={
             "env_vars": {
@@ -223,13 +217,13 @@ def test_rollout_without_seed_produces_different_initial_latents(request, rollou
     )
     try:
         AgentLoopManager.agent_loop_workers_class = ray.remote(DiffusionAgentLoopWorker)
-        llm_server_manager = LLMServerManager.create(config=rollout_config)
+        llm_server_manager = LLMServerManager.create(config=multi_worker_seed_rollout_config)
         agent_loop_manager = AgentLoopManager.create(
-            config=rollout_config,
+            config=multi_worker_seed_rollout_config,
             llm_client=llm_server_manager.get_client(),
         )
 
-        n = rollout_config.actor_rollout_ref.rollout.n
+        n = multi_worker_seed_rollout_config.actor_rollout_ref.rollout.n
         batch = _make_prompt_batch(num_prompts=1).repeat(n)
         batch.meta_info["global_steps"] = 1
         # Deliberately omit rollout_seed — the default behaviour.

--- a/tests/agent_loop/test_diffusion_rollout_seed_gpu.py
+++ b/tests/agent_loop/test_diffusion_rollout_seed_gpu.py
@@ -200,11 +200,18 @@ def test_rollout_seed_reproducible_and_diverse_via_agent_loop(seed_rollout_confi
         ray.shutdown()
 
 
-def test_rollout_without_seed_produces_different_initial_latents(seed_rollout_config):
+@pytest.mark.parametrize(
+    "rollout_config_fixture",
+    ["seed_rollout_config", "multi_worker_seed_rollout_config"],
+)
+def test_rollout_without_seed_produces_different_initial_latents(request, rollout_config_fixture):
     """When ``rollout_seed`` is not provided, initial latents must differ across reruns.
 
     This is the default training behaviour when the rollout config does not set a seed.
+    Verified for both single-worker and multi-worker agent loop setups.
     """
+    rollout_config = request.getfixturevalue(rollout_config_fixture)
+
     ray.init(
         runtime_env={
             "env_vars": {
@@ -216,13 +223,13 @@ def test_rollout_without_seed_produces_different_initial_latents(seed_rollout_co
     )
     try:
         AgentLoopManager.agent_loop_workers_class = ray.remote(DiffusionAgentLoopWorker)
-        llm_server_manager = LLMServerManager.create(config=seed_rollout_config)
+        llm_server_manager = LLMServerManager.create(config=rollout_config)
         agent_loop_manager = AgentLoopManager.create(
-            config=seed_rollout_config,
+            config=rollout_config,
             llm_client=llm_server_manager.get_client(),
         )
 
-        n = seed_rollout_config.actor_rollout_ref.rollout.n
+        n = rollout_config.actor_rollout_ref.rollout.n
         batch = _make_prompt_batch(num_prompts=1).repeat(n)
         batch.meta_info["global_steps"] = 1
         # Deliberately omit rollout_seed — the default behaviour.


### PR DESCRIPTION
### What does this PR do?
The CI does not cover the case when `rollout seed` is None. We added here to make the test coverage of seed complete. 

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `vllm_omni`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `diffusion`, `omni`, `tests`, `docker`
  - If this PR involves multiple modules, separate them with `,` like `[diffusion, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][diffusion, fsdp] feat: new rollout scheduler`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update the documentation.
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl-omni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
