### PR TITLE
[cfg, tests] chore: upgrade verl dependency to 0.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Visit our documentation to learn more.
     <td>Diffusion generator</td>
     <td>Text → Image</td>
     <td>DPO</td>
-    <td>WIP</td>
+    <td>✅</td>
   </tr>
 </table>
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # requirements.txt records the full set of dependencies for development
-verl>=0.7.1
+verl>=0.8.0
 accelerate
 cachetools
 codetiming

--- a/tests/special_e2e/build_sd3_tiny_random.py
+++ b/tests/special_e2e/build_sd3_tiny_random.py
@@ -34,8 +34,6 @@ from tokenizers.trainers import BpeTrainer
 from transformers import (
     CLIPTextConfig,
     CLIPTextModelWithProjection,
-    CLIPTokenizer,
-    CLIPTokenizerFast,
     PreTrainedTokenizerFast,
     T5Config,
     T5EncoderModel,
@@ -68,8 +66,8 @@ _CLIP_VOCAB_WORDS = (
 )
 
 
-def _build_tiny_clip_tokenizer() -> CLIPTokenizerFast:
-    """Build a minimal CLIP tokenizer in memory (no Hub download)."""
+def _build_tiny_clip_tokenizer() -> PreTrainedTokenizerFast:
+    """Build a minimal CLIP-style tokenizer in memory (no Hub download)."""
     tokenizer = Tokenizer(BPE(unk_token="<|endoftext|>"))
     tokenizer.pre_tokenizer = ByteLevelPreTokenizer(add_prefix_space=False)
     tokenizer.decoder = ByteLevelDecoder()
@@ -84,22 +82,13 @@ def _build_tiny_clip_tokenizer() -> CLIPTokenizerFast:
         "a green triangle next to an orange rectangle",
     ]
     tokenizer.train_from_iterator(corpus, trainer=trainer)
-    # Export BPE vocab/merges, then round-trip via slow CLIP tokenizer — required by transformers>=4.17.
-    import tempfile
-
-    with tempfile.TemporaryDirectory() as tmp:
-        tokenizer.model.save(tmp)
-        slow_tokenizer = CLIPTokenizer(
-            vocab_file=os.path.join(tmp, "vocab.json"),
-            merges_file=os.path.join(tmp, "merges.txt"),
-            bos_token="<|startoftext|>",
-            eos_token="<|endoftext|>",
-            pad_token="<|endoftext|>",
-            model_max_length=77,
-        )
-        out_dir = os.path.join(tmp, "clip")
-        slow_tokenizer.save_pretrained(out_dir)
-        return CLIPTokenizerFast.from_pretrained(out_dir, from_slow=True)
+    return PreTrainedTokenizerFast(
+        tokenizer_object=tokenizer,
+        bos_token="<|startoftext|>",
+        eos_token="<|endoftext|>",
+        pad_token="<|endoftext|>",
+        model_max_length=77,
+    )
 
 
 def _build_tiny_t5_tokenizer(*, vocab_size: int = 1000, model_max_length: int = 512) -> PreTrainedTokenizerFast:

--- a/tests/special_e2e/build_sd3_tiny_random.py
+++ b/tests/special_e2e/build_sd3_tiny_random.py
@@ -34,6 +34,7 @@ from tokenizers.trainers import BpeTrainer
 from transformers import (
     CLIPTextConfig,
     CLIPTextModelWithProjection,
+    CLIPTokenizer,
     CLIPTokenizerFast,
     PreTrainedTokenizerFast,
     T5Config,
@@ -83,13 +84,22 @@ def _build_tiny_clip_tokenizer() -> CLIPTokenizerFast:
         "a green triangle next to an orange rectangle",
     ]
     tokenizer.train_from_iterator(corpus, trainer=trainer)
-    return CLIPTokenizerFast(
-        tokenizer_object=tokenizer,
-        bos_token="<|startoftext|>",
-        eos_token="<|endoftext|>",
-        pad_token="<|endoftext|>",
-        model_max_length=77,
-    )
+    # Export BPE vocab/merges, then round-trip via slow CLIP tokenizer — required by transformers>=4.17.
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tokenizer.model.save(tmp)
+        slow_tokenizer = CLIPTokenizer(
+            vocab_file=os.path.join(tmp, "vocab.json"),
+            merges_file=os.path.join(tmp, "merges.txt"),
+            bos_token="<|startoftext|>",
+            eos_token="<|endoftext|>",
+            pad_token="<|endoftext|>",
+            model_max_length=77,
+        )
+        out_dir = os.path.join(tmp, "clip")
+        slow_tokenizer.save_pretrained(out_dir)
+        return CLIPTokenizerFast.from_pretrained(out_dir, from_slow=True)
 
 
 def _build_tiny_t5_tokenizer(*, vocab_size: int = 1000, model_max_length: int = 512) -> PreTrainedTokenizerFast:

--- a/tests/special_e2e/create_dummy_offline_dpo_data.py
+++ b/tests/special_e2e/create_dummy_offline_dpo_data.py
@@ -54,9 +54,7 @@ def _encode_image_latent(pipe, image: Image.Image, height: int, width: int, devi
     pixel_values = pixel_values.to(device=device, dtype=pipe.vae.dtype)
     with torch.no_grad():
         # Tiny SD3 VAE can fail cuDNN SDPA plan selection; fall back to math SDP.
-        import torch.nn.attention as attention
-
-        with attention.sdpa_kernel(backends=[attention.SDPBackend.MATH]):
+        with torch.nn.attention.sdpa_kernel(backends=[torch.nn.attention.SDPBackend.MATH]):
             latents = pipe.vae.encode(pixel_values).latent_dist.sample()
     scaling_factor = getattr(pipe.vae.config, "scaling_factor", 1.0)
     shift_factor = getattr(pipe.vae.config, "shift_factor", 0.0)

--- a/tests/special_e2e/create_dummy_offline_dpo_data.py
+++ b/tests/special_e2e/create_dummy_offline_dpo_data.py
@@ -53,7 +53,11 @@ def _encode_image_latent(pipe, image: Image.Image, height: int, width: int, devi
     pixel_values = pipe.image_processor.preprocess([image], height=height, width=width)
     pixel_values = pixel_values.to(device=device, dtype=pipe.vae.dtype)
     with torch.no_grad():
-        latents = pipe.vae.encode(pixel_values).latent_dist.sample()
+        # Tiny SD3 VAE can fail cuDNN SDPA plan selection; fall back to math SDP.
+        import torch.nn.attention as attention
+
+        with attention.sdpa_kernel(backends=[attention.SDPBackend.MATH]):
+            latents = pipe.vae.encode(pixel_values).latent_dist.sample()
     scaling_factor = getattr(pipe.vae.config, "scaling_factor", 1.0)
     shift_factor = getattr(pipe.vae.config, "shift_factor", 0.0)
     latents = (latents - shift_factor) * scaling_factor


### PR DESCRIPTION
### What does this PR do?

upgrade verl dependency to 0.8.0

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `vllm_omni`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `diffusion`, `omni`, `tests`, `docker`
  - If this PR involves multiple modules, separate them with `,` like `[diffusion, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][diffusion, fsdp] feat: new rollout scheduler`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

<img width="2822" height="1272" alt="image" src="https://github.com/user-attachments/assets/e707a3ab-ef0d-45a4-8d13-80981e036c49" />


<img width="984" height="714" alt="image" src="https://github.com/user-attachments/assets/c05ad6d0-dea6-4085-8ad4-9638c71749b0" />



### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update the documentation.
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl-omni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
