### PR TITLE
[vllm_omni, rollout, trainer, reward, fsdp, algo, tests, doc] feat: add Qwen-Image-Edit-2511 FlowGRPO training support

### DIFF
--- a/docs/algo/flowgrpo.md
+++ b/docs/algo/flowgrpo.md
@@ -300,6 +300,32 @@ bash examples/flowgrpo_trainer/run_qwen_image_ocr_lora_sp2.sh
 ```
 
 
+### Image Editing (Qwen-Image-Edit-Plus)
+
+FlowGRPO supports image-to-image editing models via the `QwenImageEditPlusPipeline`
+adapter. This handles condition-image latent concatenation and norm-preserving
+(rescaled) CFG during rollout.
+
+```bash
+bash examples/flowgrpo_trainer/run_qwen_image_edit_lora.sh
+```
+
+Key differences from the text-to-image OCR example:
+
+- `actor_rollout_ref.model.path=Qwen/Qwen-Image-Edit-2511`
+- The parquet data must include a `condition_image` column (source image for editing)
+- Reward is computed by `compute_score_image_edit` in
+  `verl_omni/utils/reward_score/genrm_image_edit.py`
+
+Prepare the image-editing dataset (ShareGPT-4o-Image-Mini) with:
+
+```bash
+python3 examples/flowgrpo_trainer/data_process/qwenimageedit_sharegpt4o.py \
+    --input_dir ~/data/sharegpt4o_image_mini \
+    --output_dir ~/data/sharegpt4o_image_mini_qwen_image_edit
+```
+
+
 ## Citation
 
 ```bibtex

--- a/examples/flowgrpo_trainer/README.md
+++ b/examples/flowgrpo_trainer/README.md
@@ -110,6 +110,24 @@ An NPU script for Atlas A3 with 16 NPUs is also provided. Before running, set th
 bash examples/flowgrpo_trainer/run_qwen_image_ocr_npu.sh
 ```
 
+### Image Editing (Qwen-Image-Edit-Plus)
+
+FlowGRPO also supports image-to-image editing models. The Qwen-Image-Edit-2511 script
+uses the `QwenImageEditPlusPipeline` adapter with condition-image latent concatenation
+and norm-preserving CFG:
+
+```bash
+bash examples/flowgrpo_trainer/run_qwen_image_edit_lora.sh
+```
+
+Prepare the image-editing dataset with:
+
+```bash
+python3 examples/flowgrpo_trainer/data_process/qwenimageedit_sharegpt4o.py \
+    --input_dir ~/data/sharegpt4o_image_mini \
+    --output_dir ~/data/sharegpt4o_image_mini_qwen_image_edit
+```
+
 ## Performance
 
 > All experiments were conducted on *NVIDIA H800* GPUs using the OCR reward.

--- a/examples/flowgrpo_trainer/data_process/qwenimageedit_sharegpt4o.py
+++ b/examples/flowgrpo_trainer/data_process/qwenimageedit_sharegpt4o.py
@@ -1,0 +1,133 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Preprocess ShareGPT-4o-Image-Mini into Qwen-Image-Edit parquet format."""
+
+import argparse
+import io
+import json
+import os
+from pathlib import Path
+
+import pandas as pd
+from PIL import Image, ImageOps
+from verl.utils.hdfs_io import copy, makedirs
+
+SYSTEM_PROMPT = (
+    "You are an image editing assistant. Given the input image and the user's edit instruction, "
+    "generate a new image that follows the instruction while preserving unrelated content."
+)
+
+
+def _load_image_bytes(image_dir: Path, image_name: str, image_size: int) -> bytes:
+    image_path = image_dir / image_name
+    image = Image.open(image_path).convert("RGB")
+    image = ImageOps.contain(image, (image_size, image_size), method=Image.Resampling.LANCZOS)
+    padded = Image.new("RGB", (image_size, image_size), color=(255, 255, 255))
+    left = (image_size - image.width) // 2
+    top = (image_size - image.height) // 2
+    padded.paste(image, (left, top))
+    buffer = io.BytesIO()
+    padded.save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+def _convert_split(input_dir: Path, split: str, max_samples: int, image_size: int) -> pd.DataFrame:
+    jsonl_path = input_dir / f"{split}.jsonl"
+    image_dir = input_dir / "images"
+    rows = []
+    with open(jsonl_path) as f:
+        for line in f:
+            example = json.loads(line)
+            instruction = str(example["prompt"])
+            image_name = str(example["image"])
+            source_img = {"bytes": _load_image_bytes(image_dir, image_name, image_size)}
+            rows.append(
+                {
+                    "data_source": "sharegpt4o_image_mini",
+                    "prompt": [
+                        {"role": "system", "content": SYSTEM_PROMPT},
+                        {"role": "user", "content": f"<image>\n{instruction}"},
+                    ],
+                    "negative_prompt": [
+                        {"role": "system", "content": SYSTEM_PROMPT},
+                        {"role": "user", "content": "<image>\n "},
+                    ],
+                    "ability": "image_edit",
+                    "images": [source_img],
+                    "reward_model": {"style": "model", "ground_truth": instruction},
+                    "extra_info": {
+                        "split": split,
+                        "index": len(rows),
+                        "instruction": instruction,
+                        "image": image_name,
+                        "source_img": source_img,
+                        "target_img": None,
+                    },
+                }
+            )
+            if max_samples > 0 and len(rows) >= max_samples:
+                break
+    return pd.DataFrame(rows)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Convert ShareGPT-4o-Image-Mini to Qwen-Image-Edit parquet format.")
+    parser.add_argument("--hdfs_dir", default=None)
+    parser.add_argument(
+        "--input_dir",
+        default="~/data/sharegpt4o_image_mini",
+        help="Path to the ShareGPT-4o-Image-Mini dataset directory.",
+    )
+    parser.add_argument(
+        "--output_dir",
+        default="~/data/sharegpt4o_image_mini_qwen_image_edit",
+        help="Directory to save converted parquet files.",
+    )
+    parser.add_argument("--train_size", type=int, default=-1, help="Maximum train samples; -1 keeps all samples.")
+    parser.add_argument("--val_size", type=int, default=-1, help="Maximum validation samples; -1 keeps all samples.")
+    parser.add_argument(
+        "--image_size",
+        type=int,
+        default=512,
+        help="Resize and pad condition images to this square size.",
+    )
+
+    args = parser.parse_args()
+    input_dir = Path(os.path.expanduser(args.input_dir))
+    output_dir = Path(os.path.expanduser(args.output_dir))
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    train_df = _convert_split(
+        input_dir=input_dir,
+        split="train",
+        max_samples=args.train_size,
+        image_size=args.image_size,
+    )
+    test_df = _convert_split(
+        input_dir=input_dir,
+        split="test",
+        max_samples=args.val_size,
+        image_size=args.image_size,
+    )
+
+    train_path = output_dir / "train.parquet"
+    test_path = output_dir / "test.parquet"
+    train_df.to_parquet(train_path)
+    test_df.to_parquet(test_path)
+    print(f"Wrote {len(train_df)} train samples to {train_path}")
+    print(f"Wrote {len(test_df)} test samples to {test_path}")
+
+    if args.hdfs_dir is not None:
+        makedirs(args.hdfs_dir)
+        copy(src=str(output_dir), dst=args.hdfs_dir)

--- a/examples/flowgrpo_trainer/run_qwen_image_edit_lora.sh
+++ b/examples/flowgrpo_trainer/run_qwen_image_edit_lora.sh
@@ -1,0 +1,142 @@
+# Qwen-Image-Edit-2511 LoRA RL on ShareGPT-4o-Image-Mini, vllm_omni rollout
+set -x
+
+export RAY_DEDUP_LOGS=0
+
+model_name=${MODEL_PATH:-Qwen/Qwen-Image-Edit-2511}
+reward_model_name=${REWARD_MODEL_PATH:-Qwen/Qwen3-VL-8B-Instruct}
+reward_function_path=${REWARD_FUNCTION_PATH:-verl_omni/utils/reward_score/genrm_image_edit.py}
+
+NUM_GPUS_ACTOR_ROLLOUT_REWARD=${NUM_GPUS_ACTOR_ROLLOUT_REWARD:-4}
+ACTOR_SP=${ACTOR_SP:-1}
+ROLLOUT_TP=${ROLLOUT_TP:-1}
+REWARD_TP=${REWARD_TP:-4}
+IMAGE_RESOLUTION=${IMAGE_RESOLUTION:-512}
+MAX_PROMPT_LENGTH=${MAX_PROMPT_LENGTH:-8192}
+
+ENGINE=vllm_omni
+REWARD_ENGINE=vllm
+
+# Qwen-Image-Edit stores its processor in a `processor/` subdirectory that lacks
+# a config.json with `model_type`, causing verl's hf_processor (AutoConfig) to fail.
+# Patch: write a minimal config.json into the processor dir so AutoConfig can
+# resolve the model type. This is idempotent and does not affect model weights.
+python3 - <<'PATCH_PROCESSOR'
+import json, pathlib, subprocess, sys
+
+model_id = "Qwen/Qwen-Image-Edit-2511"
+
+# Resolve the snapshot directory from HF cache
+try:
+    from huggingface_hub import snapshot_download
+    local = snapshot_download(model_id, local_files_only=True)
+except Exception:
+    import os
+    cache = os.path.expanduser("~/.cache/huggingface/hub")
+    slug = "models--" + model_id.replace("/", "--")
+    refs = pathlib.Path(cache) / slug / "refs" / "main"
+    if refs.exists():
+        sha = refs.read_text().strip()
+        local = str(pathlib.Path(cache) / slug / "snapshots" / sha)
+    else:
+        print("WARNING: could not locate Qwen-Image-Edit-2511 in HF cache; skipping processor patch", file=sys.stderr)
+        sys.exit(0)
+
+proc_dir = pathlib.Path(local) / "processor"
+cfg_file = proc_dir / "config.json"
+if proc_dir.exists() and not cfg_file.exists():
+    cfg_file.write_text(json.dumps({"model_type": "qwen2_vl"}))
+    print(f"Patched processor config: {cfg_file}")
+else:
+    print(f"Processor config already present or processor dir missing: {cfg_file}")
+PATCH_PROCESSOR
+
+# Optional reproducibility (yaml defaults are null / unseeded):
+#   data.seed=42
+#   actor_rollout_ref.rollout.seed=42
+
+script_path=$(readlink -f "$0")
+script_name=$(basename "$script_path" .sh)
+repo_root=$(dirname "$script_path")
+while [[ "$repo_root" != "/" && ! -f "$repo_root/LICENSE" ]]; do
+    repo_root=$(dirname "$repo_root")
+done
+if [[ ! -f "$repo_root/LICENSE" ]]; then
+    echo "Unable to locate repo root from $script_path: no LICENSE found" >&2
+    exit 1
+fi
+
+# Set WORKSPACE to any writable directory; defaults to the repository root.
+WORKSPACE=${WORKSPACE:-$repo_root}
+train_path=${TRAIN_FILES:-$WORKSPACE/data/sharegpt4o_image_mini_qwen_image_edit/train.parquet}
+test_path=${VAL_FILES:-$WORKSPACE/data/sharegpt4o_image_mini_qwen_image_edit/test.parquet}
+
+output_dir=$repo_root/outputs/$script_name
+checkpoint_dir=$output_dir/checkpoints
+run_timestamp=$(date +"%Y%m%d_%H%M")
+log_file=$output_dir/logs/$run_timestamp/${NODE_RANK:-0}.log
+rollout_data_dir=$output_dir/logs/$run_timestamp/rollout_images
+mkdir -p "$checkpoint_dir" "$(dirname "$log_file")"
+exec > >(tee -a "$log_file") 2>&1
+echo "Logging to $log_file"
+
+python3 -m verl_omni.trainer.main_diffusion \
+    data.train_files=$train_path \
+    data.val_files=$test_path \
+    data.train_batch_size=32 \
+    data.max_prompt_length=$MAX_PROMPT_LENGTH \
+    actor_rollout_ref.model.algorithm=flow_grpo \
+    actor_rollout_ref.model.path=$model_name \
+    actor_rollout_ref.model.lora_rank=64 \
+    actor_rollout_ref.model.lora_alpha=128 \
+    actor_rollout_ref.model.target_modules="['to_q','to_k','to_v','to_out.0','add_q_proj','add_k_proj','add_v_proj','to_add_out','img_mlp.net.0.proj','img_mlp.net.2','txt_mlp.net.0.proj','txt_mlp.net.2']" \
+    actor_rollout_ref.actor.optim.lr=3e-4 \
+    actor_rollout_ref.actor.optim.weight_decay=0.0001 \
+    actor_rollout_ref.actor.ppo_mini_batch_size=16 \
+    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=16 \
+    actor_rollout_ref.actor.fsdp_config.param_offload=True \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=True \
+    actor_rollout_ref.actor.fsdp_config.model_dtype=bfloat16 \
+    actor_rollout_ref.actor.fsdp_config.ulysses_sequence_parallel_size=$ACTOR_SP \
+    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=32 \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=$ROLLOUT_TP \
+    actor_rollout_ref.rollout.name=$ENGINE \
+    actor_rollout_ref.rollout.n=16 \
+    actor_rollout_ref.rollout.agent.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / ROLLOUT_TP)) \
+    actor_rollout_ref.rollout.load_format=safetensors \
+    actor_rollout_ref.rollout.layered_summon=True \
+    actor_rollout_ref.rollout.prompt_length=$MAX_PROMPT_LENGTH \
+    actor_rollout_ref.rollout.pipeline.num_inference_steps=10 \
+    actor_rollout_ref.rollout.pipeline.true_cfg_scale=4.0 \
+    actor_rollout_ref.rollout.pipeline.height=$IMAGE_RESOLUTION \
+    actor_rollout_ref.rollout.pipeline.width=$IMAGE_RESOLUTION \
+    actor_rollout_ref.rollout.pipeline.max_sequence_length=$MAX_PROMPT_LENGTH \
+    actor_rollout_ref.rollout.algo.noise_level=1.2 \
+    actor_rollout_ref.rollout.algo.sde_type="sde" \
+    actor_rollout_ref.rollout.algo.sde_window_size=2 \
+    actor_rollout_ref.rollout.algo.sde_window_range="[0,5]" \
+    actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=28 \
+    actor_rollout_ref.rollout.val_kwargs.algo.noise_level=0.0 \
+    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=32 \
+    reward.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / REWARD_TP)) \
+    reward.reward_model.enable=True \
+    reward.reward_model.model_path=$reward_model_name \
+    reward.reward_model.rollout.name=$REWARD_ENGINE \
+    reward.reward_model.rollout.tensor_model_parallel_size=$REWARD_TP \
+    reward.custom_reward_function.path=$reward_function_path \
+    reward.custom_reward_function.name=compute_score_image_edit \
+    trainer.logger='["console", "tensorboard"]' \
+    trainer.project_name=flow_grpo \
+    trainer.experiment_name=qwen_image_edit_sharegpt4o_image_mini_lora \
+    trainer.default_local_dir=$checkpoint_dir \
+    +trainer.rollout_data_dir=$rollout_data_dir \
+    trainer.log_val_generations=8 \
+    trainer.val_before_train=False \
+    trainer.n_gpus_per_node=$NUM_GPUS_ACTOR_ROLLOUT_REWARD \
+    trainer.nnodes=1 \
+    trainer.save_freq=1 \
+    trainer.test_freq=1 \
+    trainer.total_epochs=15 \
+    trainer.total_training_steps=300 \
+    '+reward.reward_model.rollout.engine_kwargs.vllm={mm_processor_cache_gb:0}' \
+    trainer.resume_mode=auto "$@"

--- a/tests/pipelines/test_qwen_image_edit_adapter_on_cpu.py
+++ b/tests/pipelines/test_qwen_image_edit_adapter_on_cpu.py
@@ -1,0 +1,671 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU tests for QwenImageEditPlus FlowGRPO training adapter
+and the rollout-side ``_get_qwen_prompt_embeds`` visual-feature wiring.
+
+Necessity: These adapters are the boundary between rollout-collected tensors and
+the transformer forward. Tests cover the I2I-specific condition-image latent
+concatenation, prompt input routing, CFG branching, and the noise-pred slicing
+that isolates target tokens from condition tokens. The rollout-adapter case
+asserts that ``pixel_values`` and ``image_grid_thw`` derived from
+``condition_images`` are forwarded to the Qwen2.5-VL text encoder — without
+this, ``<|image_pad|>`` tokens in the rollout's pre-tokenized prompt collapse
+to empty word embeddings and the diffusion transformer denoises into noise.
+All tests run on CPU without loading real weights.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+from tensordict import NonTensorData, TensorDict
+
+from verl_omni.pipelines.model_base import DiffusionModelBase
+from verl_omni.pipelines.qwen_image_edit_flow_grpo.diffusers_training_adapter import QwenImageEditPlus
+from verl_omni.pipelines.qwen_image_edit_flow_grpo.vllm_omni_rollout_adapter import (
+    QwenImageEditPlusPipelineWithLogProb,
+)
+from verl_omni.workers.config.diffusion.model import DiffusionModelConfig
+from verl_omni.workers.config.diffusion.rollout import DiffusionPipelineConfig, DiffusionRolloutAlgoConfig
+
+# ---------------------------------------------------------------------------
+# Tensor dimensions used throughout the tests
+#   batch_size         = 2
+#   n_steps            = 3   (SDE window steps stored in all_latents)
+#   latent_seq_len     = 16  (target image tokens in packed latent space)
+#   cond_seq_len       = 8   (condition image tokens — only for I2I)
+#   latent_channels    = 8
+#   text_seq_len       = 12
+#   text_channels      = 64
+# ---------------------------------------------------------------------------
+
+_B = 2
+_N = 3
+_LS = 16  # latent seq len (target)
+_CS = 8  # condition seq len
+_LC = 8  # latent channels
+_TS = 12  # text seq len
+_TC = 64  # text channels
+
+
+# ---------------------------------------------------------------------------
+# Config helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_model_config(
+    *,
+    algorithm: str = "flow_grpo",
+    true_cfg_scale: float = 1.0,
+    noise_level: float = 0.7,
+    sde_type: str = "sde",
+) -> DiffusionModelConfig:
+    """Build a minimal DiffusionModelConfig without triggering __post_init__."""
+    cfg = object.__new__(DiffusionModelConfig)
+    object.__setattr__(cfg, "architecture", "QwenImageEditPlusPipeline")
+    object.__setattr__(cfg, "algorithm", algorithm)
+    object.__setattr__(cfg, "external_lib", None)
+    object.__setattr__(cfg, "pipeline", DiffusionPipelineConfig(true_cfg_scale=true_cfg_scale))
+    object.__setattr__(cfg, "algo", DiffusionRolloutAlgoConfig(noise_level=noise_level, sde_type=sde_type))
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# Tensor helpers
+# ---------------------------------------------------------------------------
+
+
+def _batch_tensors():
+    """Return a dict of realistic test tensors."""
+    return {
+        # all_latents from rollout: [B, N+1, seq_len, C]
+        "all_latents": torch.randn(_B, _N + 1, _LS, _LC),
+        # all_timesteps from rollout: [B, N]
+        "all_timesteps": torch.rand(_B, _N) * 1000,
+        # condition image latents (I2I): [B, cond_seq_len, C]
+        "image_latents": torch.randn(_B, _CS, _LC),
+        "prompt_embeds": torch.randn(_B, _TS, _TC),
+        "prompt_embeds_mask": torch.ones(_B, _TS, dtype=torch.bool),
+        "negative_prompt_embeds": torch.randn(_B, _TS, _TC),
+        "negative_prompt_embeds_mask": torch.ones(_B, _TS, dtype=torch.bool),
+    }
+
+
+def _make_micro_batch(
+    tensors: dict, *, include_image_latents: bool = True, include_img_shapes: bool = True
+) -> TensorDict:
+    """Build a TensorDict micro_batch as the training worker would produce it."""
+    td_data = {}
+    if include_image_latents:
+        td_data["image_latents"] = tensors["image_latents"]
+
+    td = TensorDict(td_data, batch_size=_B)
+
+    if include_img_shapes:
+        # img_shapes for edit model: two image regions (target + condition)
+        img_shapes = [[(1, _LS // 4, _LS // 4), (1, _CS // 4, _CS // 4)]] * _B
+        td["img_shapes"] = NonTensorData(img_shapes)
+
+    return td
+
+
+def _make_scheduler_inputs(tensors: dict) -> dict:
+    return {
+        "all_latents": tensors["all_latents"],
+        "all_timesteps": tensors["all_timesteps"],
+    }
+
+
+# ===========================================================================
+# 1. Registry
+# ===========================================================================
+
+
+class TestQwenImageEditPlusRegistry:
+    def test_registered_for_flow_grpo(self):
+        cfg = _make_model_config(algorithm="flow_grpo")
+        assert DiffusionModelBase.get_class(cfg) is QwenImageEditPlus
+
+
+# ===========================================================================
+# 2. prepare_model_inputs — input construction
+# ===========================================================================
+
+
+class TestQwenImageEditPlusPrepareModelInputs:
+    def test_without_image_latents_hidden_states_equals_target_latent(self):
+        """When no condition image, hidden_states must be exactly the target latent."""
+        tensors = _batch_tensors()
+        micro_batch = _make_micro_batch(tensors, include_image_latents=False)
+        step = 0
+
+        model_inputs, negative_model_inputs = QwenImageEditPlus.prepare_model_inputs(
+            module=MagicMock(),
+            model_config=_make_model_config(),
+            latents=tensors["all_latents"],
+            timesteps=tensors["all_timesteps"],
+            prompt_embeds=tensors["prompt_embeds"],
+            prompt_embeds_mask=tensors["prompt_embeds_mask"],
+            negative_prompt_embeds=tensors["negative_prompt_embeds"],
+            negative_prompt_embeds_mask=tensors["negative_prompt_embeds_mask"],
+            micro_batch=micro_batch,
+            step=step,
+        )
+
+        expected_hidden = tensors["all_latents"][:, step]  # [B, LS, LC]
+        torch.testing.assert_close(model_inputs["hidden_states"], expected_hidden)
+
+    def test_image_latents_concatenated_along_seq_dim(self):
+        """Condition image latents must be concatenated with target latents on dim-1."""
+        tensors = _batch_tensors()
+        micro_batch = _make_micro_batch(tensors, include_image_latents=True)
+        step = 0
+
+        model_inputs, _ = QwenImageEditPlus.prepare_model_inputs(
+            module=MagicMock(),
+            model_config=_make_model_config(),
+            latents=tensors["all_latents"],
+            timesteps=tensors["all_timesteps"],
+            prompt_embeds=tensors["prompt_embeds"],
+            prompt_embeds_mask=tensors["prompt_embeds_mask"],
+            negative_prompt_embeds=tensors["negative_prompt_embeds"],
+            negative_prompt_embeds_mask=tensors["negative_prompt_embeds_mask"],
+            micro_batch=micro_batch,
+            step=step,
+        )
+
+        # hidden_states should be [B, LS + CS, LC]
+        assert model_inputs["hidden_states"].shape == (_B, _LS + _CS, _LC)
+
+    def test_positive_and_negative_share_hidden_states(self):
+        """Both positive and negative inputs use the same noised latent (only prompts differ)."""
+        tensors = _batch_tensors()
+        micro_batch = _make_micro_batch(tensors)
+        step = 1
+
+        model_inputs, negative_model_inputs = QwenImageEditPlus.prepare_model_inputs(
+            module=MagicMock(),
+            model_config=_make_model_config(),
+            latents=tensors["all_latents"],
+            timesteps=tensors["all_timesteps"],
+            prompt_embeds=tensors["prompt_embeds"],
+            prompt_embeds_mask=tensors["prompt_embeds_mask"],
+            negative_prompt_embeds=tensors["negative_prompt_embeds"],
+            negative_prompt_embeds_mask=tensors["negative_prompt_embeds_mask"],
+            micro_batch=micro_batch,
+            step=step,
+        )
+
+        torch.testing.assert_close(
+            model_inputs["hidden_states"],
+            negative_model_inputs["hidden_states"],
+        )
+
+    def test_timestep_is_divided_by_1000(self):
+        """Timestep must be scaled to [0, 1] range before being passed to the transformer."""
+        tensors = _batch_tensors()
+        micro_batch = _make_micro_batch(tensors)
+        step = 2
+
+        model_inputs, _ = QwenImageEditPlus.prepare_model_inputs(
+            module=MagicMock(),
+            model_config=_make_model_config(),
+            latents=tensors["all_latents"],
+            timesteps=tensors["all_timesteps"],
+            prompt_embeds=tensors["prompt_embeds"],
+            prompt_embeds_mask=tensors["prompt_embeds_mask"],
+            negative_prompt_embeds=tensors["negative_prompt_embeds"],
+            negative_prompt_embeds_mask=tensors["negative_prompt_embeds_mask"],
+            micro_batch=micro_batch,
+            step=step,
+        )
+
+        expected_timestep = tensors["all_timesteps"][:, step] / 1000.0
+        torch.testing.assert_close(model_inputs["timestep"], expected_timestep)
+
+    def test_positive_prompt_embeds_routed_correctly(self):
+        """Positive prompt embeds must end up in model_inputs, not negative_model_inputs."""
+        tensors = _batch_tensors()
+        micro_batch = _make_micro_batch(tensors)
+
+        model_inputs, negative_model_inputs = QwenImageEditPlus.prepare_model_inputs(
+            module=MagicMock(),
+            model_config=_make_model_config(),
+            latents=tensors["all_latents"],
+            timesteps=tensors["all_timesteps"],
+            prompt_embeds=tensors["prompt_embeds"],
+            prompt_embeds_mask=tensors["prompt_embeds_mask"],
+            negative_prompt_embeds=tensors["negative_prompt_embeds"],
+            negative_prompt_embeds_mask=tensors["negative_prompt_embeds_mask"],
+            micro_batch=micro_batch,
+            step=0,
+        )
+
+        torch.testing.assert_close(model_inputs["encoder_hidden_states"], tensors["prompt_embeds"])
+        torch.testing.assert_close(negative_model_inputs["encoder_hidden_states"], tensors["negative_prompt_embeds"])
+
+    def test_guidance_embed_is_none(self):
+        """QwenImageEditPlus does not use guidance embeds (always None)."""
+        tensors = _batch_tensors()
+        micro_batch = _make_micro_batch(tensors)
+
+        model_inputs, _ = QwenImageEditPlus.prepare_model_inputs(
+            module=MagicMock(),
+            model_config=_make_model_config(),
+            latents=tensors["all_latents"],
+            timesteps=tensors["all_timesteps"],
+            prompt_embeds=tensors["prompt_embeds"],
+            prompt_embeds_mask=tensors["prompt_embeds_mask"],
+            negative_prompt_embeds=tensors["negative_prompt_embeds"],
+            negative_prompt_embeds_mask=tensors["negative_prompt_embeds_mask"],
+            micro_batch=micro_batch,
+            step=0,
+        )
+
+        assert model_inputs["guidance"] is None
+
+    def test_img_shapes_from_micro_batch_used_when_present(self):
+        """img_shapes stored in micro_batch should pass through unchanged."""
+        tensors = _batch_tensors()
+        custom_shapes = [[(1, 4, 4), (1, 2, 2)]] * _B
+        micro_batch = TensorDict({}, batch_size=_B)
+        micro_batch["img_shapes"] = NonTensorData(custom_shapes)
+
+        model_inputs, _ = QwenImageEditPlus.prepare_model_inputs(
+            module=MagicMock(),
+            model_config=_make_model_config(),
+            latents=tensors["all_latents"],
+            timesteps=tensors["all_timesteps"],
+            prompt_embeds=tensors["prompt_embeds"],
+            prompt_embeds_mask=tensors["prompt_embeds_mask"],
+            negative_prompt_embeds=tensors["negative_prompt_embeds"],
+            negative_prompt_embeds_mask=tensors["negative_prompt_embeds_mask"],
+            micro_batch=micro_batch,
+            step=0,
+        )
+
+        assert model_inputs["img_shapes"] == custom_shapes
+
+
+# ===========================================================================
+# 3. forward_and_sample_previous_step — noise-pred and SDE step
+# ===========================================================================
+
+
+class TestQwenImageEditPlusForwardAndSamplePreviousStep:
+    def _make_scheduler_mock(self):
+        """Return a scheduler mock whose sample_previous_step returns plausible values."""
+        log_prob = torch.randn(_B)
+        prev_sample_mean = torch.randn(_B, _LS, _LC)
+        std_dev_t = torch.tensor(0.1)
+        sqrt_dt = torch.tensor(0.01)
+        scheduler = MagicMock()
+        scheduler.sample_previous_step.return_value = (
+            MagicMock(),  # unused prev_sample
+            log_prob,
+            prev_sample_mean,
+            std_dev_t,
+            sqrt_dt,
+        )
+        return scheduler
+
+    def test_noise_pred_sliced_to_target_seq_len(self):
+        """Transformer output (target + condition tokens) must be sliced to target tokens only."""
+        tensors = _batch_tensors()
+        step = 0
+        target_seq_len = tensors["all_latents"][:, step].shape[1]  # _LS
+
+        # Simulate transformer returning target + condition tokens concatenated
+        full_pred = torch.randn(_B, _LS + _CS, _LC)
+        module = MagicMock(return_value=(full_pred,))
+        scheduler = self._make_scheduler_mock()
+
+        model_inputs = {
+            "hidden_states": torch.randn(_B, _LS + _CS, _LC),
+            "return_dict": False,
+        }
+
+        QwenImageEditPlus.forward_and_sample_previous_step(
+            module=module,
+            scheduler=scheduler,
+            model_config=_make_model_config(true_cfg_scale=1.0),
+            model_inputs=model_inputs,
+            negative_model_inputs=None,
+            scheduler_inputs=_make_scheduler_inputs(tensors),
+            step=step,
+        )
+
+        # Verify sample_previous_step received noise_pred sliced to [B, LS, LC]
+        call_kwargs = scheduler.sample_previous_step.call_args
+        passed_noise_pred = call_kwargs.kwargs.get("model_output")
+        if passed_noise_pred is None:
+            passed_noise_pred = call_kwargs.args[1]
+        assert passed_noise_pred.shape == (_B, target_seq_len, _LC)
+
+    def test_no_cfg_single_forward_pass(self):
+        """When true_cfg_scale <= 1.0, the transformer must be called exactly once."""
+        tensors = _batch_tensors()
+        step = 0
+        noise_pred = torch.randn(_B, _LS, _LC)
+        module = MagicMock(return_value=(noise_pred,))
+        scheduler = self._make_scheduler_mock()
+
+        model_inputs = {"hidden_states": torch.randn(_B, _LS, _LC), "return_dict": False}
+
+        QwenImageEditPlus.forward_and_sample_previous_step(
+            module=module,
+            scheduler=scheduler,
+            model_config=_make_model_config(true_cfg_scale=1.0),
+            model_inputs=model_inputs,
+            negative_model_inputs=None,
+            scheduler_inputs=_make_scheduler_inputs(tensors),
+            step=step,
+        )
+
+        module.assert_called_once()
+
+    def test_cfg_requires_two_forward_passes(self):
+        """When true_cfg_scale > 1.0, the transformer is called for both positive and negative."""
+        tensors = _batch_tensors()
+        step = 0
+        pos_pred = torch.randn(_B, _LS, _LC)
+        neg_pred = torch.randn(_B, _LS, _LC)
+        module = MagicMock(side_effect=[(pos_pred,), (neg_pred,)])
+        scheduler = self._make_scheduler_mock()
+
+        model_inputs = {"hidden_states": torch.randn(_B, _LS, _LC), "return_dict": False}
+        negative_model_inputs = {"hidden_states": torch.randn(_B, _LS, _LC), "return_dict": False}
+
+        QwenImageEditPlus.forward_and_sample_previous_step(
+            module=module,
+            scheduler=scheduler,
+            model_config=_make_model_config(true_cfg_scale=3.0),
+            model_inputs=model_inputs,
+            negative_model_inputs=negative_model_inputs,
+            scheduler_inputs=_make_scheduler_inputs(tensors),
+            step=step,
+        )
+
+        assert module.call_count == 2
+
+    def test_cfg_applies_rescaled_norm_formula(self):
+        """Verify the norm-preserving CFG: combined pred is rescaled to positive pred's norm."""
+        tensors = _batch_tensors()
+        step = 0
+        true_cfg_scale = 3.0
+
+        pos_pred = torch.ones(_B, _LS, _LC)
+        neg_pred = torch.zeros(_B, _LS, _LC)
+        module = MagicMock(side_effect=[(pos_pred,), (neg_pred,)])
+        scheduler = self._make_scheduler_mock()
+
+        model_inputs = {"hidden_states": torch.randn(_B, _LS, _LC), "return_dict": False}
+        negative_model_inputs = {"hidden_states": torch.randn(_B, _LS, _LC), "return_dict": False}
+
+        QwenImageEditPlus.forward_and_sample_previous_step(
+            module=module,
+            scheduler=scheduler,
+            model_config=_make_model_config(true_cfg_scale=true_cfg_scale),
+            model_inputs=model_inputs,
+            negative_model_inputs=negative_model_inputs,
+            scheduler_inputs=_make_scheduler_inputs(tensors),
+            step=step,
+        )
+
+        call_kwargs = scheduler.sample_previous_step.call_args
+        passed_noise_pred = call_kwargs.kwargs.get("model_output")
+        if passed_noise_pred is None:
+            passed_noise_pred = call_kwargs.args[1]
+
+        comb = neg_pred + true_cfg_scale * (pos_pred - neg_pred)
+        cond_norm = torch.norm(pos_pred, dim=-1, keepdim=True)
+        noise_norm = torch.norm(comb, dim=-1, keepdim=True)
+        expected = comb * (cond_norm / noise_norm)
+        torch.testing.assert_close(passed_noise_pred, expected)
+
+    def test_requires_scheduler_inputs(self):
+        """scheduler_inputs=None must raise AssertionError (latent history is mandatory)."""
+        with pytest.raises(AssertionError):
+            QwenImageEditPlus.forward_and_sample_previous_step(
+                module=MagicMock(),
+                scheduler=MagicMock(),
+                model_config=_make_model_config(),
+                model_inputs={"hidden_states": torch.randn(_B, _LS, _LC), "return_dict": False},
+                negative_model_inputs=None,
+                scheduler_inputs=None,
+                step=0,
+            )
+
+
+# ===========================================================================
+# 4. Rollout adapter — _get_qwen_prompt_embeds visual-feature wiring
+# ===========================================================================
+
+
+class _SyntheticImage:
+    """Lightweight stand-in for PIL.Image — enough for downstream mocks."""
+
+    def __init__(self, size=(64, 64)):
+        self.size = size
+        self.mode = "RGB"
+
+
+class _RecordingTextEncoder:
+    """Captures the kwargs the rollout adapter passes into text_encoder()."""
+
+    dtype = torch.float32
+
+    def __init__(self, hidden_dim: int):
+        self.hidden_dim = hidden_dim
+        self.last_kwargs = None
+
+    def __call__(self, *, input_ids, attention_mask, output_hidden_states, pixel_values=None, image_grid_thw=None):
+        self.last_kwargs = {
+            "input_ids": input_ids,
+            "attention_mask": attention_mask,
+            "pixel_values": pixel_values,
+            "image_grid_thw": image_grid_thw,
+        }
+        batch, seq_len = input_ids.shape
+        return SimpleNamespace(hidden_states=[torch.randn(batch, seq_len, self.hidden_dim, dtype=torch.float32)])
+
+
+def _make_image_processor_mock(num_features_per_image: int = 4, hw: int = 14):
+    """Mimic Qwen2VLImageProcessor outputs without loading transformers weights."""
+
+    def _impl(*, images, return_tensors):
+        n = len(images)
+        return {
+            "pixel_values": torch.randn(n, num_features_per_image, hw * hw, dtype=torch.float32),
+            "image_grid_thw": torch.tensor([[1, hw, hw]] * n, dtype=torch.long),
+        }
+
+    proc = MagicMock(side_effect=lambda **kw: _impl(**kw))
+    return proc
+
+
+def _make_rollout_self(text_encoder, image_processor):
+    """Build a SimpleNamespace exposing every attribute that
+    QwenImageEditPlusPipelineWithLogProb._get_qwen_prompt_embeds reads.
+    Bypasses heavy QwenImageEditPlusPipeline construction.
+    """
+    return SimpleNamespace(
+        device=torch.device("cpu"),
+        text_encoder=text_encoder,
+        processor=SimpleNamespace(image_processor=image_processor),
+        prompt_template_encode_start_idx=0,
+        # Real impl splits hidden_states via the attention mask. For the test we
+        # just emit one row per batch item; that's all the surrounding code needs.
+        _extract_masked_hidden=lambda hidden_states, mask: list(hidden_states),
+    )
+
+
+class TestQwenImageEditRolloutVisualFeaturesWiring:
+    """Regression tests for the rollout fix that injects pixel_values /
+    image_grid_thw into the Qwen2.5-VL text_encoder. Without this wiring the
+    transformer denoises into noise — empirical symptom: noisy / garbled rollout
+    images.
+    """
+
+    def _run(self, condition_images):
+        text_encoder = _RecordingTextEncoder(hidden_dim=16)
+        image_processor = _make_image_processor_mock()
+        fake_self = _make_rollout_self(text_encoder, image_processor)
+        prompt_ids = torch.tensor([[1, 2, 3, 4, 5, 6, 7, 8]], dtype=torch.long)
+
+        prompt_embeds, mask = QwenImageEditPlusPipelineWithLogProb._get_qwen_prompt_embeds(
+            fake_self,
+            prompt_ids,
+            condition_images=condition_images,
+        )
+        return text_encoder, image_processor, prompt_embeds, mask
+
+    def test_pixel_values_and_image_grid_thw_injected_when_condition_images_present(self):
+        """The fix: condition_images must produce non-None pixel_values and
+        image_grid_thw on the text_encoder call.
+        """
+        text_encoder, image_processor, _, _ = self._run([_SyntheticImage(), _SyntheticImage()])
+
+        image_processor.assert_called_once()
+        kw = text_encoder.last_kwargs
+        assert kw is not None, "text_encoder was never invoked"
+        assert kw["pixel_values"] is not None, "pixel_values must be forwarded to text_encoder"
+        assert kw["image_grid_thw"] is not None, "image_grid_thw must be forwarded to text_encoder"
+        # N condition images -> N feature rows so each <|image_pad|> aligns to a real image
+        assert kw["pixel_values"].shape[0] == 2
+        assert kw["image_grid_thw"].shape[0] == 2
+
+    def test_pixel_values_dtype_matches_text_encoder(self):
+        """pixel_values must be cast to text_encoder.dtype to avoid silent fp mismatches."""
+        text_encoder, _, _, _ = self._run([_SyntheticImage()])
+        assert text_encoder.last_kwargs["pixel_values"].dtype == _RecordingTextEncoder.dtype
+
+    def test_no_image_processing_when_condition_images_none(self):
+        """The pre-fix path (no condition images) must keep image-feature kwargs as None."""
+        text_encoder, image_processor, _, _ = self._run(None)
+        assert image_processor.called is False
+        assert text_encoder.last_kwargs["pixel_values"] is None
+        assert text_encoder.last_kwargs["image_grid_thw"] is None
+
+    def test_no_image_processing_when_condition_images_empty(self):
+        """Empty list short-circuits image processing — guards against zero-image edge case."""
+        text_encoder, image_processor, _, _ = self._run([])
+        assert image_processor.called is False
+        assert text_encoder.last_kwargs["pixel_values"] is None
+        assert text_encoder.last_kwargs["image_grid_thw"] is None
+
+
+# ===========================================================================
+# 6. Rollout adapter — _pick_condition_images selection contract
+# ===========================================================================
+
+
+class TestPickConditionImagesSelection:
+    """``_pick_condition_images`` must prefer the *raw* PIL list that the agent
+    loop used to expand ``<|image_pad|>`` placeholders. Picking the resized
+    list from ``additional_information["condition_images"]`` would mismatch
+    the placeholder count and trigger a ``ValueError`` in the Qwen2.5-VL
+    text encoder. These tests pin the selection contract.
+    """
+
+    def _pick(self, custom_prompt):
+        from verl_omni.pipelines.qwen_image_edit_flow_grpo.vllm_omni_rollout_adapter import (
+            _pick_condition_images,
+        )
+
+        return _pick_condition_images(custom_prompt)
+
+    def test_prefers_raw_multi_modal_data_image_over_resized_additional(self):
+        raw = [_SyntheticImage(size=(512, 512)), _SyntheticImage(size=(640, 480))]
+        resized = [_SyntheticImage(size=(384, 384))]
+        custom_prompt = {
+            "multi_modal_data": {"image": raw},
+            "additional_information": {"condition_images": resized},
+        }
+        # The selection must return the RAW list (length 2, the actual images),
+        # not the resized one (length 1).
+        assert self._pick(custom_prompt) is raw
+
+    def test_picks_raw_even_when_shorter_than_resized(self):
+        """The contract is "raw beats resized when raw is non-empty" — not
+        "longer beats shorter". A regression that adds a length comparison
+        (e.g. ``if len(raw) >= len(resized)``) would flip the wrong way for
+        single-image edits and silently route the resized list through.
+        """
+        raw = [_SyntheticImage(size=(512, 512))]
+        resized = [
+            _SyntheticImage(size=(384, 384)),
+            _SyntheticImage(size=(384, 384)),
+            _SyntheticImage(size=(384, 384)),
+        ]
+        custom_prompt = {
+            "multi_modal_data": {"image": raw},
+            "additional_information": {"condition_images": resized},
+        }
+        assert self._pick(custom_prompt) is raw
+
+    def test_falls_back_to_additional_information_when_no_multi_modal(self):
+        # When the agent loop did not populate multi_modal_data (e.g. e2e
+        # smoke), ``additional_information["condition_images"]`` is the only
+        # available list. We accept it as a best-effort fallback.
+        resized = [_SyntheticImage(size=(384, 384))]
+        custom_prompt = {"additional_information": {"condition_images": resized}}
+        assert self._pick(custom_prompt) is resized
+
+    def test_falls_back_when_multi_modal_image_is_empty_list(self):
+        resized = [_SyntheticImage()]
+        custom_prompt = {
+            "multi_modal_data": {"image": []},
+            "additional_information": {"condition_images": resized},
+        }
+        # An empty raw list means no actual images were sent — fall through.
+        assert self._pick(custom_prompt) is resized
+
+    def test_falls_back_when_multi_modal_image_is_none(self):
+        resized = [_SyntheticImage()]
+        custom_prompt = {
+            "multi_modal_data": {"image": None},
+            "additional_information": {"condition_images": resized},
+        }
+        assert self._pick(custom_prompt) is resized
+
+    def test_returns_none_when_neither_source_has_images(self):
+        # Text-only prompt with no condition images at all.
+        custom_prompt = {"multi_modal_data": {"image": []}, "additional_information": {}}
+        assert self._pick(custom_prompt) is None
+
+    def test_returns_none_for_empty_dict(self):
+        assert self._pick({}) is None
+
+    def test_returns_none_for_non_dict_custom_prompt(self):
+        # Defensive: vllm-omni may pass a non-dict prompt under exotic configs.
+        assert self._pick("plain string prompt") is None
+        assert self._pick(None) is None
+
+    def test_handles_missing_multi_modal_data_key(self):
+        # additional_information present, multi_modal_data key absent.
+        resized = [_SyntheticImage()]
+        assert self._pick({"additional_information": {"condition_images": resized}}) is resized
+
+    def test_does_not_pick_non_list_image_field(self):
+        # If multi_modal_data["image"] is not a list (e.g. a single PIL by
+        # mistake), we do NOT take it — fall through to the resized list.
+        resized = [_SyntheticImage()]
+        custom_prompt = {
+            "multi_modal_data": {"image": _SyntheticImage()},
+            "additional_information": {"condition_images": resized},
+        }
+        # Selection contract requires a list to consume the raw branch.
+        assert self._pick(custom_prompt) is resized

--- a/tests/special_e2e/create_dummy_image_edit_data.py
+++ b/tests/special_e2e/create_dummy_image_edit_data.py
@@ -1,0 +1,111 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Create a small synthetic parquet dataset for Qwen-Image-Edit e2e testing.
+
+Generates data with an images column and a <image> placeholder in the prompt,
+matching RLHFDataset's multimodal input convention. Uses jpeg_compressibility
+reward so no external reward model is needed.
+"""
+
+import argparse
+import io
+import os
+
+import numpy as np
+import pandas as pd
+from PIL import Image
+
+SYSTEM_PROMPT = (
+    "Describe the key features of the input image "
+    "(color, shape, size, texture, objects, background), then explain how the user's "
+    "text instruction should alter or modify the image. Generate a new image that meets "
+    "the user's requirements while maintaining consistency with the original input where "
+    "appropriate."
+)
+
+USER_PROMPTS = [
+    "Change the background color to blue",
+    "Add a red hat to the character",
+    "Make the image look like a watercolor painting",
+    "Remove the text from the image",
+    "Convert the style to 3D cartoon",
+    "Add sunglasses to the person",
+    "Change the season from summer to winter",
+    "Make it look like a pencil sketch",
+]
+
+
+def _create_dummy_image(width: int = 256, height: int = 256, seed: int = 0) -> bytes:
+    """Create a small random RGB image and return PNG bytes."""
+    rng = np.random.default_rng(seed)
+    arr = rng.integers(0, 255, (height, width, 3), dtype=np.uint8)
+    img = Image.fromarray(arr, "RGB")
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def build_rows(split: str, n: int):
+    rows = []
+    for i in range(n):
+        prompt_text = USER_PROMPTS[i % len(USER_PROMPTS)]
+        condition_img_bytes = _create_dummy_image(256, 256, seed=i)
+        rows.append(
+            {
+                "data_source": "jpeg_compressibility",
+                "prompt": [
+                    {"role": "system", "content": SYSTEM_PROMPT},
+                    {"role": "user", "content": f"<image>\n{prompt_text}"},
+                ],
+                "negative_prompt": [
+                    {"role": "system", "content": SYSTEM_PROMPT},
+                    {"role": "user", "content": "<image>\n "},
+                ],
+                "images": [{"bytes": condition_img_bytes}],
+                "reward_model": {"style": "rule", "ground_truth": ""},
+                "extra_info": {"split": split, "index": i},
+            }
+        )
+    return rows
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate dummy image-edit parquet data for e2e testing")
+    parser.add_argument(
+        "--local_save_dir",
+        default=os.path.expanduser("~/data/dummy_image_edit"),
+        help="Directory to write train.parquet and test.parquet",
+    )
+    parser.add_argument("--train_size", type=int, default=4, help="Number of training samples")
+    parser.add_argument("--val_size", type=int, default=4, help="Number of validation samples")
+    args = parser.parse_args()
+
+    os.makedirs(args.local_save_dir, exist_ok=True)
+
+    train_df = pd.DataFrame(build_rows("train", args.train_size))
+    val_df = pd.DataFrame(build_rows("test", args.val_size))
+
+    train_path = os.path.join(args.local_save_dir, "train.parquet")
+    val_path = os.path.join(args.local_save_dir, "test.parquet")
+
+    train_df.to_parquet(train_path)
+    val_df.to_parquet(val_path)
+
+    print(f"Wrote {len(train_df)} train samples to {train_path}")
+    print(f"Wrote {len(val_df)} val samples to {val_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/special_e2e/run_flowgrpo_qwen_image_edit.sh
+++ b/tests/special_e2e/run_flowgrpo_qwen_image_edit.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# FlowGRPO diffusion e2e smoke test for Qwen-Image-Edit-Plus (vllm_omni rollout).
+#
+# Exercises the FlowGRPO pipeline with image editing model:
+#   parquet load (with condition_image) -> vllm_omni rollout -> visual reward
+#   (jpeg_compressibility, no reward model) -> flow_grpo -> FSDP LoRA -> sync.
+#
+# Requires: vllm-omni (commit c7178d89), diffusers>=0.37,
+#   tiny qwen-image-edit-plus at ~/models/tiny-random/qwen-image-edit-plus
+set -xeuo pipefail
+
+NUM_GPUS=${NUM_GPUS:-1}
+MODEL_PATH=${MODEL_PATH:-${HOME}/models/tiny-random/qwen-image-edit-plus}
+DATA_DIR=${DATA_DIR:-${HOME}/data/dummy_image_edit}
+dummy_train_path=${TRAIN_FILES:-${DATA_DIR}/train.parquet}
+dummy_test_path=${VAL_FILES:-${DATA_DIR}/test.parquet}
+TOTAL_TRAIN_STEPS=${TOTAL_TRAIN_STEPS:-1}
+ROLLOUT_TP=${ROLLOUT_TP:-1}
+ROLLOUT_WORKERS=${ROLLOUT_WORKERS:-$((NUM_GPUS / ROLLOUT_TP))}
+if [[ "${ROLLOUT_WORKERS}" -lt 1 ]]; then
+    echo "ROLLOUT_WORKERS must be >= 1 (NUM_GPUS=${NUM_GPUS}, ROLLOUT_TP=${ROLLOUT_TP})" >&2
+    exit 2
+fi
+
+ENGINE=vllm_omni
+max_prompt_length=512
+
+n_resp_per_prompt=2
+micro_bsz_per_gpu=1
+micro_bsz=$((micro_bsz_per_gpu * NUM_GPUS))
+mini_bsz=${micro_bsz}
+train_batch_size=$((mini_bsz * n_resp_per_prompt))
+
+# tiny-random/qwen-image-edit-plus ships processor files without config.json.
+# verl's hf_processor calls AutoConfig, so add the minimal metadata needed for
+# multimodal prompt extraction in local smoke tests.
+if [[ -d "${MODEL_PATH}/processor" && ! -f "${MODEL_PATH}/processor/config.json" ]]; then
+    python3 - <<PY
+from pathlib import Path
+Path("${MODEL_PATH}/processor/config.json").write_text('{"model_type":"qwen2_vl"}\n')
+PY
+fi
+
+python3 tests/special_e2e/create_dummy_image_edit_data.py \
+    --local_save_dir "${DATA_DIR}" \
+    --train_size "${train_batch_size}" \
+    --val_size 4
+
+# ── FlowGRPO: no reward model (jpeg_compressibility rule reward) ──────────────
+python3 -m verl_omni.trainer.main_diffusion \
+    data.train_files=${dummy_train_path} \
+    data.val_files=${dummy_test_path} \
+    data.train_batch_size=${train_batch_size} \
+    data.max_prompt_length=${max_prompt_length} \
+    actor_rollout_ref.model.algorithm=flow_grpo \
+    actor_rollout_ref.model.path=${MODEL_PATH} \
+    actor_rollout_ref.model.lora_rank=8 \
+    actor_rollout_ref.model.lora_alpha=16 \
+    actor_rollout_ref.model.target_modules="['to_q','to_k','to_v','to_out.0','add_q_proj','add_k_proj','add_v_proj','to_add_out']" \
+    actor_rollout_ref.actor.optim.lr=1e-4 \
+    actor_rollout_ref.actor.optim.weight_decay=0.0001 \
+    actor_rollout_ref.actor.ppo_mini_batch_size=${mini_bsz} \
+    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=${micro_bsz_per_gpu} \
+    actor_rollout_ref.actor.fsdp_config.param_offload=True \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=True \
+    actor_rollout_ref.actor.fsdp_config.model_dtype=bfloat16 \
+    actor_rollout_ref.actor.use_kl_loss=True \
+    actor_rollout_ref.actor.kl_loss_coef=0.04 \
+    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=${micro_bsz_per_gpu} \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=${ROLLOUT_TP} \
+    actor_rollout_ref.rollout.name=${ENGINE} \
+    actor_rollout_ref.rollout.n=${n_resp_per_prompt} \
+    actor_rollout_ref.rollout.agent.num_workers=${ROLLOUT_WORKERS} \
+    actor_rollout_ref.rollout.load_format=safetensors \
+    actor_rollout_ref.rollout.layered_summon=True \
+    actor_rollout_ref.rollout.pipeline.num_inference_steps=4 \
+    actor_rollout_ref.rollout.pipeline.height=512 \
+    actor_rollout_ref.rollout.pipeline.width=512 \
+    actor_rollout_ref.rollout.enforce_eager=True \
+    actor_rollout_ref.rollout.pipeline.true_cfg_scale=4.0 \
+    actor_rollout_ref.rollout.pipeline.max_sequence_length=${max_prompt_length} \
+    actor_rollout_ref.rollout.algo.noise_level=1.0 \
+    actor_rollout_ref.rollout.algo.sde_type="sde" \
+    actor_rollout_ref.rollout.algo.sde_window_size=2 \
+    actor_rollout_ref.rollout.algo.sde_window_range="[0,4]" \
+    actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=4 \
+    actor_rollout_ref.rollout.val_kwargs.algo.noise_level=0.0 \
+    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=${micro_bsz_per_gpu} \
+    reward.num_workers=1 \
+    reward.reward_model.enable=False \
+    trainer.logger=console \
+    trainer.project_name=verl-test \
+    trainer.experiment_name=flowgrpo-qwen-image-edit-e2e \
+    trainer.log_val_generations=0 \
+    trainer.n_gpus_per_node=${NUM_GPUS} \
+    trainer.nnodes=1 \
+    trainer.val_before_train=False \
+    trainer.test_freq=-1 \
+    trainer.save_freq=-1 \
+    trainer.resume_mode=disable \
+    trainer.total_training_steps=${TOTAL_TRAIN_STEPS} \
+    "$@"
+
+echo "FlowGRPO Qwen-Image-Edit e2e test passed (training completed successfully)."

--- a/tests/workers/rollout/rollout_vllm/test_vllm_omni_qwen_image_edit_generate.py
+++ b/tests/workers/rollout/rollout_vllm/test_vllm_omni_qwen_image_edit_generate.py
@@ -1,0 +1,213 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+E2E test for Qwen-Image-Edit-Plus vLLMOmniHttpServer generate flow.
+
+Usage:
+    pytest tests/workers/rollout/rollout_vllm/test_vllm_omni_qwen_image_edit_generate.py -v -s
+    python tests/workers/rollout/rollout_vllm/test_vllm_omni_qwen_image_edit_generate.py
+"""
+
+import os
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+import ray
+import torch
+from omegaconf import OmegaConf
+from PIL import Image
+from transformers import AutoProcessor
+from verl.utils.chat_template import apply_chat_template
+from verl.utils.tokenizer import normalize_token_ids
+from verl.workers.rollout.replica import RolloutMode
+
+from verl_omni.workers.rollout.replica import DiffusionOutput
+from verl_omni.workers.rollout.vllm_rollout.vllm_omni_async_server import vLLMOmniHttpServer
+
+MODEL_PATH = Path(os.path.expanduser("~/models/tiny-random/qwen-image-edit-plus"))
+
+
+# ---------------------------------------------------------------------
+#                Test Helper Functions & Fixtures
+# ---------------------------------------------------------------------
+
+
+def _ensure_tiny_processor_config() -> None:
+    """Add minimal processor metadata missing from the tiny-random test model."""
+    config_path = MODEL_PATH / "processor" / "config.json"
+    if config_path.parent.is_dir() and not config_path.exists():
+        config_path.write_text('{"model_type":"qwen2_vl"}\n')
+
+
+def _make_image(color: tuple[int, int, int]) -> Image.Image:
+    """Create a deterministic condition image for image-edit generation."""
+    return Image.new("RGB", (256, 256), color=color)
+
+
+def _tokenize_prompt(text: str, image: Image.Image) -> list[int]:
+    """Tokenize a multimodal edit prompt into valid token IDs for the model."""
+    _ensure_tiny_processor_config()
+    processor = AutoProcessor.from_pretrained(os.path.join(MODEL_PATH, "processor"), trust_remote_code=True)
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "image", "image": image},
+                {"type": "text", "text": text},
+            ],
+        }
+    ]
+    raw_prompt = apply_chat_template(processor, messages, add_generation_prompt=True, tokenize=False)
+    model_inputs = processor(text=[raw_prompt], images=[image], return_tensors="pt", do_sample_frames=False)
+    return normalize_token_ids(model_inputs.pop("input_ids"))
+
+
+@pytest.fixture
+def init_server():
+    """Create and launch a vLLMOmniHttpServer Ray actor with Qwen-Image-Edit-Plus."""
+    _ensure_tiny_processor_config()
+    model_path = MODEL_PATH
+
+    ray.init(
+        runtime_env={
+            "env_vars": {
+                "TOKENIZERS_PARALLELISM": "true",
+                "NCCL_DEBUG": "WARN",
+                "VLLM_LOGGING_LEVEL": "INFO",
+            }
+        },
+        ignore_reinit_error=True,
+    )
+
+    rollout_cfg = OmegaConf.create(
+        {
+            "_target_": "verl_omni.workers.config.diffusion.DiffusionRolloutConfig",
+            "name": "vllm_omni",
+            "mode": "async",
+            "tensor_model_parallel_size": 1,
+            "data_parallel_size": 1,
+            "pipeline_model_parallel_size": 1,
+            "gpu_memory_utilization": 0.8,
+            "max_num_batched_tokens": 8192,
+            "max_num_seqs": 256,
+            "max_model_len": 1024,
+            "dtype": "bfloat16",
+            "load_format": "safetensors",
+            "enforce_eager": True,
+            "enable_chunked_prefill": False,
+            "enable_prefix_caching": False,
+            "enable_sleep_mode": False,
+            "free_cache_engine": True,
+            "disable_log_stats": True,
+            "n": 1,
+            "pipeline": {
+                "_target_": "verl_omni.workers.config.diffusion.rollout.DiffusionPipelineConfig",
+                "height": 512,
+                "width": 512,
+                "num_inference_steps": 4,
+                "true_cfg_scale": 4.0,
+                "max_sequence_length": 512,
+            },
+        }
+    )
+
+    model_cfg = OmegaConf.create(
+        {
+            "_target_": "verl_omni.workers.config.diffusion.DiffusionModelConfig",
+            "path": model_path,
+            "tokenizer_path": os.path.join(model_path, "tokenizer"),
+            "trust_remote_code": True,
+            "load_tokenizer": True,
+            "algorithm": "flow_grpo",
+        }
+    )
+
+    ServerCls = ray.remote(vLLMOmniHttpServer)
+    server = ServerCls.options(
+        runtime_env={
+            "env_vars": {
+                "RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES": "1",
+                "RAY_EXPERIMENTAL_NOSET_ASCEND_RT_VISIBLE_DEVICES": "1",
+                "NCCL_CUMEM_ENABLE": "0",
+            }
+        },
+        max_concurrency=10,
+    ).remote(
+        config=rollout_cfg,
+        model_config=model_cfg,
+        rollout_mode=RolloutMode.STANDALONE,
+        workers=[],
+        replica_rank=0,
+        node_rank=0,
+        gpus_per_node=1,
+        nnodes=1,
+        cuda_visible_devices="0",
+    )
+
+    ray.get(server.launch_server.remote())
+
+    yield server
+
+    ray.shutdown()
+
+
+def test_generate(init_server):
+    """Generate with a condition image, negative prompt, logprobs, and edit latent fields."""
+    server = init_server
+    image = _make_image((120, 40, 200))
+    rid = f"qwen_image_edit_{uuid4().hex[:8]}"
+
+    output = ray.get(
+        server.generate.remote(
+            prompt_ids=_tokenize_prompt("Change the background to blue.", image),
+            negative_prompt_ids=_tokenize_prompt(" ", image),
+            image_data=[image],
+            sampling_params={
+                "num_inference_steps": 4,
+                "true_cfg_scale": 4.0,
+                "height": 512,
+                "width": 512,
+                "max_sequence_length": 512,
+                "logprobs": True,
+                "noise_level": 1.0,
+                "sde_type": "sde",
+                "sde_window_size": 2,
+                "sde_window_range": [0, 4],
+            },
+            request_id=rid,
+        ),
+        timeout=600,
+    )
+
+    assert isinstance(output, DiffusionOutput), "expected DiffusionOutput"
+    assert len(output.diffusion_output) == 3, "expected 3 channels (CHW)"
+    h, w = len(output.diffusion_output[0]), len(output.diffusion_output[0][0])
+    assert h > 0 and w > 0, "image dimensions must be positive"
+    assert output.stop_reason in ("completed", "aborted", None), f"unexpected stop_reason: {output.stop_reason}"
+    assert 0.0 <= output.diffusion_output[0][0][0] <= 1.0, "pixel values must be in [0, 1]"
+
+    lp = output.log_probs
+    assert lp is not None, "log_probs should be present when logprobs=True"
+    if isinstance(lp, torch.Tensor):
+        assert lp.numel() > 0
+    else:
+        assert len(lp) > 0
+
+    assert output.extra_fields["image_latents"] is not None
+    assert output.extra_fields["img_shapes"] is not None
+    assert len(output.extra_fields["img_shapes"]) == 2
+
+    print("Qwen-Image-Edit request returned valid DiffusionOutput")

--- a/verl_omni/pipelines/__init__.py
+++ b/verl_omni/pipelines/__init__.py
@@ -15,10 +15,12 @@
 from . import (
     _patch,  # noqa: F401 — apply Ulysses mask fix
     qwen_image_diffusion_nft,
+    qwen_image_edit_flow_grpo,
     qwen_image_flow_grpo,
     qwen_image_mix_grpo,
 )
 from .qwen_image_diffusion_nft import *  # noqa: F401, F403
+from .qwen_image_edit_flow_grpo import *  # noqa: F401, F403
 from .qwen_image_flow_grpo import *  # noqa: F401, F403
 from .qwen_image_mix_grpo import *  # noqa: F401, F403
 from .sd3_dpo import *  # noqa: F401, F403
@@ -27,5 +29,6 @@ from .wan22_dance_grpo import *  # noqa: F401, F403
 __all__ = list(qwen_image_flow_grpo.__all__)
 __all__ += list(qwen_image_diffusion_nft.__all__)
 __all__ += list(qwen_image_mix_grpo.__all__)
+__all__ += list(qwen_image_edit_flow_grpo.__all__)
 __all__ += list(sd3_dpo.__all__)
 __all__ += list(wan22_dance_grpo.__all__)

--- a/verl_omni/pipelines/qwen_image_edit_flow_grpo/__init__.py
+++ b/verl_omni/pipelines/qwen_image_edit_flow_grpo/__init__.py
@@ -1,0 +1,18 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .diffusers_training_adapter import QwenImageEditPlus
+from .vllm_omni_rollout_adapter import QwenImageEditPlusPipelineWithLogProb
+
+__all__ = ["QwenImageEditPlus", "QwenImageEditPlusPipelineWithLogProb"]

--- a/verl_omni/pipelines/qwen_image_edit_flow_grpo/diffusers_training_adapter.py
+++ b/verl_omni/pipelines/qwen_image_edit_flow_grpo/diffusers_training_adapter.py
@@ -1,0 +1,222 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Qwen-Image-Edit-Plus training-side adapter for diffusers-based diffusion RL.
+
+This adapter handles image-to-image editing models where condition images are
+concatenated with noise latents during the forward pass.
+"""
+
+from typing import Optional
+
+import numpy as np
+import torch
+from diffusers.models.transformers.transformer_qwenimage import QwenImageTransformer2DModel
+from diffusers.pipelines.qwenimage.pipeline_qwenimage import calculate_shift
+from tensordict import TensorDict
+from verl.utils import tensordict_utils as tu
+from verl.utils.device import get_device_name
+
+from verl_omni.pipelines.model_base import DiffusionModelBase
+from verl_omni.pipelines.qwen_image_flow_grpo.common import (
+    QWEN_IMAGE_VAE_SCALE_FACTOR,
+    build_img_shapes,
+)
+from verl_omni.pipelines.schedulers import FlowMatchSDEDiscreteScheduler
+from verl_omni.workers.config import DiffusionModelConfig
+
+__all__ = ["QwenImageEditPlus"]
+
+
+def _build_qwen_image_edit_scheduler(model_path: str) -> FlowMatchSDEDiscreteScheduler:
+    return FlowMatchSDEDiscreteScheduler.from_pretrained(
+        pretrained_model_name_or_path=model_path,
+        subfolder="scheduler",
+    )
+
+
+def _configure_qwen_image_edit_scheduler(
+    scheduler: FlowMatchSDEDiscreteScheduler,
+    *,
+    height: int,
+    width: int,
+    num_inference_steps: int,
+    device: str,
+) -> None:
+    latent_height = height // QWEN_IMAGE_VAE_SCALE_FACTOR // 2
+    latent_width = width // QWEN_IMAGE_VAE_SCALE_FACTOR // 2
+    sigmas = np.linspace(1.0, 1 / num_inference_steps, num_inference_steps)
+    mu = calculate_shift(
+        latent_height * latent_width,
+        scheduler.config.get("base_image_seq_len", 256),
+        scheduler.config.get("max_image_seq_len", 4096),
+        scheduler.config.get("base_shift", 0.5),
+        scheduler.config.get("max_shift", 1.15),
+    )
+    scheduler.set_timesteps(num_inference_steps, device=device, sigmas=sigmas, mu=mu)
+
+
+@DiffusionModelBase.register("QwenImageEditPlusPipeline", algorithm="flow_grpo")
+class QwenImageEditPlus(DiffusionModelBase):
+    """Training adapter for the Qwen-Image-Edit-Plus diffusion model.
+
+    This adapter handles image-to-image editing where condition image latents
+    are concatenated with noise latents before the transformer forward pass.
+
+    Registered under ``"QwenImageEditPlusPipeline"`` with algorithm ``"flow_grpo"``.
+    """
+
+    @classmethod
+    def build_scheduler(cls, model_config: DiffusionModelConfig):
+        scheduler = _build_qwen_image_edit_scheduler(model_config.local_path)
+        cls.set_timesteps(scheduler, model_config, get_device_name())
+        return scheduler
+
+    @classmethod
+    def set_timesteps(cls, scheduler: FlowMatchSDEDiscreteScheduler, model_config: DiffusionModelConfig, device: str):
+        _configure_qwen_image_edit_scheduler(
+            scheduler,
+            height=model_config.pipeline.height,
+            width=model_config.pipeline.width,
+            num_inference_steps=model_config.pipeline.num_inference_steps,
+            device=device,
+        )
+
+    @classmethod
+    def prepare_model_inputs(
+        cls,
+        module: QwenImageTransformer2DModel,
+        model_config: DiffusionModelConfig,
+        latents: torch.Tensor,
+        timesteps: torch.Tensor,
+        prompt_embeds: torch.Tensor,
+        prompt_embeds_mask: torch.Tensor,
+        negative_prompt_embeds: torch.Tensor,
+        negative_prompt_embeds_mask: torch.Tensor,
+        micro_batch: TensorDict,
+        step: int,
+    ) -> tuple[dict, dict]:
+        """Build Qwen-Image-Edit-Plus-specific inputs.
+
+        Key difference from QwenImage: concatenate condition image_latents
+        with the noise latents before passing to the transformer.
+        """
+        height = tu.get_non_tensor_data(data=micro_batch, key="height", default=None)
+        width = tu.get_non_tensor_data(data=micro_batch, key="width", default=None)
+        vae_scale_factor = tu.get_non_tensor_data(data=micro_batch, key="vae_scale_factor", default=None)
+
+        # Get condition image latents (pre-encoded during rollout)
+        image_latents = micro_batch.get("image_latents", None)
+
+        # Build img_shapes - for edit models, includes both target and condition image shapes.
+        # When persisted via the agent loop and re-stacked into the micro-batch, per-sample
+        # shapes come back as a tensordict NonTensorStack (or numpy object array). The
+        # diffusers QwenEmbedRope.forward requires a list[list[tuple]], so coerce back to
+        # a plain Python list.
+        img_shapes = tu.get_non_tensor_data(data=micro_batch, key="img_shapes", default=None)
+        if img_shapes is None:
+            img_shapes = build_img_shapes(height, width, latents.shape[0], vae_scale_factor)
+        elif hasattr(img_shapes, "tolist"):
+            img_shapes = img_shapes.tolist()
+
+        # QwenImageEditPlus does not use guidance_embeds (always None)
+        guidance = None
+
+        hidden_states = latents[:, step]
+        timestep = timesteps[:, step] / 1000.0
+
+        # Concatenate condition image latents if available
+        if image_latents is not None:
+            latent_model_input = torch.cat([hidden_states, image_latents], dim=1)
+        else:
+            latent_model_input = hidden_states
+
+        model_inputs = {
+            "hidden_states": latent_model_input,
+            "timestep": timestep,
+            "guidance": guidance,
+            "encoder_hidden_states_mask": prompt_embeds_mask,
+            "encoder_hidden_states": prompt_embeds,
+            "img_shapes": img_shapes,
+            "return_dict": False,
+        }
+
+        negative_model_inputs = {
+            "hidden_states": latent_model_input,
+            "timestep": timestep,
+            "guidance": guidance,
+            "encoder_hidden_states_mask": negative_prompt_embeds_mask,
+            "encoder_hidden_states": negative_prompt_embeds,
+            "img_shapes": img_shapes,
+            "return_dict": False,
+        }
+
+        return model_inputs, negative_model_inputs
+
+    @classmethod
+    def forward_and_sample_previous_step(
+        cls,
+        module: QwenImageTransformer2DModel,
+        scheduler: FlowMatchSDEDiscreteScheduler,
+        model_config: DiffusionModelConfig,
+        model_inputs: dict[str, torch.Tensor],
+        negative_model_inputs: Optional[dict[str, torch.Tensor]],
+        scheduler_inputs: Optional[TensorDict | dict[str, torch.Tensor]],
+        step: int,
+    ):
+        """Run the transformer and sample the previous denoising step.
+
+        For edit models, the noise_pred output is sliced to only include the
+        target latent portion (excluding condition image latent tokens).
+        """
+        assert scheduler_inputs is not None
+        latents = scheduler_inputs["all_latents"]
+        timesteps = scheduler_inputs["all_timesteps"]
+
+        # Get the target latent sequence length for slicing
+        target_seq_len = latents[:, step].shape[1]
+
+        noise_pred = module(**model_inputs)[0]
+        # Slice to target latent tokens only (exclude condition image tokens)
+        noise_pred = noise_pred[:, :target_seq_len]
+
+        true_cfg_scale = model_config.pipeline.true_cfg_scale
+        if true_cfg_scale > 1.0:
+            assert negative_model_inputs is not None
+            neg_noise_pred = module(**negative_model_inputs)[0]
+            neg_noise_pred = neg_noise_pred[:, :target_seq_len]
+
+            # QwenImageEditPlus uses rescaled CFG (norm-preserving).
+            # Clamp the denominator to avoid div-by-near-zero when comb_pred
+            # collapses (rare but observed under bf16 + tiny-random + few
+            # inference steps). Without the floor a single noise_norm≈0 token
+            # poisons every downstream tensor and shows up as NaN log_prob /
+            # grad_norm with no clear callsite.
+            comb_pred = neg_noise_pred + true_cfg_scale * (noise_pred - neg_noise_pred)
+            cond_norm = torch.norm(noise_pred, dim=-1, keepdim=True)
+            noise_norm = torch.norm(comb_pred, dim=-1, keepdim=True).clamp_min(1e-6)
+            noise_pred = comb_pred * (cond_norm / noise_norm)
+
+        _, log_prob, prev_sample_mean, std_dev_t, sqrt_dt = scheduler.sample_previous_step(
+            sample=latents[:, step].float(),
+            model_output=noise_pred.float(),
+            timestep=timesteps[:, step],
+            noise_level=model_config.algo.noise_level,
+            prev_sample=latents[:, step + 1].float(),
+            sde_type=model_config.algo.sde_type,
+            return_logprobs=True,
+            return_sqrt_dt=True,
+        )
+        return log_prob, prev_sample_mean, std_dev_t, sqrt_dt

--- a/verl_omni/pipelines/qwen_image_edit_flow_grpo/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/qwen_image_edit_flow_grpo/vllm_omni_rollout_adapter.py
@@ -1,0 +1,573 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Qwen-Image-Edit-Plus rollout adapter for vllm-omni with SDE log-prob collection.
+
+Extends the upstream QwenImageEditPlusPipeline to:
+1. Replace the scheduler with FlowMatchSDEDiscreteScheduler.
+2. Collect per-step latents, log-probs, and timesteps during the SDE window.
+3. Return prompt embeddings in DiffusionOutput.custom_output for the agent loop.
+"""
+
+import os
+from typing import Any, Literal
+
+import torch
+from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
+from vllm_omni.diffusion.distributed.utils import get_local_device
+from vllm_omni.diffusion.models.qwen_image.pipeline_qwen_image_edit_plus import QwenImageEditPlusPipeline
+from vllm_omni.diffusion.request import OmniDiffusionRequest
+
+from verl_omni.pipelines.model_base import VllmOmniPipelineBase
+from verl_omni.pipelines.schedulers import FlowMatchSDEDiscreteScheduler
+
+__all__ = ["QwenImageEditPlusPipelineWithLogProb"]
+
+
+def _maybe_to_cpu(value):
+    if isinstance(value, torch.Tensor):
+        return value.detach().cpu()
+    return value
+
+
+def _coalesce_not_none(value, default):
+    return default if value is None else value
+
+
+def _pick_condition_images(custom_prompt: dict) -> list | None:
+    """Choose the condition image list whose patch-grid count matches the
+    ``<|image_pad|>`` placeholder count baked into the prompt tokens.
+
+    The agent loop calls ``processor(text=..., images=raw_images, ...)`` on
+    the **raw** PIL list to expand each ``<image>`` placeholder into a run
+    of ``<|vision_start|><|image_pad|>...<|vision_end|>`` tokens whose count
+    is governed by ``image_grid_thw`` from THAT call. Any condition image
+    list that produces a different grid (e.g. the resized 384x384 list that
+    vllm-omni's ``pre_process_func`` writes to
+    ``additional_information["condition_images"]``) will surface as::
+
+        ValueError: Image features and image tokens do not match,
+            tokens: <N>, features: <M>
+
+    Resolution order (most-likely-correct first):
+
+    1. ``custom_prompt["multi_modal_data"]["image"]`` — the raw PIL list the
+       agent loop produced. ``pre_process_func`` reads it but does not
+       modify it, so the tokens were derived from this exact list.
+    2. ``additional_information["condition_images"]`` — populated by
+       upstream ``pre_process_func`` after resize. Used only as a last-
+       resort fallback when the rollout request was constructed without
+       ``multi_modal_data`` (e.g. e2e smoke tests).
+    3. ``None`` — text-only path; the encoder gets no image features.
+
+    Centralising the selection makes it unit-testable without standing up
+    the full pipeline.
+    """
+    if not isinstance(custom_prompt, dict):
+        return None
+    multi_modal_data = custom_prompt.get("multi_modal_data") or {}
+    raw_images = multi_modal_data.get("image")
+    if isinstance(raw_images, list) and len(raw_images) > 0:
+        return raw_images
+    additional_information = custom_prompt.get("additional_information") or {}
+    return additional_information.get("condition_images")
+
+
+@VllmOmniPipelineBase.register("QwenImageEditPlusPipeline", algorithm="flow_grpo")
+class QwenImageEditPlusPipelineWithLogProb(QwenImageEditPlusPipeline):
+    """Rollout pipeline for Qwen-Image-Edit-Plus that captures per-step log-probabilities.
+
+    Extends the base QwenImageEditPlusPipeline with a custom SDE-based scheduler
+    and additional output fields for RL training (FlowGRPO).
+    """
+
+    def __init__(self, *, od_config: OmniDiffusionConfig, prefix: str = ""):
+        super().__init__(od_config=od_config, prefix=prefix)
+        self.device = get_local_device()
+        model = od_config.model
+        local_files_only = os.path.exists(model)
+
+        # Replace the upstream scheduler with our SDE scheduler
+        self.scheduler = FlowMatchSDEDiscreteScheduler.from_pretrained(
+            model,
+            subfolder="scheduler",
+            local_files_only=local_files_only,
+        )
+
+    def _get_qwen_prompt_embeds(
+        self,
+        prompt_ids: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+        condition_images: list | None = None,
+        dtype: torch.dtype | None = None,
+    ):
+        dtype = dtype or self.text_encoder.dtype
+
+        if attention_mask is None:
+            attention_mask = torch.ones_like(prompt_ids, dtype=torch.long)
+
+        prompt_ids = prompt_ids.unsqueeze(0) if prompt_ids.ndim == 1 else prompt_ids
+        attention_mask = attention_mask.unsqueeze(0) if attention_mask.ndim == 1 else attention_mask
+        drop_idx = self.prompt_template_encode_start_idx
+
+        # The agent loop expanded every ``<image>`` placeholder in the prompt
+        # text into a long run of ``<|vision_start|><|image_pad|>...<|vision_end|>``
+        # tokens by calling ``processor(text=..., images=raw_images, ...)`` on
+        # the same raw PIL list. The placeholder count is governed by
+        # ``image_grid_thw`` from THAT call.
+        #
+        # Without ``pixel_values`` / ``image_grid_thw``, the Qwen2.5-VL
+        # text_encoder treats every ``<|image_pad|>`` as an empty word
+        # embedding, prompt features become garbage, and the diffusion
+        # transformer denoises noise into noise (visible as garbled rollout
+        # images). With them, the encoder fuses real image features in.
+        #
+        # IMPORTANT: ``condition_images`` here MUST be the raw PIL images
+        # forwarded by the agent loop (i.e. ``multi_modal_data["image"]`` in
+        # ``forward()``), NOT the resized list that vllm-omni's
+        # ``pre_process_func`` writes to ``additional_information["condition_images"]``.
+        # The latter is already resized to CONDITION_IMAGE_SIZE (384x384) and
+        # would produce a 14x14 (=196) patch grid — mismatched against the
+        # placeholder count derived from the raw image, surfacing as::
+        #
+        #   ValueError: Image features and image tokens do not match,
+        #     tokens: <N>, features: <M>
+        pixel_values = None
+        image_grid_thw = None
+        if condition_images is not None and len(condition_images) > 0:
+            image_inputs = self.processor.image_processor(images=condition_images, return_tensors="pt")
+            pixel_values = image_inputs["pixel_values"].to(device=self.device, dtype=self.text_encoder.dtype)
+            image_grid_thw = image_inputs["image_grid_thw"].to(self.device)
+
+        encoder_hidden_states = self.text_encoder(
+            input_ids=prompt_ids.to(self.device),
+            attention_mask=attention_mask.to(self.device),
+            pixel_values=pixel_values,
+            image_grid_thw=image_grid_thw,
+            output_hidden_states=True,
+        )
+        hidden_states = encoder_hidden_states.hidden_states[-1]
+        split_hidden_states = self._extract_masked_hidden(hidden_states, attention_mask)
+        split_hidden_states = [e[drop_idx:] for e in split_hidden_states]
+        attn_mask_list = [torch.ones(e.size(0), dtype=torch.long, device=e.device) for e in split_hidden_states]
+        max_seq_len = max([e.size(0) for e in split_hidden_states])
+        prompt_embeds = torch.stack(
+            [torch.cat([u, u.new_zeros(max_seq_len - u.size(0), u.size(1))]) for u in split_hidden_states]
+        )
+        encoder_attention_mask = torch.stack(
+            [torch.cat([u, u.new_zeros(max_seq_len - u.size(0))]) for u in attn_mask_list]
+        )
+
+        prompt_embeds = prompt_embeds.to(dtype=dtype)
+
+        return prompt_embeds, encoder_attention_mask
+
+    def encode_prompt(
+        self,
+        prompt_ids: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+        num_images_per_prompt: int = 1,
+        prompt_embeds: torch.Tensor | None = None,
+        prompt_embeds_mask: torch.Tensor | None = None,
+        max_sequence_length: int = 1024,
+        condition_images: list | None = None,
+    ):
+        """Encode text prompt token IDs into dense embeddings.
+
+        Overrides the upstream QwenImageEditPlusPipeline.encode_prompt (which
+        accepts raw text strings) to work with pre-tokenized prompt IDs as
+        required by the verl-omni rollout loop. ``condition_images`` is forwarded
+        so the Qwen2.5-VL vision tower can replace ``<|image_pad|>`` placeholders
+        with real image features instead of empty word embeddings.
+        """
+        prompt_ids = prompt_ids.unsqueeze(0) if prompt_ids.ndim == 1 else prompt_ids
+        attention_mask = (
+            attention_mask.unsqueeze(0) if attention_mask is not None and attention_mask.ndim == 1 else attention_mask
+        )
+
+        if prompt_embeds is None:
+            prompt_embeds, prompt_embeds_mask = self._get_qwen_prompt_embeds(
+                prompt_ids,
+                attention_mask=attention_mask,
+                condition_images=condition_images,
+            )
+
+        prompt_embeds = prompt_embeds[:, :max_sequence_length]
+        prompt_embeds_mask = prompt_embeds_mask[:, :max_sequence_length]
+
+        if num_images_per_prompt > 1:
+            prompt_embeds = prompt_embeds.repeat_interleave(num_images_per_prompt, dim=0)
+            prompt_embeds_mask = prompt_embeds_mask.repeat_interleave(num_images_per_prompt, dim=0)
+
+        return prompt_embeds, prompt_embeds_mask
+
+    def diffuse(
+        self,
+        prompt_embeds,
+        prompt_embeds_mask,
+        negative_prompt_embeds,
+        negative_prompt_embeds_mask,
+        latents,
+        image_latents,
+        img_shapes,
+        txt_seq_lens,
+        negative_txt_seq_lens,
+        timesteps,
+        do_true_cfg,
+        true_cfg_scale,
+        noise_level,
+        sde_window,
+        sde_type,
+        generator,
+        logprobs,
+    ):
+        """Run the full SDE diffusion loop for image editing with rollout data collection.
+
+        Similar to QwenImagePipelineWithLogProb.diffuse but handles condition
+        image latents concatenation.
+        """
+        all_latents = []
+        all_log_probs = []
+        all_timesteps = []
+        self.scheduler.set_begin_index(0)
+        self.transformer.do_true_cfg = do_true_cfg
+
+        for i, timestep_value in enumerate(timesteps):
+            if self.interrupt:
+                continue
+
+            if i < sde_window[0]:
+                cur_noise_level = 0.0
+            elif i == sde_window[0]:
+                cur_noise_level = noise_level
+                all_latents.append(latents.float())
+            elif i > sde_window[0] and i < sde_window[1]:
+                cur_noise_level = noise_level
+            else:
+                cur_noise_level = 0.0
+
+            self._current_timestep = timestep_value
+            timestep = timestep_value.expand(latents.shape[0]).to(device=latents.device, dtype=torch.float32)
+
+            # Concatenate condition image latents and cast to model dtype for transformer forward.
+            if image_latents is not None:
+                latent_model_input = torch.cat([latents, image_latents], dim=1)
+            else:
+                latent_model_input = latents
+            latent_model_input = latent_model_input.to(self.transformer.img_in.weight.dtype)
+
+            # Forward pass for positive prompt
+            noise_pred = self.transformer(
+                hidden_states=latent_model_input,
+                timestep=timestep / 1000,
+                guidance=None,  # QwenImageEditPlus doesn't use guidance embeds
+                encoder_hidden_states_mask=prompt_embeds_mask,
+                encoder_hidden_states=prompt_embeds,
+                img_shapes=img_shapes,
+                txt_seq_lens=txt_seq_lens,
+                attention_kwargs=self.attention_kwargs,
+                return_dict=False,
+            )[0]
+            # Slice to target latent tokens only
+            noise_pred = noise_pred[:, : latents.shape[1]]
+
+            # CFG with negative prompt
+            if do_true_cfg:
+                neg_noise_pred = self.transformer(
+                    hidden_states=latent_model_input,
+                    timestep=timestep / 1000,
+                    guidance=None,
+                    encoder_hidden_states_mask=negative_prompt_embeds_mask,
+                    encoder_hidden_states=negative_prompt_embeds,
+                    img_shapes=img_shapes,
+                    txt_seq_lens=negative_txt_seq_lens,
+                    attention_kwargs=self.attention_kwargs,
+                    return_dict=False,
+                )[0]
+                neg_noise_pred = neg_noise_pred[:, : latents.shape[1]]
+
+                # Rescaled CFG (norm-preserving) specific to QwenImageEditPlus.
+                # Clamp the denominator: when comb_pred collapses to near-zero
+                # under bf16 + few-inference-steps the unclamped form produces
+                # inf/NaN that downstream get cached as the rollout's
+                # ``old_log_prob`` and silently NaN out the FSDP grad.
+                comb_pred = neg_noise_pred + true_cfg_scale * (noise_pred - neg_noise_pred)
+                cond_norm = torch.norm(noise_pred, dim=-1, keepdim=True)
+                noise_norm = torch.norm(comb_pred, dim=-1, keepdim=True).clamp_min(1e-6)
+                noise_pred = comb_pred * (cond_norm / noise_norm)
+
+            # Scheduler step
+            latents, log_prob, _, _ = self.scheduler.step(
+                noise_pred.float(),
+                timestep_value,
+                latents,
+                generator=generator,
+                noise_level=cur_noise_level,
+                sde_type=sde_type,
+                return_logprobs=logprobs,
+                return_dict=False,
+            )
+
+            if i >= sde_window[0] and i < sde_window[1]:
+                all_latents.append(latents)
+                all_log_probs.append(log_prob)
+                all_timesteps.append(timestep_value)
+
+        all_latents = torch.stack(all_latents, dim=1)
+        all_log_probs = torch.stack(all_log_probs, dim=1) if all_log_probs and all_log_probs[0] is not None else None
+        all_timesteps = torch.stack(all_timesteps).unsqueeze(0).expand(latents.shape[0], -1)
+        return latents, all_latents, all_log_probs, all_timesteps
+
+    def forward(
+        self,
+        req: OmniDiffusionRequest,
+        prompt_ids: torch.Tensor | list[int] | None = None,
+        prompt_mask: torch.Tensor | None = None,
+        negative_prompt_ids: torch.Tensor | list[int] | None = None,
+        negative_prompt_mask: torch.Tensor | None = None,
+        true_cfg_scale: float = 4.0,
+        height: int | None = None,
+        width: int | None = None,
+        num_inference_steps: int = 50,
+        sigmas: list[float] | None = None,
+        guidance_scale: float = 1.0,
+        num_images_per_prompt: int = 1,
+        generator: torch.Generator | list[torch.Generator] | None = None,
+        latents: torch.Tensor | None = None,
+        prompt_embeds: torch.Tensor | None = None,
+        prompt_embeds_mask: torch.Tensor | None = None,
+        negative_prompt_embeds: torch.Tensor | None = None,
+        negative_prompt_embeds_mask: torch.Tensor | None = None,
+        image_latents: torch.Tensor | None = None,
+        output_type: str | None = "pil",
+        attention_kwargs: dict[str, Any] | None = None,
+        max_sequence_length: int = 512,
+        noise_level: float = 0.7,
+        sde_window_size: int | None = None,
+        sde_window_range: tuple[int, int] = (0, 5),
+        sde_type: Literal["sde", "cps"] = "sde",
+        logprobs: bool = True,
+    ) -> DiffusionOutput:
+        """End-to-end image editing with rollout data collection.
+
+        Encodes the prompt, prepares latents (with condition image latents),
+        runs the SDE diffusion loop, and decodes the final output.
+        """
+        custom_prompt = req.prompts[0] if req.prompts else {}
+        condition_images = _pick_condition_images(custom_prompt)
+        if isinstance(custom_prompt, dict):
+            prompt_ids = custom_prompt.get("prompt_ids", prompt_ids)
+            prompt_mask = custom_prompt.get("prompt_mask", prompt_mask)
+            negative_prompt_ids = custom_prompt.get("negative_prompt_ids", negative_prompt_ids)
+            negative_prompt_mask = custom_prompt.get("negative_prompt_mask", negative_prompt_mask)
+            image_latents = custom_prompt.get("image_latents", image_latents)
+            additional_information = custom_prompt.get("additional_information", {})
+            vae_images = additional_information.get("vae_images")
+            vae_image_sizes = additional_information.get("vae_image_sizes")
+        else:
+            vae_images = None
+            vae_image_sizes = None
+
+        sampling_params = req.sampling_params
+        height = sampling_params.height or self.default_sample_size * self.vae_scale_factor
+        width = sampling_params.width or self.default_sample_size * self.vae_scale_factor
+        num_inference_steps = sampling_params.num_inference_steps or num_inference_steps
+        max_sequence_length = sampling_params.max_sequence_length or max_sequence_length
+
+        noise_level = _coalesce_not_none(sampling_params.extra_args.get("noise_level", None), noise_level)
+        sde_window_size = _coalesce_not_none(sampling_params.extra_args.get("sde_window_size", None), sde_window_size)
+        sde_window_range = _coalesce_not_none(
+            sampling_params.extra_args.get("sde_window_range", None), sde_window_range
+        )
+        sde_type = _coalesce_not_none(sampling_params.extra_args.get("sde_type", None), sde_type)
+        logprobs = _coalesce_not_none(sampling_params.extra_args.get("logprobs", None), logprobs)
+
+        generator = sampling_params.generator or generator
+        if generator is None and sampling_params.seed is not None:
+            generator = torch.Generator(device=self.device).manual_seed(sampling_params.seed)
+        true_cfg_scale = _coalesce_not_none(sampling_params.true_cfg_scale, true_cfg_scale)
+
+        self._guidance_scale = guidance_scale
+        self._attention_kwargs = attention_kwargs
+        self._current_timestep = None
+        self._interrupt = False
+
+        if prompt_ids is not None:
+            if isinstance(prompt_ids, list):
+                prompt_ids = torch.tensor(prompt_ids, device=self.device)
+            batch_size = prompt_ids.shape[0] if prompt_ids.ndim == 2 else 1
+        elif prompt_embeds is not None:
+            batch_size = prompt_embeds.shape[0]
+        else:
+            return DiffusionOutput(output=None, custom_output={})
+
+        if isinstance(negative_prompt_ids, list):
+            negative_prompt_ids = torch.tensor(negative_prompt_ids, device=self.device)
+
+        has_neg_prompt = negative_prompt_ids is not None or (
+            negative_prompt_embeds is not None and negative_prompt_embeds_mask is not None
+        )
+        do_true_cfg = true_cfg_scale > 1 and has_neg_prompt
+
+        # Encode prompts
+        prompt_embeds, prompt_embeds_mask = self.encode_prompt(
+            prompt_ids=prompt_ids,
+            attention_mask=prompt_mask,
+            prompt_embeds=prompt_embeds,
+            prompt_embeds_mask=prompt_embeds_mask,
+            num_images_per_prompt=num_images_per_prompt,
+            max_sequence_length=max_sequence_length,
+            condition_images=condition_images,
+        )
+        if do_true_cfg:
+            negative_prompt_embeds, negative_prompt_embeds_mask = self.encode_prompt(
+                prompt_ids=negative_prompt_ids,
+                attention_mask=negative_prompt_mask,
+                prompt_embeds=negative_prompt_embeds,
+                prompt_embeds_mask=negative_prompt_embeds_mask,
+                num_images_per_prompt=num_images_per_prompt,
+                max_sequence_length=max_sequence_length,
+                condition_images=condition_images,
+            )
+
+        # Prepare target latents
+        num_channels_latents = self.transformer.in_channels // 4
+        latents, prepared_image_latents = self.prepare_latents(
+            vae_images,
+            batch_size * num_images_per_prompt,
+            num_channels_latents,
+            height,
+            width,
+            prompt_embeds.dtype,
+            self.device,
+            generator,
+            latents,
+        )
+
+        # Use pre-encoded image_latents from the request if provided, otherwise
+        # fall back to what prepare_latents returned (None when images=None).
+        if image_latents is None:
+            image_latents = prepared_image_latents
+        if image_latents is not None:
+            image_latents = image_latents.to(device=self.device, dtype=prompt_embeds.dtype)
+
+        # Build img_shapes (includes both target and condition image shapes).
+        # Use a list comprehension instead of ``[[…]] * batch_size`` so the
+        # outer entries do not alias the same inner list — protects against
+        # latent batch_size > 1 callers that mutate per-sample shapes.
+        target_shape = (1, height // self.vae_scale_factor // 2, width // self.vae_scale_factor // 2)
+        if image_latents is not None:
+            if not vae_image_sizes:
+                # ``vae_image_sizes`` is populated by the upstream
+                # ``pre_process_func`` whenever ``vae_images`` are encoded.
+                # Without it we cannot recover the condition image's aspect
+                # ratio from the packed sequence length alone (sqrt(seq_len)
+                # only equals the side for perfect squares and otherwise
+                # silently produces wrong RoPE positions). Fail closed for
+                # both ``None`` and the empty-list case — an empty list
+                # would still pass the old ``is None`` check and produce
+                # an ``img_shapes`` entry with no condition regions, which
+                # silently corrupts the transformer's RoPE positions.
+                raise ValueError(
+                    "QwenImageEditPlusPipelineWithLogProb.forward() requires a "
+                    "non-empty additional_information['vae_image_sizes'] when "
+                    f"image_latents is provided; got {vae_image_sizes!r}. The "
+                    "upstream pre_process_func sets this field — bypass it only "
+                    "if you also supply matching vae_image_sizes."
+                )
+            condition_shapes = [
+                (1, vae_height // self.vae_scale_factor // 2, vae_width // self.vae_scale_factor // 2)
+                for vae_width, vae_height in vae_image_sizes
+            ]
+            img_shapes = [[target_shape, *condition_shapes] for _ in range(batch_size)]
+        else:
+            img_shapes = [[target_shape] for _ in range(batch_size)]
+
+        # Prepare timesteps
+        timesteps, num_inference_steps = self.prepare_timesteps(num_inference_steps, sigmas, latents.shape[1])
+        self._num_timesteps = len(timesteps)
+
+        if self.attention_kwargs is None:
+            self._attention_kwargs = {}
+
+        txt_seq_lens = prompt_embeds_mask.sum(dim=1).tolist() if prompt_embeds_mask is not None else None
+        negative_txt_seq_lens = (
+            negative_prompt_embeds_mask.sum(dim=1).tolist() if negative_prompt_embeds_mask is not None else None
+        )
+
+        if sde_window_size is not None:
+            start = torch.randint(
+                sde_window_range[0],
+                sde_window_range[1] - sde_window_size + 1,
+                (1,),
+                generator=generator,
+                device=self.device,
+            ).item()
+            end = start + sde_window_size
+            sde_window = (start, end)
+        else:
+            sde_window = (0, len(timesteps) - 1)
+
+        latents, all_latents, all_log_probs, all_timesteps = self.diffuse(
+            prompt_embeds,
+            prompt_embeds_mask,
+            negative_prompt_embeds,
+            negative_prompt_embeds_mask,
+            latents,
+            image_latents,
+            img_shapes,
+            txt_seq_lens,
+            negative_txt_seq_lens,
+            timesteps,
+            do_true_cfg,
+            true_cfg_scale,
+            noise_level,
+            sde_window,
+            sde_type,
+            generator,
+            logprobs,
+        )
+
+        self._current_timestep = None
+        if output_type == "latent":
+            image = latents
+        else:
+            latents = self._unpack_latents(latents, height, width, self.vae_scale_factor)
+            latents = latents.to(self.vae.dtype)
+            latents_mean = (
+                torch.tensor(self.vae.config.latents_mean)
+                .view(1, self.vae.config.z_dim, 1, 1, 1)
+                .to(latents.device, latents.dtype)
+            )
+            latents_std = 1.0 / torch.tensor(self.vae.config.latents_std).view(1, self.vae.config.z_dim, 1, 1, 1).to(
+                latents.device, latents.dtype
+            )
+            latents = latents / latents_std + latents_mean
+            image = self.vae.decode(latents, return_dict=False)[0][:, :, 0]
+
+        return DiffusionOutput(
+            output=_maybe_to_cpu(image),
+            custom_output={
+                "all_latents": _maybe_to_cpu(all_latents),
+                "all_log_probs": _maybe_to_cpu(all_log_probs),
+                "all_timesteps": _maybe_to_cpu(all_timesteps),
+                "prompt_embeds": _maybe_to_cpu(prompt_embeds),
+                "prompt_embeds_mask": _maybe_to_cpu(prompt_embeds_mask),
+                "negative_prompt_embeds": _maybe_to_cpu(negative_prompt_embeds),
+                "negative_prompt_embeds_mask": _maybe_to_cpu(negative_prompt_embeds_mask),
+                "image_latents": _maybe_to_cpu(image_latents),
+                "img_shapes": img_shapes,
+            },
+        )

--- a/verl_omni/utils/reward_score/genrm_image_edit.py
+++ b/verl_omni/utils/reward_score/genrm_image_edit.py
@@ -1,0 +1,273 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Image-edit quality scoring backed by a generative reward model (GRM)."""
+
+import asyncio
+import io
+import json
+import logging
+import os
+import re
+from typing import Optional
+
+import aiohttp
+import numpy as np
+import torch
+from openai.types.chat import ChatCompletion
+from PIL import Image
+from transformers import PreTrainedTokenizer
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_GRM_MODEL_PATH = "~/models/tiny-random/qwen3-vl"
+DEFAULT_SAMPLING_PARAMS = {"temperature": 0.0, "top_p": 1.0, "max_tokens": 64}
+DEFAULT_GRM_PROMPT = """Rate how well the edited image follows the edit instruction while preserving unrelated content
+from the source image and looking natural.
+
+If a reference target image is provided, also consider whether the edited image matches it.
+
+Output only one number from 0 to 1. 1 means perfect, 0 means failed."""
+DEBUG_LOG_ENV = "GENRM_IMAGE_EDIT_DEBUG_PATH"
+
+# Reward-server resilience knobs.
+# The GRM is a remote vLLM server that occasionally drops requests (e.g. when
+# the multimodal cache asserts on its receiver side, or when the server is
+# briefly overloaded). These are transient and should not crash a multi-hour
+# training run; soft-fail to a 0.0 score instead and keep going.
+_REQUEST_TIMEOUT_S = 600.0
+_MAX_ATTEMPTS = 3
+_RETRY_BASE_BACKOFF_S = 1.0
+_SOFT_FAIL_SCORE = 0.0
+
+
+class _RewardServerError(RuntimeError):
+    """Raised when the reward server cannot produce a usable response.
+
+    Caught at the public ``compute_score_image_edit`` boundary and turned
+    into a soft-fail score; never propagates up to the trainer.
+    """
+
+
+async def _chat_complete(router_address: str, chat_complete_request: dict) -> ChatCompletion:
+    """POST a chat completion request to the GRM router and parse the response.
+
+    Retries transient HTTP / network / decode failures up to ``_MAX_ATTEMPTS``
+    times with exponential backoff. Raises ``_RewardServerError`` on terminal
+    failure so the caller can soft-fail to a default score.
+    """
+    url = f"http://{router_address}/v1/chat/completions"
+    timeout = aiohttp.ClientTimeout(total=_REQUEST_TIMEOUT_S)
+    last_err: Optional[str] = None
+
+    for attempt in range(1, _MAX_ATTEMPTS + 1):
+        try:
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                async with session.post(url, json=chat_complete_request) as resp:
+                    body = await resp.text()
+                    status = resp.status
+            if status != 200:
+                # Truncate to keep log lines bounded; vLLM error pages can be huge.
+                last_err = f"HTTP {status}: {body[:500]!r}"
+                raise _RewardServerError(last_err)
+            try:
+                payload = json.loads(body)
+            except json.JSONDecodeError as e:
+                last_err = f"non-JSON body (HTTP {status}): {body[:500]!r} ({e})"
+                raise _RewardServerError(last_err) from e
+            try:
+                return ChatCompletion(**payload)
+            except (TypeError, ValueError) as e:
+                last_err = f"malformed ChatCompletion payload: {payload!r} ({e})"
+                raise _RewardServerError(last_err) from e
+        except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+            last_err = f"transport error: {type(e).__name__}: {e}"
+        except _RewardServerError:
+            # Already has a useful ``last_err`` set above; let retry logic decide.
+            pass
+
+        if attempt < _MAX_ATTEMPTS:
+            backoff = _RETRY_BASE_BACKOFF_S * (2 ** (attempt - 1))
+            logger.warning(
+                "[genrm_image_edit] reward-server attempt %d/%d failed (%s); retrying in %.1fs",
+                attempt,
+                _MAX_ATTEMPTS,
+                last_err,
+                backoff,
+            )
+            await asyncio.sleep(backoff)
+
+    raise _RewardServerError(f"reward server failed after {_MAX_ATTEMPTS} attempts: {last_err}")
+
+
+def _to_pil(image) -> Image.Image:
+    """Normalize a tensor / array / PIL image / parquet image dict to an RGB PIL image."""
+    if isinstance(image, dict):
+        if image.get("bytes") is not None:
+            image = Image.open(io.BytesIO(image["bytes"]))
+        elif image.get("path") is not None:
+            image = Image.open(image["path"])
+    if isinstance(image, torch.Tensor):
+        image = image.float().permute(1, 2, 0).cpu().numpy()
+    if isinstance(image, np.ndarray):
+        assert image.shape[-1] == 3, "must be in HWC format"
+        image = (image * 255).round().clip(0, 255).astype(np.uint8)
+        image = Image.fromarray(image)
+    assert isinstance(image, Image.Image)
+    return image.convert("RGB")
+
+
+def _parse_score(text: str) -> float:
+    """Parse the first numeric score from a GRM response."""
+    match = re.search(r"\d+(?:\.\d+)?", text)
+    if match is None:
+        return 0.0
+    score = float(match.group(0))
+    if score > 1.0:
+        score = score / 100.0
+    return max(0.0, min(1.0, score))
+
+
+def _write_debug_record(record: dict) -> None:
+    """Append a reward debugging record when ``GENRM_IMAGE_EDIT_DEBUG_PATH`` is set."""
+    debug_path = os.environ.get(DEBUG_LOG_ENV)
+    if debug_path is None:
+        return
+    os.makedirs(os.path.dirname(debug_path), exist_ok=True)
+    with open(debug_path, "a") as f:
+        f.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+
+def _clamp_score(value, default: float = 0.0) -> float:
+    """Convert a model-emitted value to a score in ``[0, 1]``."""
+    try:
+        score = float(value)
+    except (TypeError, ValueError):
+        score = default
+    return max(0.0, min(1.0, score))
+
+
+async def compute_score_image_edit(
+    data_source: str,
+    solution_image: np.ndarray | torch.Tensor,
+    ground_truth: str,
+    extra_info: dict,
+    reward_router_address: str,
+    reward_model_tokenizer: PreTrainedTokenizer = None,
+    model_name: Optional[str] = None,
+):
+    """Compute image-edit quality with a vision-language GRM judge.
+
+    The judge is instructed to output a single numeric score in ``[0, 1]``.
+    Set ``GENRM_IMAGE_EDIT_DEBUG_PATH`` to append raw GRM responses as JSONL for
+    debugging.
+    """
+    from verl.utils.ray_utils import get_event_loop
+
+    from verl_omni.utils.reward_score.reward_utils import pil_image_to_base64
+
+    instruction = extra_info.get("instruction") or ground_truth
+    source_img = extra_info.get("source_img")
+    target_img = extra_info.get("target_img")
+    # Fail closed when ``source_img`` is missing instead of letting
+    # ``_to_pil(None)`` raise an unhelpful ``AssertionError`` deep inside
+    # the converter. ``target_img`` stays optional — only the source is
+    # required for the GRM-style image-edit judge prompt.
+    if source_img is None:
+        raise ValueError(
+            "compute_score_image_edit requires extra_info['source_img'] "
+            "(the original image being edited); got None. Check the "
+            "data preprocessor wired ``source_img`` into ``extra_info``."
+        )
+    has_target = target_img is not None
+
+    if solution_image.ndim == 4:
+        solution_image = solution_image[0]
+
+    loop = get_event_loop()
+    source_base64 = await loop.run_in_executor(None, pil_image_to_base64, _to_pil(source_img))
+    solution_base64 = await loop.run_in_executor(None, pil_image_to_base64, _to_pil(solution_image))
+
+    content = [
+        {"type": "text", "text": f"Editing instruction: {instruction}"},
+        {"type": "text", "text": "Source image:"},
+        {"type": "image_url", "image_url": {"url": source_base64}},
+        {"type": "text", "text": "Edited/generated image:"},
+        {"type": "image_url", "image_url": {"url": solution_base64}},
+    ]
+    if has_target:
+        target_base64 = await loop.run_in_executor(None, pil_image_to_base64, _to_pil(target_img))
+        content.extend(
+            [
+                {"type": "text", "text": "Reference target image:"},
+                {"type": "image_url", "image_url": {"url": target_base64}},
+            ]
+        )
+    content.append({"type": "text", "text": DEFAULT_GRM_PROMPT})
+
+    model_name = model_name or os.path.expanduser(DEFAULT_GRM_MODEL_PATH)
+    chat_complete_request = {
+        "messages": [
+            {"role": "system", "content": "You are a strict image editing evaluation assistant."},
+            {"role": "user", "content": content},
+        ],
+        "model": model_name,
+        **DEFAULT_SAMPLING_PARAMS,
+    }
+    try:
+        result = await _chat_complete(router_address=reward_router_address, chat_complete_request=chat_complete_request)
+    except _RewardServerError as e:
+        # Soft-fail: a single bad GRM call should not crash a multi-hour
+        # training run. Returning the floor score lets GRPO advantage
+        # normalization treat the sample as a no-signal example. The
+        # ``genrm_response`` field doubles as a debug breadcrumb so the
+        # failure is visible in rollout dumps.
+        logger.warning("[genrm_image_edit] soft-failing to %.1f: %s", _SOFT_FAIL_SCORE, e)
+        _write_debug_record(
+            {
+                "data_source": data_source,
+                "instruction": instruction,
+                "ground_truth": ground_truth,
+                "img_id": extra_info.get("img_id"),
+                "turn_index": extra_info.get("turn_index"),
+                "score": _SOFT_FAIL_SCORE,
+                "genrm_response": None,
+                "error": str(e),
+            }
+        )
+        return {"score": _SOFT_FAIL_SCORE, "genrm_response": f"[reward-server-error] {e}"}
+
+    try:
+        grm_response = result.choices[0].message.content
+    except (AttributeError, IndexError, TypeError) as e:
+        logger.warning(
+            "[genrm_image_edit] soft-failing to %.1f: missing choices/message in response: %s",
+            _SOFT_FAIL_SCORE,
+            e,
+        )
+        return {"score": _SOFT_FAIL_SCORE, "genrm_response": f"[malformed-response] {e}"}
+
+    score = _parse_score(grm_response)
+    _write_debug_record(
+        {
+            "data_source": data_source,
+            "instruction": instruction,
+            "ground_truth": ground_truth,
+            "img_id": extra_info.get("img_id"),
+            "turn_index": extra_info.get("turn_index"),
+            "score": score,
+            "genrm_response": grm_response,
+        }
+    )
+    return {"score": score, "genrm_response": grm_response}


### PR DESCRIPTION
### What does this PR do?

Adds end-to-end FlowGRPO training support for Qwen-Image-Edit-2511 / Qwen-Image-Edit-Plus style image-editing diffusion models in VeRL-Omni.

This PR includes:

- A Qwen-Image-Edit FlowGRPO pipeline with diffusers training and vLLM-Omni rollout adapters.
- Image-edit-specific prompt, condition-image, latent, log-prob, and timestep handling.
- Qwen-Image-Edit LoRA training and smoke-test entrypoints.
- Image-edit reward utilities, including GenRM and vLLM-backed quality reward support.
- Trainer, rollout, FSDP, config, test, and documentation updates needed by the new path.

### Checklist Before Starting

- [x] Search for similar PRs. 
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `vllm_omni`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `diffusion`, `omni`, `tests`, `docker`
  - If this PR involves multiple modules, separate them with `,` like `[diffusion, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][diffusion, fsdp] feat: new rollout scheduler`

### Test

All required checks passed.

#### Pre-commit

```bash
pre-commit run --all-files
```

```text
ruff (legacy alias)..................................................................Passed
ruff format..........................................................................Passed
mypy.................................................................................Passed
Generate and verify verl_omni/trainer/config/_generated_*.yaml.......................Passed
Check docs Last updated info.........................................................Passed
Check doc string coverage............................................................Passed
Check license........................................................................Passed
Check device API usage...............................................................Passed
Check DataProto usage................................................................Passed
Validate test structure..............................................................Passed
Check naming conventions.............................................................Passed
Compile all python files.............................................................Passed
```

#### GPU smoke coverage

```bash
python -m pytest \
    tests/workers/rollout/rollout_vllm/test_vllm_omni_generate.py::test_generate \
    tests/workers/rollout/rollout_vllm/test_vllm_omni_qwen_image_edit_generate.py::test_generate \
    -s
```

```text
Test Results  —  2026-06-04 09:08:41

I================== 2 passed, 31 warnings in 572.01s (0:09:32) ==================
```

#### GitHub Actions

GitHub Actions checks passed after the PR updates.

### API and Usage Example

Prepare image-edit data, then launch Qwen-Image-Edit LoRA FlowGRPO training:

```python
# Prepare ShareGPT4O-style image-edit parquet data.
# Equivalent shell command:
# python3 examples/flowgrpo_trainer/data_process/qwenimageedit_sharegpt4o.py \
#   --input_dir /path/to/sharegpt4o_image_mini \
#   --output_dir data/sharegpt4o_image_mini_qwen_image_edit

# Launch training with:
# NUM_GPUS_ACTOR_ROLLOUT_REWARD=4 \
# MODEL_PATH=Qwen/Qwen-Image-Edit-2511 \
# REWARD_MODEL_PATH=Qwen/Qwen3-VL-8B-Instruct \
# bash examples/flowgrpo_trainer/run_qwen_image_edit_lora.sh
```

The example script defaults to:

- `actor_rollout_ref.model.algorithm=flow_grpo`
- `actor_rollout_ref.rollout.name=vllm_omni`
- `reward.custom_reward_function.name=compute_score_image_edit`
- LoRA fine-tuning for Qwen-Image-Edit target modules

### Design & Code Changes

#### Qwen-Image-Edit pipeline

- Introduces `verl_omni/pipelines/qwen_image_edit_flow_grpo/` for image-edit FlowGRPO support.
- Adds `QwenImageEditPlus` as the diffusers training adapter.
- Adds `QwenImageEditPlusPipelineWithLogProb` as the vLLM-Omni rollout adapter.
- Handles image-edit inputs with both text prompts and condition images.

#### Trainer / rollout / FSDP integration

- Extends diffusion trainer logic to support the image-edit FlowGRPO path.
- Updates rollout and log-prob plumbing for vLLM-Omni image-edit generation.
- Updates FSDP diffusers engine support for the new adapter path.
- Updates diffusion config fields and worker config handling needed by the new pipeline.

#### Rewards

- Adds `compute_score_image_edit` for image-edit reward evaluation.
- Adds vLLM quality reward utilities for model-backed visual reward scoring.
- Keeps rule-based smoke-test reward available for lightweight e2e validation.

#### Tests

- Adds CPU adapter coverage for Qwen-Image-Edit.
- Adds vLLM-Omni rollout generation coverage for Qwen-Image-Edit.
- Adds a special e2e script using tiny random Qwen-Image-Edit assets.
- Adds Qwen-Image-Edit FlowGRPO trainer coverage to the GPU smoke runner.

#### Docs

- Updates FlowGRPO and diffusion integration docs.
- Adds custom vLLM reward documentation and quick reference.
- Updates example READMEs and install / index docs to include the new flow.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
  - Ran `pre-commit run --all-files`; all checks passed.
- [x] Add / Update the documentation.
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl-omni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: added/updated tests and GPU smoke coverage for the Qwen-Image-Edit path.
- [x] AI assistance was used to help prepare this PR description and validate the summarized test results; the human submitter reviewed the changes and is responsible for the final PR content.

### Some training diagram
<img width="1741" height="648" alt="image" src="https://github.com/user-attachments/assets/a3918873-c760-4e72-83d4-4212ed3c5772" />
<img width="1798" height="892" alt="image" src="https://github.com/user-attachments/assets/f9fbdca7-92b6-4fbb-870d-833b9dee6645" />
