### PR TITLE
[diffusion] feat: add FLUX FlowGRPO adapters

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/README.md
+++ b/README.md
@@ -80,6 +80,13 @@ Visit our documentation to learn more.
     <td>WIP</td>
   </tr>
   <tr>
+    <td>FLUX</td>
+    <td>Diffusion generator</td>
+    <td>Text → Image</td>
+    <td>FlowGRPO</td>
+    <td>Experimental</td>
+  </tr>
+  <tr>
     <td>Wan2.2</td>
     <td>Diffusion generator</td>
     <td>Text → Video</td>

--- a/docs/api/pipelines.rst
+++ b/docs/api/pipelines.rst
@@ -25,6 +25,7 @@ model's ``model_index.json``; the algorithm string is taken from the model confi
 
    verl_omni.pipelines.model_base.DiffusionModelBase
    verl_omni.pipelines.model_base.VllmOmniPipelineBase
+   verl_omni.pipelines.flux_flow_grpo.Flux
    verl_omni.pipelines.qwen_image_flow_grpo.QwenImage
    verl_omni.pipelines.qwen_image_mix_grpo.QwenImageMixGRPO
    verl_omni.pipelines.sd3_dpo.StableDiffusion3DPO
@@ -63,6 +64,16 @@ Schedulers
 
 Built-in Pipelines
 ~~~~~~~~~~~~~~~~~~~
+
+FLUX (FlowGRPO)
+^^^^^^^^^^^^^^^^
+
+.. autoclass:: verl_omni.pipelines.flux_flow_grpo.Flux
+   :members: build_scheduler, set_timesteps,
+             prepare_model_inputs, forward_and_sample_previous_step
+
+.. autoclass:: verl_omni.pipelines.flux_flow_grpo.FluxPipelineWithLogProb
+   :members:
 
 Qwen-Image (FlowGRPO)
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/agent_loop/test_single_turn_agent_loop_on_cpu.py
+++ b/tests/agent_loop/test_single_turn_agent_loop_on_cpu.py
@@ -62,3 +62,15 @@ async def test_encode_prompt_ids_falls_back_to_plain_tokenizer_without_chat_temp
     prompt_ids = await loop._encode_prompt_ids([{"role": "user", "content": "a red cabin"}])
 
     assert prompt_ids == [101, 102]
+
+
+@pytest.mark.asyncio
+async def test_encode_prompt_ids_requires_text_without_chat_template():
+    class _Tokenizer:
+        chat_template = None
+
+    loop = object.__new__(DiffusionSingleTurnAgentLoop)
+    loop.tokenizer = _Tokenizer()
+
+    with pytest.raises(ValueError, match="Prompt text is empty"):
+        await loop._encode_prompt_ids([{"role": "user", "content": [{"type": "image", "image": "ignored"}]}])

--- a/tests/agent_loop/test_single_turn_agent_loop_on_cpu.py
+++ b/tests/agent_loop/test_single_turn_agent_loop_on_cpu.py
@@ -1,0 +1,64 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU tests for single-turn diffusion agent helpers."""
+
+import os
+
+os.environ["VERL_OMNI_LIGHTWEIGHT_IMPORT"] = "1"
+
+import pytest
+
+from verl_omni.agent_loop.single_turn_agent_loop import DiffusionSingleTurnAgentLoop, _messages_to_text
+
+
+def test_messages_to_text_prefers_user_content_over_system_prompt():
+    messages = [
+        {"role": "system", "content": "You are an image generator."},
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "a red cabin"},
+                {"type": "image", "image": "ignored"},
+                {"type": "text", "text": "in fresh snow"},
+            ],
+        },
+    ]
+
+    assert _messages_to_text(messages) == "a red cabin\nin fresh snow"
+
+
+def test_messages_to_text_falls_back_to_all_text_when_no_user_role():
+    assert _messages_to_text([{"role": "assistant", "content": "fallback text"}]) == "fallback text"
+
+
+def test_messages_to_text_accepts_plain_string():
+    assert _messages_to_text("plain prompt") == "plain prompt"
+
+
+@pytest.mark.asyncio
+async def test_encode_prompt_ids_falls_back_to_plain_tokenizer_without_chat_template():
+    class _Tokenizer:
+        chat_template = None
+
+        def encode(self, text, add_special_tokens=True):
+            assert add_special_tokens is True
+            assert text == "a red cabin"
+            return [101, 102]
+
+    loop = object.__new__(DiffusionSingleTurnAgentLoop)
+    loop.tokenizer = _Tokenizer()
+
+    prompt_ids = await loop._encode_prompt_ids([{"role": "user", "content": "a red cabin"}])
+
+    assert prompt_ids == [101, 102]

--- a/tests/gpu_smoke/run_gpu_smoke_tests.sh
+++ b/tests/gpu_smoke/run_gpu_smoke_tests.sh
@@ -183,7 +183,7 @@ run_selected_test() {
 
 # ── Determine which tests to run ───────────────────────────────────────────────
 declare -A RUN_TEST=(
-    [0]=1 [1]=1 [2]=1 [3]=1 [4]=1 [5]=1 [6]=1 [7]=1
+    [0]=1 [1]=1 [2]=1 [3]=1 [4]=1 [5]=1 [6]=1 [7]=1 [8]=1
 )
 
 # If explicit IDs were passed on the CLI, override to run only those.
@@ -256,6 +256,11 @@ run_selected_test 6 "SD3.5 offline DPO trainer e2e" \
 run_selected_test 7 "diffusers VeOmni engine" \
     env CUDA_VISIBLE_DEVICES="${CUDA_DEVICE_LIST}" \
     pytest -s tests/workers/test_diffusers_veomni_engine.py
+
+# Test 8: FLUX FlowGRPO trainer e2e
+run_selected_test 8 "FLUX FlowGRPO trainer e2e" \
+    env CUDA_VISIBLE_DEVICES="${CUDA_DEVICE_LIST}" NUM_GPUS="${NUM_GPUS}" \
+    bash tests/special_e2e/run_flowgrpo_flux.sh
 
 # ══════════════════════════════════════════════════════════════════════════════
 # SUMMARY

--- a/tests/pipelines/test_diffusion_model_base_on_cpu.py
+++ b/tests/pipelines/test_diffusion_model_base_on_cpu.py
@@ -83,6 +83,8 @@ class TestDiffusionModelBaseRegistry:
 
 class TestVllmOmniPipelineBaseRegistry:
     def test_builtin_qwen_rollout_algorithms_registered(self):
+        pytest.importorskip("vllm_omni")
+
         from verl_omni.pipelines.qwen_image_diffusion_nft.vllm_omni_rollout_adapter import (
             QwenImageDiffusionNFTPipeline,
         )
@@ -92,6 +94,8 @@ class TestVllmOmniPipelineBaseRegistry:
         assert VllmOmniPipelineBase.get_class("QwenImagePipeline", "diffusion_nft") is QwenImageDiffusionNFTPipeline
 
     def test_diffusion_nft_rollout_does_not_override_sde_trajectory_loop(self):
+        pytest.importorskip("vllm_omni")
+
         from verl_omni.pipelines.qwen_image_diffusion_nft.vllm_omni_rollout_adapter import (
             QwenImageDiffusionNFTPipeline,
         )

--- a/tests/pipelines/test_flux_flow_grpo_adapter_on_cpu.py
+++ b/tests/pipelines/test_flux_flow_grpo_adapter_on_cpu.py
@@ -77,8 +77,16 @@ def _batch_tensors(batch_size: int = 2):
 
 
 class _DummyModule:
-    def __init__(self, outputs: list[torch.Tensor] | None = None, *, guidance_embeds: bool = False):
+    def __init__(
+        self,
+        outputs: list[torch.Tensor] | None = None,
+        *,
+        guidance_embeds: bool = False,
+        direct_guidance_embeds: bool | None = None,
+    ):
         self.config = SimpleNamespace(guidance_embeds=guidance_embeds)
+        if direct_guidance_embeds is not None:
+            self.guidance_embeds = direct_guidance_embeds
         self.outputs = list(outputs or [])
         self.calls: list[dict] = []
 
@@ -211,6 +219,23 @@ class TestFluxFlowGRPORolloutParamCompat:
         assert _has_guidance_embeds(SimpleNamespace(guidance_embeds=True)) is True
         assert _has_guidance_embeds(SimpleNamespace()) is False
 
+    def test_extract_prompt_batch_preserves_batched_dict_prompts(self):
+        pytest.importorskip("vllm_omni")
+
+        from verl_omni.pipelines.flux_flow_grpo.vllm_omni_rollout_adapter import _extract_prompt_batch
+
+        prompts = [
+            {"prompt": "a red cabin", "prompt_2": "clip cabin", "negative_prompt": "blurry"},
+            {"prompt": "a blue lake", "prompt_2": "clip lake", "negative_prompt": "low quality"},
+        ]
+
+        prompt, prompt_2, negative_prompt, negative_prompt_2 = _extract_prompt_batch(prompts)
+
+        assert prompt == ["a red cabin", "a blue lake"]
+        assert prompt_2 == ["clip cabin", "clip lake"]
+        assert negative_prompt == ["blurry", "low quality"]
+        assert negative_prompt_2 is None
+
 
 class TestFluxFlowGRPOBuildTransformerInputs:
     def test_squeezes_position_ids_and_scales_timestep(self):
@@ -265,6 +290,32 @@ class TestFluxFlowGRPOPrepareModelInputs:
         torch.testing.assert_close(model_inputs["timestep"], tensors["timesteps"][:, 1] / 1000.0)
         torch.testing.assert_close(model_inputs["guidance"], torch.full((2,), 2.5))
         torch.testing.assert_close(model_inputs["pooled_projections"], tensors["pooled_prompt_embeds"])
+
+    def test_guidance_tensor_accepts_direct_module_flag(self):
+        tensors = _batch_tensors()
+        micro_batch = TensorDict(
+            {
+                "pooled_prompt_embeds": tensors["pooled_prompt_embeds"],
+                "text_ids": tensors["text_ids"],
+                "latent_image_ids": tensors["latent_image_ids"],
+            },
+            batch_size=2,
+        )
+
+        model_inputs, _ = Flux.prepare_model_inputs(
+            module=_DummyModule(direct_guidance_embeds=True),
+            model_config=_make_model_config(guidance_scale=2.75),
+            latents=tensors["latents"],
+            timesteps=tensors["timesteps"],
+            prompt_embeds=tensors["prompt_embeds"],
+            prompt_embeds_mask=tensors["prompt_embeds_mask"],
+            negative_prompt_embeds=tensors["negative_prompt_embeds"],
+            negative_prompt_embeds_mask=tensors["negative_prompt_embeds_mask"],
+            micro_batch=micro_batch,
+            step=0,
+        )
+
+        torch.testing.assert_close(model_inputs["guidance"], torch.full((2,), 2.75))
 
     def test_true_cfg_returns_negative_inputs(self):
         tensors = _batch_tensors()

--- a/tests/pipelines/test_flux_flow_grpo_adapter_on_cpu.py
+++ b/tests/pipelines/test_flux_flow_grpo_adapter_on_cpu.py
@@ -201,6 +201,16 @@ class TestFluxFlowGRPORolloutParamCompat:
         assert _module_parameter_dtype(torch.nn.Linear(2, 2).to(dtype=torch.bfloat16), torch.float32) == torch.bfloat16
         assert _module_parameter_dtype(torch.nn.Identity(), torch.float32) == torch.float32
 
+    def test_guidance_embeds_prefers_diffusers_config(self):
+        pytest.importorskip("vllm_omni")
+
+        from verl_omni.pipelines.flux_flow_grpo.vllm_omni_rollout_adapter import _has_guidance_embeds
+
+        assert _has_guidance_embeds(SimpleNamespace(config=SimpleNamespace(guidance_embeds=True))) is True
+        assert _has_guidance_embeds(SimpleNamespace(config=SimpleNamespace(guidance_embeds=False))) is False
+        assert _has_guidance_embeds(SimpleNamespace(guidance_embeds=True)) is True
+        assert _has_guidance_embeds(SimpleNamespace()) is False
+
 
 class TestFluxFlowGRPOBuildTransformerInputs:
     def test_squeezes_position_ids_and_scales_timestep(self):

--- a/tests/pipelines/test_flux_flow_grpo_adapter_on_cpu.py
+++ b/tests/pipelines/test_flux_flow_grpo_adapter_on_cpu.py
@@ -236,6 +236,17 @@ class TestFluxFlowGRPORolloutParamCompat:
         assert negative_prompt == ["blurry", "low quality"]
         assert negative_prompt_2 is None
 
+    def test_first_generator_accepts_optional_generator_list(self):
+        pytest.importorskip("vllm_omni")
+
+        from verl_omni.pipelines.flux_flow_grpo.vllm_omni_rollout_adapter import _first_generator
+
+        generator = torch.Generator()
+        assert _first_generator(generator) is generator
+        assert _first_generator([generator]) is generator
+        assert _first_generator([]) is None
+        assert _first_generator(None) is None
+
 
 class TestFluxFlowGRPOBuildTransformerInputs:
     def test_squeezes_position_ids_and_scales_timestep(self):

--- a/tests/pipelines/test_flux_flow_grpo_adapter_on_cpu.py
+++ b/tests/pipelines/test_flux_flow_grpo_adapter_on_cpu.py
@@ -189,6 +189,7 @@ class TestFluxFlowGRPORolloutParamCompat:
 
         from verl_omni.pipelines.flux_flow_grpo.vllm_omni_rollout_adapter import _normalize_sde_window
 
+        assert _normalize_sde_window((0, 4), num_timesteps=4) == (0, 4)
         assert _normalize_sde_window((3, 5), num_timesteps=2) == (1, 2)
         assert _normalize_sde_window((0, 4), num_timesteps=1) == (0, 1)
 

--- a/tests/pipelines/test_flux_flow_grpo_adapter_on_cpu.py
+++ b/tests/pipelines/test_flux_flow_grpo_adapter_on_cpu.py
@@ -269,11 +269,13 @@ class TestFluxFlowGRPOBuildTransformerInputs:
             text_ids=tensors["text_ids"],
             latent_image_ids=tensors["latent_image_ids"],
             guidance=guidance,
+            prompt_embeds_mask=tensors["prompt_embeds_mask"],
         )
 
         torch.testing.assert_close(inputs["hidden_states"], tensors["latents"][:, 0])
         torch.testing.assert_close(inputs["timestep"], tensors["timesteps"][:, 0] / 1000.0)
         torch.testing.assert_close(inputs["guidance"], guidance)
+        torch.testing.assert_close(inputs["encoder_attention_mask"], tensors["prompt_embeds_mask"])
         assert inputs["txt_ids"].shape == tensors["text_ids"].shape[1:]
         assert inputs["img_ids"].shape == tensors["latent_image_ids"].shape[1:]
         assert inputs["return_dict"] is False
@@ -309,6 +311,7 @@ class TestFluxFlowGRPOPrepareModelInputs:
         torch.testing.assert_close(model_inputs["timestep"], tensors["timesteps"][:, 1] / 1000.0)
         torch.testing.assert_close(model_inputs["guidance"], torch.full((2,), 2.5))
         torch.testing.assert_close(model_inputs["pooled_projections"], tensors["pooled_prompt_embeds"])
+        torch.testing.assert_close(model_inputs["encoder_attention_mask"], tensors["prompt_embeds_mask"])
 
     def test_guidance_tensor_accepts_direct_module_flag(self):
         tensors = _batch_tensors()
@@ -391,6 +394,10 @@ class TestFluxFlowGRPOPrepareModelInputs:
 
         assert negative_model_inputs is not None
         torch.testing.assert_close(negative_model_inputs["encoder_hidden_states"], tensors["negative_prompt_embeds"])
+        torch.testing.assert_close(
+            negative_model_inputs["encoder_attention_mask"],
+            tensors["negative_prompt_embeds_mask"],
+        )
         torch.testing.assert_close(
             negative_model_inputs["pooled_projections"],
             tensors["negative_pooled_prompt_embeds"],

--- a/tests/pipelines/test_flux_flow_grpo_adapter_on_cpu.py
+++ b/tests/pipelines/test_flux_flow_grpo_adapter_on_cpu.py
@@ -1,0 +1,237 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU tests for the FLUX FlowGRPO training adapter.
+
+These tests keep the adapter boundary covered without loading FLUX weights.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from tensordict import TensorDict
+
+from verl_omni.pipelines.flux_flow_grpo.diffusers_training_adapter import Flux
+from verl_omni.pipelines.model_base import DiffusionModelBase
+from verl_omni.workers.config.diffusion.model import DiffusionModelConfig
+from verl_omni.workers.config.diffusion.rollout import DiffusionPipelineConfig, DiffusionRolloutAlgoConfig
+
+
+def _make_model_config(
+    *,
+    true_cfg_scale: float = 1.0,
+    guidance_scale: float | None = 3.5,
+) -> DiffusionModelConfig:
+    cfg = object.__new__(DiffusionModelConfig)
+    object.__setattr__(cfg, "architecture", "FluxPipeline")
+    object.__setattr__(cfg, "algorithm", "flow_grpo")
+    object.__setattr__(cfg, "external_lib", None)
+    object.__setattr__(cfg, "local_path", "dummy-flux")
+    object.__setattr__(
+        cfg,
+        "pipeline",
+        DiffusionPipelineConfig(
+            height=512,
+            width=512,
+            num_inference_steps=4,
+            true_cfg_scale=true_cfg_scale,
+            guidance_scale=guidance_scale,
+        ),
+    )
+    object.__setattr__(cfg, "algo", DiffusionRolloutAlgoConfig(noise_level=0.7, sde_type="sde"))
+    return cfg
+
+
+def _batch_tensors(batch_size: int = 2):
+    seq_len = 64
+    text_len = 16
+    hidden_size = 32
+    pooled_size = 8
+    latent_width = 12
+    return {
+        "latents": torch.randn(batch_size, 3, seq_len, latent_width),
+        "timesteps": torch.tensor([[1000.0, 500.0], [900.0, 400.0]]),
+        "prompt_embeds": torch.randn(batch_size, text_len, hidden_size),
+        "negative_prompt_embeds": torch.randn(batch_size, text_len, hidden_size),
+        "prompt_embeds_mask": torch.ones(batch_size, text_len, dtype=torch.int32),
+        "negative_prompt_embeds_mask": torch.ones(batch_size, text_len, dtype=torch.int32),
+        "pooled_prompt_embeds": torch.randn(batch_size, pooled_size),
+        "negative_pooled_prompt_embeds": torch.randn(batch_size, pooled_size),
+        "text_ids": torch.zeros(batch_size, text_len, 3),
+        "negative_text_ids": torch.zeros(batch_size, text_len, 3),
+        "latent_image_ids": torch.zeros(batch_size, seq_len, 3),
+    }
+
+
+class _DummyModule:
+    def __init__(self, outputs: list[torch.Tensor] | None = None, *, guidance_embeds: bool = False):
+        self.config = SimpleNamespace(guidance_embeds=guidance_embeds)
+        self.outputs = list(outputs or [])
+        self.calls: list[dict] = []
+
+    def __call__(self, **kwargs):
+        self.calls.append(kwargs)
+        return (self.outputs.pop(0),)
+
+
+class _DummyScheduler:
+    def __init__(self):
+        self.kwargs = None
+
+    def sample_previous_step(self, **kwargs):
+        self.kwargs = kwargs
+        batch_size = kwargs["sample"].shape[0]
+        return (
+            kwargs["prev_sample"],
+            torch.ones(batch_size),
+            torch.zeros_like(kwargs["sample"]),
+            torch.ones(batch_size),
+            torch.full((batch_size,), 0.5),
+        )
+
+
+class TestFluxFlowGRPORegistry:
+    def test_registered_for_flux_flow_grpo(self):
+        assert DiffusionModelBase.get_class(_make_model_config()) is Flux
+
+
+class TestFluxFlowGRPOBuildTransformerInputs:
+    def test_squeezes_position_ids_and_scales_timestep(self):
+        tensors = _batch_tensors()
+        guidance = torch.full((2,), 3.5)
+
+        inputs = Flux.build_transformer_inputs(
+            latents=tensors["latents"][:, 0],
+            timesteps=tensors["timesteps"][:, 0],
+            prompt_embeds=tensors["prompt_embeds"],
+            pooled_prompt_embeds=tensors["pooled_prompt_embeds"],
+            text_ids=tensors["text_ids"],
+            latent_image_ids=tensors["latent_image_ids"],
+            guidance=guidance,
+        )
+
+        torch.testing.assert_close(inputs["hidden_states"], tensors["latents"][:, 0])
+        torch.testing.assert_close(inputs["timestep"], tensors["timesteps"][:, 0] / 1000.0)
+        torch.testing.assert_close(inputs["guidance"], guidance)
+        assert inputs["txt_ids"].shape == tensors["text_ids"].shape[1:]
+        assert inputs["img_ids"].shape == tensors["latent_image_ids"].shape[1:]
+        assert inputs["return_dict"] is False
+
+
+class TestFluxFlowGRPOPrepareModelInputs:
+    def test_no_cfg_returns_positive_inputs_only(self):
+        tensors = _batch_tensors()
+        micro_batch = TensorDict(
+            {
+                "pooled_prompt_embeds": tensors["pooled_prompt_embeds"],
+                "text_ids": tensors["text_ids"],
+                "latent_image_ids": tensors["latent_image_ids"],
+            },
+            batch_size=2,
+        )
+
+        model_inputs, negative_model_inputs = Flux.prepare_model_inputs(
+            module=_DummyModule(guidance_embeds=True),
+            model_config=_make_model_config(true_cfg_scale=1.0, guidance_scale=2.5),
+            latents=tensors["latents"],
+            timesteps=tensors["timesteps"],
+            prompt_embeds=tensors["prompt_embeds"],
+            prompt_embeds_mask=tensors["prompt_embeds_mask"],
+            negative_prompt_embeds=tensors["negative_prompt_embeds"],
+            negative_prompt_embeds_mask=tensors["negative_prompt_embeds_mask"],
+            micro_batch=micro_batch,
+            step=1,
+        )
+
+        assert negative_model_inputs is None
+        torch.testing.assert_close(model_inputs["hidden_states"], tensors["latents"][:, 1])
+        torch.testing.assert_close(model_inputs["timestep"], tensors["timesteps"][:, 1] / 1000.0)
+        torch.testing.assert_close(model_inputs["guidance"], torch.full((2,), 2.5))
+        torch.testing.assert_close(model_inputs["pooled_projections"], tensors["pooled_prompt_embeds"])
+
+    def test_true_cfg_returns_negative_inputs(self):
+        tensors = _batch_tensors()
+        micro_batch = TensorDict(
+            {
+                "pooled_prompt_embeds": tensors["pooled_prompt_embeds"],
+                "negative_pooled_prompt_embeds": tensors["negative_pooled_prompt_embeds"],
+                "text_ids": tensors["text_ids"],
+                "negative_text_ids": tensors["negative_text_ids"],
+                "latent_image_ids": tensors["latent_image_ids"],
+            },
+            batch_size=2,
+        )
+
+        _, negative_model_inputs = Flux.prepare_model_inputs(
+            module=_DummyModule(),
+            model_config=_make_model_config(true_cfg_scale=3.0),
+            latents=tensors["latents"],
+            timesteps=tensors["timesteps"],
+            prompt_embeds=tensors["prompt_embeds"],
+            prompt_embeds_mask=tensors["prompt_embeds_mask"],
+            negative_prompt_embeds=tensors["negative_prompt_embeds"],
+            negative_prompt_embeds_mask=tensors["negative_prompt_embeds_mask"],
+            micro_batch=micro_batch,
+            step=0,
+        )
+
+        assert negative_model_inputs is not None
+        torch.testing.assert_close(negative_model_inputs["encoder_hidden_states"], tensors["negative_prompt_embeds"])
+        torch.testing.assert_close(
+            negative_model_inputs["pooled_projections"],
+            tensors["negative_pooled_prompt_embeds"],
+        )
+
+    def test_rejects_missing_flux_rollout_fields(self):
+        tensors = _batch_tensors()
+        with pytest.raises(KeyError, match="pooled_prompt_embeds"):
+            Flux.prepare_model_inputs(
+                module=_DummyModule(),
+                model_config=_make_model_config(),
+                latents=tensors["latents"],
+                timesteps=tensors["timesteps"],
+                prompt_embeds=tensors["prompt_embeds"],
+                prompt_embeds_mask=tensors["prompt_embeds_mask"],
+                negative_prompt_embeds=tensors["negative_prompt_embeds"],
+                negative_prompt_embeds_mask=tensors["negative_prompt_embeds_mask"],
+                micro_batch=TensorDict({}, batch_size=2),
+                step=0,
+            )
+
+
+class TestFluxFlowGRPOForwardAndSample:
+    def test_true_cfg_combines_predictions_without_norm_rescale(self):
+        pos_pred = torch.ones(2, 64, 12)
+        neg_pred = torch.full((2, 64, 12), 0.25)
+        module = _DummyModule(outputs=[pos_pred, neg_pred])
+        scheduler = _DummyScheduler()
+        scheduler_inputs = {
+            "all_latents": torch.randn(2, 3, 64, 12),
+            "all_timesteps": torch.tensor([[1000.0, 500.0], [900.0, 400.0]]),
+        }
+
+        log_prob, _, _, _ = Flux.forward_and_sample_previous_step(
+            module=module,
+            scheduler=scheduler,
+            model_config=_make_model_config(true_cfg_scale=3.0),
+            model_inputs={"hidden_states": scheduler_inputs["all_latents"][:, 0]},
+            negative_model_inputs={"hidden_states": scheduler_inputs["all_latents"][:, 0]},
+            scheduler_inputs=scheduler_inputs,
+            step=0,
+        )
+
+        expected = neg_pred + 3.0 * (pos_pred - neg_pred)
+        assert scheduler.kwargs is not None
+        torch.testing.assert_close(scheduler.kwargs["model_output"], expected.float())
+        torch.testing.assert_close(log_prob, torch.ones(2))

--- a/tests/pipelines/test_flux_flow_grpo_adapter_on_cpu.py
+++ b/tests/pipelines/test_flux_flow_grpo_adapter_on_cpu.py
@@ -247,6 +247,14 @@ class TestFluxFlowGRPORolloutParamCompat:
         assert _first_generator([]) is None
         assert _first_generator(None) is None
 
+    def test_sde_window_args_parse_hydra_strings(self):
+        pytest.importorskip("vllm_omni")
+
+        from verl_omni.pipelines.flux_flow_grpo.vllm_omni_rollout_adapter import _normalize_sde_window_args
+
+        assert _normalize_sde_window_args("2", "[0,4]") == (2, (0, 4))
+        assert _normalize_sde_window_args(3, [1, 5]) == (3, (1, 5))
+
 
 class TestFluxFlowGRPOBuildTransformerInputs:
     def test_squeezes_position_ids_and_scales_timestep(self):
@@ -327,6 +335,33 @@ class TestFluxFlowGRPOPrepareModelInputs:
         )
 
         torch.testing.assert_close(model_inputs["guidance"], torch.full((2,), 2.75))
+
+    def test_guidance_tensor_unwraps_distributed_module(self):
+        tensors = _batch_tensors()
+        micro_batch = TensorDict(
+            {
+                "pooled_prompt_embeds": tensors["pooled_prompt_embeds"],
+                "text_ids": tensors["text_ids"],
+                "latent_image_ids": tensors["latent_image_ids"],
+            },
+            batch_size=2,
+        )
+
+        wrapped_module = SimpleNamespace(module=_DummyModule(direct_guidance_embeds=True))
+        model_inputs, _ = Flux.prepare_model_inputs(
+            module=wrapped_module,
+            model_config=_make_model_config(guidance_scale=3.25),
+            latents=tensors["latents"],
+            timesteps=tensors["timesteps"],
+            prompt_embeds=tensors["prompt_embeds"],
+            prompt_embeds_mask=tensors["prompt_embeds_mask"],
+            negative_prompt_embeds=tensors["negative_prompt_embeds"],
+            negative_prompt_embeds_mask=tensors["negative_prompt_embeds_mask"],
+            micro_batch=micro_batch,
+            step=0,
+        )
+
+        torch.testing.assert_close(model_inputs["guidance"], torch.full((2,), 3.25))
 
     def test_true_cfg_returns_negative_inputs(self):
         tensors = _batch_tensors()

--- a/tests/pipelines/test_flux_flow_grpo_adapter_on_cpu.py
+++ b/tests/pipelines/test_flux_flow_grpo_adapter_on_cpu.py
@@ -16,12 +16,14 @@
 These tests keep the adapter boundary covered without loading FLUX weights.
 """
 
+import json
 from types import SimpleNamespace
 
 import pytest
 import torch
 from tensordict import TensorDict
 
+from verl_omni.pipelines.flux_flow_grpo.common import getattr_not_none
 from verl_omni.pipelines.flux_flow_grpo.diffusers_training_adapter import Flux
 from verl_omni.pipelines.model_base import DiffusionModelBase
 from verl_omni.workers.config.diffusion.model import DiffusionModelConfig
@@ -104,6 +106,99 @@ class _DummyScheduler:
 class TestFluxFlowGRPORegistry:
     def test_registered_for_flux_flow_grpo(self):
         assert DiffusionModelBase.get_class(_make_model_config()) is Flux
+
+
+class TestFluxFlowGRPORolloutParamCompat:
+    def test_getattr_not_none_reads_optional_sampling_params(self):
+        assert getattr_not_none(SimpleNamespace(), "guidance_scale", 3.5) == 3.5
+        assert getattr_not_none(SimpleNamespace(guidance_scale=None), "guidance_scale", 3.5) == 3.5
+        assert getattr_not_none(SimpleNamespace(guidance_scale=2.25), "guidance_scale", 3.5) == 2.25
+
+    def test_vllm_omni_custom_pipeline_uses_dummy_initial_load(self):
+        pytest.importorskip("vllm_omni")
+
+        from verl_omni.pipelines.flux_flow_grpo.vllm_omni_rollout_adapter import FluxPipelineWithLogProb
+        from verl_omni.workers.rollout.vllm_rollout.vllm_omni_async_server import vLLMOmniHttpServer
+
+        server = object.__new__(vLLMOmniHttpServer)
+        server.model_config = SimpleNamespace(architecture="FluxPipeline", algorithm="flow_grpo")
+        engine_args = {"diffusion_load_format": "safetensors"}
+
+        server._configure_custom_pipeline(engine_args)
+
+        assert engine_args["enable_dummy_pipeline"] is True
+        assert engine_args["diffusion_load_format"] == "dummy"
+        assert engine_args["custom_pipeline_args"] == {
+            "pipeline_class": f"{FluxPipelineWithLogProb.__module__}.{FluxPipelineWithLogProb.__qualname__}"
+        }
+
+    def test_custom_pipeline_fills_missing_transformer_config_from_checkpoint(self, tmp_path):
+        pytest.importorskip("vllm_omni")
+
+        from vllm_omni.diffusion.data import TransformerConfig
+
+        from verl_omni.pipelines.flux_flow_grpo.vllm_omni_rollout_adapter import (
+            _ensure_flux_transformer_config,
+            _get_flux_transformer_config_kwargs,
+        )
+
+        model_dir = tmp_path / "flux"
+        transformer_dir = model_dir / "transformer"
+        transformer_dir.mkdir(parents=True)
+        (transformer_dir / "config.json").write_text(
+            json.dumps(
+                {
+                    "_class_name": "FluxTransformer2DModel",
+                    "guidance_embeds": False,
+                    "num_layers": 19,
+                    "num_single_layers": 38,
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        od_config = SimpleNamespace(
+            model=str(model_dir),
+            tf_model_config=TransformerConfig.from_dict({"num_layers": 2}),
+        )
+
+        _ensure_flux_transformer_config(od_config)
+
+        merged_config = od_config.tf_model_config.to_dict()
+        assert merged_config["guidance_embeds"] is False
+        assert merged_config["num_layers"] == 2
+        assert merged_config["num_single_layers"] == 38
+
+        class DummyFluxTransformer:
+            def __init__(
+                self,
+                od_config,
+                num_layers: int = 19,
+                guidance_embeds: bool = True,
+                ignored_default: str = "default",
+            ):
+                pass
+
+        config_kwargs = _get_flux_transformer_config_kwargs(DummyFluxTransformer, od_config.tf_model_config)
+        assert config_kwargs["guidance_embeds"] is False
+        assert config_kwargs["num_layers"] == 2
+        assert "ignored_default" not in config_kwargs
+
+    def test_sde_window_is_clamped_to_available_timesteps(self):
+        pytest.importorskip("vllm_omni")
+
+        from verl_omni.pipelines.flux_flow_grpo.vllm_omni_rollout_adapter import _normalize_sde_window
+
+        assert _normalize_sde_window((3, 5), num_timesteps=2) == (1, 2)
+        assert _normalize_sde_window((0, 4), num_timesteps=1) == (0, 1)
+
+    def test_module_parameter_dtype_reads_first_parameter_dtype(self):
+        pytest.importorskip("vllm_omni")
+
+        from verl_omni.pipelines.flux_flow_grpo.vllm_omni_rollout_adapter import _module_parameter_dtype
+
+        assert _module_parameter_dtype(torch.nn.Linear(2, 2).to(dtype=torch.bfloat16), torch.float32) == torch.bfloat16
+        assert _module_parameter_dtype(torch.nn.Identity(), torch.float32) == torch.float32
 
 
 class TestFluxFlowGRPOBuildTransformerInputs:

--- a/tests/special_e2e/run_flowgrpo_flux.sh
+++ b/tests/special_e2e/run_flowgrpo_flux.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# FlowGRPO diffusion e2e smoke test for FLUX, vllm_omni rollout.
+#
+# Requires: vllm-omni with FluxPipeline support, diffusers FLUX transformer
+# support, and a local FLUX checkpoint in diffusers pipeline layout.
+set -euo pipefail
+
+NUM_GPUS=${NUM_GPUS:-4}
+MODEL_PATH=${MODEL_PATH:-${HOME}/models/black-forest-labs/FLUX.1-schnell}
+TOKENIZER_PATH=${TOKENIZER_PATH:-${MODEL_PATH}/tokenizer}
+REWARD_MODEL_PATH=${REWARD_MODEL_PATH:-${HOME}/models/tiny-random/qwen3-vl}
+REWARD_TP=${REWARD_TP:-1}
+DATA_DIR=${DATA_DIR:-${HOME}/data/dummy_diffusion_flux}
+dummy_train_path=${TRAIN_FILES:-${DATA_DIR}/train.parquet}
+dummy_test_path=${VAL_FILES:-${DATA_DIR}/test.parquet}
+TOTAL_TRAIN_STEPS=${TOTAL_TRAIN_STEPS:-2}
+
+ENGINE=vllm_omni
+max_prompt_length=256
+n_resp_per_prompt=2
+micro_bsz_per_gpu=1
+micro_bsz=$((micro_bsz_per_gpu * NUM_GPUS))
+mini_bsz=${micro_bsz}
+train_batch_size=$((mini_bsz * n_resp_per_prompt))
+
+python3 tests/special_e2e/create_dummy_diffusion_data.py \
+    --local_save_dir "${DATA_DIR}" \
+    --train_size "${train_batch_size}" \
+    --val_size 4
+
+python3 -m verl_omni.trainer.main_diffusion \
+    data.train_files=${dummy_train_path} \
+    data.val_files=${dummy_test_path} \
+    data.train_batch_size=${train_batch_size} \
+    data.max_prompt_length=${max_prompt_length} \
+    actor_rollout_ref.model.algorithm=flow_grpo \
+    actor_rollout_ref.model.path=${MODEL_PATH} \
+    actor_rollout_ref.model.tokenizer_path=${TOKENIZER_PATH} \
+    actor_rollout_ref.model.custom_chat_template=null \
+    actor_rollout_ref.model.lora_rank=8 \
+    actor_rollout_ref.model.lora_alpha=16 \
+    actor_rollout_ref.model.target_modules=all-linear \
+    actor_rollout_ref.actor.optim.lr=1e-4 \
+    actor_rollout_ref.actor.optim.weight_decay=0.0001 \
+    actor_rollout_ref.actor.ppo_mini_batch_size=${mini_bsz} \
+    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=${micro_bsz_per_gpu} \
+    actor_rollout_ref.actor.fsdp_config.param_offload=True \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=True \
+    actor_rollout_ref.actor.fsdp_config.model_dtype=bfloat16 \
+    actor_rollout_ref.actor.use_kl_loss=True \
+    actor_rollout_ref.actor.kl_loss_coef=0.04 \
+    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=${micro_bsz_per_gpu} \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=1 \
+    actor_rollout_ref.rollout.name=${ENGINE} \
+    actor_rollout_ref.rollout.n=${n_resp_per_prompt} \
+    actor_rollout_ref.rollout.agent.num_workers=1 \
+    actor_rollout_ref.rollout.load_format=safetensors \
+    actor_rollout_ref.rollout.layered_summon=True \
+    actor_rollout_ref.rollout.pipeline.num_inference_steps=4 \
+    actor_rollout_ref.rollout.pipeline.height=256 \
+    actor_rollout_ref.rollout.pipeline.width=256 \
+    actor_rollout_ref.rollout.pipeline.guidance_scale=3.5 \
+    actor_rollout_ref.rollout.pipeline.true_cfg_scale=1.0 \
+    actor_rollout_ref.rollout.pipeline.max_sequence_length=${max_prompt_length} \
+    actor_rollout_ref.rollout.enforce_eager=True \
+    actor_rollout_ref.rollout.algo.noise_level=1.0 \
+    actor_rollout_ref.rollout.algo.sde_type="sde" \
+    actor_rollout_ref.rollout.algo.sde_window_size=2 \
+    actor_rollout_ref.rollout.algo.sde_window_range="[0,4]" \
+    actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=4 \
+    actor_rollout_ref.rollout.val_kwargs.algo.noise_level=0.0 \
+    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=${micro_bsz_per_gpu} \
+    reward.num_workers=1 \
+    reward.reward_model.enable=True \
+    reward.reward_model.model_path=${REWARD_MODEL_PATH} \
+    reward.reward_model.rollout.name=vllm \
+    reward.reward_model.rollout.tensor_model_parallel_size=${REWARD_TP} \
+    reward.reward_model.rollout.gpu_memory_utilization=0.4 \
+    reward.reward_model.rollout.prompt_length=${max_prompt_length} \
+    reward.reward_model.rollout.response_length=32 \
+    reward.custom_reward_function.path=verl_omni/utils/reward_score/genrm_ocr.py \
+    reward.custom_reward_function.name=compute_score_ocr \
+    trainer.logger=console \
+    trainer.project_name=verl-test \
+    trainer.experiment_name=flowgrpo-flux-e2e \
+    trainer.log_val_generations=0 \
+    trainer.n_gpus_per_node=${NUM_GPUS} \
+    trainer.nnodes=1 \
+    trainer.val_before_train=False \
+    trainer.test_freq=-1 \
+    trainer.save_freq=-1 \
+    trainer.resume_mode=disable \
+    trainer.total_training_steps=${TOTAL_TRAIN_STEPS} \
+    "$@"
+
+echo "FLUX FlowGRPO e2e test passed (training completed successfully)."

--- a/verl_omni/agent_loop/__init__.py
+++ b/verl_omni/agent_loop/__init__.py
@@ -12,8 +12,34 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .diffusion_agent_loop import DiffusionAgentLoopOutput, DiffusionAgentLoopWorker
+import logging
+import os
+
 from .single_turn_agent_loop import DiffusionSingleTurnAgentLoop
+
+logger = logging.getLogger(__name__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
+
+_LIGHTWEIGHT_IMPORT = os.getenv("VERL_OMNI_LIGHTWEIGHT_IMPORT") == "1"
+
+if _LIGHTWEIGHT_IMPORT:
+    _DIFFUSION_AGENT_LOOP_IMPORT_ERROR = RuntimeError("VERL_OMNI_LIGHTWEIGHT_IMPORT=1")
+
+    class _UnavailableModule:
+        def __getattr__(self, _):
+            raise RuntimeError("Diffusion agent-loop worker requires the full verl runtime") from (
+                _DIFFUSION_AGENT_LOOP_IMPORT_ERROR
+            )
+
+        def __call__(self, *args, **kwargs):
+            raise RuntimeError("Diffusion agent-loop worker requires the full verl runtime") from (
+                _DIFFUSION_AGENT_LOOP_IMPORT_ERROR
+            )
+
+    DiffusionAgentLoopOutput = _UnavailableModule()
+    DiffusionAgentLoopWorker = _UnavailableModule()
+else:
+    from .diffusion_agent_loop import DiffusionAgentLoopOutput, DiffusionAgentLoopWorker
 
 __all__ = [
     "DiffusionAgentLoopOutput",

--- a/verl_omni/agent_loop/single_turn_agent_loop.py
+++ b/verl_omni/agent_loop/single_turn_agent_loop.py
@@ -145,7 +145,7 @@ class DiffusionSingleTurnAgentLoop(AgentLoopBase):
 
         text = _messages_to_text(raw_prompt)
         if text is None:
-            return await self.apply_chat_template(raw_prompt, images=images, videos=videos)
+            raise ValueError("Prompt text is empty and no chat template is available on the tokenizer.")
         return self.tokenizer.encode(text, add_special_tokens=True)
 
     async def run(self, sampling_params: dict[str, Any], **kwargs) -> DiffusionAgentLoopOutput:

--- a/verl_omni/agent_loop/single_turn_agent_loop.py
+++ b/verl_omni/agent_loop/single_turn_agent_loop.py
@@ -13,21 +13,140 @@
 # limitations under the License.
 import logging
 import os
+from contextlib import contextmanager
 from typing import Any
 from uuid import uuid4
 
-from verl.experimental.agent_loop.agent_loop import AgentLoopBase, register
-from verl.utils.profiler import simple_timer
+_LIGHTWEIGHT_IMPORT = os.getenv("VERL_OMNI_LIGHTWEIGHT_IMPORT") == "1"
 
-from verl_omni.agent_loop.diffusion_agent_loop import DiffusionAgentLoopOutput
+if _LIGHTWEIGHT_IMPORT:
+    _AGENT_LOOP_IMPORT_ERROR = RuntimeError("VERL_OMNI_LIGHTWEIGHT_IMPORT=1")
+
+    class AgentLoopBase:
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError("Diffusion single-turn agent loop requires verl agent-loop runtime") from (
+                _AGENT_LOOP_IMPORT_ERROR
+            )
+
+    def register(_):
+        return lambda cls: cls
+
+else:
+    from verl.experimental.agent_loop.agent_loop import AgentLoopBase, register
+
+if _LIGHTWEIGHT_IMPORT:
+
+    @contextmanager
+    def simple_timer(name: str, timing_raw: dict[str, float]):
+        del name, timing_raw
+        yield
+
+else:
+    from verl.utils.profiler import simple_timer
+
+if _LIGHTWEIGHT_IMPORT:
+
+    class DiffusionAgentLoopOutput:
+        def __init__(
+            self,
+            *,
+            prompt_ids,
+            response_diffusion_output,
+            response_logprobs=None,
+            reward_score=None,
+            num_turns=0,
+            metrics=None,
+            extra_fields=None,
+        ):
+            self.prompt_ids = prompt_ids
+            self.response_diffusion_output = response_diffusion_output
+            self.response_logprobs = response_logprobs
+            self.reward_score = reward_score
+            self.num_turns = num_turns
+            self.metrics = metrics or {}
+            self.extra_fields = extra_fields or {}
+
+else:
+    from verl_omni.agent_loop.diffusion_agent_loop import DiffusionAgentLoopOutput
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
 
+def _as_list(value: Any) -> list | None:
+    if value is None:
+        return None
+    if hasattr(value, "tolist"):
+        value = value.tolist()
+    if isinstance(value, tuple):
+        return list(value)
+    if isinstance(value, list):
+        return value
+    return None
+
+
+def _content_to_text_parts(content: Any) -> list[str]:
+    if hasattr(content, "tolist"):
+        content = content.tolist()
+    if isinstance(content, str):
+        return [content]
+
+    items = _as_list(content)
+    if items is None:
+        return []
+
+    parts: list[str] = []
+    for item in items:
+        if isinstance(item, str):
+            parts.append(item)
+        elif isinstance(item, dict) and item.get("type") == "text":
+            parts.append(item.get("text", ""))
+    return parts
+
+
+def _messages_to_text(messages: Any) -> str | None:
+    """Extract text content for diffusion pipelines that run their own text encoders."""
+    if messages is None:
+        return None
+    if isinstance(messages, str):
+        return messages
+
+    if isinstance(messages, dict):
+        messages = [messages]
+    else:
+        messages = _as_list(messages)
+        if messages is None:
+            return None
+
+    user_parts: list[str] = []
+    fallback_parts: list[str] = []
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        role = message.get("role")
+        content = message.get("content")
+        content_parts = _content_to_text_parts(content)
+        fallback_parts.extend(content_parts)
+        if role == "user":
+            user_parts.extend(content_parts)
+
+    parts = user_parts or fallback_parts
+    text = "\n".join(part for part in parts if part)
+    return text or None
+
+
 @register("diffusion_single_turn_agent")
 class DiffusionSingleTurnAgentLoop(AgentLoopBase):
     """Agent loop for diffusion model serving."""
+
+    async def _encode_prompt_ids(self, raw_prompt, *, images=None, videos=None) -> list[int]:
+        if getattr(self.tokenizer, "chat_template", None) is not None:
+            return await self.apply_chat_template(raw_prompt, images=images, videos=videos)
+
+        text = _messages_to_text(raw_prompt)
+        if text is None:
+            return await self.apply_chat_template(raw_prompt, images=images, videos=videos)
+        return self.tokenizer.encode(text, add_special_tokens=True)
 
     async def run(self, sampling_params: dict[str, Any], **kwargs) -> DiffusionAgentLoopOutput:
         """Run one diffusion generation turn and package agent-loop output.
@@ -50,20 +169,28 @@ class DiffusionSingleTurnAgentLoop(AgentLoopBase):
         videos = multi_modal_data.get("videos")
 
         # 2. apply chat template and tokenize
-        prompt_ids = await self.apply_chat_template(raw_prompt, images=images, videos=videos)
+        prompt_ids = await self._encode_prompt_ids(raw_prompt, images=images, videos=videos)
 
         if raw_negative_prompt is not None:
-            negative_prompt_ids = await self.apply_chat_template(raw_negative_prompt, images=images, videos=videos)
+            negative_prompt_ids = await self._encode_prompt_ids(raw_negative_prompt, images=images, videos=videos)
         else:
             negative_prompt_ids = None
 
         # 3. generate sequences
         metrics = {}
+        request_sampling_params = sampling_params.copy()
+        raw_prompt_text = _messages_to_text(raw_prompt)
+        raw_negative_prompt_text = _messages_to_text(raw_negative_prompt)
+        if raw_prompt_text is not None:
+            request_sampling_params["_raw_prompt"] = raw_prompt_text
+        if raw_negative_prompt_text is not None:
+            request_sampling_params["_raw_negative_prompt"] = raw_negative_prompt_text
+
         with simple_timer("generate_sequences", metrics):
             output = await self.server_manager.generate(
                 request_id=uuid4().hex,
                 prompt_ids=prompt_ids,
-                sampling_params=sampling_params,
+                sampling_params=request_sampling_params,
                 image_data=images,
                 video_data=videos,
                 negative_prompt_ids=negative_prompt_ids,

--- a/verl_omni/pipelines/__init__.py
+++ b/verl_omni/pipelines/__init__.py
@@ -14,10 +14,14 @@
 
 from . import (
     _patch,  # noqa: F401 — apply Ulysses mask fix
+    flux_flow_grpo,
     qwen_image_diffusion_nft,
     qwen_image_flow_grpo,
     qwen_image_mix_grpo,
+    sd3_dpo,
+    wan22_dance_grpo,
 )
+from .flux_flow_grpo import *  # noqa: F401, F403
 from .qwen_image_diffusion_nft import *  # noqa: F401, F403
 from .qwen_image_flow_grpo import *  # noqa: F401, F403
 from .qwen_image_mix_grpo import *  # noqa: F401, F403
@@ -25,6 +29,7 @@ from .sd3_dpo import *  # noqa: F401, F403
 from .wan22_dance_grpo import *  # noqa: F401, F403
 
 __all__ = list(qwen_image_flow_grpo.__all__)
+__all__ += list(flux_flow_grpo.__all__)
 __all__ += list(qwen_image_diffusion_nft.__all__)
 __all__ += list(qwen_image_mix_grpo.__all__)
 __all__ += list(sd3_dpo.__all__)

--- a/verl_omni/pipelines/flux_flow_grpo/__init__.py
+++ b/verl_omni/pipelines/flux_flow_grpo/__init__.py
@@ -15,23 +15,23 @@
 import logging
 import os
 
-from .diffusers_training_adapter import *  # noqa: F401,F403
+from .diffusers_training_adapter import Flux
 
 logger = logging.getLogger(__name__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
 try:
-    from .vllm_omni_rollout_adapter import *  # noqa: F401,F403
+    from .vllm_omni_rollout_adapter import FluxPipelineWithLogProb
 except (ImportError, RuntimeError, AttributeError) as e:
-    logger.info(f"Qwen Image DiffusionNFT rollout adapter not available: {e}. vLLM-Omni required.")
+    logger.info(f"FLUX FlowGRPO rollout adapter not available: {e}. vLLM-Omni is required.")
 
     class _UnavailableModule:
         def __getattr__(self, _):
-            raise RuntimeError("Qwen Image DiffusionNFT rollout adapter requires vLLM-Omni")
+            raise RuntimeError("FLUX FlowGRPO rollout adapter requires vLLM-Omni.")
 
         def __call__(self, *args, **kwargs):
-            raise RuntimeError("Qwen Image DiffusionNFT rollout adapter requires vLLM-Omni")
+            raise RuntimeError("FLUX FlowGRPO rollout adapter requires vLLM-Omni.")
 
-    QwenImageDiffusionNFTPipeline = _UnavailableModule()
+    FluxPipelineWithLogProb = _UnavailableModule()
 
-__all__ = ["QwenImageDiffusionNFT", "QwenImageDiffusionNFTPipeline"]
+__all__ = ["Flux", "FluxPipelineWithLogProb"]

--- a/verl_omni/pipelines/flux_flow_grpo/common.py
+++ b/verl_omni/pipelines/flux_flow_grpo/common.py
@@ -27,6 +27,10 @@ def coalesce_not_none(value, default):
     return default if value is None else value
 
 
+def getattr_not_none(obj, name: str, default):
+    return coalesce_not_none(getattr(obj, name, None), default)
+
+
 def calculate_shift(
     image_seq_len: int,
     base_image_seq_len: int = 256,

--- a/verl_omni/pipelines/flux_flow_grpo/common.py
+++ b/verl_omni/pipelines/flux_flow_grpo/common.py
@@ -1,0 +1,65 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+
+FLUX_VAE_SCALE_FACTOR = 8
+
+
+def maybe_to_cpu(value):
+    if isinstance(value, torch.Tensor):
+        return value.detach().cpu()
+    return value
+
+
+def coalesce_not_none(value, default):
+    return default if value is None else value
+
+
+def calculate_shift(
+    image_seq_len: int,
+    base_image_seq_len: int = 256,
+    max_image_seq_len: int = 4096,
+    base_shift: float = 0.5,
+    max_shift: float = 1.15,
+) -> float:
+    m = (max_shift - base_shift) / (max_image_seq_len - base_image_seq_len)
+    b = base_shift - m * base_image_seq_len
+    return image_seq_len * m + b
+
+
+def packed_latent_seq_len(height: int, width: int, vae_scale_factor: int = FLUX_VAE_SCALE_FACTOR) -> int:
+    latent_height = 2 * (int(height) // (vae_scale_factor * 2))
+    latent_width = 2 * (int(width) // (vae_scale_factor * 2))
+    return (latent_height // 2) * (latent_width // 2)
+
+
+def squeeze_batch_position_ids(value: torch.Tensor | None) -> torch.Tensor | None:
+    if value is not None and value.ndim == 3:
+        return value[0]
+    return value
+
+
+def batched_position_ids(value: torch.Tensor, batch_size: int) -> torch.Tensor:
+    if value.ndim == 2:
+        return value.unsqueeze(0).expand(batch_size, -1, -1)
+    return value
+
+
+def apply_true_cfg(
+    noise_pred: torch.Tensor,
+    negative_noise_pred: torch.Tensor,
+    true_cfg_scale: float,
+) -> torch.Tensor:
+    return negative_noise_pred + true_cfg_scale * (noise_pred - negative_noise_pred)

--- a/verl_omni/pipelines/flux_flow_grpo/diffusers_training_adapter.py
+++ b/verl_omni/pipelines/flux_flow_grpo/diffusers_training_adapter.py
@@ -1,0 +1,216 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+FLUX training-side adapter for diffusers-based FlowGRPO.
+"""
+
+from typing import Optional
+
+import numpy as np
+import torch
+from diffusers import ModelMixin
+from tensordict import TensorDict
+from verl.utils.device import get_device_name
+
+from verl_omni.pipelines.model_base import DiffusionModelBase
+from verl_omni.pipelines.schedulers import FlowMatchSDEDiscreteScheduler
+from verl_omni.workers.config import DiffusionModelConfig
+
+from .common import apply_true_cfg, calculate_shift, packed_latent_seq_len, squeeze_batch_position_ids
+
+__all__ = ["Flux"]
+
+
+def _build_flux_scheduler(model_path: str) -> FlowMatchSDEDiscreteScheduler:
+    return FlowMatchSDEDiscreteScheduler.from_pretrained(
+        pretrained_model_name_or_path=model_path,
+        subfolder="scheduler",
+    )
+
+
+def _configure_flux_scheduler(
+    scheduler: FlowMatchSDEDiscreteScheduler,
+    *,
+    height: int,
+    width: int,
+    num_inference_steps: int,
+    device: str,
+) -> None:
+    sigmas = np.linspace(1.0, 1 / num_inference_steps, num_inference_steps)
+    mu = calculate_shift(
+        packed_latent_seq_len(height, width),
+        scheduler.config.get("base_image_seq_len", 256),
+        scheduler.config.get("max_image_seq_len", 4096),
+        scheduler.config.get("base_shift", 0.5),
+        scheduler.config.get("max_shift", 1.15),
+    )
+    scheduler.set_timesteps(num_inference_steps, device=device, sigmas=sigmas, mu=mu)
+
+
+def _guidance_tensor(
+    module: ModelMixin,
+    model_config: DiffusionModelConfig,
+    timesteps: torch.Tensor,
+) -> torch.Tensor | None:
+    guidance_scale = model_config.pipeline.guidance_scale
+    if guidance_scale is None:
+        guidance_scale = 3.5
+    if getattr(module.config, "guidance_embeds", False):
+        return torch.full([timesteps.shape[0]], guidance_scale, device=timesteps.device, dtype=torch.float32)
+    return None
+
+
+@DiffusionModelBase.register("FluxPipeline", algorithm="flow_grpo")
+class Flux(DiffusionModelBase):
+    """Training adapter for FLUX FlowGRPO.
+
+    FLUX uses packed latent patches plus two text-conditioning paths.  Rollout
+    therefore returns the T5 prompt embeds, pooled CLIP embeds, text position
+    ids, and latent image ids; this adapter rebuilds the transformer inputs
+    from those tensors during policy log-prob recomputation.
+    """
+
+    @classmethod
+    def build_scheduler(cls, model_config: DiffusionModelConfig):
+        scheduler = _build_flux_scheduler(model_config.local_path)
+        cls.set_timesteps(scheduler, model_config, get_device_name())
+        return scheduler
+
+    @classmethod
+    def set_timesteps(cls, scheduler: FlowMatchSDEDiscreteScheduler, model_config: DiffusionModelConfig, device: str):
+        _configure_flux_scheduler(
+            scheduler,
+            height=model_config.pipeline.height,
+            width=model_config.pipeline.width,
+            num_inference_steps=model_config.pipeline.num_inference_steps,
+            device=device,
+        )
+
+    @classmethod
+    def build_transformer_inputs(
+        cls,
+        *,
+        latents: torch.Tensor,
+        timesteps: torch.Tensor,
+        prompt_embeds: torch.Tensor,
+        pooled_prompt_embeds: torch.Tensor,
+        text_ids: torch.Tensor,
+        latent_image_ids: torch.Tensor,
+        guidance: torch.Tensor | None,
+        joint_attention_kwargs: dict | None = None,
+    ) -> dict:
+        return {
+            "hidden_states": latents,
+            "timestep": timesteps / 1000.0,
+            "guidance": guidance,
+            "pooled_projections": pooled_prompt_embeds,
+            "encoder_hidden_states": prompt_embeds,
+            "txt_ids": squeeze_batch_position_ids(text_ids),
+            "img_ids": squeeze_batch_position_ids(latent_image_ids),
+            "joint_attention_kwargs": joint_attention_kwargs or {},
+            "return_dict": False,
+        }
+
+    @classmethod
+    def prepare_model_inputs(
+        cls,
+        module: ModelMixin,
+        model_config: DiffusionModelConfig,
+        latents: torch.Tensor,
+        timesteps: torch.Tensor,
+        prompt_embeds: torch.Tensor,
+        prompt_embeds_mask: torch.Tensor,
+        negative_prompt_embeds: torch.Tensor,
+        negative_prompt_embeds_mask: torch.Tensor,
+        micro_batch: TensorDict,
+        step: int,
+    ) -> tuple[dict, Optional[dict]]:
+        if "pooled_prompt_embeds" not in micro_batch:
+            raise KeyError("FLUX FlowGRPO requires `pooled_prompt_embeds` from rollout.")
+        if "text_ids" not in micro_batch:
+            raise KeyError("FLUX FlowGRPO requires `text_ids` from rollout.")
+        if "latent_image_ids" not in micro_batch:
+            raise KeyError("FLUX FlowGRPO requires `latent_image_ids` from rollout.")
+
+        selected_latents = latents[:, step]
+        selected_timesteps = timesteps[:, step]
+        guidance = _guidance_tensor(module, model_config, selected_timesteps)
+
+        model_inputs = cls.build_transformer_inputs(
+            latents=selected_latents,
+            timesteps=selected_timesteps,
+            prompt_embeds=prompt_embeds,
+            pooled_prompt_embeds=micro_batch["pooled_prompt_embeds"],
+            text_ids=micro_batch["text_ids"],
+            latent_image_ids=micro_batch["latent_image_ids"],
+            guidance=guidance,
+        )
+
+        true_cfg_scale = model_config.pipeline.true_cfg_scale
+        if true_cfg_scale > 1.0:
+            if negative_prompt_embeds is None:
+                raise ValueError("FLUX true CFG requires negative prompt embeds when true_cfg_scale > 1.")
+            if "negative_pooled_prompt_embeds" not in micro_batch:
+                raise KeyError("FLUX true CFG requires `negative_pooled_prompt_embeds` from rollout.")
+            if "negative_text_ids" not in micro_batch:
+                raise KeyError("FLUX true CFG requires `negative_text_ids` from rollout.")
+            negative_model_inputs = cls.build_transformer_inputs(
+                latents=selected_latents,
+                timesteps=selected_timesteps,
+                prompt_embeds=negative_prompt_embeds,
+                pooled_prompt_embeds=micro_batch["negative_pooled_prompt_embeds"],
+                text_ids=micro_batch["negative_text_ids"],
+                latent_image_ids=micro_batch["latent_image_ids"],
+                guidance=guidance,
+            )
+        else:
+            negative_model_inputs = None
+
+        return model_inputs, negative_model_inputs
+
+    @classmethod
+    def forward_and_sample_previous_step(
+        cls,
+        module: ModelMixin,
+        scheduler: FlowMatchSDEDiscreteScheduler,
+        model_config: DiffusionModelConfig,
+        model_inputs: dict[str, torch.Tensor],
+        negative_model_inputs: Optional[dict[str, torch.Tensor]],
+        scheduler_inputs: Optional[TensorDict | dict[str, torch.Tensor]],
+        step: int,
+    ):
+        assert scheduler_inputs is not None
+        latents = scheduler_inputs["all_latents"]
+        timesteps = scheduler_inputs["all_timesteps"]
+
+        noise_pred = cls.forward(module, model_config, model_inputs)
+        true_cfg_scale = model_config.pipeline.true_cfg_scale
+        if true_cfg_scale > 1.0:
+            if negative_model_inputs is None:
+                raise ValueError("FLUX true CFG requires negative model inputs when true_cfg_scale > 1.")
+            neg_noise_pred = cls.forward(module, model_config, negative_model_inputs)
+            noise_pred = apply_true_cfg(noise_pred, neg_noise_pred, true_cfg_scale)
+
+        _, log_prob, prev_sample_mean, std_dev_t, sqrt_dt = scheduler.sample_previous_step(
+            sample=latents[:, step].float(),
+            model_output=noise_pred.float(),
+            timestep=timesteps[:, step],
+            noise_level=model_config.algo.noise_level,
+            prev_sample=latents[:, step + 1].float(),
+            sde_type=model_config.algo.sde_type,
+            return_logprobs=True,
+            return_sqrt_dt=True,
+        )
+        return log_prob, prev_sample_mean, std_dev_t, sqrt_dt

--- a/verl_omni/pipelines/flux_flow_grpo/diffusers_training_adapter.py
+++ b/verl_omni/pipelines/flux_flow_grpo/diffusers_training_adapter.py
@@ -67,6 +67,8 @@ def _guidance_tensor(
     guidance_scale = model_config.pipeline.guidance_scale
     if guidance_scale is None:
         guidance_scale = 3.5
+    while hasattr(module, "module"):
+        module = module.module
     if getattr(module, "guidance_embeds", False) or getattr(getattr(module, "config", None), "guidance_embeds", False):
         return torch.full([timesteps.shape[0]], guidance_scale, device=timesteps.device, dtype=torch.float32)
     return None

--- a/verl_omni/pipelines/flux_flow_grpo/diffusers_training_adapter.py
+++ b/verl_omni/pipelines/flux_flow_grpo/diffusers_training_adapter.py
@@ -111,6 +111,7 @@ class Flux(DiffusionModelBase):
         text_ids: torch.Tensor,
         latent_image_ids: torch.Tensor,
         guidance: torch.Tensor | None,
+        prompt_embeds_mask: torch.Tensor | None = None,
         joint_attention_kwargs: dict | None = None,
     ) -> dict:
         return {
@@ -119,6 +120,7 @@ class Flux(DiffusionModelBase):
             "guidance": guidance,
             "pooled_projections": pooled_prompt_embeds,
             "encoder_hidden_states": prompt_embeds,
+            "encoder_attention_mask": prompt_embeds_mask,
             "txt_ids": squeeze_batch_position_ids(text_ids),
             "img_ids": squeeze_batch_position_ids(latent_image_ids),
             "joint_attention_kwargs": joint_attention_kwargs or {},
@@ -158,6 +160,7 @@ class Flux(DiffusionModelBase):
             text_ids=micro_batch["text_ids"],
             latent_image_ids=micro_batch["latent_image_ids"],
             guidance=guidance,
+            prompt_embeds_mask=prompt_embeds_mask,
         )
 
         true_cfg_scale = model_config.pipeline.true_cfg_scale
@@ -176,6 +179,7 @@ class Flux(DiffusionModelBase):
                 text_ids=micro_batch["negative_text_ids"],
                 latent_image_ids=micro_batch["latent_image_ids"],
                 guidance=guidance,
+                prompt_embeds_mask=negative_prompt_embeds_mask,
             )
         else:
             negative_model_inputs = None

--- a/verl_omni/pipelines/flux_flow_grpo/diffusers_training_adapter.py
+++ b/verl_omni/pipelines/flux_flow_grpo/diffusers_training_adapter.py
@@ -67,7 +67,7 @@ def _guidance_tensor(
     guidance_scale = model_config.pipeline.guidance_scale
     if guidance_scale is None:
         guidance_scale = 3.5
-    if getattr(module.config, "guidance_embeds", False):
+    if getattr(module, "guidance_embeds", False) or getattr(getattr(module, "config", None), "guidance_embeds", False):
         return torch.full([timesteps.shape[0]], guidance_scale, device=timesteps.device, dtype=torch.float32)
     return None
 

--- a/verl_omni/pipelines/flux_flow_grpo/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/flux_flow_grpo/vllm_omni_rollout_adapter.py
@@ -119,6 +119,28 @@ def _has_guidance_embeds(module: torch.nn.Module) -> bool:
     return bool(getattr(module, "guidance_embeds", False))
 
 
+def _extract_prompt_batch(
+    prompts: list[Any],
+    prompt: str | list[str] | None = None,
+    prompt_2: str | list[str] | None = None,
+    negative_prompt: str | list[str] | None = None,
+    negative_prompt_2: str | list[str] | None = None,
+) -> tuple[str | list[str] | None, str | list[str] | None, str | list[str] | None, str | list[str] | None]:
+    if prompt is None and prompts:
+        prompt = [p if isinstance(p, str) else (p.get("prompt") or "") for p in prompts]
+    if prompt_2 is None and prompts and all(isinstance(p, dict) for p in prompts):
+        prompt_2 = [p.get("prompt_2") for p in prompts]
+    if negative_prompt is None and prompts:
+        negative_prompt = ["" if isinstance(p, str) else (p.get("negative_prompt") or "") for p in prompts]
+        if all(not item for item in negative_prompt):
+            negative_prompt = None
+    if negative_prompt_2 is None and prompts and all(isinstance(p, dict) for p in prompts):
+        negative_prompt_2 = [p.get("negative_prompt_2") for p in prompts]
+        if all(item is None for item in negative_prompt_2):
+            negative_prompt_2 = None
+    return prompt, prompt_2, negative_prompt, negative_prompt_2
+
+
 @contextmanager
 def _patched_flux_transformer_constructor(od_config: OmniDiffusionConfig):
     """Forward checkpoint transformer kwargs while upstream vLLM-Omni does not.
@@ -304,19 +326,13 @@ class FluxPipelineWithLogProb(FluxPipeline):
         sde_type: Literal["sde", "cps"] = "sde",
         logprobs: bool = True,
     ) -> DiffusionOutput:
-        custom_prompt = req.prompts[0] if req.prompts else {}
-        if isinstance(custom_prompt, dict):
-            prompt = custom_prompt.get("prompt", prompt)
-            prompt_2 = custom_prompt.get("prompt_2", prompt_2)
-            negative_prompt = custom_prompt.get("negative_prompt", negative_prompt)
-            negative_prompt_2 = custom_prompt.get("negative_prompt_2", negative_prompt_2)
-
-        if prompt is None and req.prompts:
-            prompt = [p if isinstance(p, str) else (p.get("prompt") or "") for p in req.prompts]
-        if negative_prompt is None and req.prompts:
-            negative_prompt = ["" if isinstance(p, str) else (p.get("negative_prompt") or "") for p in req.prompts]
-            if all(not item for item in negative_prompt):
-                negative_prompt = None
+        prompt, prompt_2, negative_prompt, negative_prompt_2 = _extract_prompt_batch(
+            req.prompts,
+            prompt,
+            prompt_2,
+            negative_prompt,
+            negative_prompt_2,
+        )
 
         sampling_params = req.sampling_params
         height = sampling_params.height or self.default_sample_size * self.vae_scale_factor

--- a/verl_omni/pipelines/flux_flow_grpo/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/flux_flow_grpo/vllm_omni_rollout_adapter.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import inspect
+import ast
 import json
 import logging
 import os
@@ -145,6 +146,19 @@ def _first_generator(generator: torch.Generator | list[torch.Generator] | None) 
     if isinstance(generator, list):
         return generator[0] if generator else None
     return generator
+
+
+def _normalize_sde_window_args(
+    sde_window_size: int | str | None,
+    sde_window_range: tuple[int, int] | list[int] | str,
+) -> tuple[int | None, tuple[int, int]]:
+    if sde_window_size is not None:
+        sde_window_size = int(sde_window_size)
+    if isinstance(sde_window_range, str):
+        sde_window_range = ast.literal_eval(sde_window_range)
+    if len(sde_window_range) != 2:
+        raise ValueError("FLUX rollout sde_window_range must contain exactly two values.")
+    return sde_window_size, (int(sde_window_range[0]), int(sde_window_range[1]))
 
 
 @contextmanager
@@ -284,7 +298,7 @@ class FluxPipelineWithLogProb(FluxPipeline):
                 noise_pred.float(),
                 timestep_value,
                 latents,
-                generator=generator,
+                generator=_first_generator(generator),
                 noise_level=cur_noise_level,
                 sde_type=sde_type,
                 return_logprobs=logprobs,
@@ -292,7 +306,7 @@ class FluxPipelineWithLogProb(FluxPipeline):
             )
 
             if i >= sde_window[0] and i < sde_window[1]:
-                all_latents.append(latents)
+                all_latents.append(latents.float())
                 all_log_probs.append(log_prob)
                 all_timesteps.append(timestep_value)
 
@@ -360,6 +374,7 @@ class FluxPipelineWithLogProb(FluxPipeline):
         noise_level = coalesce_not_none(sampling_params.extra_args.get("noise_level", None), noise_level)
         sde_window_size = coalesce_not_none(sampling_params.extra_args.get("sde_window_size", None), sde_window_size)
         sde_window_range = coalesce_not_none(sampling_params.extra_args.get("sde_window_range", None), sde_window_range)
+        sde_window_size, sde_window_range = _normalize_sde_window_args(sde_window_size, sde_window_range)
         sde_type = coalesce_not_none(sampling_params.extra_args.get("sde_type", None), sde_type)
         logprobs = coalesce_not_none(sampling_params.extra_args.get("logprobs", None), logprobs)
 

--- a/verl_omni/pipelines/flux_flow_grpo/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/flux_flow_grpo/vllm_omni_rollout_adapter.py
@@ -112,6 +112,13 @@ def _module_parameter_dtype(module: torch.nn.Module, default: torch.dtype) -> to
     return parameter.dtype if parameter is not None else default
 
 
+def _has_guidance_embeds(module: torch.nn.Module) -> bool:
+    config = getattr(module, "config", None)
+    if config is not None and hasattr(config, "guidance_embeds"):
+        return bool(getattr(config, "guidance_embeds"))
+    return bool(getattr(module, "guidance_embeds", False))
+
+
 @contextmanager
 def _patched_flux_transformer_constructor(od_config: OmniDiffusionConfig):
     """Forward checkpoint transformer kwargs while upstream vLLM-Omni does not.
@@ -402,7 +409,7 @@ class FluxPipelineWithLogProb(FluxPipeline):
         timesteps, _ = self.prepare_timesteps(num_inference_steps, sigmas, latents.shape[1])
         self._num_timesteps = len(timesteps)
 
-        if self.transformer.guidance_embeds:
+        if _has_guidance_embeds(self.transformer):
             guidance = torch.full([1], guidance_scale, dtype=torch.float32, device=self.device)
             guidance = guidance.expand(latents.shape[0])
         else:

--- a/verl_omni/pipelines/flux_flow_grpo/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/flux_flow_grpo/vllm_omni_rollout_adapter.py
@@ -141,6 +141,12 @@ def _extract_prompt_batch(
     return prompt, prompt_2, negative_prompt, negative_prompt_2
 
 
+def _first_generator(generator: torch.Generator | list[torch.Generator] | None) -> torch.Generator | None:
+    if isinstance(generator, list):
+        return generator[0] if generator else None
+    return generator
+
+
 @contextmanager
 def _patched_flux_transformer_constructor(od_config: OmniDiffusionConfig):
     """Forward checkpoint transformer kwargs while upstream vLLM-Omni does not.
@@ -439,11 +445,12 @@ class FluxPipelineWithLogProb(FluxPipeline):
                 sde_window_range[0],
                 min(sde_window_range[1], len(timesteps)) - sde_window_size,
             )
+            sde_generator = _first_generator(generator)
             start = torch.randint(
                 sde_window_range[0],
                 max_sde_window_start + 1,
                 (1,),
-                generator=generator,
+                generator=sde_generator,
                 device=self.device,
             ).item()
             end = start + sde_window_size

--- a/verl_omni/pipelines/flux_flow_grpo/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/flux_flow_grpo/vllm_omni_rollout_adapter.py
@@ -1,0 +1,349 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from typing import Any, Literal
+
+import torch
+from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
+from vllm_omni.diffusion.distributed.utils import get_local_device
+from vllm_omni.diffusion.models.flux import FluxPipeline
+from vllm_omni.diffusion.request import OmniDiffusionRequest
+
+from verl_omni.pipelines.model_base import VllmOmniPipelineBase
+from verl_omni.pipelines.schedulers import FlowMatchSDEDiscreteScheduler
+
+from .common import batched_position_ids, coalesce_not_none, maybe_to_cpu
+
+__all__ = ["FluxPipelineWithLogProb"]
+
+
+@VllmOmniPipelineBase.register("FluxPipeline", algorithm="flow_grpo")
+class FluxPipelineWithLogProb(FluxPipeline):
+    """vLLM-Omni FLUX rollout pipeline that returns FlowGRPO trajectory data."""
+
+    def __init__(self, *, od_config: OmniDiffusionConfig, prefix: str = ""):
+        super().__init__(od_config=od_config, prefix=prefix)
+        self.device = get_local_device()
+        model = od_config.model
+        local_files_only = os.path.exists(model)
+
+        self.scheduler = FlowMatchSDEDiscreteScheduler.from_pretrained(
+            model,
+            subfolder="scheduler",
+            local_files_only=local_files_only,
+        )
+
+    def diffuse(
+        self,
+        prompt_embeds: torch.Tensor,
+        pooled_prompt_embeds: torch.Tensor,
+        negative_prompt_embeds: torch.Tensor | None,
+        negative_pooled_prompt_embeds: torch.Tensor | None,
+        latents: torch.Tensor,
+        latent_image_ids: torch.Tensor,
+        text_ids: torch.Tensor,
+        negative_text_ids: torch.Tensor | None,
+        timesteps: torch.Tensor,
+        do_true_cfg: bool,
+        guidance: torch.Tensor | None,
+        true_cfg_scale: float,
+        noise_level: float,
+        sde_window: tuple[int, int],
+        sde_type: str,
+        generator: torch.Generator | list[torch.Generator] | None,
+        logprobs: bool,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None, torch.Tensor]:
+        all_latents = []
+        all_log_probs = []
+        all_timesteps = []
+        self.scheduler.set_begin_index(0)
+        self.transformer.do_true_cfg = do_true_cfg
+
+        for i, timestep_value in enumerate(timesteps):
+            if self.interrupt:
+                continue
+
+            if i < sde_window[0]:
+                cur_noise_level = 0.0
+            elif i == sde_window[0]:
+                cur_noise_level = noise_level
+                all_latents.append(latents.float())
+            elif i > sde_window[0] and i < sde_window[1]:
+                cur_noise_level = noise_level
+            else:
+                cur_noise_level = 0.0
+
+            self._current_timestep = timestep_value
+            timestep = timestep_value.expand(latents.shape[0]).to(device=latents.device, dtype=latents.dtype)
+
+            positive_kwargs = {
+                "hidden_states": latents,
+                "timestep": timestep / 1000,
+                "guidance": guidance,
+                "pooled_projections": pooled_prompt_embeds,
+                "encoder_hidden_states": prompt_embeds,
+                "txt_ids": text_ids,
+                "img_ids": latent_image_ids,
+                "joint_attention_kwargs": self.joint_attention_kwargs,
+                "return_dict": False,
+            }
+
+            negative_kwargs = None
+            if do_true_cfg:
+                negative_kwargs = {
+                    "hidden_states": latents,
+                    "timestep": timestep / 1000,
+                    "guidance": guidance,
+                    "pooled_projections": negative_pooled_prompt_embeds,
+                    "encoder_hidden_states": negative_prompt_embeds,
+                    "txt_ids": negative_text_ids,
+                    "img_ids": latent_image_ids,
+                    "joint_attention_kwargs": self.joint_attention_kwargs,
+                    "return_dict": False,
+                }
+
+            noise_pred = self.predict_noise_maybe_with_cfg(
+                do_true_cfg,
+                true_cfg_scale,
+                positive_kwargs,
+                negative_kwargs,
+                cfg_normalize=False,
+            )
+
+            latents, log_prob, _, _ = self.scheduler.step(
+                noise_pred.float(),
+                timestep_value,
+                latents,
+                generator=generator,
+                noise_level=cur_noise_level,
+                sde_type=sde_type,
+                return_logprobs=logprobs,
+                return_dict=False,
+            )
+
+            if i >= sde_window[0] and i < sde_window[1]:
+                all_latents.append(latents)
+                all_log_probs.append(log_prob)
+                all_timesteps.append(timestep_value)
+
+        all_latents = torch.stack(all_latents, dim=1)
+        all_log_probs = torch.stack(all_log_probs, dim=1) if all_log_probs and all_log_probs[0] is not None else None
+        all_timesteps = torch.stack(all_timesteps).unsqueeze(0).expand(latents.shape[0], -1)
+        return latents, all_latents, all_log_probs, all_timesteps
+
+    def forward(
+        self,
+        req: OmniDiffusionRequest,
+        prompt: str | list[str] | None = None,
+        prompt_2: str | list[str] | None = None,
+        negative_prompt: str | list[str] | None = None,
+        negative_prompt_2: str | list[str] | None = None,
+        true_cfg_scale: float = 1.0,
+        height: int | None = None,
+        width: int | None = None,
+        num_inference_steps: int = 28,
+        sigmas: list[float] | None = None,
+        guidance_scale: float = 3.5,
+        num_images_per_prompt: int = 1,
+        generator: torch.Generator | list[torch.Generator] | None = None,
+        latents: torch.FloatTensor | None = None,
+        prompt_embeds: torch.FloatTensor | None = None,
+        pooled_prompt_embeds: torch.FloatTensor | None = None,
+        negative_prompt_embeds: torch.FloatTensor | None = None,
+        negative_pooled_prompt_embeds: torch.FloatTensor | None = None,
+        output_type: str | None = "pil",
+        return_dict: bool = True,
+        joint_attention_kwargs: dict[str, Any] | None = None,
+        callback_on_step_end_tensor_inputs: tuple[str, ...] = ("latents",),
+        max_sequence_length: int = 512,
+        noise_level: float = 0.7,
+        sde_window_size: int | None = None,
+        sde_window_range: tuple[int, int] = (0, 5),
+        sde_type: Literal["sde", "cps"] = "sde",
+        logprobs: bool = True,
+    ) -> DiffusionOutput:
+        custom_prompt = req.prompts[0] if req.prompts else {}
+        if isinstance(custom_prompt, dict):
+            prompt = custom_prompt.get("prompt", prompt)
+            prompt_2 = custom_prompt.get("prompt_2", prompt_2)
+            negative_prompt = custom_prompt.get("negative_prompt", negative_prompt)
+            negative_prompt_2 = custom_prompt.get("negative_prompt_2", negative_prompt_2)
+
+        if prompt is None and req.prompts:
+            prompt = [p if isinstance(p, str) else (p.get("prompt") or "") for p in req.prompts]
+        if negative_prompt is None and req.prompts:
+            negative_prompt = ["" if isinstance(p, str) else (p.get("negative_prompt") or "") for p in req.prompts]
+            if all(not item for item in negative_prompt):
+                negative_prompt = None
+
+        sampling_params = req.sampling_params
+        height = sampling_params.height or self.default_sample_size * self.vae_scale_factor
+        width = sampling_params.width or self.default_sample_size * self.vae_scale_factor
+        num_inference_steps = sampling_params.num_inference_steps or num_inference_steps
+        sigmas = sampling_params.sigmas or sigmas
+        if getattr(sampling_params, "guidance_scale_provided", False):
+            guidance_scale = sampling_params.guidance_scale
+        generator = sampling_params.generator or generator
+        if generator is None and sampling_params.seed is not None:
+            generator = torch.Generator(device=self.device).manual_seed(sampling_params.seed)
+        true_cfg_scale = coalesce_not_none(sampling_params.true_cfg_scale, true_cfg_scale)
+        num_images_per_prompt = (
+            sampling_params.num_outputs_per_prompt
+            if sampling_params.num_outputs_per_prompt > 0
+            else num_images_per_prompt
+        )
+        max_sequence_length = sampling_params.max_sequence_length or max_sequence_length
+
+        noise_level = coalesce_not_none(sampling_params.extra_args.get("noise_level", None), noise_level)
+        sde_window_size = coalesce_not_none(sampling_params.extra_args.get("sde_window_size", None), sde_window_size)
+        sde_window_range = coalesce_not_none(sampling_params.extra_args.get("sde_window_range", None), sde_window_range)
+        sde_type = coalesce_not_none(sampling_params.extra_args.get("sde_type", None), sde_type)
+        logprobs = coalesce_not_none(sampling_params.extra_args.get("logprobs", None), logprobs)
+
+        self.check_inputs(
+            prompt,
+            prompt_2,
+            height,
+            width,
+            negative_prompt=negative_prompt,
+            negative_prompt_2=negative_prompt_2,
+            prompt_embeds=prompt_embeds,
+            negative_prompt_embeds=negative_prompt_embeds,
+            pooled_prompt_embeds=pooled_prompt_embeds,
+            negative_pooled_prompt_embeds=negative_pooled_prompt_embeds,
+            callback_on_step_end_tensor_inputs=callback_on_step_end_tensor_inputs,
+            max_sequence_length=max_sequence_length,
+        )
+
+        self._guidance_scale = guidance_scale
+        self._joint_attention_kwargs = joint_attention_kwargs
+        self._current_timestep = None
+        self._interrupt = False
+
+        if prompt is not None and isinstance(prompt, str):
+            batch_size = 1
+        elif prompt is not None and isinstance(prompt, list):
+            batch_size = len(prompt)
+        else:
+            batch_size = prompt_embeds.shape[0]
+
+        has_neg_prompt = negative_prompt is not None or (
+            negative_prompt_embeds is not None and negative_pooled_prompt_embeds is not None
+        )
+        do_true_cfg = true_cfg_scale > 1 and has_neg_prompt
+        self.check_cfg_parallel_validity(true_cfg_scale, has_neg_prompt)
+
+        prompt_embeds, pooled_prompt_embeds, text_ids = self.encode_prompt(
+            prompt=prompt,
+            prompt_2=prompt_2,
+            prompt_embeds=prompt_embeds,
+            pooled_prompt_embeds=pooled_prompt_embeds,
+            num_images_per_prompt=num_images_per_prompt,
+            max_sequence_length=max_sequence_length,
+        )
+
+        negative_text_ids = None
+        if do_true_cfg:
+            negative_prompt_embeds, negative_pooled_prompt_embeds, negative_text_ids = self.encode_prompt(
+                prompt=negative_prompt,
+                prompt_2=negative_prompt_2,
+                prompt_embeds=negative_prompt_embeds,
+                pooled_prompt_embeds=negative_pooled_prompt_embeds,
+                num_images_per_prompt=num_images_per_prompt,
+                max_sequence_length=max_sequence_length,
+            )
+
+        num_channels_latents = self.transformer.in_channels // 4
+        latents, latent_image_ids = self.prepare_latents(
+            batch_size * num_images_per_prompt,
+            num_channels_latents,
+            height,
+            width,
+            prompt_embeds.dtype,
+            self.device,
+            generator,
+            latents,
+        )
+
+        timesteps, _ = self.prepare_timesteps(num_inference_steps, sigmas, latents.shape[1])
+        self._num_timesteps = len(timesteps)
+
+        if self.transformer.guidance_embeds:
+            guidance = torch.full([1], guidance_scale, dtype=torch.float32, device=self.device)
+            guidance = guidance.expand(latents.shape[0])
+        else:
+            guidance = None
+
+        if self.joint_attention_kwargs is None:
+            self._joint_attention_kwargs = {}
+
+        if sde_window_size is not None:
+            start = torch.randint(
+                sde_window_range[0],
+                sde_window_range[1] - sde_window_size + 1,
+                (1,),
+                generator=generator,
+                device=self.device,
+            ).item()
+            end = start + sde_window_size
+            sde_window = (start, end)
+        else:
+            sde_window = (0, len(timesteps) - 1)
+
+        latents, all_latents, all_log_probs, all_timesteps = self.diffuse(
+            prompt_embeds,
+            pooled_prompt_embeds,
+            negative_prompt_embeds,
+            negative_pooled_prompt_embeds,
+            latents,
+            latent_image_ids,
+            text_ids,
+            negative_text_ids,
+            timesteps,
+            do_true_cfg,
+            guidance,
+            true_cfg_scale,
+            noise_level,
+            sde_window,
+            sde_type,
+            generator,
+            logprobs,
+        )
+
+        self._current_timestep = None
+        if output_type == "latent":
+            image = latents
+        else:
+            latents = self._unpack_latents(latents, height, width, self.vae_scale_factor)
+            latents = (latents / self.vae.config.scaling_factor) + self.vae.config.shift_factor
+            image = self.vae.decode(latents, return_dict=False)[0]
+
+        return DiffusionOutput(
+            output=maybe_to_cpu(image),
+            custom_output={
+                "all_latents": maybe_to_cpu(all_latents),
+                "all_log_probs": maybe_to_cpu(all_log_probs),
+                "all_timesteps": maybe_to_cpu(all_timesteps),
+                "prompt_embeds": maybe_to_cpu(prompt_embeds),
+                "pooled_prompt_embeds": maybe_to_cpu(pooled_prompt_embeds),
+                "text_ids": maybe_to_cpu(batched_position_ids(text_ids, latents.shape[0])),
+                "negative_prompt_embeds": maybe_to_cpu(negative_prompt_embeds),
+                "negative_pooled_prompt_embeds": maybe_to_cpu(negative_pooled_prompt_embeds),
+                "negative_text_ids": maybe_to_cpu(
+                    batched_position_ids(negative_text_ids, latents.shape[0]) if negative_text_ids is not None else None
+                ),
+                "latent_image_ids": maybe_to_cpu(batched_position_ids(latent_image_ids, latents.shape[0])),
+            },
+        )

--- a/verl_omni/pipelines/flux_flow_grpo/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/flux_flow_grpo/vllm_omni_rollout_adapter.py
@@ -12,11 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
+import json
+import logging
 import os
+from collections.abc import Mapping
+from contextlib import contextmanager
 from typing import Any, Literal
 
 import torch
-from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
+from vllm.transformers_utils.config import get_hf_file_to_dict
+from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig, TransformerConfig
 from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.models.flux import FluxPipeline
 from vllm_omni.diffusion.request import OmniDiffusionRequest
@@ -24,9 +30,123 @@ from vllm_omni.diffusion.request import OmniDiffusionRequest
 from verl_omni.pipelines.model_base import VllmOmniPipelineBase
 from verl_omni.pipelines.schedulers import FlowMatchSDEDiscreteScheduler
 
-from .common import batched_position_ids, coalesce_not_none, maybe_to_cpu
+from .common import batched_position_ids, coalesce_not_none, getattr_not_none, maybe_to_cpu
 
 __all__ = ["FluxPipelineWithLogProb"]
+
+logger = logging.getLogger(__name__)
+
+
+def _tf_config_to_dict(tf_model_config: Any) -> dict[str, Any]:
+    if tf_model_config is None:
+        return {}
+    if hasattr(tf_model_config, "to_dict"):
+        return dict(tf_model_config.to_dict())
+    if isinstance(tf_model_config, Mapping):
+        return dict(tf_model_config)
+    return {}
+
+
+def _load_flux_transformer_config(model: str | None) -> dict[str, Any] | None:
+    if not model:
+        return None
+
+    if os.path.isdir(model):
+        config_path = os.path.join(model, "transformer", "config.json")
+        if os.path.isfile(config_path):
+            with open(config_path, encoding="utf-8") as f:
+                return json.load(f)
+
+    try:
+        return get_hf_file_to_dict("transformer/config.json", model)
+    except (OSError, ValueError) as exc:
+        logger.warning("Could not load FLUX transformer config for %s: %s", model, exc)
+        return None
+
+
+def _ensure_flux_transformer_config(od_config: OmniDiffusionConfig) -> None:
+    """Fill missing structural FLUX transformer kwargs before vLLM-Omni builds it."""
+    current_config = _tf_config_to_dict(getattr(od_config, "tf_model_config", None))
+    checkpoint_config = _load_flux_transformer_config(getattr(od_config, "model", None))
+    if not checkpoint_config:
+        return
+
+    current_overrides = {key: value for key, value in current_config.items() if value is not None}
+    merged_config = {**checkpoint_config, **current_overrides}
+    tf_model_config = TransformerConfig.from_dict(merged_config)
+    if hasattr(od_config, "set_tf_model_config"):
+        od_config.set_tf_model_config(tf_model_config)
+    else:
+        od_config.tf_model_config = tf_model_config
+
+
+def _get_flux_transformer_config_kwargs(transformer_cls: type, tf_model_config: Any) -> dict[str, Any]:
+    tf_config = _tf_config_to_dict(tf_model_config)
+    if not tf_config:
+        return {}
+
+    try:
+        parameters = inspect.signature(transformer_cls.__init__).parameters
+    except (TypeError, ValueError):
+        return {}
+
+    return {
+        name: tf_config[name]
+        for name in parameters
+        if name not in {"self", "od_config"} and tf_config.get(name) is not None
+    }
+
+
+def _normalize_sde_window(sde_window: tuple[int, int], num_timesteps: int) -> tuple[int, int]:
+    if num_timesteps <= 0:
+        raise ValueError("FLUX rollout requires at least one denoising timestep.")
+
+    start, end = sde_window
+    start = max(0, min(int(start), num_timesteps - 1))
+    end = max(start + 1, min(int(end), num_timesteps))
+    return start, end
+
+
+def _module_parameter_dtype(module: torch.nn.Module, default: torch.dtype) -> torch.dtype:
+    parameter = next(module.parameters(), None)
+    return parameter.dtype if parameter is not None else default
+
+
+@contextmanager
+def _patched_flux_transformer_constructor(od_config: OmniDiffusionConfig):
+    """Forward checkpoint transformer kwargs while upstream vLLM-Omni does not.
+
+    vLLM-Omni's FLUX pipeline constructs ``FluxTransformer2DModel`` inside its
+    own ``__init__`` and currently only reads part of ``tf_model_config`` there.
+    Patch that constructor only for the duration of ``super().__init__`` instead
+    of copying the upstream pipeline initialization.
+    """
+    init_globals = FluxPipeline.__init__.__globals__
+    transformer_cls = init_globals.get("FluxTransformer2DModel")
+    if transformer_cls is None:
+        yield
+        return
+
+    def configured_flux_transformer(*args: Any, **kwargs: Any):
+        call_od_config = kwargs.get("od_config")
+        if call_od_config is None and args:
+            call_od_config = args[0]
+        if call_od_config is None:
+            call_od_config = od_config
+
+        config_kwargs = _get_flux_transformer_config_kwargs(
+            transformer_cls,
+            getattr(call_od_config, "tf_model_config", None),
+        )
+        for name, value in config_kwargs.items():
+            kwargs.setdefault(name, value)
+        return transformer_cls(*args, **kwargs)
+
+    init_globals["FluxTransformer2DModel"] = configured_flux_transformer
+    try:
+        yield
+    finally:
+        init_globals["FluxTransformer2DModel"] = transformer_cls
 
 
 @VllmOmniPipelineBase.register("FluxPipeline", algorithm="flow_grpo")
@@ -34,7 +154,9 @@ class FluxPipelineWithLogProb(FluxPipeline):
     """vLLM-Omni FLUX rollout pipeline that returns FlowGRPO trajectory data."""
 
     def __init__(self, *, od_config: OmniDiffusionConfig, prefix: str = ""):
-        super().__init__(od_config=od_config, prefix=prefix)
+        _ensure_flux_transformer_config(od_config)
+        with _patched_flux_transformer_constructor(od_config):
+            super().__init__(od_config=od_config, prefix=prefix)
         self.device = get_local_device()
         model = od_config.model
         local_files_only = os.path.exists(model)
@@ -68,6 +190,7 @@ class FluxPipelineWithLogProb(FluxPipeline):
         all_latents = []
         all_log_probs = []
         all_timesteps = []
+        sde_window = _normalize_sde_window(sde_window, len(timesteps))
         self.scheduler.set_begin_index(0)
         self.transformer.do_true_cfg = do_true_cfg
 
@@ -193,8 +316,7 @@ class FluxPipelineWithLogProb(FluxPipeline):
         width = sampling_params.width or self.default_sample_size * self.vae_scale_factor
         num_inference_steps = sampling_params.num_inference_steps or num_inference_steps
         sigmas = sampling_params.sigmas or sigmas
-        if getattr(sampling_params, "guidance_scale_provided", False):
-            guidance_scale = sampling_params.guidance_scale
+        guidance_scale = getattr_not_none(sampling_params, "guidance_scale", guidance_scale)
         generator = sampling_params.generator or generator
         if generator is None and sampling_params.seed is not None:
             generator = torch.Generator(device=self.device).manual_seed(sampling_params.seed)
@@ -290,9 +412,13 @@ class FluxPipelineWithLogProb(FluxPipeline):
             self._joint_attention_kwargs = {}
 
         if sde_window_size is not None:
+            max_sde_window_start = max(
+                sde_window_range[0],
+                min(sde_window_range[1], len(timesteps)) - sde_window_size,
+            )
             start = torch.randint(
                 sde_window_range[0],
-                sde_window_range[1] - sde_window_size + 1,
+                max_sde_window_start + 1,
                 (1,),
                 generator=generator,
                 device=self.device,
@@ -328,6 +454,7 @@ class FluxPipelineWithLogProb(FluxPipeline):
         else:
             latents = self._unpack_latents(latents, height, width, self.vae_scale_factor)
             latents = (latents / self.vae.config.scaling_factor) + self.vae.config.shift_factor
+            latents = latents.to(dtype=_module_parameter_dtype(self.vae, latents.dtype))
             image = self.vae.decode(latents, return_dict=False)[0]
 
         return DiffusionOutput(

--- a/verl_omni/pipelines/flux_flow_grpo/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/flux_flow_grpo/vllm_omni_rollout_adapter.py
@@ -426,7 +426,7 @@ class FluxPipelineWithLogProb(FluxPipeline):
             end = start + sde_window_size
             sde_window = (start, end)
         else:
-            sde_window = (0, len(timesteps) - 1)
+            sde_window = (0, len(timesteps))
 
         latents, all_latents, all_log_probs, all_timesteps = self.diffuse(
             prompt_embeds,

--- a/verl_omni/pipelines/qwen_image_flow_grpo/__init__.py
+++ b/verl_omni/pipelines/qwen_image_flow_grpo/__init__.py
@@ -12,7 +12,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+import os
+
 from .diffusers_training_adapter import QwenImage
-from .vllm_omni_rollout_adapter import QwenImagePipelineWithLogProb
+
+logger = logging.getLogger(__name__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
+
+try:
+    from .vllm_omni_rollout_adapter import QwenImagePipelineWithLogProb
+except (ImportError, RuntimeError, AttributeError) as e:
+    logger.info(f"Qwen Image FlowGRPO rollout adapter not available: {e}. vLLM-Omni required.")
+
+    class _UnavailableModule:
+        def __getattr__(self, _):
+            raise RuntimeError("Qwen Image FlowGRPO rollout adapter requires vLLM-Omni")
+
+        def __call__(self, *args, **kwargs):
+            raise RuntimeError("Qwen Image FlowGRPO rollout adapter requires vLLM-Omni")
+
+    QwenImagePipelineWithLogProb = _UnavailableModule()
 
 __all__ = ["QwenImage", "QwenImagePipelineWithLogProb"]

--- a/verl_omni/pipelines/qwen_image_mix_grpo/__init__.py
+++ b/verl_omni/pipelines/qwen_image_mix_grpo/__init__.py
@@ -12,7 +12,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+import os
+
 from .diffusers_training_adapter import QwenImageMixGRPO
-from .vllm_omni_rollout_adapter import QwenImageMixGRPOPipelineWithLogProb
+
+logger = logging.getLogger(__name__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
+
+try:
+    from .vllm_omni_rollout_adapter import QwenImageMixGRPOPipelineWithLogProb
+except (ImportError, RuntimeError, AttributeError) as e:
+    logger.info(f"Qwen Image MixGRPO rollout adapter not available: {e}. vLLM-Omni required.")
+
+    class _UnavailableModule:
+        def __getattr__(self, _):
+            raise RuntimeError("Qwen Image MixGRPO rollout adapter requires vLLM-Omni")
+
+        def __call__(self, *args, **kwargs):
+            raise RuntimeError("Qwen Image MixGRPO rollout adapter requires vLLM-Omni")
+
+    QwenImageMixGRPOPipelineWithLogProb = _UnavailableModule()
 
 __all__ = ["QwenImageMixGRPO", "QwenImageMixGRPOPipelineWithLogProb"]

--- a/verl_omni/utils/vllm_omni/utils.py
+++ b/verl_omni/utils/vllm_omni/utils.py
@@ -31,9 +31,6 @@ from vllm.utils.torch_utils import set_default_torch_dtype
 from vllm_omni.diffusion.data import OmniDiffusionConfig
 from vllm_omni.diffusion.lora.manager import DiffusionLoRAManager, logger
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
-from vllm_omni.diffusion.models.diffusers_adapter.pipeline_diffusers_adapter import (
-    DiffusersAdapterPipeline,
-)
 from vllm_omni.diffusion.registry import initialize_model
 from vllm_omni.lora.request import LoRARequest as OmniLoRARequest
 
@@ -180,11 +177,19 @@ class VLLMOmniHijack:
                             if load_format == "default":
                                 model = initialize_model(od_config)
                             elif load_format == "diffusers":
+                                from vllm_omni.diffusion.models.diffusers_adapter.pipeline_diffusers_adapter import (
+                                    DiffusersAdapterPipeline,
+                                )
+
                                 model = DiffusersAdapterPipeline(od_config=od_config, device=target_device)
                             else:
                                 raise ValueError(f"Unknown load_format: {load_format}")
                 logger.debug("Loading weights on %s ...", load_device)
                 if load_format == "diffusers":
+                    from vllm_omni.diffusion.models.diffusers_adapter.pipeline_diffusers_adapter import (
+                        DiffusersAdapterPipeline,
+                    )
+
                     cast(DiffusersAdapterPipeline, model).load_weights()
                 elif self._is_gguf_quantization(od_config):
                     self._load_weights_with_gguf(model, od_config)

--- a/verl_omni/workers/engine/__init__.py
+++ b/verl_omni/workers/engine/__init__.py
@@ -11,12 +11,42 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from .fsdp import (  # noqa: F401
-    DiffusersFSDPEngine,
-    DPODiffusersFSDPEngine,
-    NFTDiffusersFSDPEngine,
-    PPODiffusersFSDPEngine,
-)
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
+
+
+class _UnavailableEngine:
+    def __init__(self, name: str, reason: BaseException):
+        self._name = name
+        self._reason = reason
+
+    def __getattr__(self, _):
+        raise RuntimeError(f"{self._name} is unavailable because its backend dependencies failed to import") from (
+            self._reason
+        )
+
+    def __call__(self, *args, **kwargs):
+        raise RuntimeError(f"{self._name} is unavailable because its backend dependencies failed to import") from (
+            self._reason
+        )
+
+
+try:
+    from .fsdp import (  # noqa: F401
+        DiffusersFSDPEngine,
+        DPODiffusersFSDPEngine,
+        NFTDiffusersFSDPEngine,
+        PPODiffusersFSDPEngine,
+    )
+except (ImportError, RuntimeError, AttributeError, NameError) as e:
+    logger.info(f"Diffusers FSDP engines not available: {e}")
+    DiffusersFSDPEngine = _UnavailableEngine("DiffusersFSDPEngine", e)
+    DPODiffusersFSDPEngine = _UnavailableEngine("DPODiffusersFSDPEngine", e)
+    NFTDiffusersFSDPEngine = _UnavailableEngine("NFTDiffusersFSDPEngine", e)
+    PPODiffusersFSDPEngine = _UnavailableEngine("PPODiffusersFSDPEngine", e)
 
 try:
     from .veomni import VeOmniDiffusionEngine  # noqa: F401

--- a/verl_omni/workers/rollout/vllm_rollout/vllm_omni_async_server.py
+++ b/verl_omni/workers/rollout/vllm_rollout/vllm_omni_async_server.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import argparse
+import inspect
 import logging
 import os
 from dataclasses import asdict
-from typing import Any, Optional
+from typing import Any, Optional, TypeAlias
 
 import numpy as np
 import ray
@@ -37,7 +38,7 @@ from vllm.entrypoints.openai.api_server import build_app
 from vllm_omni.engine.arg_utils import OmniEngineArgs
 from vllm_omni.entrypoints import AsyncOmni
 from vllm_omni.entrypoints.openai.api_server import omni_init_app_state
-from vllm_omni.inputs.data import OmniCustomPrompt, OmniDiffusionSamplingParams
+from vllm_omni.inputs.data import OmniDiffusionSamplingParams
 from vllm_omni.lora.request import LoRARequest
 from vllm_omni.outputs import OmniRequestOutput
 
@@ -48,6 +49,8 @@ from verl_omni.workers.rollout.replica import DiffusionOutput
 
 logger = logging.getLogger(__file__)
 logger.setLevel(logging.INFO)
+
+OmniCustomPrompt: TypeAlias = dict[str, Any]
 
 
 class vLLMOmniHttpServer(vLLMHttpServer):
@@ -126,14 +129,7 @@ class vLLMOmniHttpServer(vLLMHttpServer):
         engine_args = asdict(engine_args)
 
         import_external_libs(self.config.external_lib)
-        pipeline_path = VllmOmniPipelineBase.get_pipeline_path(
-            architecture=self.model_config.architecture,
-            algorithm=self.model_config.algorithm,
-        )
-        # TODO (mike): read custom_pipeline from engine_args
-        if pipeline_path is not None:
-            engine_args["enable_dummy_pipeline"] = True
-            engine_args["custom_pipeline_args"] = {"pipeline_class": pipeline_path}
+        self._configure_custom_pipeline(engine_args)
 
         diffusion_master_port, diffusion_master_sock = get_free_port("127.0.0.1", with_alive_sock=True)
         diffusion_master_sock.close()
@@ -151,6 +147,17 @@ class vLLMOmniHttpServer(vLLMHttpServer):
         self.engine = engine_client
         self._server_port, self._server_task = await run_uvicorn(app, args, self._server_address)
 
+    def _configure_custom_pipeline(self, engine_args: dict[str, Any]) -> None:
+        pipeline_path = VllmOmniPipelineBase.get_pipeline_path(
+            architecture=self.model_config.architecture,
+            algorithm=self.model_config.algorithm,
+        )
+        # TODO (mike): read custom_pipeline from engine_args
+        if pipeline_path is not None:
+            engine_args["enable_dummy_pipeline"] = True
+            engine_args["diffusion_load_format"] = "dummy"
+            engine_args["custom_pipeline_args"] = {"pipeline_class": pipeline_path}
+
     async def run_headless(self, args: argparse.Namespace):
         """Run headless server in a separate thread."""
         # TODO (mike): support multi node
@@ -163,20 +170,34 @@ class vLLMOmniHttpServer(vLLMHttpServer):
     def _get_wake_up_tags(self) -> list[str]:
         return ["weights"]
 
+    async def _call_engine_method(
+        self, method_name: str, kwargs: dict[str, Any] | None = None, *, collective: bool = True
+    ):
+        kwargs = kwargs or {}
+        if collective and hasattr(self.engine, "collective_rpc"):
+            result = self.engine.collective_rpc(method_name, kwargs=kwargs)
+        else:
+            method = getattr(self.engine, method_name)
+            result = method(**kwargs)
+        if inspect.isawaitable(result):
+            return await result
+        return result
+
     async def wake_up(self, tags: list[str] | None = None):
-        """Override parent to use collective_rpc instead of engine.wake_up().
+        """Override parent to avoid server-process CUDA initialization when possible.
 
         The parent (verl ``1927ad33``+) calls ``self.engine.wake_up(tags=...)``
         which triggers CUDA initialisation in this HTTP server process when
         running under vLLM-Omni (AsyncOmni engine).
-        Use ``collective_rpc`` instead.
+        Use ``collective_rpc`` when vLLM-Omni exposes it; older AsyncOmni
+        builds only provide a direct synchronous ``wake_up`` method.
 
         # TODO (long): drop this override once vllm-omni wake_up
         without triggering GPU initialisation.
         """
         if self.node_rank != 0:
             return
-        await self.engine.collective_rpc(
+        await self._call_engine_method(
             "wake_up", kwargs={"tags": tags if tags is not None else self._get_wake_up_tags()}
         )
 
@@ -191,8 +212,11 @@ class vLLMOmniHttpServer(vLLMHttpServer):
         """
         # TODO (andy): use `sleep_level=2` in the future when the
         #  trainer side incorporates the whole components of the model.
-        await self.engine.collective_rpc("sleep", kwargs={"level": 1})
-        await self.engine.reset_encoder_cache()
+        await self._call_engine_method("sleep", kwargs={"level": 1})
+        if hasattr(self.engine, "reset_encoder_cache"):
+            await self._call_engine_method("reset_encoder_cache", collective=False)
+        elif hasattr(self.engine, "reset_mm_cache"):
+            await self._call_engine_method("reset_mm_cache", collective=False)
 
     async def generate(
         self,

--- a/verl_omni/workers/rollout/vllm_rollout/vllm_omni_async_server.py
+++ b/verl_omni/workers/rollout/vllm_rollout/vllm_omni_async_server.py
@@ -202,10 +202,15 @@ class vLLMOmniHttpServer(vLLMHttpServer):
         image_data: Optional[list[Any]] = None,
         video_data: Optional[list[Any]] = None,
         negative_prompt_ids: Optional[list[int]] = None,
+        raw_prompt: Optional[str] = None,
+        raw_negative_prompt: Optional[str] = None,
         priority: int = 0,
     ) -> DiffusionOutput:
         """Generate sequence with token-in-image-out."""
         prompt_ids = normalize_token_ids(prompt_ids)
+        sampling_params = sampling_params.copy()
+        raw_prompt = raw_prompt or sampling_params.pop("_raw_prompt", None)
+        raw_negative_prompt = raw_negative_prompt or sampling_params.pop("_raw_negative_prompt", None)
 
         multi_modal_data = {}
         if image_data is not None:
@@ -225,8 +230,12 @@ class vLLMOmniHttpServer(vLLMHttpServer):
 
         # Build OmniCustomPrompt with pre-tokenized IDs
         custom_prompt: OmniCustomPrompt = {"prompt_ids": prompt_ids}
+        if raw_prompt is not None:
+            custom_prompt["prompt"] = raw_prompt
         if negative_prompt_ids is not None:
             custom_prompt["negative_prompt_ids"] = negative_prompt_ids
+        if raw_negative_prompt is not None:
+            custom_prompt["negative_prompt"] = raw_negative_prompt
         if multi_modal_data:
             custom_prompt["extra_args"] = {"multi_modal_data": multi_modal_data}
 
@@ -276,8 +285,13 @@ class vLLMOmniHttpServer(vLLMHttpServer):
         all_timesteps = mm_output.get("all_timesteps")
         prompt_embeds = mm_output.get("prompt_embeds")
         prompt_embeds_mask = mm_output.get("prompt_embeds_mask")
+        pooled_prompt_embeds = mm_output.get("pooled_prompt_embeds")
+        text_ids = mm_output.get("text_ids")
+        latent_image_ids = mm_output.get("latent_image_ids")
         negative_prompt_embeds = mm_output.get("negative_prompt_embeds")
         negative_prompt_embeds_mask = mm_output.get("negative_prompt_embeds_mask")
+        negative_pooled_prompt_embeds = mm_output.get("negative_pooled_prompt_embeds")
+        negative_text_ids = mm_output.get("negative_text_ids")
         latents_clean = mm_output.get("latents_clean")
         train_timesteps = mm_output.get("train_timesteps")
 
@@ -289,10 +303,17 @@ class vLLMOmniHttpServer(vLLMHttpServer):
             "train_timesteps": train_timesteps[0] if train_timesteps is not None else None,
             "prompt_embeds": prompt_embeds[0] if prompt_embeds is not None else None,
             "prompt_embeds_mask": prompt_embeds_mask[0] if prompt_embeds_mask is not None else None,
+            "pooled_prompt_embeds": pooled_prompt_embeds[0] if pooled_prompt_embeds is not None else None,
+            "text_ids": text_ids[0] if text_ids is not None else None,
+            "latent_image_ids": latent_image_ids[0] if latent_image_ids is not None else None,
             "negative_prompt_embeds": negative_prompt_embeds[0] if negative_prompt_embeds is not None else None,
             "negative_prompt_embeds_mask": negative_prompt_embeds_mask[0]
             if negative_prompt_embeds_mask is not None
             else None,
+            "negative_pooled_prompt_embeds": negative_pooled_prompt_embeds[0]
+            if negative_pooled_prompt_embeds is not None
+            else None,
+            "negative_text_ids": negative_text_ids[0] if negative_text_ids is not None else None,
             "global_steps": self.global_steps,
         }
 


### PR DESCRIPTION
### What does this PR do?

This PR adds first-class FLUX FlowGRPO support to verl-omni.

It introduces a new `flux_flow_grpo` pipeline package with both sides of the verl-omni diffusion integration:

- a training-side `DiffusionModelBase` adapter for FLUX FlowGRPO log-prob recomputation
- a vLLM-Omni custom rollout pipeline that returns the trajectory tensors and conditioning metadata required by FlowGRPO

Compared with existing Qwen-Image / Wan / SD3 integrations, FLUX needs its own adapter because it uses packed latent sequences, FLUX-specific text/image position ids, pooled CLIP projections, T5 prompt embeddings, and guidance behavior that does not map cleanly to the existing pipelines.

### Checklist Before Starting

- [x] Search for similar PRs. Query link: https://github.com/verl-project/verl-omni/pulls?q=is%3Apr+FLUX+FlowGRPO
- [x] Format the PR title as `[{modules}] {type}: {description}`. Title: `[diffusion] feat: add FLUX FlowGRPO adapters`

### Test

Validated in a project environment with vLLM-Omni dependencies:

```bash
python -m pytest tests/pipelines/test_flux_flow_grpo_adapter_on_cpu.py -q
```

Result:

```text
11 passed
```

Also validated:

```bash
python -m ruff check verl_omni/pipelines/flux_flow_grpo tests/pipelines/test_flux_flow_grpo_adapter_on_cpu.py
python -m ruff format --check verl_omni/pipelines/flux_flow_grpo tests/pipelines/test_flux_flow_grpo_adapter_on_cpu.py
python -m compileall -q verl_omni/pipelines/flux_flow_grpo tests/pipelines/test_flux_flow_grpo_adapter_on_cpu.py
```

A real FLUX checkpoint smoke check confirmed that the custom pipeline constructor receives the checkpoint transformer config, including `guidance_embeds=False`.

Note: a full Ray e2e run is environment-sensitive. The included special e2e script assumes a local FLUX checkpoint in diffusers layout and a vLLM-Omni installation with FLUX support.

### API and Usage Example

FLUX FlowGRPO is registered through the existing model/pipeline registry mechanism:

```python
@DiffusionModelBase.register("FluxPipeline", algorithm="flow_grpo")
class Flux(DiffusionModelBase):
    ...

@VllmOmniPipelineBase.register("FluxPipeline", algorithm="flow_grpo")
class FluxPipelineWithLogProb(FluxPipeline):
    ...
```

Example smoke entrypoint:

```bash
MODEL_PATH=/path/to/FLUX.1-schnell \
TOKENIZER_PATH=/path/to/FLUX.1-schnell/tokenizer \
NUM_GPUS=4 \
bash tests/special_e2e/run_flowgrpo_flux.sh
```

Relevant rollout config values include:

```bash
actor_rollout_ref.model.algorithm=flow_grpo
actor_rollout_ref.rollout.name=vllm_omni
actor_rollout_ref.rollout.pipeline.num_inference_steps=4
actor_rollout_ref.rollout.pipeline.guidance_scale=3.5
actor_rollout_ref.rollout.pipeline.true_cfg_scale=1.0
actor_rollout_ref.rollout.algo.sde_window_size=2
actor_rollout_ref.rollout.algo.sde_window_range="[0,4]"
```

### Design & Code Changes

#### FLUX FlowGRPO training adapter

Adds `verl_omni.pipelines.flux_flow_grpo.Flux`, which handles:

- FLUX scheduler construction and timestep setup
- packed latent sequence sizing and shift calculation
- FLUX transformer input construction
- `prompt_embeds`, `pooled_prompt_embeds`, `text_ids`, and `latent_image_ids`
- optional true CFG negative conditioning
- FlowGRPO previous-step sampling and log-prob recomputation

#### FLUX vLLM-Omni rollout adapter

Adds `FluxPipelineWithLogProb`, which returns FlowGRPO training data through `custom_output`, including:

- `all_latents`
- `all_log_probs`
- `all_timesteps`
- `prompt_embeds`
- `pooled_prompt_embeds`
- `text_ids`
- `negative_prompt_embeds`
- `negative_pooled_prompt_embeds`
- `negative_text_ids`
- `latent_image_ids`

#### vLLM-Omni custom pipeline integration

Updates the vLLM-Omni async server path so registered custom diffusion pipelines are initialized through the dummy initial load path, then replaced by the custom pipeline class. This is needed for FLUX because the custom pipeline owns the FlowGRPO rollout behavior and output contract.

#### FLUX compatibility hardening

Adds compatibility handling for real FLUX checkpoints and current vLLM-Omni behavior:

- loads and merges `transformer/config.json` into `tf_model_config`
- forwards checkpoint transformer kwargs such as `guidance_embeds`
- handles sampling params where `guidance_scale` is present without `guidance_scale_provided`
- clamps SDE windows to available denoising timesteps
- aligns VAE decode input dtype with VAE parameter dtype
- keeps vLLM-Omni imports tolerant across versions where some optional modules/types are unavailable

#### Agent loop prompt support

Updates the diffusion single-turn agent loop to preserve raw prompt text for diffusion pipelines that run their own text encoders, while still supporting tokenized prompt ids for the rollout request.

#### Tests and docs

Adds CPU tests, registry coverage, vLLM-Omni custom pipeline configuration coverage, a special e2e smoke entrypoint, and README/API documentation entries for FLUX FlowGRPO.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
  - Full pre-commit was not run locally; targeted ruff, ruff format check, compileall, and adapter CPU tests were run as listed above.
- [x] Add / Update the documentation.
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl-omni/tree/main/.github/workflows) to cover all the code.