### PR TITLE
[model] refactor: relocate diffusers patches to verl_omni.models

### DIFF
--- a/tests/workers/test_diffusers_ulysses.py
+++ b/tests/workers/test_diffusers_ulysses.py
@@ -29,7 +29,9 @@ from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.distributed.fsdp import MixedPrecision, ShardingStrategy
 
-import verl_omni.pipelines._patch  # noqa: F401
+from verl_omni.models.diffusers.qwen_image import apply_qwen_image_ulysses_mask_fix
+
+apply_qwen_image_ulysses_mask_fix()
 
 
 def get_device_name() -> str:

--- a/verl_omni/models/__init__.py
+++ b/verl_omni/models/__init__.py
@@ -11,15 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 
-with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), "version/version")) as f:
-    __version__ = f.read().strip()
+from .diffusers import apply_flash_attention_3_varlen_hub_fix, apply_qwen_image_ulysses_mask_fix
 
+# register diffusers patches
+apply_flash_attention_3_varlen_hub_fix()  # apply FA3 varlen hub fix universally
 
-# Apply model patches and auto-register pipelines / rollout / reward loop / engines
-import verl_omni.models  # noqa: E402, F401
-import verl_omni.pipelines  # noqa: E402, F401
-import verl_omni.reward_loop  # noqa: E402, F401
-import verl_omni.workers.engine  # noqa: E402, F401
-import verl_omni.workers.rollout  # noqa: E402, F401
+__all__ = ["apply_flash_attention_3_varlen_hub_fix", "apply_qwen_image_ulysses_mask_fix"]

--- a/verl_omni/models/diffusers/__init__.py
+++ b/verl_omni/models/diffusers/__init__.py
@@ -15,6 +15,4 @@
 from .flash_attention_3 import apply_flash_attention_3_varlen_hub_fix
 from .qwen_image import apply_qwen_image_ulysses_mask_fix
 
-apply_flash_attention_3_varlen_hub_fix()  # apply FA3 varlen hub fix universally
-
 __all__ = ["apply_flash_attention_3_varlen_hub_fix", "apply_qwen_image_ulysses_mask_fix"]

--- a/verl_omni/models/diffusers/__init__.py
+++ b/verl_omni/models/diffusers/__init__.py
@@ -11,15 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 
-with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), "version/version")) as f:
-    __version__ = f.read().strip()
+from .flash_attention_3 import apply_flash_attention_3_varlen_hub_fix
+from .qwen_image import apply_qwen_image_ulysses_mask_fix
 
+apply_flash_attention_3_varlen_hub_fix()  # apply FA3 varlen hub fix universally
 
-# Apply model patches and auto-register pipelines / rollout / reward loop / engines
-import verl_omni.models  # noqa: E402, F401
-import verl_omni.pipelines  # noqa: E402, F401
-import verl_omni.reward_loop  # noqa: E402, F401
-import verl_omni.workers.engine  # noqa: E402, F401
-import verl_omni.workers.rollout  # noqa: E402, F401
+__all__ = ["apply_flash_attention_3_varlen_hub_fix", "apply_qwen_image_ulysses_mask_fix"]

--- a/verl_omni/models/diffusers/flash_attention_3.py
+++ b/verl_omni/models/diffusers/flash_attention_3.py
@@ -14,71 +14,13 @@
 import logging
 
 import diffusers
-import torch
 from packaging import version
 
 logger = logging.getLogger(__name__)
 
 
-# TODO (mike): It was fixed in diffusers main branch. Remove this patch once we upgrade the diffusers version.
-def _apply_qwen_image_ulysses_mask_fix() -> None:
-    if version.parse(diffusers.__version__) < version.parse("0.38.0"):
-        return
-
-    from diffusers.models.transformers.transformer_qwenimage import QwenImageTransformer2DModel
-
-    _orig_forward = QwenImageTransformer2DModel.forward
-    if getattr(_orig_forward, "_verl_omni_ulysses_mask_patched", False):
-        return
-
-    def _patched_forward(
-        self,
-        hidden_states,
-        encoder_hidden_states=None,
-        encoder_hidden_states_mask=None,
-        attention_kwargs=None,
-        **kwargs,
-    ):
-        parallel_config = getattr(self, "_parallel_config", None)
-        cp_config = parallel_config.context_parallel_config if parallel_config is not None else None
-        ulysses_degree = cp_config.ulysses_degree if cp_config is not None else 1
-
-        if ulysses_degree > 1 and encoder_hidden_states_mask is not None:
-            if not _patched_forward._warned:
-                logger.warning(
-                    "verl_omni patch applied: QwenImageTransformer2DModel.forward has been monkey-patched to fix "
-                    "the Ulysses SP joint-attention-mask layout bug (diffusers==0.38). "
-                    "The joint mask is now built in interleaved [txt_0, img_0, txt_1, img_1, ...] order "
-                    "to match the post-all-to-all sequence layout when ulysses_degree > 1. "
-                    "Remove this patch once the fix is upstreamed to diffusers."
-                )
-                _patched_forward._warned = True
-            # Build the joint mask in the interleaved layout that matches the
-            # post-all-to-all sequence order: [txt_0, img_0, txt_1, img_1, ...]
-            batch_size, image_seq_len = hidden_states.shape[:2]
-            image_mask = torch.ones((batch_size, image_seq_len), dtype=torch.bool, device=hidden_states.device)
-            txt_chunks = encoder_hidden_states_mask.chunk(ulysses_degree, dim=1)
-            img_chunks = image_mask.chunk(ulysses_degree, dim=1)
-            joint_mask = torch.cat([x for pair in zip(txt_chunks, img_chunks, strict=False) for x in pair], dim=1)
-            attention_kwargs = dict(attention_kwargs or {}, attention_mask=joint_mask[:, None, None, :])
-            encoder_hidden_states_mask = None
-
-        return _orig_forward(
-            self,
-            hidden_states,
-            encoder_hidden_states=encoder_hidden_states,
-            encoder_hidden_states_mask=encoder_hidden_states_mask,
-            attention_kwargs=attention_kwargs,
-            **kwargs,
-        )
-
-    _patched_forward._verl_omni_ulysses_mask_patched = True
-    _patched_forward._warned = False
-    QwenImageTransformer2DModel.forward = _patched_forward
-
-
 # TODO (mike): drop this once it is fixed in upstream diffusers.
-def _apply_flash_attention_3_varlen_hub_fix() -> None:
+def apply_flash_attention_3_varlen_hub_fix() -> None:
     """Patch ``_flash_attention_3_varlen_hub`` to support non-contiguous attention masks.
 
     diffusers==0.38.0 packs the valid key/value tokens with ``key[b, :valid_len]``, which
@@ -168,7 +110,3 @@ def _apply_flash_attention_3_varlen_hub_fix() -> None:
 
     registry._backends[backend] = _patched_flash_attention_3_varlen_hub
     _ad._flash_attention_3_varlen_hub = _patched_flash_attention_3_varlen_hub
-
-
-_apply_qwen_image_ulysses_mask_fix()
-_apply_flash_attention_3_varlen_hub_fix()

--- a/verl_omni/models/diffusers/qwen_image.py
+++ b/verl_omni/models/diffusers/qwen_image.py
@@ -1,0 +1,77 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+
+import diffusers
+import torch
+from packaging import version
+
+logger = logging.getLogger(__name__)
+
+
+# TODO (mike): It was fixed in diffusers main branch. Remove this patch once we upgrade the diffusers version.
+def apply_qwen_image_ulysses_mask_fix() -> None:
+    if version.parse(diffusers.__version__) < version.parse("0.38.0"):
+        return
+
+    from diffusers.models.transformers.transformer_qwenimage import QwenImageTransformer2DModel
+
+    _orig_forward = QwenImageTransformer2DModel.forward
+    if getattr(_orig_forward, "_verl_omni_ulysses_mask_patched", False):
+        return
+
+    def _patched_forward(
+        self,
+        hidden_states,
+        encoder_hidden_states=None,
+        encoder_hidden_states_mask=None,
+        attention_kwargs=None,
+        **kwargs,
+    ):
+        parallel_config = getattr(self, "_parallel_config", None)
+        cp_config = parallel_config.context_parallel_config if parallel_config is not None else None
+        ulysses_degree = cp_config.ulysses_degree if cp_config is not None else 1
+
+        if ulysses_degree > 1 and encoder_hidden_states_mask is not None:
+            if not _patched_forward._warned:
+                logger.warning(
+                    "verl_omni patch applied: QwenImageTransformer2DModel.forward has been monkey-patched to fix "
+                    "the Ulysses SP joint-attention-mask layout bug (diffusers==0.38). "
+                    "The joint mask is now built in interleaved [txt_0, img_0, txt_1, img_1, ...] order "
+                    "to match the post-all-to-all sequence layout when ulysses_degree > 1. "
+                    "Remove this patch once the fix is upstreamed to diffusers."
+                )
+                _patched_forward._warned = True
+            # Build the joint mask in the interleaved layout that matches the
+            # post-all-to-all sequence order: [txt_0, img_0, txt_1, img_1, ...]
+            batch_size, image_seq_len = hidden_states.shape[:2]
+            image_mask = torch.ones((batch_size, image_seq_len), dtype=torch.bool, device=hidden_states.device)
+            txt_chunks = encoder_hidden_states_mask.chunk(ulysses_degree, dim=1)
+            img_chunks = image_mask.chunk(ulysses_degree, dim=1)
+            joint_mask = torch.cat([x for pair in zip(txt_chunks, img_chunks, strict=False) for x in pair], dim=1)
+            attention_kwargs = dict(attention_kwargs or {}, attention_mask=joint_mask[:, None, None, :])
+            encoder_hidden_states_mask = None
+
+        return _orig_forward(
+            self,
+            hidden_states,
+            encoder_hidden_states=encoder_hidden_states,
+            encoder_hidden_states_mask=encoder_hidden_states_mask,
+            attention_kwargs=attention_kwargs,
+            **kwargs,
+        )
+
+    _patched_forward._verl_omni_ulysses_mask_patched = True
+    _patched_forward._warned = False
+    QwenImageTransformer2DModel.forward = _patched_forward

--- a/verl_omni/models/diffusers/qwen_image.py
+++ b/verl_omni/models/diffusers/qwen_image.py
@@ -22,6 +22,16 @@ logger = logging.getLogger(__name__)
 
 # TODO (mike): It was fixed in diffusers main branch. Remove this patch once we upgrade the diffusers version.
 def apply_qwen_image_ulysses_mask_fix() -> None:
+    """Patch ``QwenImageTransformer2DModel.forward`` for Ulysses sequence-parallel attention masks.
+
+    diffusers==0.38.0 builds the joint text/image attention mask in contiguous
+    ``[txt..., img...]`` order, but Ulysses all-to-all reorders tokens to interleaved
+    ``[txt_0, img_0, txt_1, img_1, ...]``. When ``ulysses_degree > 1``, this patch
+    rebuilds the joint mask in that interleaved layout before calling the original
+    forward pass.
+
+    Remove this patch once the fix is upstreamed to diffusers.
+    """
     if version.parse(diffusers.__version__) < version.parse("0.38.0"):
         return
 

--- a/verl_omni/models/transformers/__init__.py
+++ b/verl_omni/models/transformers/__init__.py
@@ -11,15 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-
-with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), "version/version")) as f:
-    __version__ = f.read().strip()
-
-
-# Apply model patches and auto-register pipelines / rollout / reward loop / engines
-import verl_omni.models  # noqa: E402, F401
-import verl_omni.pipelines  # noqa: E402, F401
-import verl_omni.reward_loop  # noqa: E402, F401
-import verl_omni.workers.engine  # noqa: E402, F401
-import verl_omni.workers.rollout  # noqa: E402, F401

--- a/verl_omni/pipelines/__init__.py
+++ b/verl_omni/pipelines/__init__.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from . import (
-    _patch,  # noqa: F401 — apply Ulysses mask & FA3 varlen mask fixes
     qwen_image_diffusion_nft,
     qwen_image_dpo,
     qwen_image_flow_grpo,

--- a/verl_omni/pipelines/model_base.py
+++ b/verl_omni/pipelines/model_base.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 from abc import ABC, abstractmethod
 from typing import Optional
 
@@ -20,6 +21,8 @@ from diffusers import ModelMixin, SchedulerMixin
 from tensordict import TensorDict
 
 from verl_omni.workers.config import DiffusionModelConfig
+
+logger = logging.getLogger(__name__)
 
 
 class DiffusionModelBase(ABC):
@@ -68,8 +71,11 @@ class DiffusionModelBase(ABC):
 
         try:
             if architecture == "QwenImagePipeline":
-                # TODO (mike): It was fixed in diffusers main branch.
-                # Remove this patch once we upgrade the diffusers version.
+                logger.info(
+                    "Applying monkey-patch for QwenImageTransformer2DModel Ulysses SP "
+                    "This workaround will be removed once we upgrade to a diffusers release that "
+                    "includes the upstream fix."
+                )
                 from verl_omni.models.diffusers.qwen_image import apply_qwen_image_ulysses_mask_fix
 
                 apply_qwen_image_ulysses_mask_fix()

--- a/verl_omni/pipelines/model_base.py
+++ b/verl_omni/pipelines/model_base.py
@@ -67,6 +67,12 @@ class DiffusionModelBase(ABC):
             import_external_libs(model_config.external_lib)
 
         try:
+            if architecture == "QwenImagePipeline":
+                # TODO (mike): It was fixed in diffusers main branch.
+                # Remove this patch once we upgrade the diffusers version.
+                from verl_omni.models.diffusers.qwen_image import apply_qwen_image_ulysses_mask_fix
+
+                apply_qwen_image_ulysses_mask_fix()
             return cls._registry[key]
         except KeyError:
             registered = sorted(cls._registry.keys())


### PR DESCRIPTION
## Summary

- Introduce `verl_omni/models/` as the home for model-level workarounds and patches (mimic the structure of https://github.com/verl-project/verl/tree/main/verl/models) :
  - `models/diffusers/` — diffusers monkey-patches (moved from `pipelines/_patch.py`)
    - `flash_attention_3.py` — FA3 varlen hub non-contiguous attention mask fix
    - `qwen_image.py` — Qwen-Image Ulysses SP joint-attention-mask fix
  - `models/transformers/` — placeholder for future transformers-related patches (empty `__init__.py`)
- Split patch application timing:
  - **FA3 varlen hub fix** — applied globally on `import verl_omni` (via `verl_omni.models`)
  - **Qwen-Image Ulysses mask fix** — applied lazily when `DiffusionModelBase.get_class()` resolves `architecture == "QwenImagePipeline"`
- Wire `import verl_omni` → `import verl_omni.models` instead of importing patches through `verl_omni.pipelines`.

## Motivation

Previously both patches lived in `pipelines/_patch.py` and were applied unconditionally when importing `verl_omni.pipelines`. That coupled unrelated diffusers workarounds to the pipeline registry and applied the Qwen-Image-specific Ulysses mask fix even when no Qwen-Image model was in use.

Centralizing patches under `verl_omni.models` makes the layering clearer (model-level workarounds vs. pipeline adapters) and limits the Qwen-Image patch to the code paths that actually need it. The `transformers/` subpackage is added as scaffolding for future HuggingFace transformers patches.

## Changes

| Before | After |
|--------|-------|
| `verl_omni/pipelines/_patch.py` | `verl_omni/models/diffusers/flash_attention_3.py` |
| (same file) | `verl_omni/models/diffusers/qwen_image.py` |
| — | `verl_omni/models/transformers/` (empty placeholder) |
| Applied via `pipelines/__init__.py` | FA3: `verl_omni/models/__init__.py` on import |
| Both patches always applied | Qwen-Image: `DiffusionModelBase.get_class()` when architecture is `QwenImagePipeline` |


## Test plan

- [x] `torchrun --nproc_per_node=4 --local-ranks-filter=0 tests/workers/test_diffusers_ulysses.py` (requires multi-GPU; explicitly calls `apply_qwen_image_ulysses_mask_fix()`)
- [x] Verify `import verl_omni` applies FA3 patch without error when diffusers ≥ 0.38 is installed
- [x] Run`examples/flowgrpo_trainer/run_qwen_image_ocr_lora_sp2.sh`

## AI assistance

AI assistance was used to implement this refactor.
### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update the documentation.
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl-omni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
