### PR TITLE
[Draft]Support Qwen3-Omni Megatron LoRA rollout

### DIFF
--- a/tests/workers/rollout/test_vllm_omni_async_server_ar.py
+++ b/tests/workers/rollout/test_vllm_omni_async_server_ar.py
@@ -1,0 +1,141 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+pytestmark = pytest.mark.cpu
+
+
+def _install_module(name: str, **attrs):
+    module = sys.modules.get(name, types.ModuleType(name))
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    sys.modules[name] = module
+    if "." in name:
+        parent_name, child_name = name.rsplit(".", 1)
+        parent = sys.modules.setdefault(parent_name, types.ModuleType(parent_name))
+        setattr(parent, child_name, sys.modules[name])
+    return sys.modules[name]
+
+
+def _install_lightweight_imports():
+    repo_root = Path(__file__).resolve().parents[3]
+
+    for package_name, package_path in {
+        "verl_omni": repo_root / "verl_omni",
+        "verl_omni.pipelines": repo_root / "verl_omni" / "pipelines",
+        "verl_omni.utils": repo_root / "verl_omni" / "utils",
+        "verl_omni.workers": repo_root / "verl_omni" / "workers",
+        "verl_omni.workers.config": repo_root / "verl_omni" / "workers" / "config",
+        "verl_omni.workers.rollout": repo_root / "verl_omni" / "workers" / "rollout",
+        "verl_omni.workers.rollout.vllm_rollout": repo_root
+        / "verl_omni"
+        / "workers"
+        / "rollout"
+        / "vllm_rollout",
+    }.items():
+        package = _install_module(package_name)
+        package.__path__ = [str(package_path)]
+
+    class FakeHijack:
+        @staticmethod
+        def hijack():
+            pass
+
+    class FakeDiffusionModelConfig:
+        pass
+
+    class FakeDiffusionRolloutConfig:
+        pass
+
+    class FakeVllmOmniPipelineBase:
+        @classmethod
+        def get_pipeline_path(cls, *_args, **_kwargs):
+            return None
+
+    _install_module("verl_omni.pipelines.model_base", VllmOmniPipelineBase=FakeVllmOmniPipelineBase)
+    _install_module("verl_omni.utils.vllm_omni", VLLMOmniHijack=FakeHijack)
+    _install_module(
+        "verl_omni.workers.config",
+        DiffusionModelConfig=FakeDiffusionModelConfig,
+        DiffusionRolloutConfig=FakeDiffusionRolloutConfig,
+    )
+    _install_module("verl_omni.workers.rollout.replica", DiffusionOutput=SimpleNamespace)
+
+    _install_module("vllm_omni")
+    _install_module("vllm_omni.entrypoints")
+    _install_module("vllm_omni.entrypoints.cli")
+    _install_module("vllm_omni.entrypoints.cli.serve")
+    _install_module("vllm_omni.entrypoints.openai")
+    _install_module("vllm_omni.entrypoints.openai.api_server", omni_init_app_state=lambda *_args, **_kwargs: None)
+    _install_module("vllm_omni.engine.arg_utils", OmniEngineArgs=SimpleNamespace)
+    _install_module("vllm_omni.entrypoints", AsyncOmni=object)
+    _install_module("vllm_omni.inputs.data", OmniCustomPrompt=dict, OmniDiffusionSamplingParams=SimpleNamespace)
+    _install_module("vllm_omni.lora.request", LoRARequest=SimpleNamespace)
+    _install_module("vllm_omni.outputs", OmniRequestOutput=SimpleNamespace)
+
+
+_install_lightweight_imports()
+
+from verl_omni.workers.rollout.vllm_rollout.vllm_omni_async_server import vLLMOmniHttpServer
+from verl_omni.workers.rollout.vllm_rollout import vllm_omni_async_server as server_mod
+
+
+class _Config(dict):
+    def __getattr__(self, name):
+        return self[name]
+
+    def __setattr__(self, name, value):
+        self[name] = value
+
+
+def test_ar_mode_uses_hf_model_config_and_rollout_generation_defaults(monkeypatch):
+    def fake_omega_conf_to_dataclass(_config, dataclass_type=None):
+        return SimpleNamespace(dataclass_type=dataclass_type)
+
+    monkeypatch.setattr(server_mod, "omega_conf_to_dataclass", fake_omega_conf_to_dataclass)
+
+    server = object.__new__(vLLMOmniHttpServer)
+    server.config = _Config(
+        engine_kwargs={"vllm_omni": {"output_mode": "ar"}},
+        max_model_len=None,
+        prompt_length=8,
+        response_length=4,
+        temperature=1.0,
+        top_k=-1,
+        top_p=1.0,
+    )
+
+    model_config = server._init_model_config({"path": "dummy", "trust_remote_code": True})
+    server._validate_configs()
+
+    assert server._ar_mode is True
+    assert model_config.dataclass_type.__name__ == "HFModelConfig"
+    assert server.config.max_model_len == 12
+    assert server._get_override_generation_config()["max_new_tokens"] == 4
+
+
+def test_preprocess_engine_kwargs_removes_internal_ar_mode_key():
+    server = object.__new__(vLLMOmniHttpServer)
+    server._ar_mode = True
+    engine_kwargs = {
+        "output_mode": "ar",
+        "custom_pipeline": "ignored",
+        "stage_configs_path": "/tmp/stage.yaml",
+        "async_chunk": True,
+    }
+
+    server._preprocess_engine_kwargs(engine_kwargs)
+
+    assert "output_mode" not in engine_kwargs
+    assert "custom_pipeline" not in engine_kwargs
+    assert engine_kwargs["stage-configs-path"] == "/tmp/stage.yaml"
+    assert engine_kwargs["async-chunk"] is True

--- a/tests/workers/rollout/test_vllm_omni_weight_update.py
+++ b/tests/workers/rollout/test_vllm_omni_weight_update.py
@@ -1,0 +1,188 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+
+from __future__ import annotations
+
+import logging
+import sys
+import types
+from contextlib import contextmanager
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+from verl.utils.vllm import TensorLoRARequest
+
+
+def _install_module(name: str, **attrs):
+    module = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    sys.modules.setdefault(name, module)
+    if "." in name:
+        parent_name, child_name = name.rsplit(".", 1)
+        parent = sys.modules.setdefault(parent_name, types.ModuleType(parent_name))
+        setattr(parent, child_name, sys.modules[name])
+    return sys.modules[name]
+
+
+def _install_lightweight_imports():
+    repo_root = Path(__file__).resolve().parents[3]
+
+    for package_name, package_path in {
+        "verl_omni": repo_root / "verl_omni",
+        "verl_omni.utils": repo_root / "verl_omni" / "utils",
+        "verl_omni.workers": repo_root / "verl_omni" / "workers",
+        "verl_omni.workers.rollout": repo_root / "verl_omni" / "workers" / "rollout",
+        "verl_omni.workers.rollout.vllm_rollout": repo_root
+        / "verl_omni"
+        / "workers"
+        / "rollout"
+        / "vllm_rollout",
+    }.items():
+        package = _install_module(package_name)
+        package.__path__ = [str(package_path)]
+
+    class FakeOmniDiffusionConfig:
+        def __post_init__(self):
+            pass
+
+    class FakeDiffusionLoRAManager:
+        pass
+
+    class FakeDiffusersPipelineLoader:
+        pass
+
+    class FakeDiffusersAdapterPipeline:
+        pass
+
+    class FakeCustomPipelineWorkerExtension:
+        pass
+
+    @contextmanager
+    def set_default_torch_dtype(_dtype):
+        yield
+
+    _install_module("vllm.utils.import_utils", resolve_obj_by_qualname=lambda _name: None)
+    _install_module("vllm.utils.mem_utils", GiB_bytes=1024**3)
+    _install_module("vllm.utils.torch_utils", set_default_torch_dtype=set_default_torch_dtype)
+
+    _install_module("vllm_omni")
+    _install_module("vllm_omni.diffusion")
+    _install_module("vllm_omni.diffusion.data", OmniDiffusionConfig=FakeOmniDiffusionConfig)
+    _install_module(
+        "vllm_omni.diffusion.lora.manager",
+        DiffusionLoRAManager=FakeDiffusionLoRAManager,
+        logger=logging.getLogger("test_vllm_omni_lora"),
+    )
+    _install_module(
+        "vllm_omni.diffusion.model_loader.diffusers_loader",
+        DiffusersPipelineLoader=FakeDiffusersPipelineLoader,
+    )
+    _install_module(
+        "vllm_omni.diffusion.models.diffusers_adapter.pipeline_diffusers_adapter",
+        DiffusersAdapterPipeline=FakeDiffusersAdapterPipeline,
+    )
+    _install_module("vllm_omni.diffusion.registry", initialize_model=lambda *_args, **_kwargs: None)
+    _install_module(
+        "vllm_omni.diffusion.worker.diffusion_worker",
+        CustomPipelineWorkerExtension=FakeCustomPipelineWorkerExtension,
+    )
+
+
+_install_lightweight_imports()
+
+from verl_omni.utils.vllm_omni import OmniTensorLoRARequest
+from verl_omni.workers.rollout.vllm_rollout import utils as rollout_utils
+
+pytestmark = pytest.mark.cpu
+
+
+def _make_worker(*, lora_enabled: bool = True):
+    worker = object.__new__(rollout_utils.vLLMOmniColocateWorkerExtension)
+    worker.device = torch.device("cpu")
+    worker.local_rank = 0
+    worker.vllm_config = SimpleNamespace(lora_config=object() if lora_enabled else None)
+    worker._get_zmq_handle = lambda: "ipc:///tmp/test.sock"
+    return worker
+
+
+def test_omni_tensor_lora_request_uses_verl_tensor_request():
+    assert issubclass(OmniTensorLoRARequest, TensorLoRARequest)
+
+
+def test_update_weights_from_ipc_accumulates_lora_buckets(monkeypatch):
+    received = []
+
+    class FakeReceiver:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def receive_weights(self, on_bucket_received):
+            on_bucket_received([("a", torch.tensor([1]))])
+            on_bucket_received([("b", torch.tensor([2]))])
+
+    import verl.workers.rollout.vllm_rollout.bucketed_weight_transfer as transfer_mod
+
+    monkeypatch.setattr(transfer_mod, "BucketedWeightReceiver", FakeReceiver)
+
+    worker = _make_worker()
+    worker.remove_lora = lambda _adapter_id: None
+    worker._update_weights = lambda weights, peft_config, base_sync_done: received.append(
+        (list(weights), peft_config, base_sync_done)
+    )
+
+    worker.update_weights_from_ipc(peft_config={"r": 16}, base_sync_done=True)
+
+    assert len(received) == 1
+    assert [name for name, _ in received[0][0]] == ["a", "b"]
+    assert received[0][1] == {"r": 16}
+    assert received[0][2] is True
+
+
+def test_update_weights_from_ipc_drains_adapter_update_when_lora_disabled(monkeypatch):
+    drained = []
+
+    class FakeReceiver:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def receive_weights(self, on_bucket_received):
+            on_bucket_received([("adapter.weight", torch.tensor([1]))])
+            drained.append(True)
+
+    import verl.workers.rollout.vllm_rollout.bucketed_weight_transfer as transfer_mod
+
+    monkeypatch.setattr(transfer_mod, "BucketedWeightReceiver", FakeReceiver)
+
+    worker = _make_worker(lora_enabled=False)
+    worker.remove_lora = lambda _adapter_id: pytest.fail("disabled LoRA should not remove adapters")
+    worker._update_weights = lambda *_args, **_kwargs: pytest.fail("disabled LoRA should drain without loading")
+
+    worker.update_weights_from_ipc(peft_config={"r": 16}, base_sync_done=True)
+
+    assert drained == [True]
+
+
+def test_update_weights_releases_lora_tensor_reference():
+    requests = []
+    worker = _make_worker()
+    worker.add_lora = requests.append
+
+    weights = [("a", torch.tensor([1])), ("b", torch.tensor([2]))]
+    worker._update_weights(weights, peft_config={"r": 16}, base_sync_done=True)
+
+    assert len(requests) == 1
+    assert requests[0].peft_config == {"r": 16}
+    assert requests[0].lora_tensors is None
+
+
+def test_get_zmq_handle_can_use_fixed_split_placement_handles(monkeypatch):
+    monkeypatch.setenv("VERL_VLLM_WEIGHT_SYNC_ZMQ_HANDLES", "ipc:///tmp/r0.sock,ipc:///tmp/r1.sock")
+    worker = _make_worker()
+    del worker._get_zmq_handle
+    worker.rank = 1
+
+    assert worker._get_zmq_handle() == "ipc:///tmp/r1.sock"

--- a/verl_omni/utils/vllm_omni/utils.py
+++ b/verl_omni/utils/vllm_omni/utils.py
@@ -17,13 +17,13 @@ import os
 from typing import cast
 
 import torch
-from msgspec import field
 
 try:
     from vllm.lora.lora_model import LoRAModel
 except ImportError:
     from vllm.lora.models import LoRAModel
 
+from verl.utils.vllm import TensorLoRARequest, VLLMHijack
 from vllm.lora.peft_helper import PEFTHelper
 from vllm.lora.utils import get_adapter_absolute_path
 from vllm.utils.import_utils import resolve_obj_by_qualname
@@ -35,12 +35,10 @@ from vllm_omni.diffusion.models.diffusers_adapter.pipeline_diffusers_adapter imp
     DiffusersAdapterPipeline,
 )
 from vllm_omni.diffusion.registry import initialize_model
-from vllm_omni.lora.request import LoRARequest as OmniLoRARequest
 
 
-class OmniTensorLoRARequest(OmniLoRARequest):
-    peft_config: dict = field(default=None)
-    lora_tensors: dict = field(default=None)
+class OmniTensorLoRARequest(TensorLoRARequest):
+    """Tensor-backed LoRA request for vLLM-Omni hot loading."""
 
 
 class VLLMOmniHijack:
@@ -86,6 +84,11 @@ class VLLMOmniHijack:
                 peft_helper.target_modules,
             )
 
+            model = getattr(self, "pipeline", None)
+            hf_to_vllm_mapper = None
+            if model is not None and getattr(model, "hf_to_vllm_mapper", None) is not None:
+                hf_to_vllm_mapper = model.hf_to_vllm_mapper
+
             if isinstance(lora_request, OmniTensorLoRARequest):
                 lora_model = LoRAModel.from_lora_tensors(
                     tensors=lora_tensors,
@@ -94,7 +97,7 @@ class VLLMOmniHijack:
                     device="cpu",  # consistent w/ vllm's behavior
                     dtype=self.dtype,
                     model_vocab_size=None,
-                    weights_mapper=None,
+                    weights_mapper=hf_to_vllm_mapper,
                 )
             else:
                 lora_model = LoRAModel.from_local_checkpoint(
@@ -106,7 +109,7 @@ class VLLMOmniHijack:
                     dtype=self.dtype,
                     model_vocab_size=None,
                     tensorizer_config_dict=lora_request.tensorizer_config_dict,
-                    weights_mapper=None,
+                    weights_mapper=hf_to_vllm_mapper,
                 )
 
             logger.info(
@@ -239,3 +242,5 @@ class VLLMOmniHijack:
         if not getattr(OmniDiffusionConfig, "_verl_omni_master_port_hijacked", False):
             do_hijack(OmniDiffusionConfig, "__post_init__", hijack_omni_diffusion_config_post_init)
             OmniDiffusionConfig._verl_omni_master_port_hijacked = True
+
+        VLLMHijack.hijack()

--- a/verl_omni/workers/rollout/vllm_rollout/utils.py
+++ b/verl_omni/workers/rollout/vllm_rollout/utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import logging
 import os
+from typing import Any
 
 import torch
 from verl.workers.rollout.vllm_rollout.utils import VLLM_LORA_INT_ID, VLLM_LORA_NAME, VLLM_LORA_PATH, set_death_signal
@@ -23,6 +24,34 @@ from verl_omni.workers.rollout.vllm_rollout.npu_utils import NPUColocateWorkerMi
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
+
+
+def get_weight_sync_zmq_handle(rank: int, default_handle: str) -> str:
+    """Return an optional fixed ZMQ handle for split train/vLLM placement."""
+    handles = os.getenv("VERL_VLLM_WEIGHT_SYNC_ZMQ_HANDLES", "").strip()
+    if not handles:
+        return default_handle
+
+    parts = [part.strip() for part in handles.replace(";", ",").split(",") if part.strip()]
+    if len(parts) == 1:
+        return parts[0]
+    if rank < 0 or rank >= len(parts):
+        raise ValueError(
+            "VERL_VLLM_WEIGHT_SYNC_ZMQ_HANDLES must contain either one handle or one handle per rank; "
+            f"got {len(parts)} handles and rank={rank}"
+        )
+    return parts[rank]
+
+
+def _vllm_lora_enabled(worker: Any) -> bool:
+    model_runner = getattr(worker, "model_runner", None)
+    if getattr(model_runner, "lora_config", None) is not None:
+        return True
+
+    vllm_config = getattr(model_runner, "vllm_config", None) or getattr(worker, "vllm_config", None)
+    if vllm_config is None:
+        return True
+    return getattr(vllm_config, "lora_config", None) is not None
 
 
 class vLLMOmniColocateWorkerExtension(NPUColocateWorkerMixin, CustomPipelineWorkerExtension):
@@ -52,8 +81,11 @@ class vLLMOmniColocateWorkerExtension(NPUColocateWorkerMixin, CustomPipelineWork
 
         from verl.workers.rollout.vllm_rollout.bucketed_weight_transfer import BucketedWeightReceiver
 
-        # In async mode, make sure the old lora is removed before adding the new one
-        if peft_config and base_sync_done:
+        adapter_update = bool(peft_config and base_sync_done)
+        lora_enabled = _vllm_lora_enabled(self)
+
+        # In async mode, make sure the old lora is removed before adding the new one.
+        if adapter_update and lora_enabled:
             self.remove_lora(VLLM_LORA_INT_ID)
 
         assert self.device is not None
@@ -62,14 +94,40 @@ class vLLMOmniColocateWorkerExtension(NPUColocateWorkerMixin, CustomPipelineWork
             device=self.device,
             use_shm=use_shm,
         )
-        receiver.receive_weights(
-            on_bucket_received=lambda weights: self._update_weights(
-                weights, peft_config=peft_config, base_sync_done=base_sync_done
+        if adapter_update and not lora_enabled:
+            logger.info("Draining adapter-only weight update because vLLM-Omni LoRA is disabled")
+            receiver.receive_weights(on_bucket_received=lambda _weights: None)
+            return
+
+        if adapter_update:
+            accumulated_weights: list[tuple[str, torch.Tensor]] = []
+
+            def _accumulate(weights: list[tuple[str, torch.Tensor]]) -> None:
+                accumulated_weights.extend(weights)
+
+            receiver.receive_weights(on_bucket_received=_accumulate)
+            try:
+                self._update_weights(
+                    accumulated_weights,
+                    peft_config=peft_config,
+                    base_sync_done=base_sync_done,
+                )
+            finally:
+                accumulated_weights.clear()
+                if torch.cuda.is_available():
+                    torch.cuda.empty_cache()
+        else:
+            receiver.receive_weights(
+                on_bucket_received=lambda weights: self._update_weights(
+                    weights, peft_config=peft_config, base_sync_done=base_sync_done
+                )
             )
-        )
 
     def _update_weights(self, weights: list[tuple[str, torch.Tensor]], peft_config: dict, base_sync_done: bool):
         if peft_config and base_sync_done:
+            if not _vllm_lora_enabled(self):
+                logger.info("Skipping adapter-only weight update because vLLM-Omni LoRA is disabled")
+                return
             weights = dict(weights)
             lora_request = OmniTensorLoRARequest(
                 lora_name=VLLM_LORA_NAME,
@@ -79,6 +137,7 @@ class vLLMOmniColocateWorkerExtension(NPUColocateWorkerMixin, CustomPipelineWork
                 lora_tensors=weights,
             )
             self.add_lora(lora_request)
+            lora_request.lora_tensors = None
             logger.info(f"vLLM-Omni load weights, loaded_params: {len(weights)}")
         else:
             logger.info("Loading standard weights (async)")
@@ -95,4 +154,6 @@ class vLLMOmniColocateWorkerExtension(NPUColocateWorkerMixin, CustomPipelineWork
         """
         replica_rank = os.environ.get("VERL_REPLICA_RANK", "0")
         job_id = os.environ.get("VERL_RAY_JOB_ID", "0")
-        return f"ipc:///tmp/rl-colocate-zmq-{job_id}-replica-{replica_rank}-rank-{self.local_rank}.sock"
+        default_handle = f"ipc:///tmp/rl-colocate-zmq-{job_id}-replica-{replica_rank}-rank-{self.local_rank}.sock"
+        rank = int(getattr(self, "rank", getattr(self, "local_rank", 0)))
+        return get_weight_sync_zmq_handle(rank, default_handle)

--- a/verl_omni/workers/rollout/vllm_rollout/vllm_omni_async_server.py
+++ b/verl_omni/workers/rollout/vllm_rollout/vllm_omni_async_server.py
@@ -26,6 +26,8 @@ from verl.utils.config import omega_conf_to_dataclass
 from verl.utils.import_utils import import_external_libs
 from verl.utils.net_utils import get_free_port
 from verl.utils.tokenizer import normalize_token_ids
+from verl.workers.config import HFModelConfig, RolloutConfig
+from verl.workers.rollout.replica import TokenOutput
 from verl.workers.rollout.utils import run_uvicorn
 from verl.workers.rollout.vllm_rollout.utils import (
     VLLM_LORA_INT_ID,
@@ -33,6 +35,7 @@ from verl.workers.rollout.vllm_rollout.utils import (
     VLLM_LORA_PATH,
 )
 from verl.workers.rollout.vllm_rollout.vllm_async_server import vLLMHttpServer, vLLMReplica
+from vllm import SamplingParams
 from vllm.entrypoints.openai.api_server import build_app
 from vllm_omni.engine.arg_utils import OmniEngineArgs
 from vllm_omni.entrypoints import AsyncOmni
@@ -51,10 +54,11 @@ logger.setLevel(logging.INFO)
 
 
 class vLLMOmniHttpServer(vLLMHttpServer):
-    """vLLM-Omni http server in single node, this is equivalent to launch server with command line:
-    ```
-    vllm serve --tensor-parallel-size=8 ...
-    ```
+    """vLLM-Omni http server supporting diffusion and AR modes.
+
+    Mode is selected by ``engine_kwargs.vllm_omni.output_mode``:
+    - ``diffusion`` (default): token-in, image-out generation
+    - ``ar``: token-in, token-out generation, used by thinker-only Qwen3-Omni
     """
 
     # -----------------------------------------------------------------------
@@ -62,24 +66,32 @@ class vLLMOmniHttpServer(vLLMHttpServer):
     # -----------------------------------------------------------------------
 
     def _init_model_config(self, model_config):
-        """Use DiffusionModelConfig instead of HFModelConfig."""
+        engine_kwargs = getattr(self.config, "engine_kwargs", None) or {}
+        omni_kwargs = engine_kwargs.get("vllm_omni", {}) or {}
+        self._ar_mode = omni_kwargs.get("output_mode", "diffusion") == "ar"
+
+        if self._ar_mode:
+            return omega_conf_to_dataclass(model_config, dataclass_type=HFModelConfig)
         return omega_conf_to_dataclass(model_config, dataclass_type=DiffusionModelConfig)
 
     def _validate_configs(self) -> None:
-        """No-op: diffusion models don't have max_position_embeddings."""
-        pass
+        if self._ar_mode and self.config.max_model_len is None:
+            self.config.max_model_len = self.config.prompt_length + self.config.response_length
 
     def _post_init(self, cuda_visible_devices: str) -> None:
-        """Omni-specific post-init: create PIL→tensor converter, then log."""
-        self._to_tensor = T.PILToTensor()
-        super()._post_init(cuda_visible_devices)
+        if self._ar_mode:
+            vLLMHttpServer._post_init(self, cuda_visible_devices)
+        else:
+            self._to_tensor = T.PILToTensor()
+            super()._post_init(cuda_visible_devices)
 
     # -----------------------------------------------------------------------
     # launch_server hooks
     # -----------------------------------------------------------------------
 
     def _get_override_generation_config(self) -> dict:
-        """Diffusion models have no LLM sampling params; return empty dict."""
+        if self._ar_mode:
+            return vLLMHttpServer._get_override_generation_config(self)
         return {}
 
     def _get_engine_kwargs_key(self) -> str:
@@ -93,6 +105,14 @@ class vLLMOmniHttpServer(vLLMHttpServer):
 
     def _get_cli_description(self) -> str:
         return "vLLM-Omni CLI"
+
+    def _preprocess_engine_kwargs(self, engine_kwargs: dict) -> None:
+        engine_kwargs.pop("output_mode", None)
+        if self._ar_mode:
+            engine_kwargs.pop("custom_pipeline", None)
+            for underscore_key in ("stage_configs_path", "deploy_config", "stage_overrides", "async_chunk"):
+                if underscore_key in engine_kwargs:
+                    engine_kwargs[underscore_key.replace("_", "-")] = engine_kwargs.pop(underscore_key)
 
     # TODO: drop it after updating verl pin (at least 5ff595ac9fcb4)
     async def launch_server(self, master_address: str = None, master_port: int = None, dp_rpc_port: int = None):
@@ -125,22 +145,28 @@ class vLLMOmniHttpServer(vLLMHttpServer):
         engine_args = OmniEngineArgs.from_cli_args(args)
         engine_args = asdict(engine_args)
 
-        import_external_libs(self.config.external_lib)
-        pipeline_path = VllmOmniPipelineBase.get_pipeline_path(
-            architecture=self.model_config.architecture,
-            algorithm=self.model_config.algorithm,
-        )
-        # TODO (mike): read custom_pipeline from engine_args
-        if pipeline_path is not None:
-            engine_args["enable_dummy_pipeline"] = True
-            engine_args["custom_pipeline_args"] = {"pipeline_class": pipeline_path}
+        if self._ar_mode:
+            if isinstance(engine_args.get("compilation_config"), dict):
+                engine_args["compilation_config"] = {
+                    k: v for k, v in engine_args["compilation_config"].items() if v is not None
+                }
+        else:
+            import_external_libs(self.config.external_lib)
+            pipeline_path = VllmOmniPipelineBase.get_pipeline_path(
+                architecture=self.model_config.architecture,
+                algorithm=self.model_config.algorithm,
+            )
+            # TODO (mike): read custom_pipeline from engine_args
+            if pipeline_path is not None:
+                engine_args["enable_dummy_pipeline"] = True
+                engine_args["custom_pipeline_args"] = {"pipeline_class": pipeline_path}
 
-        diffusion_master_port, diffusion_master_sock = get_free_port("127.0.0.1", with_alive_sock=True)
-        diffusion_master_sock.close()
+            diffusion_master_port, diffusion_master_sock = get_free_port("127.0.0.1", with_alive_sock=True)
+            diffusion_master_sock.close()
 
-        os.environ["MASTER_ADDR"] = "127.0.0.1"
-        os.environ["MASTER_PORT"] = str(diffusion_master_port)
-        logger.info("Using MASTER_PORT=%s for vLLM-Omni diffusion workers", os.environ["MASTER_PORT"])
+            os.environ["MASTER_ADDR"] = "127.0.0.1"
+            os.environ["MASTER_PORT"] = str(diffusion_master_port)
+            logger.info("Using MASTER_PORT=%s for vLLM-Omni diffusion workers", os.environ["MASTER_PORT"])
 
         # Apply before AsyncOmni builds OmniDiffusionConfig in this process.
         VLLMOmniHijack.hijack()
@@ -195,6 +221,22 @@ class vLLMOmniHttpServer(vLLMHttpServer):
         await self.engine.reset_encoder_cache()
 
     async def generate(
+        self,
+        prompt_ids: list[int],
+        sampling_params: dict[str, Any],
+        request_id: str,
+        image_data: Optional[list[Any]] = None,
+        video_data: Optional[list[Any]] = None,
+        negative_prompt_ids: Optional[list[int]] = None,
+        priority: int = 0,
+    ) -> DiffusionOutput | TokenOutput:
+        if self._ar_mode:
+            return await self._generate_ar(prompt_ids, sampling_params, request_id, image_data, video_data, priority)
+        return await self._generate_diffusion(
+            prompt_ids, sampling_params, request_id, image_data, video_data, negative_prompt_ids, priority
+        )
+
+    async def _generate_diffusion(
         self,
         prompt_ids: list[int],
         sampling_params: dict[str, Any],
@@ -321,6 +363,112 @@ class vLLMOmniHttpServer(vLLMHttpServer):
             extra_fields=extra_fields,
         )
 
+    async def _generate_ar(
+        self,
+        prompt_ids: list[int],
+        sampling_params: dict[str, Any],
+        request_id: str,
+        image_data: Optional[list[Any]] = None,
+        video_data: Optional[list[Any]] = None,
+        priority: int = 0,
+    ) -> TokenOutput:
+        """Generate sequence with token-in-token-out."""
+        prompt_ids = normalize_token_ids(prompt_ids)
+
+        max_possible_tokens = self.config.max_model_len - len(prompt_ids)
+        if max_possible_tokens < 1:
+            raise ValueError(
+                f"Prompt length ({len(prompt_ids)}) leaves no room to generate within the "
+                f"model's maximum context length ({self.config.max_model_len}); need at least "
+                "1 token of headroom."
+            )
+
+        if "max_tokens" in sampling_params:
+            max_tokens = sampling_params.pop("max_tokens")
+        elif "max_new_tokens" in sampling_params:
+            max_tokens = sampling_params.pop("max_new_tokens")
+        else:
+            max_tokens = min(
+                self.config.response_length,
+                self.config.prompt_length + self.config.response_length - len(prompt_ids),
+            )
+        max_tokens = max(1, min(max_tokens, max_possible_tokens))
+
+        sampling_params["logprobs"] = 0 if sampling_params.pop("logprobs", False) else None
+        sampling_params.setdefault("repetition_penalty", self.config.get("repetition_penalty", 1.0))
+        sampling_params = SamplingParams(max_tokens=max_tokens, **sampling_params)
+
+        multi_modal_data = {}
+        if image_data is not None:
+            multi_modal_data["image"] = image_data
+        if video_data is not None:
+            multi_modal_data["video"] = video_data
+
+        prompt = {"prompt_token_ids": prompt_ids}
+        if multi_modal_data:
+            prompt["multi_modal_data"] = multi_modal_data
+
+        lora_request = None
+        if self.lora_as_adapter:
+            try:
+                lora_loaded = VLLM_LORA_INT_ID in await self.engine.list_loras()
+            except TypeError:
+                lora_loaded = True
+            if lora_loaded:
+                lora_request = LoRARequest(
+                    lora_name=VLLM_LORA_NAME, lora_int_id=VLLM_LORA_INT_ID, lora_path=VLLM_LORA_PATH
+                )
+
+        generator = self.engine.generate(
+            prompt=prompt,
+            sampling_params=sampling_params,
+            request_id=request_id,
+            lora_request=lora_request,
+            priority=priority,
+        )
+
+        final_res: Optional[OmniRequestOutput] = None
+        async for output in generator:
+            final_res = output
+        assert final_res is not None
+
+        req_output = final_res.request_output
+        assert req_output is not None, "AR mode expects request_output with token IDs"
+
+        if not req_output.outputs:
+            return TokenOutput(
+                token_ids=[],
+                log_probs=None,
+                routed_experts=None,
+                stop_reason="aborted",
+                extra_fields={"global_steps": self.global_steps},
+            )
+
+        token_ids = req_output.outputs[0].token_ids
+        log_probs = None
+        if sampling_params.logprobs is not None:
+            log_probs = [logprobs[token_ids[i]].logprob for i, logprobs in enumerate(req_output.outputs[0].logprobs)]
+
+        finish_reason = req_output.outputs[0].finish_reason
+        if finish_reason == "abort":
+            stop_reason = "aborted"
+        elif finish_reason in ("stop", "length"):
+            stop_reason = "completed"
+        else:
+            stop_reason = finish_reason
+
+        num_preempted = None
+        if hasattr(req_output.outputs[0], "num_preempted"):
+            num_preempted = req_output.outputs[0].num_preempted
+
+        return TokenOutput(
+            token_ids=token_ids,
+            log_probs=log_probs,
+            stop_reason=stop_reason,
+            num_preempted=num_preempted,
+            extra_fields={"global_steps": self.global_steps},
+        )
+
     async def wait_for_requests_to_drain(self):
         # TODO (mike): implement this once DP is supported.
         pass
@@ -330,8 +478,8 @@ class vLLMOmniReplica(vLLMReplica):
     def __init__(
         self,
         replica_rank: int,
-        config: DiffusionRolloutConfig,
-        model_config: DiffusionModelConfig,
+        config: DiffusionRolloutConfig | RolloutConfig,
+        model_config: DiffusionModelConfig | HFModelConfig,
         gpus_per_node: int = 8,
         is_reward_model: bool = False,
     ):


### PR DESCRIPTION
## Summary

Add Qwen3-Omni Megatron LoRA rollout support for split Megatron/vLLM-Omni placement.

## Context

This path is validated with split placement: Megatron actor/ref and vLLM-Omni rollout run on separate GPU sets. It is not relying on colocated rollout execution.

## Changes

- Support tensor-backed LoRA requests via `OmniTensorLoRARequest`.
- Use model `hf_to_vllm_mapper` when materializing LoRA tensors.
- Accumulate adapter weight buckets before loading LoRA into vLLM-Omni.
- Support rank-indexed ZMQ handles for split train/rollout weight sync.
- Drain adapter-only updates when LoRA is disabled to avoid sync hangs.
- Add AR rollout mode for Qwen3-Omni thinker-only token generation.
- Keep latest diffusion/NPU fixes intact.

## Tests

- `pytest -q tests/workers/rollout/test_vllm_omni_weight_update.py tests/workers/rollout/test_vllm_omni_async_server_ar.py`
- `python -m py_compile ...`
- `git diff --check`

related PRs
https://github.com/verl-project/verl/pull/6713
https://github.com/vllm-project/vllm-omni/pull/4388