### PR TITLE
[recipe,doc] feat: Add qwen image dpo npu example

### DIFF
--- a/examples/dpo_trainer/README.md
+++ b/examples/dpo_trainer/README.md
@@ -35,11 +35,29 @@ then `examples/flowgrpo_trainer/data_process/qwenimage_ocr.py` to write
 
 ### Run
 
+### NVIDIA GPU
+
 ```bash
 bash examples/dpo_trainer/run_qwen_image_online_dpo_lora.sh \
   data.train_files=$WORKSPACE/data/ocr/qwen_image/train.parquet \
   data.val_files=$WORKSPACE/data/ocr/qwen_image/test.parquet
 ```
+
+### NPU
+
+For Huawei Ascend NPUs, use the NPU-optimized script:
+
+```bash
+bash examples/dpo_trainer/run_qwen_image_online_dpo_lora_npu.sh \
+  data.train_files=$WORKSPACE/data/ocr/qwen_image/train.parquet \
+  data.val_files=$WORKSPACE/data/ocr/qwen_image/test.parquet
+```
+
+This script uses a 16-NPU global distribution strategy with:
+- `actor_rollout_ref.model.attn_backend='_native_npu'`
+- `actor_rollout_ref.rollout.tensor_model_parallel_size=2`
+- `reward.reward_model.rollout.tensor_model_parallel_size=4`
+- `trainer.n_gpus_per_node=16`
 
 ### Notes
 
@@ -51,15 +69,15 @@ bash examples/dpo_trainer/run_qwen_image_online_dpo_lora.sh \
 
 ### Performance
 
-> Online DPO experiment conducted on *NVIDIA H800* GPUs with the same OCR reward and prompt parquet as FlowGRPO Qwen-Image training.
+> All experiments were conducted on *NVIDIA H800* GPUs; NPU experiments use *16× Ascend NPUs*. The OCR reward was used for all experiments.
 
+| Script | Model | Algorithm | Hybrid Engine | # Cards | Reward Fn | # Cards for Actor | # Cards for Rollout | # Cards for Async Reward | Batch Size | `rollout.n` | lr   | # Val Samples | Training Samples per Step | `ppo_micro_batch_size_per_gpu` | Throughput (Samples / Card / Seconds) | Time per Step (Seconds) |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `run_qwen_image_online_dpo_lora.sh` | Qwen-Image | Online DPO | True | 4 (NVIDIA) | qwenvl-ocr-vllm | 4 | 4 | 0 (sync) | 32 | 16 | 3e-4 | 1k (full set) | 32×2=64 | 8 | 0.040 | 408 |
+| `run_qwen_image_online_dpo_lora_npu.sh` | Qwen-Image | Online DPO | True | 16 (NPU) | qwenvl-ocr-vllm | 16 | 16 | 0 (sync) | 32 | 16 | 3e-4 | 1k (full set) | 32×2=64 | 4 | 0.003 | 1188 |
 
-| Script | Model | Algorithm | Hybrid Engine | # Cards | Reward Fn | # GPUs for Actor | # GPUs for Rollout | # GPUs for Async Reward | Batch Size | `rollout.n` | lr   | # Val Samples | Training Samples per Step | `ppo_micro_batch_size_per_gpu` | Throughput (Samples / GPU / Seconds) | Time per Step (Seconds) |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| `run_qwen_image_online_dpo_lora.sh` | Qwen-Image | Online DPO | True | 4 | qwenvl-ocr-vllm | 4 | 4 | 0 (sync) | 32 | 16 | 3e-4 | 1k (full set) | 32×2=64 | 8 | 0.040 | 408 |
-
-- Colocated actor, vLLM-Omni rollout, and sync OCR reward on 4 GPUs; `rollout.n=16` samples candidates, then top/bottom pairing keeps 64 actor-update images per step (`perf/total_num_images=64`).
-- Validation uses `trainer.val_before_train=True` on the full OCR test parquet (same as FlowGRPO).
+- Colocated actor, vLLM-Omni rollout, and sync OCR reward on 4 NVIDIA GPUs (or 16 NPUs for NPU script); `rollout.n=16` samples candidates, then top/bottom pairing keeps 64 actor-update images per step.
+- Validation uses the full OCR test parquet.
 - Unlike policy-gradient trainers (e.g. FlowGRPO), where actor updates use `train_batch_size × rollout.n` images per step, online DPO keeps one `[chosen, rejected]` pair per prompt (`train_batch_size × 2`), so throughput numbers are not directly comparable—use the **Training Samples per Step** column.
 
 > **Note:** Reward curves may differ between runs because online DPO depends on stochastic diffusion rollouts and the example scripts do not fix the data seed.

--- a/examples/dpo_trainer/run_qwen_image_online_dpo_lora_npu.sh
+++ b/examples/dpo_trainer/run_qwen_image_online_dpo_lora_npu.sh
@@ -1,4 +1,4 @@
-# Qwen-Image DiffusionNFT LoRA RL, vllm_omni rollout
+# Qwen-Image Diffusion DPO LoRA RL, vllm_omni rollout
 set -x
 
 # Set WORKSPACE to any writable directory; defaults to $HOME

--- a/examples/dpo_trainer/run_qwen_image_online_dpo_lora_npu.sh
+++ b/examples/dpo_trainer/run_qwen_image_online_dpo_lora_npu.sh
@@ -1,0 +1,75 @@
+# Qwen-Image DiffusionNFT LoRA RL, vllm_omni rollout
+set -x
+
+# Set WORKSPACE to any writable directory; defaults to $HOME
+WORKSPACE=${WORKSPACE:-$HOME}
+
+ocr_train_path=$WORKSPACE/data/ocr/train.parquet
+ocr_test_path=$WORKSPACE/data/ocr/test.parquet
+
+model_name=Qwen/Qwen-Image
+reward_model_name=Qwen/Qwen3-VL-8B-Instruct
+reward_function_path=verl_omni/utils/reward_score/genrm_ocr.py
+
+NUM_GPUS_ACTOR_ROLLOUT_REWARD=16
+ROLLOUT_TP=2
+REWARD_TP=4
+
+ENGINE=vllm_omni
+REWARD_ENGINE=vllm
+
+python3 -m verl_omni.trainer.main_diffusion \
+    algorithm.trainer_type=direct_preference \
+    algorithm.sample_source=online \
+    algorithm.paired_preference=true \
+    data.train_files=$ocr_train_path \
+    data.val_files=$ocr_test_path \
+    data.train_batch_size=32 \
+    data.max_prompt_length=256 \
+    actor_rollout_ref.model.attn_backend='_native_npu' \
+    actor_rollout_ref.model.path=$model_name \
+    actor_rollout_ref.model.algorithm=dpo \
+    actor_rollout_ref.model.model_type=diffusion_dpo_model \
+    actor_rollout_ref.model.external_lib=verl_omni.pipelines.qwen_image_dpo \
+    actor_rollout_ref.model.lora_rank=64 \
+    actor_rollout_ref.model.lora_alpha=128 \
+    actor_rollout_ref.model.target_modules="['to_q','to_k','to_v','to_out.0','add_q_proj','add_k_proj','add_v_proj','to_add_out','img_mlp.net.0.proj','img_mlp.net.2','txt_mlp.net.0.proj','txt_mlp.net.2']" \
+    actor_rollout_ref.actor.diffusion_loss.loss_mode=dpo \
+    actor_rollout_ref.actor.diffusion_loss.dpo_beta=100.0 \
+    actor_rollout_ref.actor.optim.lr=3e-4 \
+    actor_rollout_ref.actor.optim.weight_decay=0.0001 \
+    actor_rollout_ref.actor.ppo_mini_batch_size=32 \
+    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=4 \
+    actor_rollout_ref.actor.fsdp_config.param_offload=True \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=True \
+    actor_rollout_ref.actor.fsdp_config.model_dtype=bfloat16 \
+    actor_rollout_ref.rollout.name=$ENGINE \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=$ROLLOUT_TP \
+    actor_rollout_ref.rollout.n=16 \
+    actor_rollout_ref.rollout.calculate_log_probs=false \
+    actor_rollout_ref.rollout.agent.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / ROLLOUT_TP)) \
+    actor_rollout_ref.rollout.load_format=safetensors \
+    actor_rollout_ref.rollout.layered_summon=True \
+    actor_rollout_ref.rollout.pipeline.num_inference_steps=35 \
+    actor_rollout_ref.rollout.pipeline.true_cfg_scale=1.0 \
+    actor_rollout_ref.rollout.pipeline.max_sequence_length=256 \
+    actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=50 \
+    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=4 \
+    reward.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / REWARD_TP)) \
+    reward.reward_model.enable=True \
+    reward.reward_model.model_path=$reward_model_name \
+    reward.reward_model.rollout.name=$REWARD_ENGINE \
+    reward.reward_model.rollout.tensor_model_parallel_size=$REWARD_TP \
+    reward.custom_reward_function.path=$reward_function_path \
+    reward.custom_reward_function.name=compute_score_ocr \
+    trainer.logger='["console", "tensorboard"]' \
+    trainer.project_name=online_dpo \
+    trainer.experiment_name=qwen_image_online_dpo_lora \
+    trainer.log_val_generations=8 \
+    trainer.val_before_train=False \
+    trainer.n_gpus_per_node=$NUM_GPUS_ACTOR_ROLLOUT_REWARD \
+    trainer.nnodes=1 \
+    trainer.save_freq=30 \
+    trainer.test_freq=30 \
+    trainer.total_epochs=15 \
+    trainer.total_training_steps=300 "$@"

--- a/examples/dpo_trainer/run_qwen_image_online_dpo_lora_npu.sh
+++ b/examples/dpo_trainer/run_qwen_image_online_dpo_lora_npu.sh
@@ -73,3 +73,4 @@ python3 -m verl_omni.trainer.main_diffusion \
     trainer.test_freq=30 \
     trainer.total_epochs=15 \
     trainer.total_training_steps=300 "$@"
+

--- a/examples/dpo_trainer/run_qwen_image_online_dpo_lora_npu.sh
+++ b/examples/dpo_trainer/run_qwen_image_online_dpo_lora_npu.sh
@@ -4,8 +4,8 @@ set -x
 # Set WORKSPACE to any writable directory; defaults to $HOME
 WORKSPACE=${WORKSPACE:-$HOME}
 
-ocr_train_path=$WORKSPACE/data/ocr/train.parquet
-ocr_test_path=$WORKSPACE/data/ocr/test.parquet
+ocr_train_path=$WORKSPACE/data/ocr/qwen_image/train.parquet
+ocr_test_path=$WORKSPACE/data/ocr/qwen_image/test.parquet
 
 model_name=Qwen/Qwen-Image
 reward_model_name=Qwen/Qwen3-VL-8B-Instruct

--- a/verl_omni/workers/engine/fsdp/diffusers_impl.py
+++ b/verl_omni/workers/engine/fsdp/diffusers_impl.py
@@ -930,7 +930,7 @@ class PPODiffusersFSDPEngine(DiffusersFSDPEngine):
         return loss, output
 
 
-@EngineRegistry.register(model_type="diffusion_dpo_model", backend=["fsdp", "fsdp2"], device=["cuda","npu"])
+@EngineRegistry.register(model_type="diffusion_dpo_model", backend=["fsdp", "fsdp2"], device=["cuda", "npu"])
 class DPODiffusersFSDPEngine(DiffusersFSDPEngine):
     """Diffusers FSDP engine variant for diffusion DPO."""
 

--- a/verl_omni/workers/engine/fsdp/diffusers_impl.py
+++ b/verl_omni/workers/engine/fsdp/diffusers_impl.py
@@ -930,7 +930,7 @@ class PPODiffusersFSDPEngine(DiffusersFSDPEngine):
         return loss, output
 
 
-@EngineRegistry.register(model_type="diffusion_dpo_model", backend=["fsdp", "fsdp2"], device=["cuda"])
+@EngineRegistry.register(model_type="diffusion_dpo_model", backend=["fsdp", "fsdp2"], device=["cuda","npu"])
 class DPODiffusersFSDPEngine(DiffusersFSDPEngine):
     """Diffusers FSDP engine variant for diffusion DPO."""
 


### PR DESCRIPTION
## What does this PR do?

This PR adds NPU support for the Qwen-Image online DPO LoRA example.

Main changes:

* Add `examples/dpo_trainer/run_qwen_image_online_dpo_lora_npu.sh` for running Qwen-Image online DPO LoRA training on Huawei Ascend NPUs.
* Update `examples/dpo_trainer/README.md` with:

  * separate NVIDIA GPU and NPU run commands;
  * NPU-specific configuration notes;
  * an updated performance table including the 16-NPU setup.
* Enable the `diffusion_dpo_model` FSDP/FSDP2 engine registry entry on NPU by changing the supported device list from `["cuda"]` to `["cuda", "npu"]`.

## NPU configuration

The new NPU script uses a 16-NPU global distribution strategy:

* actor / rollout / reward colocated on 16 NPUs;
* rollout tensor parallel size: `2`;
* reward model tensor parallel size: `4`;
* actor micro batch size per device: `4`;
* Qwen-Image attention backend: `_native_npu`.

The script keeps the same online DPO workflow as the existing CUDA example:

1. sample multiple candidate images per prompt with vLLM-Omni rollout;
2. score generated images with the OCR reward model;
3. construct top-vs-bottom preference pairs;
4. update the diffusion DPO actor with LoRA.

## Training curves

### Actor metrics

<img width="686" height="392" alt="屏幕截图 2026-06-15 091922" src="https://github.com/user-attachments/assets/ad7a79bc-d21c-4e1e-904f-9bb2aa84878a" />

### Critic / reward metrics

<!-- Replace the placeholder below with the critic or reward metrics training curve. -->

<img width="691" height="401" alt="屏幕截图 2026-06-15 091658" src="https://github.com/user-attachments/assets/72f2089f-419d-4649-bb6c-175f723432f4" />


## Files changed

* `examples/dpo_trainer/run_qwen_image_online_dpo_lora_npu.sh`
* `examples/dpo_trainer/README.md`
* `verl_omni/workers/engine/fsdp/diffusers_impl.py`

## Notes

The NPU script follows the same Qwen-Image online DPO setup as the existing GPU script, but adjusts the device/backend and parallelism settings for Ascend NPUs.

The engine registry update is required so that `diffusion_dpo_model` can be selected when running with `device=npu` under FSDP/FSDP2.
