### PR TITLE
[doc] chore: document CUDA 12.8 / driver 535 install workaround

### DIFF
--- a/docs/start/install.md
+++ b/docs/start/install.md
@@ -99,6 +99,28 @@ python -c "from veomni.distributed.offloading import load_model_to_gpu, load_opt
 
 If you want VeOmni's full `[gpu,dit]` extras (flash-attn variants, liger-kernel, cuda-python, etc.), install them in a separate environment not pinned to vllm 0.22.0; verl-omni does not need them.
 
+### Older CUDA drivers (CUDA 12.8, driver 535)
+
+The `gpu` extra installs `vllm`, whose prebuilt wheels are compiled targeting CUDA >= 12.9 by default. On hosts with CUDA 12.8 / NVIDIA driver 535, importing the stack can fail with:
+
+```text
+RuntimeError: The NVIDIA driver on your system is too old (found version 12080).
+```
+
+The recommended workaround is NVIDIA CUDA forward compatibility, using a conda/micromamba environment (the `cuda-compat` package is distributed on conda-forge): install the [`cuda-compat`](https://anaconda.org/conda-forge/cuda-compat) package, version >= 12.9.0, into the environment, then point the loader at it before running:
+
+```bash
+export LD_LIBRARY_PATH=${CONDA_PREFIX}/cuda-compat:$LD_LIBRARY_PATH
+```
+
+If you followed the `uv venv` flow above rather than conda, replace `${CONDA_PREFIX}/cuda-compat` with the directory where `cuda-compat` was installed.
+
+CUDA forward compatibility works only with the Proprietary (closed) NVIDIA kernel module, not the Open kernel module, and is limited to select datacenter/professional GPUs. This mirrors [vLLM's guidance for older CUDA drivers](https://docs.vllm.ai/en/stable/getting_started/installation/gpu/#running-on-systems-with-older-cuda-drivers).
+
+If forward compatibility cannot be used, for example with the Open kernel module, a community-validated but unofficial alternative is to build vLLM from source against the local CUDA 12.8 toolkit. Set `CUDA_HOME` to the local CUDA install and pass `--no-binary vllm` / `--no-build-isolation` to the install command; see [issue #133](https://github.com/verl-project/verl-omni/issues/133) for the full reference script.
+
+A maintainer-provided alternative is to use an NVIDIA Docker image with the appropriate driver compatibility.
+
 ## Post-Installation Verification
 
 For NVIDIA GPU:


### PR DESCRIPTION
### What does this PR do?

Adds an **"Older CUDA drivers (CUDA 12.8, driver 535)"** subsection to `docs/start/install.md`. The `gpu` extra installs `vllm`, whose prebuilt wheels target CUDA >= 12.9, so on a CUDA 12.8 / driver 535 host the post-install import fails with `RuntimeError: The NVIDIA driver on your system is too old (found version 12080)`. The current install guide only states "CUDA: Version >= 12.8" with no note about this prebuilt-wheel constraint or a recovery path.

The new subsection documents two recovery paths surfaced and validated in [#133](https://github.com/verl-project/verl-omni/issues/133):

- the conda-forge `cuda-compat` forward-compatibility package (maintainer-endorsed in-thread by @zhtmike), including the caveat that it works only with the Proprietary kernel module and select datacenter/professional GPUs;
- building `vllm` from source against the local CUDA 12.8 toolkit (community-validated on CUDA 12.8 / H200 in the thread), linked back to the issue for the full reference script.

It mirrors [vLLM's own "Running on systems with older CUDA drivers" guidance](https://docs.vllm.ai/en/stable/getting_started/installation/gpu/#running-on-systems-with-older-cuda-drivers), which @zhtmike pointed to as the model. Documentation-only; no code paths change.

Closes #133

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: [open PRs matching "133 in:body"](https://github.com/verl-project/verl-omni/pulls?q=is%3Apr+is%3Aopen+133+in%3Abody) and [open PRs matching "cuda driver install"](https://github.com/verl-project/verl-omni/pulls?q=is%3Apr+is%3Aopen+cuda+driver+install) — no existing PR addresses the CUDA 12.8 / driver 535 install workaround.
- [x] Format the PR title as `[{modules}] {type}: {description}` (`[doc] chore: ...`).

### Test

Documentation-only change; no CI-testable code paths. Verification performed:

- Every claim is traced to issue #133 or to vLLM's upstream docs — the prebuilt-wheel CUDA >= 12.9 constraint, the `cuda-compat` + `LD_LIBRARY_PATH` step, the Proprietary-vs-Open kernel-module caveat, and the build-from-source path (`CUDA_HOME` + `--no-binary vllm` / `--no-build-isolation`).
- Confirmed `--no-binary` and `--no-build-isolation` are valid `uv pip install` flags via `uv pip install --help`.
- Markdown renders cleanly: the new subsection sits under the install page TOC, before `## Post-Installation Verification`, with no broken links or malformed blocks.

### API and Usage Example

No API change. For reference, the documented older-driver workaround:

```bash
# Add code snippet or script demonstrating how to use this
# Older CUDA driver (CUDA 12.8 / driver 535) forward-compatibility path:
export LD_LIBRARY_PATH=${CONDA_PREFIX}/cuda-compat:$LD_LIBRARY_PATH
```

### Design & Code Changes

- `docs/start/install.md`: new `### Older CUDA drivers (CUDA 12.8, driver 535)` subsection inserted before `## Post-Installation Verification`. No other content changed; the existing `CUDA: Version >= 12.8` requirement line is untouched.

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] Documentation updated (this PR).
- [x] No unit / e2e test added: the change is documentation-only with no code paths to cover.

AI assistance was used to draft this documentation change; every claim was verified by the human submitter against issue #133 and the linked vLLM upstream documentation before submission.
