### PR TITLE
[omni, rollout] feat: add Ascend NPU support for Qwen3-Omni Thinker GSPO training

### DIFF
--- a/examples/gspo_trainer/qwen3_omni/qwen3_omni_thinker_only_npu.yaml
+++ b/examples/gspo_trainer/qwen3_omni/qwen3_omni_thinker_only_npu.yaml
@@ -1,0 +1,50 @@
+# Thinker-only stage config for Qwen3-Omni RL training with verl.
+#
+# vLLM-Omni normally loads 3 stages (Thinker, Talker, Code2Wav), splitting
+# GPUs across them.  For Thinker-only RL (GSPO/GRPO), we need a single
+# stage that uses ALL available GPUs for tensor parallelism.
+#
+# Adjust `devices` and `tensor_parallel_size` to match your GPU count.
+stage_args:
+  - stage_id: 0
+    runtime:
+      devices: "0,1"
+    engine_args:
+      # ── Stage identity ──
+      model_stage: thinker
+      model_arch: Qwen3OmniMoeThinkerForConditionalGeneration
+      worker_type: ar
+      scheduler_cls: vllm_omni.core.sched.omni_ar_scheduler.OmniARScheduler
+      engine_output_type: text
+      hf_config_name: thinker_config
+
+      # ── Parallelism & backend ──
+      tensor_parallel_size: 2
+      distributed_executor_backend: "mp"
+
+      # ── Memory & batching (critical: top-level CLI args are stripped) ──
+      max_model_len: 16384
+      gpu_memory_utilization: 0.6
+      max_num_seqs: 32
+      max_num_batched_tokens: 32768
+      enable_chunked_prefill: true
+
+      # ── Model loading ──
+      dtype: bfloat16
+      load_format: safetensors
+      trust_remote_code: true
+      enable_prefix_caching: false
+      enforce_eager: false
+
+      # ── MoE backend ──
+      moe_backend: auto
+
+      # ── verl integration ──
+      enable_sleep_mode: true
+      logprobs_mode: processed_logprobs
+      disable_log_stats: true
+      additional_config:
+        weight_nz_mode: 0
+    final_output: true
+    final_output_type: text
+    is_comprehension: true

--- a/examples/gspo_trainer/qwen3_omni/run_qwen3_omni_thinker_gspo_npu.sh
+++ b/examples/gspo_trainer/qwen3_omni/run_qwen3_omni_thinker_gspo_npu.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Qwen3-Omni Thinker GSPO full-parameter training (FSDP + vLLM-Omni AR rollout).
+# Hardware: Atlas 800T A3 (16x NPUs).
+set -x
+
+export CPATH=/usr/include${CPATH:+:$CPATH}
+export VLLM_ASCEND_ENABLE_NZ=0
+export VERL_USE_EXTERNAL_MODULES=verl_omni,verl_omni.models.transformers.qwen3_omni_thinker
+
+MODEL_PATH=${MODEL_PATH:-"Qwen/Qwen3-Omni-30B-A3B-Instruct"}
+TRAIN_FILE=${TRAIN_FILE:-"$HOME/data/math/train.parquet"}
+VAL_FILE=${VAL_FILE:-"$HOME/data/math/test.parquet"}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STAGE_CONFIG="${SCRIPT_DIR}/qwen3_omni_thinker_only_npu.yaml"
+
+NUM_GPUS_ACTOR_ROLLOUT_REWARD=16
+ROLLOUT_TP=2
+
+python3 -m verl.trainer.main_ppo \
+    --config-path="${SCRIPT_DIR}/config" \
+    --config-name=qwen3_omni_thinker_gspo \
+    data.train_files="${TRAIN_FILE}" \
+    data.val_files="${VAL_FILE}" \
+    data.filter_overlong_prompts_workers=64 \
+    actor_rollout_ref.model.lora_rank=0 \
+    actor_rollout_ref.model.path="${MODEL_PATH}" \
+    actor_rollout_ref.model.external_lib=verl_omni.models.transformers.qwen3_omni_thinker \
+    ++actor_rollout_ref.rollout.engine_kwargs.vllm_omni.stage_configs_path="${STAGE_CONFIG}" \
+    actor_rollout_ref.actor.fsdp_config.use_torch_compile=False \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=${ROLLOUT_TP} \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.6 \
+    actor_rollout_ref.rollout.agent.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / ROLLOUT_TP)) \
+    trainer.logger='["console","tensorboard"]' \
+    trainer.project_name='qwen3_omni_thinker_rl' \
+    trainer.experiment_name='gspo_math_npu' \
+    trainer.n_gpus_per_node=${NUM_GPUS_ACTOR_ROLLOUT_REWARD} \
+    trainer.nnodes=1 \
+    trainer.save_freq=100 \
+    "$@"

--- a/verl_omni/models/transformers/qwen3_omni_thinker.py
+++ b/verl_omni/models/transformers/qwen3_omni_thinker.py
@@ -173,10 +173,64 @@ def patch_hf_processor_for_qwen3_omni() -> None:
         _utils_mod.hf_processor = _patched_hf_processor
 
 
+def patch_hf_tokenizer_for_qwen3_omni() -> None:
+    """Wrap ``verl.utils.tokenizer.hf_tokenizer`` to auto-load chat_template from chat_template.json.
+
+    Some models (e.g., Qwen3-Omni) store chat_template in a separate file
+    instead of tokenizer_config.json. This patch ensures the tokenizer
+    has a valid chat_template before returning it.
+    """
+    import functools
+    import json
+    import os
+
+    try:
+        import verl.utils.tokenizer as _vt
+    except ImportError:
+        return
+
+    _original_hf_tokenizer = _vt.hf_tokenizer
+
+    @functools.wraps(_original_hf_tokenizer)
+    def _patched_hf_tokenizer(name_or_path, *args, **kwargs):
+        tokenizer = _original_hf_tokenizer(name_or_path, *args, **kwargs)
+
+        if getattr(tokenizer, "chat_template", None) is None and isinstance(name_or_path, str):
+            chat_template_path = os.path.join(name_or_path, "chat_template.json")
+            if os.path.exists(chat_template_path):
+                try:
+                    with open(chat_template_path) as f:
+                        data = json.load(f)
+                        chat_template = data.get("chat_template")
+                        if chat_template:
+                            tokenizer.chat_template = chat_template
+                except (OSError, json.JSONDecodeError):
+                    pass
+
+        return tokenizer
+
+    _vt.hf_tokenizer = _patched_hf_tokenizer
+
+    # Patch sys.modules entries that already imported hf_tokenizer
+    import sys
+
+    for mod_name in list(sys.modules.keys()):
+        if not mod_name.startswith("verl"):
+            continue
+        mod = sys.modules.get(mod_name)
+        if (
+            mod is not None
+            and hasattr(mod, "hf_tokenizer")
+            and mod.__dict__.get("hf_tokenizer") is _original_hf_tokenizer
+        ):
+            mod.hf_tokenizer = _patched_hf_tokenizer
+
+
 def apply_qwen3_omni_thinker_patches() -> None:
     """Apply all Qwen3-Omni Thinker patches (idempotent registrations)."""
     _register_qwen3_omni_automodel()
     patch_hf_processor_for_qwen3_omni()
+    patch_hf_tokenizer_for_qwen3_omni()
 
 
 # Apply on import so this module works as a verl ``external_lib`` target.

--- a/verl_omni/workers/rollout/vllm_rollout/npu_utils.py
+++ b/verl_omni/workers/rollout/vllm_rollout/npu_utils.py
@@ -19,8 +19,7 @@ from contextlib import AbstractContextManager, contextmanager, nullcontext
 import torch
 from vllm.utils.mem_utils import GiB_bytes
 
-__all__ = ["NPUColocateWorkerMixin"]
-
+from verl_omni.workers.rollout.vllm_rollout.utils import vLLMOmniColocateWorkerExtension
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
@@ -96,14 +95,8 @@ def _skip_diffusers_npu_empty_cache():
 # ---------------------------------------------------------------------------
 
 
-class NPUColocateWorkerMixin:
+class vLLMOmniNPUColocateWorkerExtension(vLLMOmniColocateWorkerExtension):
     """Mixin that overrides memory-pool, sleep, and wake_up on Ascend NPU.
-
-    Usage::
-
-        class vLLMOmniColocateWorkerExtension(NPUColocateWorkerMixin, CustomPipelineWorkerExtension):
-            ...
-
     The mixin guards every method with ``_is_npu_platform()`` and falls back to
     the super-class implementation on non-NPU hardware, so it is safe to use
     unconditionally in a cross-platform codebase.

--- a/verl_omni/workers/rollout/vllm_rollout/utils.py
+++ b/verl_omni/workers/rollout/vllm_rollout/utils.py
@@ -25,24 +25,7 @@ logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
 
-# Add the NPU mixin only on NPU; on GPU it redefines existing worker methods and
-# trips vLLM v1 multiproc_executor's no-attribute-redefinition assertion.
-def _platform_extension_bases():
-    # TODO: the NPU (Ascend) path below is not yet verified on real NPU hardware;
-    #       only the GPU branch is exercised by current tests / training runs.
-    try:
-        from vllm.platforms import current_platform
-
-        if current_platform.device_type == "npu":
-            from verl_omni.workers.rollout.vllm_rollout.npu_utils import NPUColocateWorkerMixin
-
-            return (NPUColocateWorkerMixin, CustomPipelineWorkerExtension)
-    except Exception:
-        pass
-    return (CustomPipelineWorkerExtension,)
-
-
-class vLLMOmniColocateWorkerExtension(*_platform_extension_bases()):
+class vLLMOmniColocateWorkerExtension(CustomPipelineWorkerExtension):
     """
     The class for vLLM-Omni's worker to inherit from, in the colocate setting.
     By defining an extension class, the code can work no matter what is

--- a/verl_omni/workers/rollout/vllm_rollout/vllm_omni_async_server.py
+++ b/verl_omni/workers/rollout/vllm_rollout/vllm_omni_async_server.py
@@ -103,7 +103,22 @@ class vLLMOmniHttpServer(vLLMHttpServer):
         return "vllm_omni"
 
     def _get_worker_extension_cls(self) -> str:
-        return "verl_omni.workers.rollout.vllm_rollout.utils.vLLMOmniColocateWorkerExtension"
+        device_type = ""
+        try:
+            from vllm.platforms import current_platform
+
+            device_type = current_platform.device_type
+        except Exception:
+            pass
+
+        # vLLMOmniColocateWorkerExtension supports LoRA + weight updates for GPU.
+        # vLLMOmniNPUColocateWorkerExtension additionally mixes in NPUColocateWorkerMixin
+        # for NPU memory pool, sleep, and wake_up.
+        # ar_mode uses vllm-ascend which already handles NPU natively, so the base extension suffices.
+        if device_type != "npu" or self._ar_mode:
+            return "verl_omni.workers.rollout.vllm_rollout.utils.vLLMOmniColocateWorkerExtension"
+        else:
+            return "verl_omni.workers.rollout.vllm_rollout.npu_utils.vLLMOmniNPUColocateWorkerExtension"
 
     def _get_cli_modules(self) -> list:
         return [vllm_omni.entrypoints.cli.serve]
@@ -375,7 +390,7 @@ class vLLMOmniHttpServer(vLLMHttpServer):
         if self._ar_mode:
             generator = self.engine.generate(
                 prompt=prompt,
-                sampling_params=params,
+                sampling_params_list=params,
                 request_id=request_id,
                 lora_request=lora_request,
                 priority=priority,


### PR DESCRIPTION
### What does this PR do?

Add Ascend NPU support for Qwen3-Omni Thinker model GSPO (Group Relative Policy Optimization) training, on top of the [PR #113](https://github.com/verl-project/verl-omni/pull/113).

Qwen3-Omni consists of three stages (Thinker, Talker, Code2Wav). For Thinker-only RL (GSPO/GRPO), a single stage must use ALL available NPUs of an Atlas 800T A3 server for tensor parallelism.

This PR provides:

1. A **Thinker-only stage config** (`qwen3_omni_thinker_only_npu.yaml`) for NPU deployments
2. A **full training script** (`run_qwen3_omni_thinker_gspo_npu.sh`) using 16 NPUs
3. **Device-aware worker extension selection** — GPU (any mode) and NPU+AR mode use the base extension; NPU+non-AR mode uses the NPU-extended extension with memory-pool / sleep / wake_up
4. **Tokenizer patch** (`verl_omni/models/transformers/qwen3_omni_thinker.py`) to load `chat_template` from `chat_template.json` for Qwen3-Omni models
5. **Bug fix** for `ar_mode` generate call — use `sampling_params_list` instead of `sampling_params`

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl-omni/pull/113
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `vllm_omni`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `diffusion`, `omni`, `tests`, `docker`
  - If this PR involves multiple modules, separate them with `,` like `[diffusion, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][diffusion, fsdp] feat: new rollout scheduler`

### Test

Validated on **16 Ascend NPUs** (Atlas 800T A3) with Qwen3-Omni-30B-A3B-Instruct model. Training completes a full GSPO step (forward → rollout → reward → backward → weight sync) without errors.

**Required environment variables for NPU training:**
```bash
export VLLM_ASCEND_ENABLE_NZ=0
export RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO=0
```
- Full model (Qwen3-Omni-30B Thinker, Atlas 800T A3 with 16 NPUs)
- Validated stack: vLLM 0.22.0, vLLM-Omni 0.22.0, verl v0.8.0, and CANN 9.0.0
- Training reward on MATH-lighteval (full model):
<img width="1229" height="369" alt="qwen3-omni" src="https://github.com/user-attachments/assets/3e05183f-0758-4700-8f37-8933fb864287" />


### API and Usage Example

No new public API is introduced.

**Training command (16 NPUs):**
```bash
bash examples/gspo_trainer/run_qwen3_omni_thinker_gspo_npu.sh \
    data.train_files=$HOME/data/math/train.parquet \
    data.val_files=$HOME/data/math/test.parquet
```

### Design & Code Changes

| File | Change |
|------|--------|
| `examples/gspo_trainer/qwen3_omni_thinker_only_npu.yaml` | New — Thinker-only stage config for NPU: `model_stage: thinker`, `worker_type: ar`, `enable_sleep_mode: true` |
| `examples/gspo_trainer/run_qwen3_omni_thinker_gspo_npu.sh` | New — NPU training script for 16 NPUs with env vars and config overrides |
| `verl_omni/models/transformers/qwen3_omni_thinker.py` | Modified — Added `patch_hf_tokenizer_for_qwen3_omni` to lazily load `chat_template.json` |
| `verl_omni/__init__.py` | Modified — Auto-import `verl_omni.utils.tokenizer_patch` to register patches at module load time |
| `verl_omni/workers/rollout/vllm_rollout/utils.py` | Modified — Removed `_platform_extension_bases()` dynamic mixin; `vLLMOmniColocateWorkerExtension` now inherits directly from `CustomPipelineWorkerExtension` |
| `verl_omni/workers/rollout/vllm_rollout/npu_utils.py` | Modified — `NPUColocateWorkerMixin` replaced by `vLLMOmniNPUColocateWorkerExtension(vLLMOmniColocateWorkerExtension)` |
| `verl_omni/workers/rollout/vllm_rollout/vllm_omni_async_server.py` | Modified — Device-aware worker extension selection; fix `ar_mode` generate call to use `sampling_params_list` |

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update the documentation.
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl-omni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...

### Notes for Reviewers

- This PR **depends on** PR #113 (multi-stage vLLM-Omni rollout infrastructure) and should be merged after it.
- `verl_omni.models.transformers.qwen3_omni_thinker` (from #113) provides the core Thinker model patches; this PR adds the NPU-specific training recipe, the tokenizer registration wrapper, and extends the worker extension for NPU compatibility.