### PR TITLE
[rollout] chore: Revert txt_seq_lens calc and latent dtype cast for qwen_image

### DIFF
--- a/verl_omni/pipelines/qwen_image_flow_grpo/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/qwen_image_flow_grpo/vllm_omni_rollout_adapter.py
@@ -181,9 +181,6 @@ class QwenImagePipelineWithLogProb(QwenImageTokenIdPromptMixin, QwenImagePipelin
                 all_log_probs.append(log_prob)
                 all_timesteps.append(timestep_value)
 
-            # Cast back to model dtype for next transformer forward.
-            latents = latents.to(x.dtype)
-
         all_latents = torch.stack(all_latents, dim=1)
         all_log_probs = torch.stack(all_log_probs, dim=1) if all_log_probs and all_log_probs[0] is not None else None
         all_timesteps = torch.stack(all_timesteps).unsqueeze(0).expand(latents.shape[0], -1)

--- a/verl_omni/pipelines/qwen_image_flow_grpo/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/qwen_image_flow_grpo/vllm_omni_rollout_adapter.py
@@ -353,7 +353,7 @@ class QwenImagePipelineWithLogProb(QwenImageTokenIdPromptMixin, QwenImagePipelin
             num_channels_latents,
             height,
             width,
-            torch.float32,
+            prompt_embeds.dtype,
             self.device,
             generator,
             latents,
@@ -372,14 +372,10 @@ class QwenImagePipelineWithLogProb(QwenImageTokenIdPromptMixin, QwenImagePipelin
         if self.attention_kwargs is None:
             self._attention_kwargs = {}
 
-        # Set RoPE length from padded embed width (match diffusers text_seq_len),
-        # not from mask.sum() (valid token count).
-        txt_seq_lens = [int(prompt_embeds.shape[1])] * int(prompt_embeds.shape[0])
-        if negative_prompt_embeds is not None:
-            neg_seq_len = int(negative_prompt_embeds.shape[1])
-            negative_txt_seq_lens = [neg_seq_len] * int(negative_prompt_embeds.shape[0])
-        else:
-            negative_txt_seq_lens = None
+        txt_seq_lens = prompt_embeds_mask.sum(dim=1).tolist() if prompt_embeds_mask is not None else None
+        negative_txt_seq_lens = (
+            negative_prompt_embeds_mask.sum(dim=1).tolist() if negative_prompt_embeds_mask is not None else None
+        )
 
         if sde_window_size is not None:
             start = torch.randint(


### PR DESCRIPTION
# How to run

`bash examples/flowgrpo_trainer/run_qwen_image_ocr_lora.sh`


### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `vllm_omni`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `diffusion`, `omni`, `tests`, `docker`
  - If this PR involves multiple modules, separate them with `,` like `[diffusion, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][diffusion, fsdp] feat: new rollout scheduler`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update the documentation.
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl-omni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
