### PR TITLE
[doc] chore: Update qwen3omni installation

### DIFF
--- a/examples/gspo_trainer/README.md
+++ b/examples/gspo_trainer/README.md
@@ -20,7 +20,7 @@ following stack (rollout↔actor pearson ≈ 0.993):
 | torch | `2.11.0+cu130` |
 | flash-attn | `2.8.3` |
 | accelerate | `1.12.0` |
-| verl | commit: 8a69493027 (w/ FSDP LoRA fixes) |
+| verl | commit: `8a69493027` (w/ FSDP LoRA fixes) |
 
 This pins to the upcoming `vllm 0.22.0` + `vllm-omni 0.22.0` release so the recipe
 stays aligned with what maintainers ship.

--- a/examples/gspo_trainer/README.md
+++ b/examples/gspo_trainer/README.md
@@ -20,7 +20,7 @@ following stack (rollout↔actor pearson ≈ 0.993):
 | torch | `2.11.0+cu130` |
 | flash-attn | `2.8.3` |
 | accelerate | `1.12.0` |
-| verl | the companion PR branch (FSDP LoRA fixes) |
+| verl | commit: 8a69493027 (w/ FSDP LoRA fixes) |
 
 This pins to the upcoming `vllm 0.22.0` + `vllm-omni 0.22.0` release so the recipe
 stays aligned with what maintainers ship.
@@ -34,7 +34,7 @@ pip install "vllm-omni @ git+https://github.com/vllm-project/vllm-omni.git@v0.22
 pip install pydub
 
 # verl (must include the FSDP layered-summon fix)
-pip install "verl @ git+https://github.com/verl-project/verl.git@main"
+pip install "verl @ git+https://github.com/verl-project/verl.git@8a69493027"
 
 # verl-omni (this repo)
 pip install -e .


### PR DESCRIPTION
### What does this PR do?

Update qwen3omni installation

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `vllm_omni`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `diffusion`, `omni`, `tests`, `docker`
  - If this PR involves multiple modules, separate them with `,` like `[diffusion, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][diffusion, fsdp] feat: new rollout scheduler`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update the documentation.
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl-omni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
