### PR TITLE
[recipe, diffusion] chore: update Qwen-Image NPU example scripts

### DIFF
--- a/examples/diffusionnft_trainer/run_qwen_image_ocr_lora_npu.sh
+++ b/examples/diffusionnft_trainer/run_qwen_image_ocr_lora_npu.sh
@@ -47,6 +47,7 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.actor.fsdp_config.optimizer_offload=True \
     actor_rollout_ref.actor.fsdp_config.model_dtype=bfloat16 \
     actor_rollout_ref.rollout.tensor_model_parallel_size=$ROLLOUT_TP \
+    actor_rollout_ref.rollout.rollout_attn_backend=TORCH_SDPA \
     actor_rollout_ref.rollout.name=$ENGINE \
     actor_rollout_ref.rollout.n=16 \
     actor_rollout_ref.rollout.agent.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / ROLLOUT_TP)) \

--- a/examples/dpo_trainer/run_qwen_image_online_dpo_lora_npu.sh
+++ b/examples/dpo_trainer/run_qwen_image_online_dpo_lora_npu.sh
@@ -45,6 +45,7 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.actor.fsdp_config.model_dtype=bfloat16 \
     actor_rollout_ref.rollout.name=$ENGINE \
     actor_rollout_ref.rollout.tensor_model_parallel_size=$ROLLOUT_TP \
+    actor_rollout_ref.rollout.rollout_attn_backend=TORCH_SDPA \
     actor_rollout_ref.rollout.n=16 \
     actor_rollout_ref.rollout.calculate_log_probs=false \
     actor_rollout_ref.rollout.agent.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / ROLLOUT_TP)) \

--- a/examples/flowgrpo_trainer/run_qwen_image_ocr_lora_npu.sh
+++ b/examples/flowgrpo_trainer/run_qwen_image_ocr_lora_npu.sh
@@ -48,6 +48,7 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.actor.diffusion_loss.loss_mode=flow_grpo \
     actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=32 \
     actor_rollout_ref.rollout.tensor_model_parallel_size=$ROLLOUT_TP \
+    actor_rollout_ref.rollout.rollout_attn_backend=TORCH_SDPA \
     actor_rollout_ref.rollout.name=$ENGINE \
     actor_rollout_ref.rollout.n=16 \
     actor_rollout_ref.rollout.agent.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / ROLLOUT_TP)) \

--- a/examples/flowgrpo_trainer/run_qwen_image_ocr_npu.sh
+++ b/examples/flowgrpo_trainer/run_qwen_image_ocr_npu.sh
@@ -45,6 +45,7 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.actor.diffusion_loss.clip_ratio=1e-5 \
     actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=32 \
     actor_rollout_ref.rollout.tensor_model_parallel_size=$ROLLOUT_TP \
+    actor_rollout_ref.rollout.rollout_attn_backend=TORCH_SDPA \
     actor_rollout_ref.rollout.name=$ENGINE \
     actor_rollout_ref.rollout.n=16 \
     actor_rollout_ref.rollout.agent.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / ROLLOUT_TP)) \

--- a/examples/grpoguard_trainer/run_qwen_image_ocr_lora_npu.sh
+++ b/examples/grpoguard_trainer/run_qwen_image_ocr_lora_npu.sh
@@ -60,6 +60,7 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=50 \
     actor_rollout_ref.rollout.val_kwargs.algo.noise_level=0.0 \
     actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=32 \
+    actor_rollout_ref.rollout.rollout_attn_backend=TORCH_SDPA \
     reward.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / REWARD_TP)) \
     reward.reward_model.enable=True \
     reward.reward_model.model_path=$reward_model_name \

--- a/examples/mixgrpo_trainer/run_qwen_image_ocr_lora_mixgrpo_npu.sh
+++ b/examples/mixgrpo_trainer/run_qwen_image_ocr_lora_mixgrpo_npu.sh
@@ -49,6 +49,7 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.actor.diffusion_loss.loss_mode=flow_grpo \
     actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=32 \
     actor_rollout_ref.rollout.tensor_model_parallel_size=$ROLLOUT_TP \
+    actor_rollout_ref.rollout.rollout_attn_backend=TORCH_SDPA \
     actor_rollout_ref.rollout.name=$ENGINE \
     actor_rollout_ref.rollout.n=16 \
     actor_rollout_ref.rollout.agent.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / ROLLOUT_TP)) \


### PR DESCRIPTION
### What does this PR do?

This PR updates the Qwen-Image NPU example training scripts across several recipes, including OCR LoRA, online DPO LoRA, FlowGRPO, GRPOGuard, and MixGRPO examples.

In the current latest version, the NPU examples require explicitly setting the diffusion attention backend. Without this parameter, training fails due to an attention backend mismatch between `attn_backend` and `rollout_attn_backend`.

The error is:

```text
Traceback (most recent call last):
  File "/workspace/src/verl-omni/verl_omni/trainer/main_diffusion.py", line 44, in main
    validate_attention_consistency(config)
  File "/workspace/src/verl-omni/verl_omni/utils/diffusion_attention.py", line 112, in validate_attention_consistency
    raise ValueError(
ValueError: Attention backend mismatch: attn_backend='_native_npu' requires rollout_attn_backend='TORCH_SDPA', but got 'FLASH_ATTN'. Both must use the same attention implementation. Set rollout_attn_backend via --diffusion-attention-backend flag or in the rollout config.

Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace.
```

### Test

Not run. This PR only updates example launch scripts.

### API and Usage Example

No API changes.

### Design & Code Changes

* Update Qwen-Image OCR LoRA NPU example scripts
* Update Qwen-Image online DPO LoRA NPU example script
* Update FlowGRPO / GRPOGuard / MixGRPO NPU example scripts
* Add the required diffusion attention backend parameter for NPU examples to avoid attention backend mismatch errors
* Keep Dockerfile changes out of this PR
