### PR TITLE
[docker, doc] feat: add Ascend NPU Dockerfiles and install guide

### DIFF
--- a/docker/Dockerfile.910B.npu
+++ b/docker/Dockerfile.910B.npu
@@ -1,0 +1,150 @@
+FROM quay.io/ascend/cann:9.0.0-a3-ubuntu22.04-py3.12
+
+ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
+ARG ASCEND_PIP_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pypi"
+ARG PYTORCH_CPU_INDEX_URL="https://download.pytorch.org/whl/cpu/"
+
+ARG VLLM_REPO="https://github.com/vllm-project/vllm.git"
+ARG VLLM_REF="v0.22.0"
+
+ARG VLLM_ASCEND_REPO="https://github.com/vllm-project/vllm-ascend.git"
+ARG VLLM_ASCEND_REF="bb4d0776eee8fc45c3484a45c971a7049f1a2bbf"
+
+ARG VLLM_OMNI_REPO="https://github.com/vllm-project/vllm-omni.git"
+ARG VLLM_OMNI_REF="v0.22.0"
+
+ARG VERL_REPO="https://github.com/verl-project/verl.git"
+ARG VERL_REF="v0.8.0"
+
+ARG SOC_VERSION="ascend910_9391"
+ARG COMPILE_CUSTOM_KERNELS=1
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PYTHONUNBUFFERED=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    SOC_VERSION=${SOC_VERSION} \
+    COMPILE_CUSTOM_KERNELS=${COMPILE_CUSTOM_KERNELS} \
+    TASK_QUEUE_ENABLE=1 \
+    OMP_NUM_THREADS=1 \
+    VLLM_WORKER_MULTIPROC_METHOD=spawn \
+    PATH=/usr/local/bin:/usr/local/sbin:/usr/local/Ascend/driver/tools:${PATH} \
+    LD_LIBRARY_PATH=/usr/local/Ascend/driver/lib64:/usr/local/Ascend/driver/lib64/common:/usr/local/Ascend/driver/lib64/driver:${LD_LIBRARY_PATH}
+
+WORKDIR /workspace
+
+RUN mkdir -p /workspace/src
+
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        git \
+        vim \
+        wget \
+        curl \
+        ca-certificates \
+        net-tools \
+        gcc \
+        g++ \
+        cmake \
+        make \
+        build-essential \
+        numactl \
+        libnuma-dev \
+        libjemalloc2 \
+        clang-15 \
+        ninja-build && \
+    update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 20 && \
+    update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-15 20 && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN python3 -m pip config set global.index-url ${PIP_INDEX_URL} && \
+    python3 -m pip install --upgrade pip setuptools wheel packaging
+
+# Match useful runtime dependencies from the official vLLM-Ascend A3 Dockerfile.
+# modelscope is useful for model download, and ray is required by distributed workloads.
+RUN python3 -m pip install \
+        modelscope \
+        'ray>=2.47.1,<=2.48.0' \
+        'protobuf>3.20.0'
+
+# Align torch stack for Ascend.
+RUN python3 -m pip install --force-reinstall \
+        torch==2.10.0+cpu \
+        torchvision==0.25.0+cpu \
+        torchaudio==2.10.0+cpu \
+        --index-url ${PYTORCH_CPU_INDEX_URL} && \
+    python3 -m pip install --force-reinstall \
+        torch-npu==2.10.0 \
+        --extra-index-url ${ASCEND_PIP_INDEX_URL} \
+        --extra-index-url ${PYTORCH_CPU_INDEX_URL}
+
+# Install vLLM.
+# Use VLLM_TARGET_DEVICE=empty so vLLM itself does not build CUDA backend.
+# Ascend backend is provided by vllm-ascend.
+RUN git clone --depth 1 -b ${VLLM_REF} ${VLLM_REPO} /workspace/src/vllm && \
+    cd /workspace/src/vllm && \
+    VLLM_TARGET_DEVICE="empty" python3 -m pip install -e ".[audio]" \
+        --extra-index-url ${PYTORCH_CPU_INDEX_URL} && \
+    python3 -m pip uninstall -y triton || true
+
+# Install vLLM-Ascend.
+RUN git clone ${VLLM_ASCEND_REPO} /workspace/src/vllm-ascend && \
+    cd /workspace/src/vllm-ascend && \
+    git checkout ${VLLM_ASCEND_REF} && \
+    git submodule update --init --recursive && \
+    export PIP_EXTRA_INDEX_URL="${ASCEND_PIP_INDEX_URL}" && \
+    export VLLM_BATCH_INVARIANT=1 && \
+    . /usr/local/Ascend/ascend-toolkit/set_env.sh && \
+    . /usr/local/Ascend/nnal/atb/set_env.sh && \
+    python3 -m pip install -e /workspace/src/vllm-ascend \
+        --extra-index-url ${ASCEND_PIP_INDEX_URL} \
+        --extra-index-url ${PYTORCH_CPU_INDEX_URL} && \
+    python3 -m pip uninstall -y triton triton-ascend || true && \
+    python3 -m pip install triton-ascend==3.2.1 \
+        --extra-index-url ${ASCEND_PIP_INDEX_URL}
+
+# Install vLLM-Omni.
+RUN git clone --depth 1 -b ${VLLM_OMNI_REF} ${VLLM_OMNI_REPO} /workspace/src/vllm-omni && \
+    cd /workspace/src/vllm-omni && \
+    VLLM_OMNI_TARGET_DEVICE=npu python3 -m pip install -e . \
+        --extra-index-url ${ASCEND_PIP_INDEX_URL} \
+        --extra-index-url ${PYTORCH_CPU_INDEX_URL}
+
+# Install verl from source.
+RUN git clone --depth 1 -b ${VERL_REF} ${VERL_REPO} /workspace/src/verl && \
+    cd /workspace/src/verl && \
+    python3 -m pip install -e . \
+        --extra-index-url ${ASCEND_PIP_INDEX_URL} \
+        --extra-index-url ${PYTORCH_CPU_INDEX_URL}
+
+# Install verl-omni from current build context.
+WORKDIR /workspace/src/verl-omni
+
+COPY . .
+
+RUN python3 -m pip install -e ".[train,ocr]" \
+        --extra-index-url ${ASCEND_PIP_INDEX_URL} \
+        --extra-index-url ${PYTORCH_CPU_INDEX_URL}
+
+# Re-align torch / torch-npu / numpy after dependency resolution.
+# This prevents downstream extras from upgrading torch/numpy to incompatible versions.
+RUN python3 -m pip install --force-reinstall \
+        torch==2.10.0+cpu \
+        torchvision==0.25.0+cpu \
+        torchaudio==2.10.0+cpu \
+        --index-url ${PYTORCH_CPU_INDEX_URL} && \
+    python3 -m pip install --force-reinstall \
+        torch-npu==2.10.0 \
+        --extra-index-url ${ASCEND_PIP_INDEX_URL} \
+        --extra-index-url ${PYTORCH_CPU_INDEX_URL} && \
+    python3 -m pip install --force-reinstall numpy==1.26.4
+
+RUN echo "source /usr/local/Ascend/ascend-toolkit/set_env.sh" >> /root/.bashrc && \
+    echo "source /usr/local/Ascend/nnal/atb/set_env.sh" >> /root/.bashrc && \
+    echo "export VLLM_WORKER_MULTIPROC_METHOD=spawn" >> /root/.bashrc && \
+    echo "export LD_PRELOAD=/usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2:\$LD_PRELOAD" >> /root/.bashrc && \
+    echo "export LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:/usr/local/lib" >> /root/.bashrc
+
+WORKDIR /workspace
+
+ENTRYPOINT []
+CMD ["/bin/bash"]

--- a/docker/Dockerfile.910C.npu
+++ b/docker/Dockerfile.910C.npu
@@ -1,0 +1,150 @@
+FROM quay.io/ascend/cann:9.0.0-a3-ubuntu22.04-py3.12
+
+ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
+ARG ASCEND_PIP_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pypi"
+ARG PYTORCH_CPU_INDEX_URL="https://download.pytorch.org/whl/cpu/"
+
+ARG VLLM_REPO="https://github.com/vllm-project/vllm.git"
+ARG VLLM_REF="v0.22.0"
+
+ARG VLLM_ASCEND_REPO="https://github.com/vllm-project/vllm-ascend.git"
+ARG VLLM_ASCEND_REF="bb4d0776eee8fc45c3484a45c971a7049f1a2bbf"
+
+ARG VLLM_OMNI_REPO="https://github.com/vllm-project/vllm-omni.git"
+ARG VLLM_OMNI_REF="v0.22.0"
+
+ARG VERL_REPO="https://github.com/verl-project/verl.git"
+ARG VERL_REF="v0.8.0"
+
+ARG SOC_VERSION="ascend910_9391"
+ARG COMPILE_CUSTOM_KERNELS=1
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PYTHONUNBUFFERED=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    SOC_VERSION=${SOC_VERSION} \
+    COMPILE_CUSTOM_KERNELS=${COMPILE_CUSTOM_KERNELS} \
+    TASK_QUEUE_ENABLE=1 \
+    OMP_NUM_THREADS=1 \
+    VLLM_WORKER_MULTIPROC_METHOD=spawn \
+    PATH=/usr/local/bin:/usr/local/sbin:/usr/local/Ascend/driver/tools:${PATH} \
+    LD_LIBRARY_PATH=/usr/local/Ascend/driver/lib64:/usr/local/Ascend/driver/lib64/common:/usr/local/Ascend/driver/lib64/driver:${LD_LIBRARY_PATH}
+
+WORKDIR /workspace
+
+RUN mkdir -p /workspace/src
+
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        git \
+        vim \
+        wget \
+        curl \
+        ca-certificates \
+        net-tools \
+        gcc \
+        g++ \
+        cmake \
+        make \
+        build-essential \
+        numactl \
+        libnuma-dev \
+        libjemalloc2 \
+        clang-15 \
+        ninja-build && \
+    update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 20 && \
+    update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-15 20 && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN python3 -m pip config set global.index-url ${PIP_INDEX_URL} && \
+    python3 -m pip install --upgrade pip setuptools wheel packaging
+
+# Match useful runtime dependencies from the official vLLM-Ascend A3 Dockerfile.
+# modelscope is useful for model download, and ray is required by distributed workloads.
+RUN python3 -m pip install \
+        modelscope \
+        'ray>=2.47.1,<=2.48.0' \
+        'protobuf>3.20.0'
+
+# Align torch stack for Ascend.
+RUN python3 -m pip install --force-reinstall \
+        torch==2.10.0+cpu \
+        torchvision==0.25.0+cpu \
+        torchaudio==2.10.0+cpu \
+        --index-url ${PYTORCH_CPU_INDEX_URL} && \
+    python3 -m pip install --force-reinstall \
+        torch-npu==2.10.0 \
+        --extra-index-url ${ASCEND_PIP_INDEX_URL} \
+        --extra-index-url ${PYTORCH_CPU_INDEX_URL}
+
+# Install vLLM.
+# Use VLLM_TARGET_DEVICE=empty so vLLM itself does not build CUDA backend.
+# Ascend backend is provided by vllm-ascend.
+RUN git clone --depth 1 -b ${VLLM_REF} ${VLLM_REPO} /workspace/src/vllm && \
+    cd /workspace/src/vllm && \
+    VLLM_TARGET_DEVICE="empty" python3 -m pip install -e ".[audio]" \
+        --extra-index-url ${PYTORCH_CPU_INDEX_URL} && \
+    python3 -m pip uninstall -y triton || true
+
+# Install vLLM-Ascend.
+RUN git clone ${VLLM_ASCEND_REPO} /workspace/src/vllm-ascend && \
+    cd /workspace/src/vllm-ascend && \
+    git checkout ${VLLM_ASCEND_REF} && \
+    git submodule update --init --recursive && \
+    export PIP_EXTRA_INDEX_URL="${ASCEND_PIP_INDEX_URL}" && \
+    export VLLM_BATCH_INVARIANT=1 && \
+    . /usr/local/Ascend/ascend-toolkit/set_env.sh && \
+    . /usr/local/Ascend/nnal/atb/set_env.sh && \
+    python3 -m pip install -e /workspace/src/vllm-ascend \
+        --extra-index-url ${ASCEND_PIP_INDEX_URL} \
+        --extra-index-url ${PYTORCH_CPU_INDEX_URL} && \
+    python3 -m pip uninstall -y triton triton-ascend || true && \
+    python3 -m pip install triton-ascend==3.2.1 \
+        --extra-index-url ${ASCEND_PIP_INDEX_URL}
+
+# Install vLLM-Omni.
+RUN git clone --depth 1 -b ${VLLM_OMNI_REF} ${VLLM_OMNI_REPO} /workspace/src/vllm-omni && \
+    cd /workspace/src/vllm-omni && \
+    VLLM_OMNI_TARGET_DEVICE=npu python3 -m pip install -e . \
+        --extra-index-url ${ASCEND_PIP_INDEX_URL} \
+        --extra-index-url ${PYTORCH_CPU_INDEX_URL}
+
+# Install verl from source.
+RUN git clone --depth 1 -b ${VERL_REF} ${VERL_REPO} /workspace/src/verl && \
+    cd /workspace/src/verl && \
+    python3 -m pip install -e . \
+        --extra-index-url ${ASCEND_PIP_INDEX_URL} \
+        --extra-index-url ${PYTORCH_CPU_INDEX_URL}
+
+# Install verl-omni from current build context.
+WORKDIR /workspace/src/verl-omni
+
+COPY . .
+
+RUN python3 -m pip install -e ".[train,ocr]" \
+        --extra-index-url ${ASCEND_PIP_INDEX_URL} \
+        --extra-index-url ${PYTORCH_CPU_INDEX_URL}
+
+# Re-align torch / torch-npu / numpy after dependency resolution.
+# This prevents downstream extras from upgrading torch/numpy to incompatible versions.
+RUN python3 -m pip install --force-reinstall \
+        torch==2.10.0+cpu \
+        torchvision==0.25.0+cpu \
+        torchaudio==2.10.0+cpu \
+        --index-url ${PYTORCH_CPU_INDEX_URL} && \
+    python3 -m pip install --force-reinstall \
+        torch-npu==2.10.0 \
+        --extra-index-url ${ASCEND_PIP_INDEX_URL} \
+        --extra-index-url ${PYTORCH_CPU_INDEX_URL} && \
+    python3 -m pip install --force-reinstall numpy==1.26.4
+
+RUN echo "source /usr/local/Ascend/ascend-toolkit/set_env.sh" >> /root/.bashrc && \
+    echo "source /usr/local/Ascend/nnal/atb/set_env.sh" >> /root/.bashrc && \
+    echo "export VLLM_WORKER_MULTIPROC_METHOD=spawn" >> /root/.bashrc && \
+    echo "export LD_PRELOAD=/usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2:\$LD_PRELOAD" >> /root/.bashrc && \
+    echo "export LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:/usr/local/lib" >> /root/.bashrc
+
+WORKDIR /workspace
+
+ENTRYPOINT []
+CMD ["/bin/bash"]

--- a/docs/start/install.md
+++ b/docs/start/install.md
@@ -1,16 +1,18 @@
 # Installation
 
-Last updated: 06/22/2026
+Last updated: 06/24/2026
 
 ## Requirements
 
 For NVIDIA GPU:
-- **Python**: Version >= 3.10
-- **CUDA**: Version >= 12.8
+
+* **Python**: Version >= 3.10
+* **CUDA**: Version >= 12.8
 
 For Ascend NPU:
-- **Python**: Version >= 3.10
-- **CANN**: Version >= 8.5.0
+
+* **Python**: Version >= 3.10
+* **CANN**: Version >= 8.5.0
 
 ## Install
 
@@ -53,21 +55,21 @@ It will install vllm-omni, verl, and verl-omni.
 
 ### Extras
 
-| Extra | Adds | When |
-|---|---|---|
-| `gpu` | `vllm==0.22.0`, `kernels==0.14.1`, `liger-kernel` | CUDA rollout + actor FA3 |
-| `vllm-omni` | `vllm-omni==0.22.0` | vLLM-Omni rollout |
-| `train` | `verl==0.8.0` | RL training |
-| `dev` | `pytest`, `pre-commit`, `Levenshtein`, … | Local development / CI |
-| `ocr` | `Levenshtein` | OCR reward (FlowGRPO) |
+| Extra       | Adds                                              | When                     |
+| ----------- | ------------------------------------------------- | ------------------------ |
+| `gpu`       | `vllm==0.22.0`, `kernels==0.14.1`, `liger-kernel` | CUDA rollout + actor FA3 |
+| `vllm-omni` | `vllm-omni==0.22.0`                               | vLLM-Omni rollout        |
+| `train`     | `verl==0.8.0`                                     | RL training              |
+| `dev`       | `pytest`, `pre-commit`, `Levenshtein`, …          | Local development / CI   |
+| `ocr`       | `Levenshtein`                                     | OCR reward (FlowGRPO)    |
 
 ## Optional Dependencies
 
-| Extra | Install | When needed |
-|---|---|---|
-| OCR reward | `uv pip install -e ".[ocr]"` | FlowGRPO training with OCR-based reward |
-| Dev tools | `uv pip install -e ".[dev]"` | Linting and unit tests |
-| VeOmni engine backend | See [Optional engine backends](#optional-engine-backends) | VeOmni instead of default FSDP2 |
+| Extra                 | Install                                                   | When needed                             |
+| --------------------- | --------------------------------------------------------- | --------------------------------------- |
+| OCR reward            | `uv pip install -e ".[ocr]"`                              | FlowGRPO training with OCR-based reward |
+| Dev tools             | `uv pip install -e ".[dev]"`                              | Linting and unit tests                  |
+| VeOmni engine backend | See [Optional engine backends](#optional-engine-backends) | VeOmni instead of default FSDP2         |
 
 ### Flash Attention 3
 
@@ -122,12 +124,20 @@ python -c "import verl_omni; print('VeRL-Omni ready')"
 
 ## Build Your Own Docker Image
 
-The repository has a CUDA Dockerfile at [`docker/Dockerfile.cuda`](https://github.com/verl-project/verl-omni/blob/main/docker/Dockerfile.cuda). The default base image uses **CUDA 13.0.2** on Ubuntu 22.04 (override with `--build-arg CUDA_VERSION=…` if needed). Build context is controlled by the repo-root [`.dockerignore`](https://github.com/verl-project/verl-omni/blob/main/.dockerignore); keep large local folders such as `.venv`, `data/`, and `checkpoints/` out of the context.
+The repository provides Dockerfiles for both NVIDIA GPU and Ascend NPU environments:
+
+* CUDA Dockerfile: [`docker/Dockerfile.cuda`](https://github.com/verl-project/verl-omni/blob/main/docker/Dockerfile.cuda)
+* Ascend NPU Dockerfile: `docker/Dockerfile.npu`
+
+The CUDA image is intended for NVIDIA GPU training and rollout. The NPU image is intended for Ascend 910B / 910C environments with CANN, `torch-npu`, `vllm-ascend`, and `vllm-omni`.
+
+Build context is controlled by the repo-root [`.dockerignore`](https://github.com/verl-project/verl-omni/blob/main/.dockerignore); keep large local folders such as `.venv`, `data/`, and `checkpoints/` out of the context.
+
+## CUDA Docker Image
 
 ### Prerequisites
 
-- Docker with [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html)
-
+* Docker with [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html)
 
 ### Build commands
 
@@ -143,7 +153,6 @@ docker build -f docker/Dockerfile.cuda --target ocr -t verl-omni:gpu-ocr .
 # Local development tools (adds the `dev` extra)
 docker build -f docker/Dockerfile.cuda --target dev -t verl-omni:gpu-dev .
 ```
-
 
 The image bakes in `verl_omni` and its Python dependencies. Recipe scripts under `examples/` are **not** copied into the image — mount the repository at runtime (see below).
 
@@ -169,23 +178,156 @@ docker run --gpus all --shm-size=16g -it --rm \
   /bin/bash
 ```
 
-Inside the container, confirm the installation (same checks as [Post-Installation Verification](#post-installation-verification)).
-
+Inside the container, confirm the installation using the same checks as [Post-Installation Verification](#post-installation-verification).
 
 Notes:
 
-- **`--shm-size=16g`** — Ray and vLLM use shared memory; larger shared memory is needed training.
-- **Mount the repo** — training recipes live in `examples/`; mounting `$REPO` lets you edit scripts locally and run them immediately in the container.
-- **`WORKSPACE`** — example scripts read datasets and write checkpoints under this path (default: `$HOME` inside the container, i.e. `/root` unless overridden).
-- **Hugging Face cache** — mounting `~/.cache/huggingface` avoids re-downloading `Qwen/Qwen-Image` and reward models on every run.
+* **`--shm-size=16g`** — Ray and vLLM use shared memory; larger shared memory is needed for training.
+* **Mount the repo** — training recipes live in `examples/`; mounting `$REPO` lets you edit scripts locally and run them immediately in the container.
+* **`WORKSPACE`** — example scripts read datasets and write checkpoints under this path (default: `$HOME` inside the container, i.e. `/root` unless overridden).
+* **Hugging Face cache** — mounting `~/.cache/huggingface` avoids re-downloading `Qwen/Qwen-Image` and reward models on every run.
 
-### Example: Qwen-Image FlowGRPO training in Docker
+## Ascend NPU Docker Image
 
-This walkthrough follows the [FlowGRPO quickstart](flowgrpo_quickstart.md) using the OCR dataset and `examples/flowgrpo_trainer/run_qwen_image_ocr_lora.sh`. Use the **`ocr` image target** (`verl-omni:gpu-ocr`) so the `Levenshtein` dependency is present.
+### Prerequisites
 
-**1. Launch the interactive container** (command above).
+The Ascend NPU Docker image expects the host machine to provide the Ascend driver and device files.
 
-**2. Prepare the OCR dataset** inside the container:
+Before launching the container, make sure the host has:
+
+* Ascend driver installed.
+* CANN-compatible runtime environment.
+* `npu-smi` available on the host.
+* Ascend device nodes under `/dev`, such as `/dev/davinci0`, `/dev/davinci_manager`, `/dev/devmm_svm`, and `/dev/hisi_hdc`.
+* Docker permission to pass NPU devices into the container.
+
+The NPU container mounts the host driver directory:
+
+```bash
+-v /usr/local/Ascend/driver:/usr/local/Ascend/driver:ro
+```
+
+This allows the containerized CANN / `torch-npu` runtime to use the host Ascend driver.
+
+### Build command
+
+From the repository root:
+
+```bash
+docker build \
+  -f docker/Dockerfile.npu \
+  -t verl-omni:npu \
+  .
+```
+
+If you want to use the 910B launch command below without changing the image name, build the image with the matching tag:
+
+```bash
+docker build \
+  -f docker/Dockerfile.npu \
+  -t verl-omni-npu:v0.22 \
+  .
+```
+
+Alternatively, keep a single image tag and replace the image name in the `docker run` command.
+
+### Launch on Ascend 910C, 16 NPU
+
+Use this command on a 16-card Ascend 910C machine:
+
+```bash
+DEVICES=""
+for i in $(seq 0 15); do
+  DEVICES="$DEVICES --device=/dev/davinci$i"
+done
+
+docker run -it --rm \
+  --name verl_omni_16npu \
+  --network host \
+  --ipc host \
+  --privileged \
+  $DEVICES \
+  --device=/dev/davinci_manager \
+  --device=/dev/devmm_svm \
+  --device=/dev/hisi_hdc \
+  -v /usr/local/sbin/npu-smi:/usr/local/sbin/npu-smi:ro \
+  -v /usr/local/Ascend/driver:/usr/local/Ascend/driver:ro \
+  -v /mnt/data:/mnt/data \
+  verl-omni:npu \
+  bash
+```
+
+### Launch on Ascend 910B, 8 NPU
+
+Use this command on an 8-card Ascend 910B machine:
+
+```bash
+DEVICES=""
+for i in $(seq 0 7); do
+  DEVICES="$DEVICES --device=/dev/davinci$i"
+done
+
+docker run -it --rm \
+  --name verl_omni_8npu \
+  --network host \
+  --ipc host \
+  --privileged \
+  $DEVICES \
+  --device=/dev/davinci_manager \
+  --device=/dev/devmm_svm \
+  --device=/dev/hisi_hdc \
+  -v /usr/local/sbin/npu-smi:/usr/local/sbin/npu-smi:ro \
+  -v /usr/local/Ascend/driver:/usr/local/Ascend/driver:ro \
+  -v /home:/home \
+  verl-omni-npu:v0.22 \
+  bash
+```
+
+If you built the image as `verl-omni:npu`, replace the last image name with:
+
+```bash
+verl-omni:npu
+```
+
+### Notes for NPU containers
+
+* **`--network host`** — useful for Ray, distributed training, and multi-process communication.
+* **`--ipc host`** — avoids shared-memory limitations during training and rollout.
+* **`--privileged`** — commonly required for Ascend device access inside containers.
+* **`/dev/davinci*` devices** — expose Ascend NPU cards to the container.
+* **`/dev/davinci_manager`**, **`/dev/devmm_svm`**, and **`/dev/hisi_hdc`** — required Ascend runtime device files.
+* **`/usr/local/Ascend/driver`** — mounted read-only from the host so the container can use the installed Ascend driver.
+* **`npu-smi`** — mounted from the host to inspect device status inside the container.
+* **910C 16 NPU** — exposes `/dev/davinci0` through `/dev/davinci15`.
+* **910B 8 NPU** — exposes `/dev/davinci0` through `/dev/davinci7`.
+
+Inside the container, confirm the NPU environment:
+
+```bash
+npu-smi info
+python -c "import torch; import torch_npu; print('torch', torch.__version__, '| NPU', torch.npu.is_available())"
+python -c "import vllm; print('vllm', vllm.__version__)"
+python -c "import verl; print('verl', verl.__version__)"
+python -c "import verl_omni; print('VeRL-Omni ready')"
+```
+
+## Example: Qwen-Image FlowGRPO training in Docker
+
+This walkthrough follows the [FlowGRPO quickstart](flowgrpo_quickstart.md) using the OCR dataset and `examples/flowgrpo_trainer/run_qwen_image_ocr_lora.sh`.
+
+For CUDA, use the **`ocr` image target** (`verl-omni:gpu-ocr`) so the `Levenshtein` dependency is present.
+
+For Ascend NPU, use the NPU image and the NPU-specific recipe options. NPU recipes should override the attention backend with:
+
+```bash
+actor_rollout_ref.model.attn_backend=_native_npu
+```
+
+### 1. Launch the interactive container
+
+Use either the CUDA or NPU launch command above.
+
+### 2. Prepare the OCR dataset inside the container
 
 ```bash
 export WORKSPACE=${WORKSPACE:-$HOME}
@@ -200,16 +342,24 @@ python3 examples/flowgrpo_trainer/data_process/qwenimage_ocr.py \
   --output_dir $WORKSPACE/data/ocr/qwen_image
 ```
 
-**3. (Optional) Set W&B credentials:**
+### 3. Optional: Set W&B credentials
 
 ```bash
 export WANDB_API_KEY=<your_wandb_api_key>
 ```
 
-**4. Run FlowGRPO training** (4 GPUs by default in the script):
+### 4. Run FlowGRPO training
+
+For CUDA, the default OCR LoRA script uses 4 GPUs by default:
 
 ```bash
 bash examples/flowgrpo_trainer/run_qwen_image_ocr_lora.sh
+```
+
+For Ascend NPU, use the corresponding NPU recipe script if available in your checkout, or run the training command with NPU-specific Hydra overrides, especially:
+
+```bash
+actor_rollout_ref.model.attn_backend=_native_npu
 ```
 
 The script launches `python3 -m verl_omni.trainer.main_diffusion` with FlowGRPO + `vllm_omni` rollout and OCR reward (`compute_score_ocr`). Checkpoints are written to:
@@ -217,5 +367,3 @@ The script launches `python3 -m verl_omni.trainer.main_diffusion` with FlowGRPO 
 ```bash
 checkpoints/flow_grpo/qwen_image_ocr_lora
 ```
-
-

--- a/examples/diffusionnft_trainer/run_qwen_image_ocr_lora_npu.sh
+++ b/examples/diffusionnft_trainer/run_qwen_image_ocr_lora_npu.sh
@@ -47,6 +47,7 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.actor.fsdp_config.optimizer_offload=True \
     actor_rollout_ref.actor.fsdp_config.model_dtype=bfloat16 \
     actor_rollout_ref.rollout.tensor_model_parallel_size=$ROLLOUT_TP \
+    actor_rollout_ref.rollout.rollout_attn_backend=TORCH_SDPA \
     actor_rollout_ref.rollout.name=$ENGINE \
     actor_rollout_ref.rollout.n=16 \
     actor_rollout_ref.rollout.agent.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / ROLLOUT_TP)) \

--- a/examples/dpo_trainer/run_qwen_image_online_dpo_lora_npu.sh
+++ b/examples/dpo_trainer/run_qwen_image_online_dpo_lora_npu.sh
@@ -45,6 +45,7 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.actor.fsdp_config.model_dtype=bfloat16 \
     actor_rollout_ref.rollout.name=$ENGINE \
     actor_rollout_ref.rollout.tensor_model_parallel_size=$ROLLOUT_TP \
+    actor_rollout_ref.rollout.rollout_attn_backend=TORCH_SDPA \
     actor_rollout_ref.rollout.n=16 \
     actor_rollout_ref.rollout.calculate_log_probs=false \
     actor_rollout_ref.rollout.agent.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / ROLLOUT_TP)) \

--- a/examples/flowgrpo_trainer/run_qwen_image_ocr_lora_npu.sh
+++ b/examples/flowgrpo_trainer/run_qwen_image_ocr_lora_npu.sh
@@ -48,6 +48,7 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.actor.diffusion_loss.loss_mode=flow_grpo \
     actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=32 \
     actor_rollout_ref.rollout.tensor_model_parallel_size=$ROLLOUT_TP \
+    actor_rollout_ref.rollout.rollout_attn_backend=TORCH_SDPA \
     actor_rollout_ref.rollout.name=$ENGINE \
     actor_rollout_ref.rollout.n=16 \
     actor_rollout_ref.rollout.agent.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / ROLLOUT_TP)) \

--- a/examples/flowgrpo_trainer/run_qwen_image_ocr_npu.sh
+++ b/examples/flowgrpo_trainer/run_qwen_image_ocr_npu.sh
@@ -45,6 +45,7 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.actor.diffusion_loss.clip_ratio=1e-5 \
     actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=32 \
     actor_rollout_ref.rollout.tensor_model_parallel_size=$ROLLOUT_TP \
+    actor_rollout_ref.rollout.rollout_attn_backend=TORCH_SDPA \
     actor_rollout_ref.rollout.name=$ENGINE \
     actor_rollout_ref.rollout.n=16 \
     actor_rollout_ref.rollout.agent.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / ROLLOUT_TP)) \

--- a/examples/grpoguard_trainer/run_qwen_image_ocr_lora_npu.sh
+++ b/examples/grpoguard_trainer/run_qwen_image_ocr_lora_npu.sh
@@ -60,6 +60,7 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=50 \
     actor_rollout_ref.rollout.val_kwargs.algo.noise_level=0.0 \
     actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=32 \
+    actor_rollout_ref.rollout.rollout_attn_backend=TORCH_SDPA \
     reward.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / REWARD_TP)) \
     reward.reward_model.enable=True \
     reward.reward_model.model_path=$reward_model_name \

--- a/examples/mixgrpo_trainer/run_qwen_image_ocr_lora_mixgrpo_npu.sh
+++ b/examples/mixgrpo_trainer/run_qwen_image_ocr_lora_mixgrpo_npu.sh
@@ -49,6 +49,7 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.actor.diffusion_loss.loss_mode=flow_grpo \
     actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=32 \
     actor_rollout_ref.rollout.tensor_model_parallel_size=$ROLLOUT_TP \
+    actor_rollout_ref.rollout.rollout_attn_backend=TORCH_SDPA \
     actor_rollout_ref.rollout.name=$ENGINE \
     actor_rollout_ref.rollout.n=16 \
     actor_rollout_ref.rollout.agent.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / ROLLOUT_TP)) \


### PR DESCRIPTION
### What does this PR do?

This PR adds Ascend NPU Dockerfiles and updates the installation guide for running VeRL-Omni on Ascend NPUs.

Main changes:

* Add `docker/Dockerfile.910B.npu`
* Add `docker/Dockerfile.910C.npu`
* Update `docs/start/install.md` with Ascend NPU Docker build and runtime instructions

### Checklist Before Starting

* [x] Search for similar PRs. Related PR: `#195 [docker] feat: add CUDA Dockerfile and install guide`
* [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

The Dockerfiles and installation instructions were checked manually.

Tested:

* Dockerfile syntax and build flow
* Ascend NPU runtime command structure
* Installation guide command consistency

CI unit tests are not added because this PR only adds Dockerfiles and documentation.

### API and Usage Example

No Python API changes.

Example usage is documented in `docs/start/install.md`.

### Design & Code Changes

This PR introduces two Ascend NPU Dockerfiles for different NPU targets and documents how to build and run them.

The Dockerfiles provide a reproducible environment for Ascend NPU training, while the install guide explains the expected build and runtime commands.

### Checklist Before Submitting

* [x] Read the Contribute Guide.
* [x] Apply pre-commit checks: `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
* [x] Add / Update the documentation.
* [x] Add unit or end-to-end test(s), or explain why not feasible: this PR only adds Dockerfiles and documentation, so CI test coverage is not directly applicable.
