### PR TITLE
[trainer] feat: bagel flow-grpo training vllm-omni 0.22

### DIFF
--- a/docs/contributing/integrating_a_diffusion_model.md
+++ b/docs/contributing/integrating_a_diffusion_model.md
@@ -13,6 +13,11 @@ for PPO-like policy-gradient algorithms, and
 [`integrating_a_new_direct_preference_algorithm_for_diffusion_model.md`](integrating_a_new_direct_preference_algorithm_for_diffusion_model.md)
 for direct-preference algorithms.
 
+**If diffusers cannot load your model**, use
+[`integrating_a_non_diffusers_model.md`](integrating_a_non_diffusers_model.md)
+instead. That guide covers the `NonDiffusersModelBase` path using BAGEL-7B-MoT as the
+worked example.
+
 We use the **Qwen-Image** integration
 ([`verl_omni/pipelines/qwen_image_flow_grpo/`](../../verl_omni/pipelines/qwen_image_flow_grpo/__init__.py))
 as the worked example throughout. Read the source alongside this guide — the

--- a/docs/contributing/integrating_a_non_diffusers_model.md
+++ b/docs/contributing/integrating_a_non_diffusers_model.md
@@ -1,0 +1,453 @@
+(integrating_a_non_diffusers_model)=
+# How to Integrate a Non-Diffusers Model for FlowGRPO Training
+
+Last updated: 06/15/2026.
+
+This guide walks you through integrating a **non-diffusers model** — a
+standalone `nn.Module` that does **not** inherit from `diffusers.ModelMixin`
+and is **not** loaded through `diffusers.AutoModel.from_pretrained` — into
+VeRL-Omni so it can be trained end-to-end with the **FlowGRPO** algorithm.
+
+Non-diffusers models manage their own architecture, configuration format,
+and weight-loading logic — none of which go through diffusers APIs. BAGEL-7B-MoT
+is the reference implementation.
+
+If your model is a standard diffusers model, use
+[`integrating_a_diffusion_model.md`](integrating_a_diffusion_model.md)
+instead. This guide extends the contracts defined there and focuses on
+what is **different** for non-diffusers models.
+
+We use the **BAGEL-7B-MoT** integration
+([`verl_omni/pipelines/bagel_flow_grpo/`](../../verl_omni/pipelines/bagel_flow_grpo/__init__.py))
+as the worked example throughout.
+
+---
+
+## TL;DR
+
+A new non-diffusers model needs **four files in one new package** plus
+**three registry hooks**:
+
+```
+verl_omni/pipelines/<model>_flow_grpo/
+├── __init__.py                       # re-exports adapters + model class
+├── <model>_model.py                  # nn.Module subclass of NonDiffusersModelBase
+├── diffusers_training_adapter.py     # subclass of DiffusionModelBase
+└── vllm_omni_rollout_adapter.py      # subclass of upstream vllm-omni Pipeline
+```
+
+The **training adapter** (`diffusers_training_adapter.py`) follows the
+same `DiffusionModelBase` contract as standard diffusers models, but
+overrides `build_module()` to use your custom `from_pretrained()` path
+instead of `diffusers.AutoModel`. The **rollout adapter** is identical
+in structure to the diffusers case.
+
+The **model module** (`<model>_model.py`) is the new piece: a standalone
+`nn.Module` that subclasses `NonDiffusersModelBase` and provides:
+
+- `from_pretrained(model_path, torch_dtype)` — classmethod for weight loading
+- `forward(**kwargs)` — the generation forward pass
+- `_no_split_modules` — FSDP sharding hints
+- Optional gradient checkpointing support
+
+---
+
+## When to Use NonDiffusersModelBase
+
+Use `NonDiffusersModelBase` when **diffusers cannot load the model**.
+Everything else (custom configs, weight loading, FSDP sharding)
+can be handled through the standard ``DiffusionModelBase`` path by
+overriding ``build_module()``.
+
+---
+
+## Mental Model
+
+The training side for non-diffusers models follows the same two-context
+architecture as diffusers models, but the **module** is built through a
+different path:
+
+```text
+  ┌─────────────────────────────────┐                ┌──────────────────────────────┐
+  │ Rollout worker (vllm-omni)      │   trajectory   │ Trainer worker (FSDP)        │
+  │                                 │ ─────────────▶ │                              │
+  │ <Name>Pipeline (upstream)       │  latents,      │ <Name>ForTraining            │
+  │  └─ forward() + SDE loop        │  log_probs,    │  (NonDiffusersModelBase)     │
+  │                                 │  prompt ids    │  └─ forward(...)             │
+  │ <Name>PipelineWithLogProb       │                │                              │
+  │  └─ wraps with SDE scheduler    │                │                              │
+  │  └─ handles prompt format       │                │                              │
+  └─────────────────────────────────┘                └──────────────────────────────┘
+```
+
+The key difference from the diffusers path:
+
+| Aspect | Diffusers model | Non-diffusers model |
+|---|---|---|
+| Module loading | `diffusers.AutoModel.from_pretrained()` | `MyModel.from_pretrained(model_path)` |
+| Module base class | `ModelMixin` (from diffusers) | `NonDiffusersModelBase` (from verl-omni) |
+| `build_module()` | Return `None` → default AutoModel path | Return `MyModel.from_pretrained(...)` |
+| Config | `model_index.json` → `_class_name` | `config.json` → custom struct (e.g. `BagelTrainingConfig`) |
+| Architecture registration | Auto-detected from `model_index.json` | Explicit: `+actor_rollout_ref.model.architecture=...` |
+
+---
+
+## Prerequisites
+
+Before you start, the new model must already be supported upstream by:
+
+- **vllm-omni** — provides the rollout-side `<Name>Pipeline`. Your
+  rollout adapter inherits from this class. The pipeline must be capable of
+  running diffusion (text-to-image, or whatever modality you are training).
+- **A downloadable checkpoint** — the model weights (`.safetensors`) and
+  config files must be available locally or on Hugging Face Hub.
+
+Unlike the diffusers path, **diffusers does not need to support the model**
+— that is the whole point of the non-diffusers path. However, you must
+port or reimplement the transformer architecture locally (see Step 2).
+
+If the model is not yet supported in vllm-omni, upstream it there first.
+Nothing below will work without vllm-omni rollout support.
+
+---
+
+## Step 1 — Understand the Upstream Pipeline and the Rollout→Training Contract
+
+Read the vllm-omni pipeline's `forward()` method and answer the same
+questions as in the diffusers guide, plus these non-diffusers-specific ones:
+
+1. **How does the upstream pipeline process text?** Does it expect raw text
+   strings or token IDs? If it expects strings, you may need a decode
+   workaround in the rollout adapter (see the BAGEL integration's
+   `_ensure_bagel_prompt_text` for an example).
+2. **What is the model's forward signature?** Non-diffusers models define
+   their own forward convention — it will not match the diffusers
+   `(sample, timestep, encoder_hidden_states)` pattern. Document the
+   signature; ``prepare_model_inputs()`` must produce matching kwargs.
+3. **How does the model handle CFG?** If it supports classifier-free
+   guidance, identify the negative-branch parameters (e.g. `None` for
+   text-conditioning) so training can replicate the CFG logic.
+4. **What is the checkpoint format?** Note the weight file name, key prefix
+   conventions, and any architectural details that must be remapped.
+5. **What are the layer class names?** List them — FSDP needs these for
+   `_no_split_modules` so it can wrap the model correctly.
+6. **What are the special token IDs?** If the model uses boundary tokens
+   (start-of-image, end-of-image, etc.), identify whether they come from
+   config or the tokenizer. The data preprocessor must produce consistent
+   token sequences.
+
+---
+
+## Step 2 — Port the Model Architecture
+
+Create `verl_omni/pipelines/<model>_flow_grpo/<model>_model.py`. This is
+the most involved step. You are porting the transformer architecture from
+the upstream model into a standalone `nn.Module` and subclassing
+`NonDiffusersModelBase`.
+
+### 2.1 Subclass `NonDiffusersModelBase`
+
+```python
+from verl_omni.pipelines.non_diffusers_model_base import NonDiffusersModelBase
+
+class MyModelForTraining(NonDiffusersModelBase):
+    _no_split_modules = ["MyTransformerLayer"]
+    _supports_gradient_checkpointing = True
+
+    def __init__(self, config: MyTrainingConfig):
+        super().__init__()
+        self.config = config
+        # ... build layers, embeddings, etc.
+```
+
+`NonDiffusersModelBase` provides for free:
+
+| Feature | How to use |
+|---|---|
+| **LoRA/PEFT injection** | Inherits `add_adapter()`, `load_lora_adapter()`, `set_adapter()`, `disable_adapters()`, `enable_adapters()` |
+| **Gradient checkpointing** | Set `_supports_gradient_checkpointing = True` and wrap layer calls with `self._checkpointed_call(fn, *args)` |
+| **FSDP sharding** | Set `_no_split_modules` to your layer class names |
+| **Checkpoint persistence** | Inherits `save_pretrained()` (saves `model.safetensors` + `config.json`) |
+
+### 2.2 Implement `from_pretrained`
+
+```python
+@classmethod
+def from_pretrained(cls, model_path: str, torch_dtype=torch.bfloat16) -> MyModelForTraining:
+    config = MyTrainingConfig.from_model_path(model_path)
+    ckpt_path = os.path.join(model_path, "ema.safetensors")  # or whatever the checkpoint file is
+    from safetensors.torch import load_file
+    state_dict = load_file(ckpt_path)
+
+    model = cls(config)
+    mapped = _map_checkpoint_to_training(state_dict, config)
+    missing, unexpected = model.load_state_dict(mapped, strict=False)
+    if missing:
+        logger.warning(f"Missing keys: {len(missing)}")
+    model = model.to(torch_dtype)
+    return model
+```
+
+Key points:
+
+- You control the entire loading logic. No `diffusers.AutoModel` involved.
+- Remap checkpoint keys to match your local parameter names
+  (see the BAGEL integration's ``bagel_model.py`` for an example).
+- Handle dtype conversion yourself.
+
+### 2.3 Implement `forward`
+
+The forward signature is **model-dependent**. For example, an image
+generation model might take ``(hidden_states, timestep, text_token_ids,
+latent_pos_ids, **kwargs)``. The only constraint is that
+``prepare_model_inputs()`` in the training adapter must build a dict
+whose keys match this signature exactly.
+
+For gradient checkpointing, wrap layer calls:
+
+```python
+def forward(self, *args, **kwargs):
+    # ...
+    for layer in self.layers:
+        sequence = self._checkpointed_call(layer, sequence, ...)
+    # ...
+    return (output,)
+```
+
+Return a **tuple** `(velocity,)` — the FSDP engine expects a single-element
+tuple.
+
+### 2.4 Implement the Config
+
+Create a `@dataclass` config class with a `save_pretrained()` method and a
+`from_model_path()` classmethod:
+
+```python
+@dataclass
+class MyTrainingConfig:
+    hidden_size: int = 3584
+    num_hidden_layers: int = 28
+    # ...
+
+    def save_pretrained(self, save_directory: str):
+        output_path = os.path.join(save_directory, "config.json")
+        with open(output_path, "w") as f:
+            json.dump(asdict(self), f, indent=4, sort_keys=True)
+
+    @classmethod
+    def from_model_path(cls, model_path: str) -> MyTrainingConfig:
+        cfg_path = os.path.join(model_path, "config.json")
+        with open(cfg_path) as f:
+            raw = json.load(f)
+        return cls(
+            hidden_size=raw.get("hidden_size", 3584),
+            # ...
+        )
+```
+
+The config is saved alongside weights in `save_pretrained()`.
+
+---
+
+## Step 3 — Write the Training Adapter
+
+Create `verl_omni/pipelines/<model>_flow_grpo/diffusers_training_adapter.py`.
+This follows the same `DiffusionModelBase` contract as the diffusers guide
+({doc}`integrating_a_diffusion_model`), with one key difference:
+**override `build_module()`** to use your custom loading path.
+
+### 3.1 Override `build_module`
+
+```python
+@DiffusionModelBase.register("OmniMyModelForConditionalGeneration", algorithm="flow_grpo")
+class MyModelDiffusion(DiffusionModelBase):
+    @classmethod
+    def build_module(cls, model_config: DiffusionModelConfig, torch_dtype: torch.dtype):
+        logger.info("Loading MyModelForTraining from %s", model_config.local_path)
+        return MyModelForTraining.from_pretrained(model_config.local_path, torch_dtype=torch_dtype)
+```
+
+When `build_module()` returns a non-`None` value, the FSDP engine uses it
+directly. When it returns `None` (the default), the engine falls back to
+`diffusers.AutoModel.from_pretrained`.
+
+### 3.2 Implement `prepare_model_inputs`
+
+This classmethod receives the training module, model config, latents,
+timesteps, prompt embeddings (plus masks), and the micro-batch from the
+trainer engine, returning a pair of model-kwargs dicts (positive and
+negative).  See {doc}`integrating_a_diffusion_model` for the full
+signature.  Note: non-diffusers models often ignore the ``prompt_embeds*``
+parameters and read token IDs directly from ``micro_batch`` instead
+(see the BAGEL integration's ``_prompt_token_ids_to_batch`` for an example).
+
+### 3.3 Implement `forward_and_sample_previous_step`
+
+This follows the same pattern as the diffusers guide. If your model
+supports classifier-free guidance, implement multi-branch forwarding
+(e.g. conditional + unconditional) and combine the outputs before calling
+``scheduler.sample_previous_step()``. The BAGEL integration demonstrates
+a 3-branch CFG with sigma-interval gating as a reference.
+
+The return signature is always ``(log_prob, prev_sample_mean, std_dev_t, sqrt_dt)``.
+
+### 3.4 Implement the Scheduler
+
+Non-diffusers models use ``FlowMatchSDEDiscreteScheduler`` just like
+diffusers models. If your model needs custom sigma schedules (e.g.
+time-shifted sigmas), place the setup logic in a shared ``common.py``
+so both the training and rollout adapters use the identical schedule.
+See the BAGEL integration's ``setup_bagel_sigmas`` for a worked example.
+
+---
+
+## Step 4 — Write the Rollout Adapter
+
+Create `verl_omni/pipelines/<model>_flow_grpo/vllm_omni_rollout_adapter.py`.
+This is nearly identical to the diffusers guide — subclass the upstream
+vllm-omni pipeline and wrap with the SDE scheduler.
+
+Key considerations for non-diffusers models:
+
+**Prompt format.** The verl-omni agent loop ships token IDs in
+``req.prompts[0]["prompt_token_ids"]``, but the upstream vllm-omni
+pipeline may expect text strings. If needed, add a decode workaround
+in your adapter's ``forward()`` (see the BAGEL integration's
+``_ensure_bagel_prompt_text`` for an example).
+
+**Scheduler adapter.** Some upstream pipelines use non-standard
+``step()`` argument conventions. If the standard
+``FlowMatchSDEDiscreteScheduler`` is incompatible, wrap it in a
+lightweight adapter that reshapes inputs and outputs to match the
+pipeline's expectation. Most models will not need this —
+``FlowMatchSDEDiscreteScheduler`` works directly with the standard
+interface.
+
+**SDE window.** ``forward()`` must set up an SDE window (selecting a
+subset of denoising steps), compensate for any vllm-omni version-specific
+step-count quirks, and slice the trajectory to return only the
+windowed steps.
+
+---
+
+## Step 5 — Wire Up Registries and Package
+
+### 5.1 `__init__.py`
+
+Export the adapter classes so their `@register(...)` decorators run on import.
+The model module is typically imported by the training adapter directly and
+does not need to be in the public API, but including it is fine:
+
+```python
+from .diffusers_training_adapter import MyModelDiffusion
+from .vllm_omni_rollout_adapter import MyModelPipelineWithLogProb
+
+__all__ = ["MyModelDiffusion", "MyModelPipelineWithLogProb"]
+```
+
+### 5.2 Register in `verl_omni/pipelines/__init__.py`
+
+```python
+from .my_model_flow_grpo import *  # noqa: F401, F403
+__all__ += my_model_flow_grpo.__all__
+```
+
+### 5.3 Architecture String
+
+The architecture string passed to both `@DiffusionModelBase.register()` and
+`@VllmOmniPipelineBase.register()` must be consistent. For non-diffusers
+models, there is no `model_index.json` to auto-detect from, so users must
+pass the architecture explicitly on the CLI:
+
+```bash
++actor_rollout_ref.model.architecture=OmniMyModelForConditionalGeneration
+```
+
+---
+
+## Step 6 — Add a Data Preprocessor
+
+The data preprocessor must match the tokenisation used by the upstream
+pipeline.  For most models the agent loop's ``prompts`` tensor is enough.
+
+If the upstream pipeline processes prompts differently from the default
+chat template (e.g. it has its own tokenization path), the data
+preprocessor must produce token sequences consistent with what the
+pipeline expects.  The BAGEL integration demonstrates this pattern: the
+preprocessor uses a model-specific ``tokenize_<model>_prompt()`` wrapper
+to match the pipeline's ``prepare_prompts`` output, storing the result as
+a pre-tokenized column that the training adapter reads via
+``_prompt_token_ids_to_batch()``.
+(See ``examples/flowgrpo_trainer/data_process/`` for reference implementations.)
+
+---
+
+## Step 7 — Add a Smoke Test
+
+Follow the same pattern as the diffusers guide (Step 6 of
+{doc}`integrating_a_diffusion_model`), but with these additions:
+
+1. The dummy data must include the ``prompt`` chat messages (standard batch
+   ``prompts`` / ``attention_mask`` from the agent loop).
+2. The architecture override must be passed explicitly:
+   `+actor_rollout_ref.model.architecture=OmniMyModelForConditionalGeneration`.
+
+---
+
+## Reference: BAGEL Implementation Checklist
+
+The BAGEL integration is the canonical non-diffusers example. Use this
+checklist to verify your implementation against it:
+
+### Model module (`bagel_model.py`)
+- [ ] `BagelTrainingConfig` dataclass with `save_pretrained()` and
+  `from_model_path()`
+- [ ] `BagelForTraining(NonDiffusersModelBase)` with:
+  - [ ] `_no_split_modules = ["BagelMoTLayer"]`
+  - [ ] `_supports_gradient_checkpointing = True`
+  - [ ] `forward()` with gradient checkpointing via `_checkpointed_call()`
+  - [ ] `from_pretrained()` loading from `ema.safetensors` with key remapping
+  - [ ] Token embedding, timestep embedding, VAE projection, position embedding
+  - [ ] MoT dual-pathway attention (text `*_proj` + gen `*_moe_gen`)
+  - [ ] SOI/EOI boundary token handling
+
+### Training adapter (`diffusers_training_adapter.py`)
+- [ ] `@DiffusionModelBase.register("OmniBagelForConditionalGeneration", algorithm="flow_grpo")`
+- [ ] `build_module()` returns `BagelForTraining.from_pretrained(...)`
+- [ ] `build_scheduler()` and `set_timesteps()` with shifted sigmas
+- [ ] `prepare_model_inputs()` reads ``prompts`` and ``attention_mask``
+      from micro-batch (standard tensors, no extra field needed)
+- [ ] `forward_and_sample_previous_step()` with 3-branch CFG combining
+
+### Rollout adapter (`vllm_omni_rollout_adapter.py`)
+- [ ] `@VllmOmniPipelineBase.register("OmniBagelForConditionalGeneration", algorithm="flow_grpo")`
+- [ ] Subclasses `BagelPipeline` from vllm-omni
+- [ ] Wraps scheduler in `_BagelSchedulerAdapter` for 4-arg `step()` convention
+- [ ] SDE `step()` passes batched `(1, tokens, C)` tensors so log-probs match training
+- [ ] `_ensure_bagel_prompt_text()` workaround for text-prompt requirement
+- [ ] `forward()` sets up SDE window, vllm-omni 0.22 timestep compensation, returns sliced trajectory
+
+### Shared utilities (`common.py`)
+- [ ] `setup_bagel_sigmas()` — shared sigma schedule for rollout and training
+- [ ] `bagel_time_shift()` — SD3-style timestep shift of `3.0`
+- [ ] CFG defaults (`BAGEL_FLOWGRPO_CFG_DEFAULTS`) — consistent between adapters
+
+### Data preprocessor (see ``examples/flowgrpo_trainer/data_process/``)
+- [ ] Stores prompts in standard chat-message format (``prompt`` key)
+- [ ] (BAGEL only) Pre-tokenizes captions via ``tokenize_bagel_prompt()`` and the training
+      adapter reads them via ``_prompt_token_ids_to_batch()``
+
+### Wiring
+- [ ] `verl_omni/pipelines/bagel_flow_grpo/__init__.py` re-exports the two adapter classes
+      (``BagelDiffusion`` and ``BagelPipelineWithLogProb``)
+- [ ] `verl_omni/pipelines/__init__.py` imports `bagel_flow_grpo`
+- [ ] Example launch script at `examples/flowgrpo_trainer/run_bagel_flowgrpo_lora.sh`
+- [ ] Deploy config at `examples/flowgrpo_trainer/bagel_deploy_config.yaml`
+
+---
+
+## When to Use the Diffusers Path Instead
+
+If diffusers can load the model, use
+{doc}`integrating_a_diffusion_model`.  Override ``build_module()`` there
+for any custom loading you need.

--- a/docs/index.md
+++ b/docs/index.md
@@ -85,6 +85,7 @@ api/utils.rst
 
 contributing/editing-agent-instructions.md
 contributing/integrating_a_diffusion_model.md
+contributing/integrating_a_non_diffusers_model.md
 contributing/integrating_a_stepwise_continuous_batching_model.md
 contributing/integrating_a_new_policy_gradient_algorithm_for_diffusion_model.md
 contributing/integrating_a_new_direct_preference_algorithm_for_diffusion_model.md

--- a/examples/flowgrpo_trainer/bagel.md
+++ b/examples/flowgrpo_trainer/bagel.md
@@ -1,0 +1,69 @@
+# BAGEL-7B-MoT FlowGRPO training
+
+[BAGEL-7B-MoT](https://github.com/ByteDance-Seed/BAGEL-7B-MoT) is a
+Mixture-of-Transformers model supporting both image understanding and
+generation.  Unlike Qwen-Image, BAGEL is a **non-diffusers** model — it
+cannot be loaded by diffusers and uses its own weight-loading path via
+``NonDiffusersModelBase``.  See
+[docs/contributing/integrating_a_non_diffusers_model.md](../../docs/contributing/integrating_a_non_diffusers_model.md)
+for the integration architecture.
+
+## Prerequisites
+
+- Install VeRL-Omni (see [docs/start/install.md](../../docs/start/install.md)).
+
+- 4 GPUs.  Run commands from the repository root.
+
+- Download the checkpoint:
+
+  ```bash
+  huggingface-cli download ByteDance-Seed/BAGEL-7B-MoT --local-dir ~/models/ByteDance-Seed/BAGEL-7B-MoT
+  ```
+
+## Prepare the dataset
+
+We use an OCR (optical character recognition) dataset that provides
+ground-truth text for evaluating image-generation quality.  Prompts are
+stored in standard chat-message format for the agent loop (see
+``bagel_ocr.py``).
+
+Preprocess the raw OCR data into parquet:
+
+```bash
+export WORKSPACE=${WORKSPACE:-$HOME}
+
+python3 examples/flowgrpo_trainer/data_process/bagel_ocr.py \
+  --model_path ~/models/ByteDance-Seed/BAGEL-7B-MoT \
+  --input_dir ~/data/ocr \
+  --output_dir $WORKSPACE/data/ocr/bagel
+```
+
+This produces ``$WORKSPACE/data/ocr/bagel/train.parquet`` and
+``test.parquet``.
+
+## Run training
+
+```bash
+bash examples/flowgrpo_trainer/run_bagel_flowgrpo_lora.sh
+```
+
+The launch script uses a [Qwen3-VL-8B-Instruct](https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct)
+reward model with vLLM rollout (TP=4) and the ``genrm_ocr.py`` custom reward
+function.
+
+## Key differences from Qwen-Image
+
+| Aspect | Qwen-Image | BAGEL-7B-MoT |
+|---|---|---|
+| Model loading | diffusers | Custom ``from_pretrained`` via ``NonDiffusersModelBase`` |
+| Architecture | Auto-detected | Explicit: ``+actor_rollout_ref.model.architecture=OmniBagelForConditionalGeneration`` |
+| Deploy config | Not needed | ``bagel_deploy_config.yaml`` (single-stage topology) |
+| LoRA targets | ``*_proj`` layers | ``*_proj`` + ``*_moe_gen`` (MoT dual-pathway) |
+| FSDP prefixes | ``transformer_blocks.`` | ``layers.`` |
+| CFG | Standard true CFG | 3-branch (gen / text-uncond / img-uncond) with global renormalisation |
+| Timestep convention | ``t / 1000`` | Raw sigma with SD3-style shift of 3.0 |
+
+## Further reading
+
+- [integrating_a_non_diffusers_model.md](../../docs/contributing/integrating_a_non_diffusers_model.md) — full integration guide using BAGEL as the worked example
+- [vLLM-Omni BAGEL docs](https://docs.vllm.ai/projects/vllm-omni/en/latest/user_guide/examples/online_serving/bagel/)

--- a/examples/flowgrpo_trainer/data_process/bagel_ocr.py
+++ b/examples/flowgrpo_trainer/data_process/bagel_ocr.py
@@ -16,7 +16,7 @@ Preprocess the OCR dataset for BAGEL FlowGRPO training.
 
 BAGEL uses raw ``tokenizer.encode(user_text)`` with BOS/EOS markers
 (no chat template).  This script pre-tokenizes prompts in BAGEL format
-so the training adapter can read ``bagel_prompt_ids`` directly instead
+so the training adapter can read ``prompt_token_ids`` directly instead
 of decoding + re-encoding chat-template tokens at every step.
 
 Usage::
@@ -86,13 +86,6 @@ if __name__ == "__main__":
         help="Max token length for BAGEL prompts.",
     )
     parser.add_argument("--hdfs_dir", default=None, help="Optional HDFS output directory.")
-    parser.add_argument(
-        "--system_prompt",
-        default="Describe the image by detailing the color, shape, size, "
-        "texture, quantity, text, spatial relationships of the objects and background:",
-        help="System prompt prepended before user text.",
-    )
-
     args = parser.parse_args()
     local_dataset_path = os.path.expanduser(args.input_dir)
 
@@ -120,25 +113,21 @@ if __name__ == "__main__":
             text = example.pop("text")
             solution = extract_ocr_solution(text)
 
-            # Build the full user text the same way the rollout does:
-            # system_prompt + "\n" + ocr_prompt + "\n"
-            user_text = f"{args.system_prompt}\n{text}\n"
+            # Official FlowGRPO feeds BAGEL the stripped OCR line as one plain prompt.
+            # Keep rollout text and actor-side token IDs byte-identical.
+            user_text = text.strip()
 
             # Pre-tokenize in BAGEL format so the training adapter
-            # can read bagel_prompt_ids directly (no runtime conversion).
-            bagel_prompt_ids = tokenize_bagel_prompt(tokenizer, user_text, max_length=args.max_prompt_length)
+            # can read prompt_token_ids directly (no runtime conversion).
+            prompt_token_ids = tokenize_bagel_prompt(tokenizer, user_text, max_length=args.max_prompt_length)
 
             return {
                 "data_source": data_source,
-                "prompt": [
-                    {"role": "system", "content": args.system_prompt},
-                    {"role": "user", "content": text},
-                ],
+                "prompt": [{"role": "user", "content": user_text}],
                 "negative_prompt": [
-                    {"role": "system", "content": args.system_prompt},
                     {"role": "user", "content": negative_user_prompt},
                 ],
-                "bagel_prompt_ids": np.array(bagel_prompt_ids, dtype=np.int64),
+                "prompt_token_ids": np.array(prompt_token_ids, dtype=np.int64),
                 "ability": "ocr",
                 "reward_model": {
                     "style": "model",

--- a/examples/flowgrpo_trainer/run_bagel_flowgrpo_lora.sh
+++ b/examples/flowgrpo_trainer/run_bagel_flowgrpo_lora.sh
@@ -50,8 +50,8 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.actor.fsdp_config.param_offload=True \
     actor_rollout_ref.actor.fsdp_config.optimizer_offload=True \
     actor_rollout_ref.actor.fsdp_config.model_dtype=bfloat16 \
-    actor_rollout_ref.actor.diffusion_loss.clip_ratio=1e-4 \
-    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=32 \
+    actor_rollout_ref.actor.diffusion_loss.clip_ratio=1e-5 \
+    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=16 \
     actor_rollout_ref.rollout.tensor_model_parallel_size=$ROLLOUT_TP \
     actor_rollout_ref.rollout.name=$ENGINE \
     actor_rollout_ref.rollout.n=16 \
@@ -67,7 +67,7 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=50 \
     actor_rollout_ref.rollout.val_kwargs.algo.noise_level=0.0 \
     +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.deploy_config=$BAGEL_DEPLOY_CONFIG \
-    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=32 \
+    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=16 \
     reward.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / REWARD_TP)) \
     reward.reward_model.enable=True \
     reward.reward_model.model_path=$reward_model_name \
@@ -85,4 +85,4 @@ python3 -m verl_omni.trainer.main_diffusion \
     trainer.save_freq=30 \
     trainer.test_freq=30 \
     trainer.total_epochs=15 \
-    trainer.total_training_steps=60 "$@"
+    trainer.total_training_steps=300 "$@"

--- a/verl_omni/pipelines/bagel_flow_grpo/bagel_model.py
+++ b/verl_omni/pipelines/bagel_flow_grpo/bagel_model.py
@@ -286,13 +286,18 @@ class BagelMoTAttention(nn.Module):
         v = v.transpose(1, 2)
 
         if L_ctx > 0:
-            text_out = F.scaled_dot_product_attention(
-                q_normed[:, :, :L_ctx],
-                k_normed[:, :, :L_ctx],
-                v[:, :, :L_ctx],
-                is_causal=True,
-            )
             if key_padding_mask is not None and not key_padding_mask.all():
+                # Official BAGEL packs prompts, so padded prompt keys do not exist there.
+                # Mask them in both branches to match packed attention semantics.
+                text_key_mask = key_padding_mask[:, :L_ctx].view(B, 1, 1, L_ctx)
+                causal_mask = torch.ones(L_ctx, L_ctx, dtype=torch.bool, device=hidden_states.device).tril()
+                text_out = F.scaled_dot_product_attention(
+                    q_normed[:, :, :L_ctx],
+                    k_normed[:, :, :L_ctx],
+                    v[:, :, :L_ctx],
+                    attn_mask=text_key_mask & causal_mask.view(1, 1, L_ctx, L_ctx),
+                    is_causal=False,
+                )
                 # key_padding_mask: True = valid key, broadcast as (B,1,1,L).
                 img_attn_mask = key_padding_mask.view(B, 1, 1, L)
                 img_out = F.scaled_dot_product_attention(
@@ -303,6 +308,12 @@ class BagelMoTAttention(nn.Module):
                     is_causal=False,
                 )
             else:
+                text_out = F.scaled_dot_product_attention(
+                    q_normed[:, :, :L_ctx],
+                    k_normed[:, :, :L_ctx],
+                    v[:, :, :L_ctx],
+                    is_causal=True,
+                )
                 img_out = F.scaled_dot_product_attention(
                     q_normed[:, :, L_ctx:],
                     k_normed,

--- a/verl_omni/pipelines/bagel_flow_grpo/common.py
+++ b/verl_omni/pipelines/bagel_flow_grpo/common.py
@@ -46,6 +46,11 @@ def bagel_time_shift(shift: float, t):
     return (shift * t) / (1 + (shift - 1) * t)
 
 
+def vllm_omni_num_timesteps(bagel_num_timesteps: int) -> int:
+    """Map official BAGEL step count to vllm-omni 0.22 generate_image input."""
+    return bagel_num_timesteps - 1 if bagel_num_timesteps > 1 else bagel_num_timesteps
+
+
 def setup_bagel_sigmas(
     scheduler: FlowMatchSDEDiscreteScheduler,
     num_steps: int,
@@ -56,7 +61,12 @@ def setup_bagel_sigmas(
 
     Returns the sigma list (dropping terminal 0) for reference.
     """
-    t = torch.linspace(1, 0, num_steps, dtype=torch.float32, device=device or "cpu")
+    if num_steps <= 0:
+        raise ValueError(f"num_steps must be positive, got {num_steps}")
+
+    # Warmup may pass one step; keep one non-terminal sigma for dummy runs.
+    schedule_points = max(num_steps, 2)
+    t = torch.linspace(1, 0, schedule_points, dtype=torch.float32, device=device or "cpu")
     t_shifted = bagel_time_shift(shift, t)
     sigmas = t_shifted[:-1].tolist()
 

--- a/verl_omni/pipelines/bagel_flow_grpo/diffusers_training_adapter.py
+++ b/verl_omni/pipelines/bagel_flow_grpo/diffusers_training_adapter.py
@@ -27,6 +27,8 @@ from typing import Optional
 
 import torch
 from tensordict import TensorDict
+from tensordict.tensorclass import NonTensorStack
+from verl.utils import tensordict_utils as tu
 from verl.utils.device import get_device_name
 
 from verl_omni.pipelines.model_base import DiffusionModelBase
@@ -47,6 +49,19 @@ class BagelDiffusion(DiffusionModelBase):
     def build_module(cls, model_config: DiffusionModelConfig, torch_dtype: torch.dtype):
         logger.info("Loading BagelForTraining from %s", model_config.local_path)
         return BagelForTraining.from_pretrained(model_config.local_path, torch_dtype=torch_dtype)
+
+    @classmethod
+    def configure_train_mode(cls, module):
+        """Match official BAGEL MoT train-mode flags while gradients stay enabled."""
+        inner = module.module if hasattr(module, "module") else module
+        if not hasattr(inner, "layers"):
+            return
+        inner.training = False
+        for layer in inner.layers:
+            layer_inner = layer.module if hasattr(layer, "module") else layer
+            layer_inner.training = False
+            if hasattr(layer_inner, "self_attn"):
+                layer_inner.self_attn.training = False
 
     @classmethod
     def build_scheduler(cls, model_config: DiffusionModelConfig):
@@ -74,27 +89,38 @@ class BagelDiffusion(DiffusionModelBase):
         pos_ids = get_flattened_position_ids(H_px, W_px, latent_ds, config.max_latent_size)
         return pos_ids.to(device)
 
-    @staticmethod
-    def _bagel_ids_to_batch(
-        bagel_prompt_ids: list,
+    @classmethod
+    def _prompt_token_ids_to_batch(
+        cls,
+        micro_batch: TensorDict,
         device: torch.device,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        """Pad variable-length BAGEL token ID lists into a uniform batch.
+        """Pad BAGEL-native ``prompt_token_ids`` from the data pipeline.
 
         Args:
-            bagel_prompt_ids: List of ``np.ndarray`` or ``list[int]``,
-                one per sample, already in BAGEL format.
-            device: Target device.
+            micro_batch: Batch containing pre-tokenized ``prompt_token_ids``,
+                one sequence per sample, already in BAGEL format.
+            device: Target device for the padded tensors.
 
         Returns:
-            ``(text_token_ids, text_attention_mask)`` — padded tensors
-            of shape ``(B, max_len)``.
+            ``(text_token_ids, text_attention_mask)`` with shape ``(B, max_len)``.
         """
-        B = len(bagel_prompt_ids)
-        max_len = max(len(ids) for ids in bagel_prompt_ids)
+        prompt_token_ids = micro_batch["prompt_token_ids"]
+        if isinstance(prompt_token_ids, NonTensorStack):
+            prompt_token_ids = [
+                tu.unwrap_non_tensor_data(prompt_token_ids[i]) for i in range(micro_batch.batch_size[0])
+            ]
+        else:
+            prompt_token_ids = tu.unwrap_non_tensor_data(prompt_token_ids)
+
+        if isinstance(prompt_token_ids, torch.Tensor) and prompt_token_ids.ndim == 1:
+            prompt_token_ids = [prompt_token_ids]
+
+        B = len(prompt_token_ids)
+        max_len = max(len(ids) for ids in prompt_token_ids)
         text_token_ids = torch.zeros(B, max_len, dtype=torch.long, device=device)
         text_attention_mask = torch.zeros(B, max_len, dtype=torch.bool, device=device)
-        for i, ids in enumerate(bagel_prompt_ids):
+        for i, ids in enumerate(prompt_token_ids):
             n = len(ids)
             text_token_ids[i, :n] = torch.as_tensor(ids, dtype=torch.long, device=device)
             text_attention_mask[i, :n] = True
@@ -120,9 +146,7 @@ class BagelDiffusion(DiffusionModelBase):
         hidden_states = latents[:, step]
         timestep = timesteps[:, step]
 
-        # Read pre-tokenized BAGEL prompt IDs from the data pipeline
-        # (produced by examples/flowgrpo_trainer/data_process/bagel_ocr.py).
-        text_token_ids, text_attention_mask = cls._bagel_ids_to_batch(micro_batch["bagel_prompt_ids"], device)
+        text_token_ids, text_attention_mask = cls._prompt_token_ids_to_batch(micro_batch, device)
 
         # Compute latent position IDs
         latent_pos_ids = cls._get_latent_pos_ids(model_config, module, device)
@@ -291,5 +315,6 @@ class BagelDiffusion(DiffusionModelBase):
             sde_type=model_config.algo.sde_type,
             return_logprobs=True,
             return_sqrt_dt=True,
+            include_logprob_normalizer=False,
         )
         return log_prob, prev_sample_mean, std_dev_t, sqrt_dt

--- a/verl_omni/pipelines/bagel_flow_grpo/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/bagel_flow_grpo/vllm_omni_rollout_adapter.py
@@ -36,6 +36,7 @@ from verl_omni.pipelines.bagel_flow_grpo.common import (
     BAGEL_FLOWGRPO_CFG_DEFAULTS,
     maybe_to_cpu,
     setup_bagel_sigmas,
+    vllm_omni_num_timesteps,
 )
 from verl_omni.pipelines.model_base import VllmOmniPipelineBase
 from verl_omni.pipelines.schedulers import FlowMatchSDEDiscreteScheduler
@@ -164,19 +165,23 @@ class _BagelSchedulerAdapter:
                 "return_logprobs": cur_return_logprobs,
             }
 
+        sample_in = sample.unsqueeze(0)
+        model_output_in = model_output.unsqueeze(0)
+        if "prev_sample" in kwargs:
+            kwargs = {**kwargs, "prev_sample": kwargs["prev_sample"].unsqueeze(0)}
+
         out = self._inner.step(
-            model_output=model_output.float(),  # cast bf16→fp32 for scheduler precision
+            model_output=model_output_in.float(),  # cast bf16→fp32 for scheduler precision
             timestep=sigma,
-            sample=sample,
+            sample=sample_in,
             return_dict=False,
             **kwargs,
         )
         self._step_counter += 1
         prev_sample, log_prob = out[0], out[1]
-        # Rollout latents are (tokens, channels); reduce to scalar to
-        # match training's batched log_prob shape.
+        prev_sample = prev_sample.squeeze(0)
         if log_prob is not None:
-            log_prob = log_prob.mean()
+            log_prob = log_prob.reshape(())
         return _AdapterStepOutput(prev_sample=prev_sample, log_prob=log_prob)
 
 
@@ -300,10 +305,13 @@ class BagelPipelineWithLogProb(BagelPipeline):
         # and return_logprobs per-step based on the SDE window.
         self.scheduler_kwargs = {k: extra_args[k] for k in ("noise_level", "sde_type", "generator") if k in extra_args}
         self.scheduler_kwargs["return_logprobs"] = logprobs
+        # BAGEL FlowGRPO compares quadratic log-prob terms only.
+        self.scheduler_kwargs["include_logprob_normalizer"] = False
 
         # Per-request scheduler setup matching training-side sigma schedule.
         assert req.sampling_params.num_inference_steps is not None, "num_inference_steps must be set for RL rollouts"
-        setup_bagel_sigmas(self.scheduler._inner, req.sampling_params.num_inference_steps)
+        bagel_num_timesteps = int(req.sampling_params.num_inference_steps)
+        setup_bagel_sigmas(self.scheduler._inner, bagel_num_timesteps)
 
         # Reset adapter state *after* set_timesteps so inner step_index is None.
         self.scheduler.begin_forward(
@@ -312,7 +320,12 @@ class BagelPipelineWithLogProb(BagelPipeline):
             return_logprobs=logprobs,
         )
 
-        output = super().forward(req)
+        # vllm-omni 0.22 runs one extra denoise step; compensate for BAGEL parity.
+        req.sampling_params.num_inference_steps = vllm_omni_num_timesteps(bagel_num_timesteps)
+        try:
+            output = super().forward(req)
+        finally:
+            req.sampling_params.num_inference_steps = bagel_num_timesteps
 
         # Slice trajectory to the SDE window so training only sees noisy steps.
         traj_latents = output.trajectory_latents

--- a/verl_omni/pipelines/model_base.py
+++ b/verl_omni/pipelines/model_base.py
@@ -98,6 +98,11 @@ class DiffusionModelBase(ABC):
         return None
 
     @classmethod
+    def configure_train_mode(cls, module: torch.nn.Module) -> None:
+        """Hook called after ``module.train()`` for architecture-specific overrides."""
+        return
+
+    @classmethod
     @abstractmethod
     def build_scheduler(cls, model_config: DiffusionModelConfig) -> SchedulerMixin:
         """Build and configure the diffusion scheduler for this model.

--- a/verl_omni/pipelines/non_diffusers_model_base.py
+++ b/verl_omni/pipelines/non_diffusers_model_base.py
@@ -108,8 +108,8 @@ class NonDiffusersModelBase(nn.Module, ABC):
         self.gradient_checkpointing = True
 
     def _checkpointed_call(self, fn, *args, **ckpt_kwargs):
-        """Call *fn*, wrapping with checkpoint when enabled and training."""
-        if not self.gradient_checkpointing or not self.training:
+        """Call *fn*, wrapping with checkpoint when enabled and grad is required."""
+        if not self.gradient_checkpointing or not torch.is_grad_enabled():
             return fn(*args)
 
         ckpt_kwargs.setdefault("use_reentrant", False)
@@ -191,9 +191,9 @@ class NonDiffusersModelBase(nn.Module, ABC):
         for module in self.modules():
             if module is self:
                 continue
-            disable_adapters_fn = getattr(module, "disable_adapters", None)
-            if callable(disable_adapters_fn):
-                disable_adapters_fn()
+            enable_adapters_fn = getattr(module, "enable_adapters", None)
+            if callable(enable_adapters_fn):
+                enable_adapters_fn(False)
 
     def enable_adapters(self) -> None:
         """Re-enable all PEFT adapters after ``disable_adapters``."""
@@ -202,7 +202,7 @@ class NonDiffusersModelBase(nn.Module, ABC):
                 continue
             enable_adapters_fn = getattr(module, "enable_adapters", None)
             if callable(enable_adapters_fn):
-                enable_adapters_fn()
+                enable_adapters_fn(True)
 
     # Checkpoint persistence
 

--- a/verl_omni/pipelines/schedulers/flow_match_sde.py
+++ b/verl_omni/pipelines/schedulers/flow_match_sde.py
@@ -67,6 +67,7 @@ class FlowMatchSDEDiscreteScheduler(FlowMatchEulerDiscreteScheduler):
         prev_sample: Optional[torch.FloatTensor] = None,
         sde_type: Literal["sde", "cps", "dance_sde"] = "sde",
         return_logprobs: bool = True,
+        include_logprob_normalizer: bool = True,
     ) -> FlowMatchSDEDiscreteSchedulerOutput | tuple:
         """
         Predict the sample from the previous timestep by reversing the SDE. This function propagates the diffusion
@@ -101,6 +102,8 @@ class FlowMatchSDEDiscreteScheduler(FlowMatchEulerDiscreteScheduler):
                 The type of SDE to use. Choose between "sde", "cps", and "dance_sde".
             return_logprobs (`bool`, *optional*, defaults to True):
                 Whether to return log probabilities of the previous sample.
+            include_logprob_normalizer (`bool`, *optional*, defaults to True):
+                Whether to include Gaussian normalizer constants in log probabilities.
         """
 
         if isinstance(timestep, int) or isinstance(timestep, torch.IntTensor) or isinstance(timestep, torch.LongTensor):
@@ -129,6 +132,7 @@ class FlowMatchSDEDiscreteScheduler(FlowMatchEulerDiscreteScheduler):
             prev_sample=prev_sample,
             sde_type=sde_type,
             return_logprobs=return_logprobs,
+            include_logprob_normalizer=include_logprob_normalizer,
         )
 
         # upon completion increase step index by one
@@ -153,6 +157,7 @@ class FlowMatchSDEDiscreteScheduler(FlowMatchEulerDiscreteScheduler):
         sde_type: Literal["cps", "sde", "dance_sde"] = "sde",
         return_logprobs: bool = True,
         return_sqrt_dt: bool = False,
+        include_logprob_normalizer: bool = True,
     ):
         """
         Run a single SDE / CPS reverse step.
@@ -182,6 +187,8 @@ class FlowMatchSDEDiscreteScheduler(FlowMatchEulerDiscreteScheduler):
                 Whether to additionally return `sqrt(-dt)` as a tensor of shape `(batch_size,)`.
                 Used by GRPO-Guard to compute the importance-ratio normalization
                 (see `GRPOGuardLoss`).
+            include_logprob_normalizer (`bool`, *optional*, defaults to True):
+                Whether to include Gaussian normalizer constants in log probabilities.
         """
         assert sde_type in ["sde", "cps", "dance_sde"]
         assert sample.dtype == torch.float32
@@ -222,11 +229,15 @@ class FlowMatchSDEDiscreteScheduler(FlowMatchEulerDiscreteScheduler):
                 prev_sample = prev_sample_mean + std_dev_t * torch.sqrt(-1 * dt) * variance_noise
 
             if return_logprobs:
-                log_prob = (
-                    -((prev_sample.detach() - prev_sample_mean) ** 2) / (2 * ((std_dev_t * torch.sqrt(-1 * dt)) ** 2))
-                    - torch.log(std_dev_t * torch.sqrt(-1 * dt))
-                    - torch.log(torch.sqrt(2 * torch.as_tensor(math.pi)))
+                log_prob = -((prev_sample.detach() - prev_sample_mean) ** 2) / (
+                    2 * ((std_dev_t * torch.sqrt(-1 * dt)) ** 2)
                 )
+                if include_logprob_normalizer:
+                    log_prob = (
+                        log_prob
+                        - torch.log(std_dev_t * torch.sqrt(-1 * dt))
+                        - torch.log(torch.sqrt(2 * torch.as_tensor(math.pi)))
+                    )
             else:
                 log_prob = None
 
@@ -287,11 +298,9 @@ class FlowMatchSDEDiscreteScheduler(FlowMatchEulerDiscreteScheduler):
                 prev_sample = prev_sample_mean + std_dev_t * variance_noise
 
             if return_logprobs:
-                log_prob = (
-                    -((prev_sample.detach() - prev_sample_mean) ** 2) / (2 * (std_dev_t**2))
-                    - torch.log(std_dev_t)
-                    - torch.log(torch.sqrt(2 * torch.as_tensor(math.pi)))
-                )
+                log_prob = -((prev_sample.detach() - prev_sample_mean) ** 2) / (2 * (std_dev_t**2))
+                if include_logprob_normalizer:
+                    log_prob = log_prob - torch.log(std_dev_t) - torch.log(torch.sqrt(2 * torch.as_tensor(math.pi)))
             else:
                 log_prob = None
 

--- a/verl_omni/workers/engine/fsdp/diffusers_impl.py
+++ b/verl_omni/workers/engine/fsdp/diffusers_impl.py
@@ -1266,9 +1266,12 @@ class EngineTrainModeCtx(BaseEngineCtx):
         super().__init__(engine=engine, mode="train", **kwargs)
 
     def __enter__(self):
+        from verl_omni.pipelines.model_base import DiffusionModelBase
+
         assert isinstance(self.engine, DiffusersFSDPEngine)
         super().__enter__()
         self.engine.module.train()
+        DiffusionModelBase.get_class(self.engine.model_config).configure_train_mode(self.engine.module)
 
     def __exit__(self, exc_type, exc_value, traceback):
         assert isinstance(self.engine, DiffusersFSDPEngine)


### PR DESCRIPTION
### What does this PR do?
Formally support bagel flowgrpo training with vllm-omni 0.22.

- Ported BAGEL OCR FlowGRPO training to vllm-omni 0.22.
- Added BAGEL denoising step-count compensation for vllm-omni 0.22 rollout parity.
- Matched rollout and actor SDE log-prob computation by using FlowGRPO BAGEL quadratic-only log-probs.
- Aligned BAGEL OCR preprocessing with official FlowGRPO: use the stripped OCR line as one plain BAGEL prompt.
- Replaced `bagel_prompt_ids` with strict `prompt_token_ids` plumbing for actor-side log-prob recompute.
- Fixed BAGEL rollout scheduler shape handling so rollout log-probs match actor-side scalar log-probs.
- Fixed padded prompt attention so batched actor forward matches official packed-prompt semantics.
- Added BAGEL train-mode hook to match official FlowGRPO MoT train-mode flags.
- Fixed gradient checkpointing to follow grad-enabled state and fixed PEFT adapter enable/disable calls for BAGEL LoRA training.
- Add corresponding documents

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `vllm_omni`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `diffusion`, `omni`, `tests`, `docker`
  - If this PR involves multiple modules, separate them with `,` like `[diffusion, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][diffusion, fsdp] feat: new rollout scheduler`

### Test

wandb result:
actor
<img width="1850" height="817" alt="螢幕截圖 2026-06-26 上午10 00 33" src="https://github.com/user-attachments/assets/a1de3029-4d76-497a-9b9b-2c5b12a7dafc" />
critic
<img width="1846" height="568" alt="螢幕截圖 2026-06-26 上午10 00 59" src="https://github.com/user-attachments/assets/b3480605-7ccc-4e06-931e-3811ac86f721" />
valid reward
<img width="617" height="268" alt="螢幕截圖 2026-06-26 上午10 01 11" src="https://github.com/user-attachments/assets/53643b3f-e3c8-4a65-8869-490a83815eb1" />
visualization
<img width="1852" height="396" alt="螢幕截圖 2026-06-26 上午10 01 34" src="https://github.com/user-attachments/assets/b557e345-9fc7-40e0-9c78-dac82f837c6e" />



> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update the documentation.
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl-omni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
