### PR TITLE
[rollout, model] fix: guard rollout_attn_backend for AR rollouts and refresh hf_processor re-export

### DIFF
--- a/verl_omni/models/transformers/qwen3_omni_thinker.py
+++ b/verl_omni/models/transformers/qwen3_omni_thinker.py
@@ -165,6 +165,12 @@ def patch_hf_processor_for_qwen3_omni() -> None:
             return None
 
     _vt.hf_processor = _patched_hf_processor
+    # Also refresh verl.utils's stale re-export (callers use `from verl.utils import hf_processor`).
+    import sys as _sys
+
+    _utils_mod = _sys.modules.get("verl.utils")
+    if _utils_mod is not None and hasattr(_utils_mod, "hf_processor"):
+        _utils_mod.hf_processor = _patched_hf_processor
 
 
 def apply_qwen3_omni_thinker_patches() -> None:

--- a/verl_omni/workers/rollout/vllm_rollout/vllm_omni_async_server.py
+++ b/verl_omni/workers/rollout/vllm_rollout/vllm_omni_async_server.py
@@ -165,8 +165,11 @@ class vLLMOmniHttpServer(vLLMHttpServer):
         os.environ["MASTER_PORT"] = str(diffusion_master_port)
         logger.info("Using MASTER_PORT=%s for vLLM-Omni workers", os.environ["MASTER_PORT"])
 
-        engine_args["diffusion_attention_backend"] = self.config.rollout_attn_backend
-        logger.info("Setting diffusion_attention_backend=%s from rollout config", self.config.rollout_attn_backend)
+        # rollout_attn_backend only exists on the diffusion rollout config, not AR text rollouts.
+        attn_backend = getattr(self.config, "rollout_attn_backend", None)
+        if attn_backend is not None:
+            engine_args["diffusion_attention_backend"] = attn_backend
+            logger.info("Setting diffusion_attention_backend=%s from rollout config", attn_backend)
 
         engine_client = AsyncOmni(**engine_args)
         app = build_app(args)


### PR DESCRIPTION
## What

1. **AR rollout crash.** `vLLMOmniHttpServer` unconditionally read `self.config.rollout_attn_backend`, a field that only exists on the *diffusion* rollout config (added in #200). AR (text) rollouts hit `AttributeError: 'RolloutConfig' object has no attribute 'rollout_attn_backend'`. It is now guarded with `getattr`, and the engine arg is only set when the field is present.

2. **`chat_template is not set`.** `patch_hf_processor_for_qwen3_omni` patched `verl.utils.tokenizer.hf_processor`, but not the snapshot re-export captured by `from verl.utils import hf_processor`. Callers on that import path got the unpatched function, so the processor came back `None`, the loader fell through to the tokenizer branch which has no chat_template, and training failed. The package-level binding is now refreshed too.

## Not a duplicate

#200 *introduced* the diffusion-only `rollout_attn_backend`; this guards the AR path it broke rather than re-implementing it. No open PR touches the `hf_processor` re-export.

## Testing

An AR GSPO+LoRA rollout that previously crashed at server launch now starts and trains end-to-end. A collaborator's `chat_template is not set` failure via `from verl.utils import hf_processor` was reproduced and confirmed fixed (the refresh returns the Qwen3-Omni processor with a non-None `chat_template`).
