### PR TITLE
[omni,model] fix: load Qwen3OmniMoeProcessor in AgentLoopWorker via stale hf_processor refresh

### DIFF
--- a/verl_omni/models/transformers/qwen3_omni_thinker.py
+++ b/verl_omni/models/transformers/qwen3_omni_thinker.py
@@ -168,9 +168,10 @@ def patch_hf_processor_for_qwen3_omni() -> None:
     # Also refresh verl.utils's stale re-export (callers use `from verl.utils import hf_processor`).
     import sys as _sys
 
-    _utils_mod = _sys.modules.get("verl.utils")
-    if _utils_mod is not None and hasattr(_utils_mod, "hf_processor"):
-        _utils_mod.hf_processor = _patched_hf_processor
+    for _mod_name in ("verl.utils", "verl.workers.config.model"):
+        _mod = _sys.modules.get(_mod_name)
+        if _mod is not None and hasattr(_mod, "hf_processor"):
+            _mod.hf_processor = _patched_hf_processor
 
 
 def apply_qwen3_omni_thinker_patches() -> None:


### PR DESCRIPTION
### What does this PR do?

Addressing #223, fixes a crash in the Qwen3-Omni Thinker GSPO recipe when async rollout reaches
`AgentLoopWorker.generate_sequences()`:

```bash
ValueError: Cannot use chat template functions because tokenizer.chat_template is not set
```

The failure happens because `HFModelConfig` loads `processor=None` on Ray workers,
so `SingleTurnAgentLoop` falls back to a bare tokenizer without `chat_template`.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `vllm_omni`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `diffusion`, `omni`, `tests`, `docker`
  - If this PR involves multiple modules, separate them with `,` like `[diffusion, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][diffusion, fsdp] feat: new rollout scheduler`


On Ray AgentLoopWorker processes the import order is:

1. `agent_loop.py` imports `HFModelConfig` → `model.py` binds the unpatched hf_processor
2. `HFModelConfig.__post_init__` calls `import_external_libs(external_lib)` → patch replaces `verl.utils.tokenizer.hf_processor`
3. `model.py` still calls its stale local binding → processor stays `None`, and falls back to a bare tokenizer without `chat_template`.


### Test
```
bash examples/gspo_trainer/qwen3_omni/run_qwen3_omni_thinker_gspo_lora.sh
```

Before fix:

```bash
ray::AgentLoopWorker.generate_sequences() (pid=1944996, ip=192.168.17.94, actor_id=ee2bad47b10989e292891da501000000, repr=<verl.experimental.agent_loop.agent_loop.AgentLoopWorker object at 0x7fb65c232210>)
  File "/root/.local/share/uv/python/cpython-3.12.13-linux-x86_64-gnu/lib/python3.12/concurrent/futures/_base.py", line 449, in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "/root/.local/share/uv/python/cpython-3.12.13-linux-x86_64-gnu/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/public/ddd/verl-omni/.venv/lib/python3.12/site-packages/verl/experimental/agent_loop/agent_loop.py", line 561, in generate_sequences
    outputs = await asyncio.gather(*tasks)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/public/ddd/verl-omni/.venv/lib/python3.12/site-packages/verl/experimental/agent_loop/agent_loop.py", line 590, in _run_agent_loop
    agent_loop = hydra.utils.instantiate(
                 ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/public/ddd/verl-omni/.venv/lib/python3.12/site-packages/hydra/_internal/instantiate/_instantiate2.py", line226, in instantiate
    return instantiate_node(
           ^^^^^^^^^^^^^^^^^
  File "/public/ddd/verl-omni/.venv/lib/python3.12/site-packages/hydra/_internal/instantiate/_instantiate2.py", line347, in instantiate_node
    return _call_target(_target_, partial, args, kwargs, full_key)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/public/ddd/verl-omni/.venv/lib/python3.12/site-packages/hydra/_internal/instantiate/_instantiate2.py", line97, in _call_target
    raise InstantiationException(msg) from e
hydra.errors.InstantiationException: Error in call to target 'verl.experimental.agent_loop.single_turn_agent_loop.SingleTurnAgentLoop':
ValueError('Cannot use chat template functions because tokenizer.chat_template is not set and no template argument was passed! For information about writing templates and setting the tokenizer.chat_template attribute, please see the documentation at https://huggingface.co/docs/transformers/main/en/chat_templating'
```

After fix: 

No error message