### PR TITLE
[ci] fix: update config vision_start_token_id for patched hf_processor

### DIFF
--- a/verl_omni/models/transformers/qwen3_omni_thinker.py
+++ b/verl_omni/models/transformers/qwen3_omni_thinker.py
@@ -129,6 +129,7 @@ def patch_hf_processor_for_qwen3_omni() -> None:
             # Token IDs / spatial_merge_size live on thinker_config, not the top-level config.
             processor.config = config.thinker_config
             processor.spatial_merge_size = config.thinker_config.vision_config.spatial_merge_size
+            processor.config.vision_start_token_id = config.talker_config.vision_start_token_id
             model_class = Qwen3OmniMoeThinkerForConditionalGeneration
             processor.get_rope_index = types.MethodType(model_class.get_rope_index, processor)
             processor.get_llm_pos_ids_for_vision = types.MethodType(model_class.get_llm_pos_ids_for_vision, processor)


### PR DESCRIPTION
### What does this PR do?

Fix [ci error](https://github.com/verl-project/verl-omni/actions/runs/28571906249/job/84714570241) for qwen3-omni smoke test. After #224 was merged, the `verl.workers.config.model` has the patched hf_processor, so AgentLoop won't skip `get_rope_index`.

After #208 updates the transformers version to `5.x`,`get_rope_index` also uses `vision_start_token_id` from `talker_config`. However, the `processor.config` was overwritten with `thinker_config`, and has no access to `talker_config.vision_start_token_id`.

This PR fixes this problem by overwritting `processor.config.vision_start_token_id` with `config.talker_config.vision_start_token_id`

### Test

```bash
bash tests/special_e2e/run_gspo_qwen3_omni_thinker_lora_smoke.sh
```

