### PR TITLE
[recipe, doc, reward] feat: add MMK12 image2text recipe for Qwen3-Omni Thinker GSPO based on npu

### DIFF
--- a/examples/gspo_trainer/README.md
+++ b/examples/gspo_trainer/README.md
@@ -1,8 +1,16 @@
-# Qwen3-Omni Thinker GSPO + LoRA Trainer
+# Qwen3-Omni Thinker GSPO Trainer
 
 This example shows how to post-train the **Qwen3-Omni-30B-A3B Thinker** with
-**GSPO + LoRA** on a math-reasoning task, using FSDP for the actor and
-`vllm-omni` as the async rollout backend.
+**GSPO** on a math-reasoning task, using FSDP for the actor and `vllm-omni` as
+the async rollout backend. Two input modalities are supported: **text → text**
+(e.g. `MATH-lighteval`) and **image → text** (e.g. `MMK12`).
+
+Both **GPU** and **NPU** training platforms are supported via two launch scripts:
+
+- [`run_qwen3_omni_thinker_gspo_lora.sh`](qwen3_omni/run_qwen3_omni_thinker_gspo_lora.sh)
+  — **GPU**, **LoRA (r=64)** on a single node with **4 × H100/H200 80GB**.
+- [`run_qwen3_omni_thinker_gspo_npu.sh`](qwen3_omni/run_qwen3_omni_thinker_gspo_npu.sh)
+  — **NPU**, **full-parameter** on a single **Atlas 800T A3** node with **16 NPUs**.
 
 For the base environment setup, see the [installation guide](../../docs/start/install.md).
 
@@ -71,10 +79,11 @@ so verl loads both on the driver via its `VERL_USE_EXTERNAL_MODULES` hook:
 patches before the driver's dataset loader runs. The GPU workers load the same
 model patch via `actor_rollout_ref.model.external_lib`.
 
-The provided script is configured for a single node with **4 × H100/H200 80GB**:
-the actor (FSDP, 30B + LoRA r=64 with param/optimizer offload) and the
-`vllm-omni` rollout (TP=4) colocate on the same 4 GPUs. Multi-node is not yet
-validated.
+The two launch scripts colocate the FSDP actor and the `vllm-omni` rollout on
+the same devices. `run_qwen3_omni_thinker_gspo_lora.sh` targets a single node with **4 × H100/H200 80GB**
+(30B + LoRA r=64 with param/optimizer offload, rollout TP=4). `run_qwen3_omni_thinker_gspo_npu.sh` targets
+a single **Atlas 800T A3** node with **16 NPUs** (full-parameter FSDP actor,
+rollout TP=2). Multi-node is not yet validated on either platform.
 
 > **Where the rollout engine's memory/batching is set.** When
 > `stage_configs_path` is provided, vLLM-Omni **ignores** the top-level engine
@@ -90,20 +99,6 @@ validated.
 > the codepaths used here are numpy-2 compatible, so the pip resolver warning is
 > safe to ignore.
 
-## Prepare the dataset
-
-A parquet dataset of math problems with `prompt` and `answer` fields, defaulting
-to `~/data/math/{train,test}.parquet`. The example was tested on
-`MATH-lighteval`; any standard RL math dataset works. To convert HuggingFace
-datasets into verl's parquet format, see
-[`verl/examples/data_preprocess/`](https://github.com/verl-project/verl/tree/main/examples/data_preprocess).
-
-```bash
-mkdir -p ~/data/math
-# … place train.parquet and test.parquet here …
-ls ~/data/math/   # train.parquet  test.parquet
-```
-
 ## Prepare the model
 
 The script uses the HuggingFace Hub ID `Qwen/Qwen3-Omni-30B-A3B-Instruct`
@@ -118,12 +113,32 @@ export MODEL_PATH=/path/to/local/Qwen3-Omni-30B-A3B-Instruct
 > `tokenizer.chat_template`; verl's dataset loader calls
 > `tokenizer.apply_chat_template(...)` and fails without it.
 
-## Run training
+## Training with `MATH-lighteval`
 
-Launch from the repository root:
+### Prepare the dataset
+
+A parquet dataset of math problems with `prompt` and `answer` fields, defaulting
+to `~/data/math/{train,test}.parquet`. The example was tested on
+`MATH-lighteval`; any standard RL math dataset works. To convert HuggingFace
+datasets into verl's parquet format, see
+[`verl/examples/data_preprocess/`](https://github.com/verl-project/verl/tree/main/examples/data_preprocess).
 
 ```bash
+mkdir -p ~/data/math
+# … place train.parquet and test.parquet here …
+ls ~/data/math/   # train.parquet  test.parquet
+```
+
+### Run training
+
+Launch from the repository root — pick the flavor that matches your hardware:
+
+```bash
+# GPU, LoRA (r=64), 4 × H100/H200
 bash examples/gspo_trainer/qwen3_omni/run_qwen3_omni_thinker_gspo_lora.sh
+
+# NPU, full-parameter, 16 × Atlas 800T A3
+bash examples/gspo_trainer/qwen3_omni/run_qwen3_omni_thinker_gspo_npu.sh
 ```
 
 The recipe config lives in
@@ -152,21 +167,16 @@ which trains on a tiny random-weight model built by
 [`build_qwen3_omni_tiny_random.py`](../../tests/special_e2e/build_qwen3_omni_tiny_random.py)
 (no 60 GB download). It is wired into the `tests/gpu_smoke` CI suite as Test 8.
 
-## Logging
-
-W&B logging is enabled by default:
-
-```bash
-export WANDB_API_KEY=<your_wandb_api_key>
-# trainer.project_name / experiment_name are already set in the script
-```
-
-## What is trained
+### What is trained
 
 Only the **Thinker** (`Qwen3OmniMoeThinkerForConditionalGeneration`):
 
-- LoRA rank 64, alpha 32, on `target_modules="q_proj,k_proj,v_proj,o_proj,gate_proj,up_proj,down_proj"`
-  (explicit names so the unfused MoE expert `gate/up/down_proj` are targeted, not just attention).
+- **GPU (LoRA)** — rank 64, alpha 32, on
+  `target_modules="q_proj,k_proj,v_proj,o_proj,gate_proj,up_proj,down_proj"`
+  (explicit names so the unfused MoE expert `gate/up/down_proj` are targeted,
+  not just attention).
+- **NPU (full-parameter)** — LoRA is disabled (`lora_rank=0`); all Thinker
+  parameters are updated under FSDP.
 - `exclude_modules` strips talker / code2wav / code_predictor / visual /
   audio_tower; `freeze_vision_tower=True` keeps the vision encoder cold.
 - The non-Thinker heads are dropped at FSDP-wrap time via `_verl_strip_modules`.
@@ -182,10 +192,11 @@ sampled response length):
   (`actor/perf/max_memory_allocated_gb` < 65).
 - `val-core/.../acc/mean@1` rising with steps.
 
-## Performance
+### Performance (GPU + LoRA)
 
 > Measured on a single node of **4 × H100/H200 80GB**, actor and rollout
-> colocated, MATH-lighteval, `dapo` reward.
+> colocated, MATH-lighteval, `dapo` reward, LoRA r=64
+> (`run_qwen3_omni_thinker_gspo_lora.sh`).
 
 | Script | Model | Algorithm | # Cards (colocate) | Batch × `rollout.n` | lr | Steps | Throughput (tok/gpu/s) | Time / Step (s) | val acc/mean@1 | rollout↔actor pearson |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -196,9 +207,9 @@ response length (mean `response_length` ranged ~0.7k–3.6k tokens over the run,
 to `max_response_length=8192` with `rollout.n=8`); `actor/perf/max_memory_allocated`
 peaks at ~64 GB.
 
-## Preliminary results
+### Preliminary results (GPU + LoRA)
 
-Over a 60-step run with the default config, the training reward
+Over a 60-step run with the default LoRA config, the training reward
 (`critic/rewards/mean`) rises from **~0.75 to ~0.90** and validation accuracy on
 MATH-lighteval is **~0.90**. Treat this
 as a plumbing-correctness signal (finite loss, reasonable grad norm, rollout↔actor
@@ -209,15 +220,84 @@ low-variance advantages on a high-baseline policy.
 
 ![training reward](reward.png)
 
+## Training with `MMK12`
+
+For visual math reasoning we ship an end-to-end pipeline on top of the
+[MMK12](https://huggingface.co/datasets/FangqingM/MMK12) dataset (image
+input + text output, K12 math). It reuses the same GSPO recipe as the
+text-only path — only the data preprocessing and the reward scorer differ.
+The launch example below uses the NPU / full-parameter flavor
+(`run_qwen3_omni_thinker_gspo_npu.sh`), but the GPU / LoRA flavor works too
+after pointing it at the MMK12 parquet.
+
+### Prepare the dataset
+
+Download the raw MMK12 parquet shards (from ModelScope or HuggingFace) into a
+local directory — the loader expects filenames like `train-*.parquet` and
+`test-*.parquet` — and convert them into the verl RL parquet layout with:
+
+```bash
+python examples/gspo_trainer/data_process/mmk12.py \
+    --local_dataset_path /path/to/mmk12/ \
+    --local_save_dir ~/data/mmk12
+```
+
+The converter emits one verl RL row per problem, with
+`data_source="math_dapo"`, a system prompt that constrains the model to emit
+`<answer>…\boxed{…}…</answer>`, and the image bytes carried inline in the
+`images` column so the parquet stays self-contained. Input / kept / dropped
+counts and answer-type tallies are printed at the end. See the module docstring
+in [`data_process/mmk12.py`](data_process/mmk12.py) for the exact output schema.
+
+### Run training
+
+The MMK12 reward scorer grades responses with
+[`math_verify`](https://github.com/huggingface/math-verify), which is **not**
+pulled in transitively by verl or verl-omni. Install it explicitly first —
+otherwise the scorer falls back to `accuracy = 0` for every sample:
+
+```bash
+pip install math-verify
+```
+
+Then point the launcher at the MMK12 parquet and register the custom reward
+scorer via CLI overrides (no yaml edits required):
+
+```bash
+TRAIN_FILE=$HOME/data/mmk12/train.parquet \
+VAL_FILE=$HOME/data/mmk12/test.parquet \
+bash examples/gspo_trainer/qwen3_omni/run_qwen3_omni_thinker_gspo_npu.sh \
+    reward.custom_reward_function.path=verl_omni/utils/reward_score/mmk12_reward.py \
+    actor_rollout_ref.actor.optim.lr=3e-6
+```
+
+The scorer combines `math_verify` accuracy with a progressive format reward on
+the `<answer>…\boxed{}…</answer>` template; see
+[`verl_omni/utils/reward_score/mmk12_reward.py`](../../verl_omni/utils/reward_score/mmk12_reward.py)
+for the full formula.
+
+## Logging
+
+W&B logging is enabled by default:
+
+```bash
+export WANDB_API_KEY=<your_wandb_api_key>
+# trainer.project_name / experiment_name are already set in the script
+```
+
 ## File map
 
 ```
 examples/gspo_trainer/
 ├── qwen3_omni/
-│   ├── run_qwen3_omni_thinker_gspo_lora.sh   ← launch script (volatile overrides only)
+│   ├── run_qwen3_omni_thinker_gspo_lora.sh   ← launch script (GPU, LoRA r=64)
+│   ├── run_qwen3_omni_thinker_gspo_npu.sh    ← launch script (NPU, full-parameter)
 │   ├── config/
 │   │   └── qwen3_omni_thinker_gspo.yaml      ← recipe config (inherits verl ppo_trainer)
-│   └── qwen3_omni_thinker_only.yaml          ← vllm-omni stage config
-├── reward.png                            ← preliminary reward curve
-└── README.md                             ← (this file)
+│   ├── qwen3_omni_thinker_only.yaml          ← vllm-omni stage config (GPU)
+│   └── qwen3_omni_thinker_only_npu.yaml      ← vllm-omni stage config (NPU)
+├── data_process/
+│   └── mmk12.py                              ← MMK12 → verl RL parquet converter
+├── reward.png                                ← preliminary reward curve
+└── README.md                                 ← (this file)
 ```

--- a/examples/gspo_trainer/data_process/mmk12.py
+++ b/examples/gspo_trainer/data_process/mmk12.py
@@ -1,0 +1,218 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Preprocess the MMK12 dataset to verl RL parquet format (image-in / text-out).
+
+Raw MMK12 schema:
+    id, question, answer, subject, image   # image is {"bytes": <png bytes>, "path": ...}
+
+Output verl RL schema (one row per problem):
+    data_source  = "math_dapo"   # routes through the math_dapo rule reward
+    prompt       = [{"role": "system", "content": <SYSTEM_PROMPT>},
+                    {"role": "user",   "content": "<image>\\n{question}"}]
+    images       = [{"bytes": <png bytes>}]   # carried inline, byte-identical to the source
+    ability      = "math_vl"
+    reward_model = {"style": "rule", "ground_truth": <answer>}
+    extra_info   = {split, index, id, dataset, subject, raw_question, raw_answer, options}
+
+Pure helpers (is_valid_image, normalize_image, can_open_image, classify_answer,
+parse_options) are importable without torch/verl so they can be unit-tested on CPU.
+"""
+
+import argparse
+import glob
+import io
+import json
+import os
+import re
+from typing import Any
+
+import datasets
+from PIL import Image
+
+DATA_SOURCE = "math_dapo"
+ABILITY = "math_vl"
+DATASET_NAME = "MMK12"
+
+SYSTEM_PROMPT = (
+    "Solve the question. The user asks a question, and you solve it. "
+    "You first think about the reasoning process in the mind and then "
+    "provide the user with the answer. The answer is in latex format and "
+    "wrapped in $...$. The final answer must be wrapped using the \\boxed{} "
+    "command. The answer should be enclosed within <answer></answer> tags, "
+    "i.e., Since $1+1=2$, so the answer is $2$. "
+    "<answer>The answer is $\\boxed{2}$</answer>, which means the final "
+    "answer assistant's output should start with <answer> and end with </answer>."
+)
+
+USER_PROMPT_TEMPLATE = "<image>\n{question}"
+
+_OPTION_LINE_RE = re.compile(r"^\s*([A-E])[.)、]\s*(.+?)\s*$", re.MULTILINE)
+
+
+def is_valid_image(image_field: Any) -> bool:
+    """True if the field carries non-empty image bytes (directly or in a dict)."""
+    if image_field is None:
+        return False
+    if isinstance(image_field, dict):
+        return bool(image_field.get("bytes"))
+    if isinstance(image_field, bytes | bytearray):
+        return True
+    return False
+
+
+def normalize_image(image_field: Any) -> dict:
+    """Return a {"bytes": ...} dict the RL dataset loader can open with PIL."""
+    if isinstance(image_field, dict):
+        if image_field.get("bytes"):
+            return {"bytes": image_field["bytes"]}
+    if isinstance(image_field, bytes | bytearray):
+        return {"bytes": bytes(image_field)}
+    raise TypeError(f"unsupported image type: {type(image_field)!r}")
+
+
+def can_open_image(image_bytes: bytes) -> bool:
+    """Verify the bytes decode as an image without fully loading them."""
+    try:
+        with Image.open(io.BytesIO(image_bytes)) as img:
+            img.verify()
+        return True
+    except Exception:
+        return False
+
+
+def classify_answer(answer: str) -> str:
+    """Coarse answer-type bucket for conversion stats."""
+    a = str(answer).strip()
+    if len(a) == 1 and a.upper() in "ABCDE":
+        return "option"
+    stripped = a.replace("-", "", 1).replace(".", "", 1)
+    if stripped.isdigit():
+        return "numeric"
+    return "other"
+
+
+def parse_options(question: str) -> dict[str, str]:
+    """Extract choice options ``{A: content, B: content, ...}`` from question text.
+
+    Matches lines like ``A. 5.25`` / ``B) content`` / ``C、 content``.  Returns
+    empty dict if no options found (e.g. fill-in-the-blank questions).
+    """
+    opts = {}
+    for m in _OPTION_LINE_RE.finditer(question or ""):
+        letter, content = m.group(1).upper(), m.group(2).strip()
+        opts[letter] = content
+    return opts
+
+
+def make_keep_fn(verify_images: bool):
+    """Return a ``.filter()`` predicate that drops empty / undecodable rows."""
+
+    def keep(example) -> bool:
+        question = str(example.get("question") or "").strip()
+        answer = str(example.get("answer") or "").strip()
+        image_field = example.get("image")
+        if not question or not answer or not is_valid_image(image_field):
+            return False
+        if verify_images and not can_open_image(normalize_image(image_field)["bytes"]):
+            return False
+        return True
+
+    return keep
+
+
+def make_map_fn(split: str):
+    """Return a ``.map()`` function that builds one verl RL row per example."""
+
+    def process_fn(example, idx):
+        question = str(example.get("question") or "").strip()
+        answer = str(example.get("answer") or "").strip()
+        image_field = example.get("image")
+        options = parse_options(question)
+        return {
+            "data_source": DATA_SOURCE,
+            "prompt": [
+                {"role": "system", "content": SYSTEM_PROMPT},
+                {"role": "user", "content": USER_PROMPT_TEMPLATE.format(question=question)},
+            ],
+            "images": [normalize_image(image_field)],
+            "ability": ABILITY,
+            "reward_model": {"style": "rule", "ground_truth": answer},
+            "extra_info": {
+                "split": split,
+                "index": idx,
+                "id": str(example.get("id") or ""),
+                "dataset": DATASET_NAME,
+                "subject": str(example.get("subject") or ""),
+                "raw_question": question,
+                "raw_answer": answer,
+                "options": json.dumps(options, ensure_ascii=False),  # JSON string; parsed in reward
+            },
+        }
+
+    return process_fn
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Convert MMK12 to verl RL parquet.")
+    parser.add_argument(
+        "--local_dataset_path",
+        default=None,
+        help="Local dir with the raw MMK12 train-*.parquet / test-*.parquet shards.",
+    )
+    parser.add_argument(
+        "--local_save_dir", default="~/data/mmk12", help="The save directory for the preprocessed dataset."
+    )
+    parser.add_argument("--no_verify_images", action="store_true", help="Skip PIL verify of image bytes.")
+    args = parser.parse_args()
+
+    local_dataset_path = args.local_dataset_path
+    if local_dataset_path is None:
+        raise ValueError("dataset does not exist. Download the raw parquet shards from HuggingFace.")
+
+    data_files = {
+        "train": sorted(glob.glob(os.path.join(local_dataset_path, "train-*.parquet"))),
+        "test": sorted(glob.glob(os.path.join(local_dataset_path, "test-*.parquet"))),
+    }
+    if not data_files["train"] and not data_files["test"]:
+        raise FileNotFoundError(f"No train-*.parquet / test-*.parquet shards found in {local_dataset_path!r}")
+    dataset = datasets.load_dataset("parquet", data_files=data_files)
+
+    verify_images = not args.no_verify_images
+    local_save_dir = os.path.expanduser(args.local_save_dir)
+    os.makedirs(local_save_dir, exist_ok=True)
+
+    for split in ("train", "test"):
+        split_dataset = dataset[split]
+        # Keep image bytes raw (skip PIL decode) so the output bytes are identical to the source.
+        split_dataset = split_dataset.cast_column("image", datasets.Image(decode=False))
+
+        n_input = len(split_dataset)
+        split_dataset = split_dataset.filter(make_keep_fn(verify_images), num_proc=8)
+        split_dataset = split_dataset.map(
+            function=make_map_fn(split),
+            with_indices=True,
+            num_proc=8,
+            remove_columns=split_dataset.column_names,
+        )
+        n_kept = len(split_dataset)
+
+        out_path = os.path.join(local_save_dir, f"{split}.parquet")
+        split_dataset.to_parquet(out_path)
+
+        answer_types = {"option": 0, "numeric": 0, "other": 0}
+        for reward_model in split_dataset["reward_model"]:
+            answer_types[classify_answer(reward_model["ground_truth"])] += 1
+        print(f"[{split}] wrote {out_path}")
+        print(f"  input={n_input} kept={n_kept} dropped={n_input - n_kept}")
+        print(f"  answer_types={answer_types}")

--- a/verl_omni/models/transformers/qwen3_omni_thinker.py
+++ b/verl_omni/models/transformers/qwen3_omni_thinker.py
@@ -325,12 +325,47 @@ def patch_hf_tokenizer_for_qwen3_omni() -> None:
             mod.hf_tokenizer = _patched_hf_tokenizer
 
 
+def patch_register_vllm_moe_model_weight_loader() -> None:
+    """Register Qwen3-Omni Thinker with verl's ``SUPPORTED_MOE_MODELS`` whitelist.
+
+    verl's ``patch_vllm_moe_model_weight_loader`` re-attaches ``weight_loader``
+    on FusedMoE ``w13_weight``/``w2_weight`` before IPC weight sync (the attr
+    that vllm-ascend's ``process_weights_after_loading`` drops when rebuilding
+    the params). But it early-returns unless the model class is in
+    ``SUPPORTED_MOE_MODELS``. Qwen3-Omni Thinker isn't there by default, so we
+    append it.
+    """
+    try:
+        from verl.utils.vllm import patch as _vp
+    except ImportError:
+        return
+
+    added = []
+    for mod_path, cls_name in [
+        (
+            "vllm_omni.model_executor.models.qwen3_omni.qwen3_omni_moe_thinker",
+            "Qwen3OmniMoeThinkerForConditionalGeneration",
+        ),
+    ]:
+        try:
+            import importlib
+
+            mod = importlib.import_module(mod_path)
+            cls = getattr(mod, cls_name, None)
+            if cls is not None and cls not in _vp.SUPPORTED_MOE_MODELS:
+                _vp.SUPPORTED_MOE_MODELS.append(cls)
+                added.append(f"{mod_path}.{cls_name}")
+        except ImportError:
+            continue
+
+
 def apply_qwen3_omni_thinker_patches() -> None:
     """Apply all Qwen3-Omni Thinker patches (idempotent registrations)."""
     _register_qwen3_omni_automodel()
     patch_hf_processor_for_qwen3_omni()
     _patch_unfuse_qwen3_omni_thinker_experts()
     patch_hf_tokenizer_for_qwen3_omni()
+    patch_register_vllm_moe_model_weight_loader()
 
 
 # Apply on import so this module works as a verl ``external_lib`` target.

--- a/verl_omni/models/transformers/qwen3_omni_thinker.py
+++ b/verl_omni/models/transformers/qwen3_omni_thinker.py
@@ -74,7 +74,10 @@ def _register_qwen3_omni_automodel() -> None:
     Qwen3OmniMoeForConditionalGeneration.get_input_embeddings = _qwen3_omni_get_input_embeddings
     Qwen3OmniMoeForConditionalGeneration.set_input_embeddings = _qwen3_omni_set_input_embeddings
     # Upstream lists Qwen3OmniMoeDecoderLayer which does not exist; fix to the real class.
-    Qwen3OmniMoeForConditionalGeneration._no_split_modules = ["Qwen3OmniMoeThinkerTextDecoderLayer"]
+    Qwen3OmniMoeForConditionalGeneration._no_split_modules = [
+        "Qwen3OmniMoeThinkerTextDecoderLayer",
+        "Qwen3OmniMoeVisionBlock",
+    ]
     # _verl_strip_modules: verl's FSDPEngine drops these sub-modules for Thinker-only training.
     Qwen3OmniMoeForConditionalGeneration._verl_strip_modules = [
         "talker",
@@ -132,7 +135,15 @@ def patch_hf_processor_for_qwen3_omni() -> None:
             processor.spatial_merge_size = config.thinker_config.vision_config.spatial_merge_size
             processor.config.vision_start_token_id = config.talker_config.vision_start_token_id
             model_class = Qwen3OmniMoeThinkerForConditionalGeneration
-            processor.get_rope_index = types.MethodType(model_class.get_rope_index, processor)
+
+            # cast to int64 to avoid BF16 large-int rounding in fsdp.
+            _ori_get_rope_index = types.MethodType(model_class.get_rope_index, processor)
+
+            def _get_rope_index_long(*args, **kwargs):
+                vision_position_ids, deltas = _ori_get_rope_index(*args, **kwargs)
+                return vision_position_ids.long(), deltas
+
+            processor.get_rope_index = _get_rope_index_long
             processor.get_llm_pos_ids_for_vision = types.MethodType(model_class.get_llm_pos_ids_for_vision, processor)
             return processor
         except Exception:

--- a/verl_omni/models/transformers/qwen3_omni_thinker.py
+++ b/verl_omni/models/transformers/qwen3_omni_thinker.py
@@ -121,6 +121,7 @@ def patch_hf_processor_for_qwen3_omni() -> None:
             return result
 
         try:
+            import numpy as np
             from transformers import AutoConfig, AutoProcessor, PreTrainedTokenizerBase
 
             processor = AutoProcessor.from_pretrained(name_or_path, **kwargs)
@@ -145,6 +146,47 @@ def patch_hf_processor_for_qwen3_omni() -> None:
 
             processor.get_rope_index = _get_rope_index_long
             processor.get_llm_pos_ids_for_vision = types.MethodType(model_class.get_llm_pos_ids_for_vision, processor)
+
+            def _dedup_pad_tokens(self, prompt_ids: list[int]) -> list[int]:
+                """Collapse consecutive multimodal pad tokens to one.
+
+                HF processor and vLLM's ``_apply_prompt_updates`` both expand the pad
+                token, causing double expansion. Collapse every run of identical
+                placeholder tokens before sending to vLLM-Omni, mirroring
+                ``verl.workers.rollout.utils.qwen2_5_vl_dedup_image_tokens``.
+                """
+                tokenizer = getattr(self, "tokenizer", None)
+                if tokenizer is None:
+                    return prompt_ids
+
+                pad_ids: set[int] = set()
+                for tok_attr in ("image_token", "video_token", "audio_token"):
+                    tok = getattr(self, tok_attr, None)
+                    if tok is None:
+                        continue
+                    try:
+                        tid = tokenizer.convert_tokens_to_ids(tok)
+                    except Exception:
+                        continue
+                    if tid is None or tid == getattr(tokenizer, "unk_token_id", None):
+                        continue
+                    pad_ids.add(int(tid))
+                if not pad_ids:
+                    return prompt_ids
+
+                arr = np.asarray(prompt_ids, dtype=np.int64)
+                if arr.size == 0:
+                    return prompt_ids
+                is_pad = np.isin(arr, list(pad_ids))
+                # Collapse consecutive identical pad tokens to one: HF processor and
+                # vLLM's _apply_prompt_updates both expand the pad token, so the raw
+                # prompt_ids already carries the full run.
+                keep = np.ones(arr.size, dtype=bool)
+                same_as_prev = is_pad[1:] & is_pad[:-1] & (arr[1:] == arr[:-1])
+                keep[1:] &= ~same_as_prev
+                return arr[keep].tolist()
+
+            processor.dedup_pad_tokens = types.MethodType(_dedup_pad_tokens, processor)
             return processor
         except Exception:
             return None
@@ -346,12 +388,13 @@ def patch_register_vllm_moe_model_weight_loader() -> None:
     ``SUPPORTED_MOE_MODELS``. Qwen3-Omni Thinker isn't there by default, so we
     append it.
     """
+    import importlib
+
     try:
         from verl.utils.vllm import patch as _vp
     except ImportError:
         return
 
-    added = []
     for mod_path, cls_name in [
         (
             "vllm_omni.model_executor.models.qwen3_omni.qwen3_omni_moe_thinker",
@@ -359,13 +402,10 @@ def patch_register_vllm_moe_model_weight_loader() -> None:
         ),
     ]:
         try:
-            import importlib
-
             mod = importlib.import_module(mod_path)
             cls = getattr(mod, cls_name, None)
             if cls is not None and cls not in _vp.SUPPORTED_MOE_MODELS:
                 _vp.SUPPORTED_MOE_MODELS.append(cls)
-                added.append(f"{mod_path}.{cls_name}")
         except ImportError:
             continue
 

--- a/verl_omni/utils/reward_score/mmk12_reward.py
+++ b/verl_omni/utils/reward_score/mmk12_reward.py
@@ -1,0 +1,166 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""MMK12 (image-in / text-out math) reward — aligned with MM-EUREKA,
+adapted for Qwen3-Omni native thinking mode.
+
+Design:
+
+1. **Correctness judgement splits by answer type**:
+
+   * **Choice questions** (ground truth is a single letter A-E) are judged by
+     a pure string match on the model output - no sympy, no subprocess, no
+     timeout. If the model output a letter, match it directly; if it output a
+     value instead, fall back to comparing that value against the correct
+     option's content (``extra_info["options"]``) for 0.5 partial credit.
+   * **Numeric / LaTeX answers** reuse verl's ``math_verify.compute_score``
+     (``ExprExtractionConfig`` + ``LatexExtractionConfig``), which is
+     subprocess-isolated and timed.
+
+   Choices need no sympy, so they skip the subprocess timeout that sympy
+   requires - no separate ``StringExtractionConfig`` pool is maintained.
+
+2. **Answer extraction** prefers the ``<answer>…</answer>`` tag.  If the tag
+   is present, only its inner text is fed to math_verify.  This avoids
+   mis-extraction when the model writes intermediate numbers inside
+   ``<think>``.
+
+3. **Format reward is progressive** (two equal-weighted checks, aligned
+   with MM-EUREKA 32B — no explicit ``<think>`` required):
+
+   * **answer_tag**: exactly one ``<answer>…</answer>`` pair.
+   * **boxed**: ``\\boxed{…}`` inside ``<answer>``.
+
+   Reward ladder (with default ``format_score=0.3``): 0.0 / 0.15 / 0.30.
+
+4. **Total reward** is additive, normalized to [0, 1]:
+   ``score = (accuracy_reward + format_reward) / (1 + format_score)``.
+"""
+
+import json
+import re
+
+from verl.utils.reward_score.math_verify import compute_score as _math_verify_score
+
+_ANGLE_RE = re.compile(r"(\d+(?:\.\d+)?)\s*(?:°|\^\\circ|\\circ)")
+_ANSWER_TAG_RE = re.compile(r"<answer>(.*?)</answer>", re.DOTALL)
+_BOXED_RE = re.compile(r"\\boxed\{")
+_CHOICE_RE = re.compile(r"(?<![A-Za-z])([A-E])(?![A-Za-z])")
+
+
+def _normalize_angle(text: str) -> str:
+    """Strip angle symbols so math_verify sees plain numbers."""
+    return _ANGLE_RE.sub(r"\1", text)
+
+
+def _extract_answer_tag(text: str) -> str | None:
+    """Return the inner text of the first ``<answer>…</answer>`` tag, or None."""
+    m = _ANSWER_TAG_RE.search(text or "")
+    return m.group(1).strip() if m else None
+
+
+def _is_choice_gt(gt: str) -> bool:
+    """True when the ground truth is a single multiple-choice letter (A-E)."""
+    return len(gt) == 1 and gt.upper() in "ABCDE"
+
+
+def _extract_choice_letter(content: str) -> str | None:
+    """Return the last standalone A-E letter in ``content``, or None.
+
+    Matches ``\\boxed{B}``, ``answer: B`` and a bare ``B`` uniformly. Returns
+    None when the model output no choice letter (e.g. it wrote a value).
+    """
+    letters = _CHOICE_RE.findall(content or "")
+    return letters[-1].upper() if letters else None
+
+
+def _compute_format_score(
+    text: str,
+    answer_inner: str | None,
+    format_score: float = 0.3,
+) -> float:
+    """Progressive format reward: two independent checks, equal-weighted.
+
+    * **answer_tag**: exactly one ``<answer>…</answer>`` pair.
+    * **boxed**: ``\\boxed{…}`` inside ``<answer>``.
+    """
+    text = text or ""
+    has_answer = answer_inner is not None and (text.count("<answer>") == 1 and text.count("</answer>") == 1)
+    has_boxed = answer_inner is not None and _BOXED_RE.search(answer_inner) is not None
+    return format_score * (has_answer + has_boxed) / 2.0
+
+
+def compute_score(
+    solution_str: str,
+    ground_truth: str,
+    format_score: float = 0.3,
+    math_verify_timeout: float = 20.0,
+    **kwargs,
+) -> dict:
+    """MMK12 reward entrypoint.
+
+    Reward formula (additive, normalized to [0, 1]):
+        score = (accuracy_reward + format_reward) / (1 + format_score)
+
+    * ``accuracy_reward`` ∈ {0, 1} - choice: string match; numeric/LaTeX: verl math_verify.
+    * ``format_reward`` ∈ [0, ``format_score``] — progressive (answer_tag + boxed).
+
+    Config:
+        reward.custom_reward_function.path=verl_omni/utils/reward_score/mmk12_reward.py
+        reward.custom_reward_function.name=compute_score
+    """
+    gt = _normalize_angle(str(ground_truth).strip())
+    solution_str = _normalize_angle(solution_str or "")
+
+    # 1. Extract <answer> inner text (used for correctness; keep solution_str for format).
+    answer_inner = _extract_answer_tag(solution_str)
+    content = answer_inner if answer_inner is not None else solution_str
+
+    # 2. Correctness judgement — dispatch by (gt type, pred type).
+    if _is_choice_gt(gt):
+        pred_letter = _extract_choice_letter(content)
+        if pred_letter is not None:
+            # gt is a letter and the model also output a letter -> pure string
+            # match. No sympy, no subprocess, no timeout needed.
+            accuracy_reward = 1.0 if pred_letter == gt.upper() else 0.0
+        else:
+            # gt is a letter but the model output a value (not a letter) ->
+            # partial credit (0.5) if the value matches the correct option's
+            # content. Reuses verl's math_verify (subprocess-isolated, timed).
+            options_raw = (kwargs.get("extra_info") or {}).get("options") or {}
+            try:
+                options = json.loads(options_raw)
+            except (ValueError, TypeError):
+                options = {}
+            option_content = options.get(gt.upper())
+            if option_content:
+                accuracy_reward = _math_verify_score(content, option_content, timeout=math_verify_timeout) * 0.5
+            else:
+                accuracy_reward = 0.0
+    else:
+        # Numeric / LaTeX answer -> reuse verl's math_verify (subprocess-isolated,
+        # with timeout).
+        accuracy_reward = _math_verify_score(content, gt, timeout=math_verify_timeout)
+
+    # 3. Format reward (progressive: answer_tag + boxed).
+    format_reward = _compute_format_score(solution_str, answer_inner, format_score)
+
+    # 4. Total reward (additive, normalized).
+    score = (accuracy_reward + format_reward) / (1.0 + format_score)
+
+    return {
+        "score": float(score),
+        "format_reward": float(format_reward),
+        "accuracy": float(accuracy_reward),
+    }

--- a/verl_omni/workers/rollout/vllm_rollout/utils.py
+++ b/verl_omni/workers/rollout/vllm_rollout/utils.py
@@ -144,6 +144,13 @@ class vLLMOmniColocateWorkerExtension(CustomPipelineWorkerExtension):
                 # model.load_weights (no per-bucket finalize), then run the single
                 # post-load processing pass once all buckets are received.
                 model, model_config = standard
+                # Re-attach weight_loader on Ascend FusedMoE params via verl's
+                # built-in patch (handles ACLGraph unwrap + SUPPORTED_MOE_MODELS
+                # whitelist, which Qwen3-Omni is registered into via
+                # patch_register_vllm_moe_model_weight_loader).
+                from verl.utils.vllm.patch import patch_vllm_moe_model_weight_loader
+
+                patch_vllm_moe_model_weight_loader(model)
                 receiver.receive_weights(on_bucket_received=lambda weights: model.load_weights(weights))
                 from vllm.model_executor.model_loader.utils import process_weights_after_loading
 

--- a/verl_omni/workers/rollout/vllm_rollout/vllm_omni_async_server.py
+++ b/verl_omni/workers/rollout/vllm_rollout/vllm_omni_async_server.py
@@ -436,6 +436,12 @@ class vLLMOmniHttpServer(vLLMHttpServer):
         Returns ``(prompt, params)`` consumed by ``_run_generation``.
         """
         if self._ar_mode:
+            if multi_modal_data:
+                # Deduplicate already-expanded multimodal pad tokens to prevent
+                # double-expansion inside vLLM-Omni.
+                processor = getattr(self.model_config, "processor", None)
+                if processor is not None and hasattr(processor, "dedup_pad_tokens"):
+                    prompt_ids = processor.dedup_pad_tokens(prompt_ids)
             max_possible_tokens = self.config.max_model_len - len(prompt_ids)
             if max_possible_tokens <= 0:
                 raise ValueError(

--- a/verl_omni/workers/rollout/vllm_rollout/vllm_omni_async_server.py
+++ b/verl_omni/workers/rollout/vllm_rollout/vllm_omni_async_server.py
@@ -333,15 +333,23 @@ class vLLMOmniHttpServer(vLLMHttpServer):
         request_id: str,
         image_data: Optional[list[Any]] = None,
         video_data: Optional[list[Any]] = None,
+        audio_data: Optional[list[Any]] = None,
+        mm_processor_kwargs: Optional[dict[str, Any]] = None,
         negative_prompt_ids: Optional[list[int]] = None,
         prompt_mask: torch.BoolTensor | None = None,
         priority: int = 0,
     ) -> DiffusionOutput | TokenOutput:
         prompt_ids = normalize_token_ids(prompt_ids)
-        multi_modal_data = self._build_multi_modal_data(image_data, video_data)
+        multi_modal_data = self._build_multi_modal_data(image_data, video_data, audio_data)
         lora_request = await self._resolve_lora_request()
         prompt, params = self._preprocess_input(
-            prompt_ids, sampling_params, multi_modal_data, lora_request, negative_prompt_ids, prompt_mask
+            prompt_ids,
+            sampling_params,
+            multi_modal_data,
+            lora_request,
+            negative_prompt_ids,
+            prompt_mask,
+            mm_processor_kwargs,
         )
         final_res = await self._run_generation(prompt, params, request_id, lora_request, priority)
         return self._process_output(final_res, params, sampling_params)
@@ -351,13 +359,19 @@ class vLLMOmniHttpServer(vLLMHttpServer):
     # -----------------------------------------------------------------------
 
     @staticmethod
-    def _build_multi_modal_data(image_data: Optional[list[Any]], video_data: Optional[list[Any]]) -> dict[str, Any]:
-        """Assemble the vLLM multi_modal_data dict from optional image/video inputs."""
+    def _build_multi_modal_data(
+        image_data: Optional[list[Any]],
+        video_data: Optional[list[Any]],
+        audio_data: Optional[list[Any]] = None,
+    ) -> dict[str, Any]:
+        """Assemble the vLLM multi_modal_data dict from optional image/video/audio inputs."""
         multi_modal_data: dict[str, Any] = {}
         if image_data is not None:
             multi_modal_data["image"] = image_data
         if video_data is not None:
             multi_modal_data["video"] = video_data
+        if audio_data is not None:
+            multi_modal_data["audio"] = audio_data
         return multi_modal_data
 
     def _invalidate_lora_request_cache(self) -> None:
@@ -415,6 +429,7 @@ class vLLMOmniHttpServer(vLLMHttpServer):
         lora_request: Optional[LoRARequest],
         negative_prompt_ids: Optional[list[int]],
         prompt_mask: torch.BoolTensor | None = None,
+        mm_processor_kwargs: Optional[dict[str, Any]] = None,
     ):
         """Build the engine prompt + sampling params for the active mode.
 
@@ -454,6 +469,8 @@ class vLLMOmniHttpServer(vLLMHttpServer):
             prompt = {"prompt_token_ids": prompt_ids}
             if multi_modal_data:
                 prompt["multi_modal_data"] = multi_modal_data
+            if mm_processor_kwargs:
+                prompt["mm_processor_kwargs"] = mm_processor_kwargs
             return prompt, params
 
         # diffusion


### PR DESCRIPTION
### What does this PR do?
Adds an end-to-end **image → text** post-training recipe for `Qwen3-Omni-30B-A3B Thinker` GSPO on top of #189 (NPU support). Uses the [MMK12](https://www.modelscope.cn/datasets/SKYLENAGE/MMK12) K12 visual-math dataset, a `math_verify`-based rule reward, and reuses the existing NPU launcher (`run_qwen3_omni_thinker_gspo_npu.sh`, 16 × Atlas 800T A3, full-parameter FSDP + TP=2 rollout). The GPU / LoRA launcher from #208 works against MMK12 too after preprocessing.

Follow-up to #189 (Ascend NPU support) and #208 (Thinker LoRA on transformers 5.x), and [verl #6923](https://github.com/verl-project/verl/pull/6923)(Thinker on transformers 5.x); no dependency on other unmerged PRs.

Key additions:

- MMK12 → verl RL parquet converter  (`examples/gspo_trainer/data_process/mmk12.py`).
- `math_verify`-based rule reward with MC-content partial credit and a progressive `<answer>…\boxed{…}…</answer>` format ladder (`verl_omni/utils/reward_score/mmk12_reward.py`).
- Multimodal-input plumbing on the async rollout server: `audio_data` and `mm_processor_kwargs` accepted alongside `image_data` / `video_data`.
- NPU worker-thread device pin: fixes `Expects tensor to be on the compute device npu:N, was on npu:0` when FSDP offload / LoRA gather runs inside `asyncio.to_thread` on multi-visible-device NPU hosts.
- README restructured to document both modalities (text→text /image→text) and both platforms (GPU / NPU).

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `vllm_omni`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `diffusion`, `omni`, `tests`, `docker`
  - If this PR involves multiple modules, separate them with `,` like `[diffusion, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][diffusion, fsdp] feat: new rollout scheduler`

### Test
Validated on **16 × Ascend NPU (Atlas 800T A3)** with `Qwen/Qwen3-Omni-30B-A3B-Instruct`, MMK12 image → text, full-parameter FSDP actor, TP=2 rollout, `rollout.n=8`.
The training result:
actor
<img width="1740" height="858" alt="image" src="https://github.com/user-attachments/assets/40ded12b-7fa5-4f50-b68c-3eca983dbfc6" />

critic/reward
<img width="1722" height="408" alt="image" src="https://github.com/user-attachments/assets/17e1ac50-4c45-4425-bd39-8e44ffdce559" />

val
<img width="394" height="290" alt="image" src="https://github.com/user-attachments/assets/0ba8743b-3dde-44b1-a62c-d1bbdce71642" />

### API and Usage Example
No new public API. Two additive optional args on `vLLMOmniHttpServer.generate(...)` (`audio_data`, `mm_processor_kwargs`), both defaulting to `None`.

```bash
# 1. Install the reward-scorer dependency (not pulled transitively).
pip install math-verify

# 2. Preprocess MMK12 shards into verl RL parquet.
python examples/gspo_trainer/data_process/mmk12.py \
    --input_dir  /path/to/mmk12/raw \
    --output_dir ~/data/mmk12

# 3. Launch training on 16 × Atlas 800T A3.
bash examples/gspo_trainer/qwen3_omni/run_qwen3_omni_thinker_gspo_npu.sh \
    reward.custom_reward_function.path=verl_omni/utils/reward_score/mmk12_reward.py \
    data.train_batch_size=32 \
    data.max_response_length=4096 \
    actor.ppo_mini_batch_size=32 \
    actor.optim.lr=2e-6
```

### Design & Code Changes
Main changed files:

- `examples/gspo_trainer/data_process/mmk12.py` — new. Raw MMK12 shards → verl RL parquet: `data_source="math_dapo"`, system prompt constrains the model to `<answer>…\boxed{…}…</answer>`, image bytes carried inline in the `images` column, in-question option lines parsed into `extra_info["options"]` for MC-content partial credit.
- `verl_omni/utils/reward_score/mmk12_reward.py` — new. Rule reward for MMK12, aligned with MM-EUREKA's `accuracy_reward_func`:
  - unified `math_verify` correctness check with `String + Latex + Expr` extraction configs (handles both letters and numeric / LaTeX uniformly),
  - MC-content fallback → `accuracy = 0.5` when the model gave the right option value but not the letter,
  - progressive format ladder on `<answer>` tag + `\boxed{}` presence (default `format_score = 0.3` → `0.0 / 0.15 / 0.30`),
  - total `= (accuracy + format) / (1 + format_score)`, normalized to `[0, 1]`.
- `verl_omni/workers/rollout/vllm_rollout/vllm_omni_async_server.py` — `vLLMOmniHttpServer.generate(...)`, `_build_multi_modal_data(...)`, `_preprocess_input(...)` extended to also accept `audio_data` and thread `mm_processor_kwargs` through to the AR engine prompt (needed for Qwen3-Omni's image / video / audio preprocessor on the rollout side). Backward-compatible: existing image-only / text-only call sites are unaffected.
- `verl_omni/workers/engine_workers.py` — worker-thread device pin. `ActorRolloutRefWorker._offload_actor_and_empty_cache(...)` and `_gather_lora_and_offload_actor(...)` run inside `asyncio.to_thread` from the async rollout path; the pool thread does not inherit the per-process default device set at worker init, so FSDP collectives materialized in those threads land on device 0 and trigger `Expects tensor to be on the compute device npu:N, was on npu:0` on NPU when `RAY_EXPERIMENTAL_NOSET_ASCEND_RT_VISIBLE_DEVICES=1`
  keeps all devices visible. Added a small `_set_worker_thread_device()` helper and call it at the top of both
  paths. GPU is unaffected.
- `examples/gspo_trainer/README.md` — restructured to cover both modalities (text→text / image→text) and both platforms (GPU / NPU), with a `Training with MMK12` section that walks through preprocessing + reward wiring + launch.
- `verl_omni/models/transformers/qwen3_omni_thinker.py` - **weight loader**: registers `Qwen3OmniMoeThinkerForConditionalGeneration` on the vllm-moe-model weight-loader patch list, so the fused 3-D MoE expert tensors are split and loaded into per-expert `nn.Linear` correctly under transformers 5.x. Without this, the Thinker loads with silently-mismatched expert weights. Depends on [verl #6923](https://github.com/verl-project/verl/pull/6923); **get_rope_index**: cast dtype of position_ids from fp32 to int64 to avoid BF16 large-int rounding in root-input casting of FSDP.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update the documentation.
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl-omni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
