### PR TITLE
[omni, tests] feat: add general image editing interface

### DIFF
--- a/tests/pipelines/test_i2i_model_base_on_cpu.py
+++ b/tests/pipelines/test_i2i_model_base_on_cpu.py
@@ -93,6 +93,12 @@ class TestDiffusionI2IModelBase:
         with pytest.raises(ValueError, match="must be 3-D"):
             DiffusionI2IModelBase.inject_condition(model_inputs, None, condition)
 
+    def test_inject_condition_rejects_missing_latents(self):
+        model_inputs = {"hidden_states": torch.zeros(1, 2, 4)}
+
+        with pytest.raises(ValueError, match=r"requires condition\['image_latents'\]"):
+            DiffusionI2IModelBase.inject_condition(model_inputs, None, {"img_shapes": [[(1, 2, 2)]]})
+
     def test_inject_condition_validates_sequence_parallel_alignment(self):
         model_inputs = {"hidden_states": torch.zeros(1, 2, 4)}
 

--- a/tests/pipelines/test_i2i_model_base_on_cpu.py
+++ b/tests/pipelines/test_i2i_model_base_on_cpu.py
@@ -1,0 +1,236 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU tests for the generic I2I diffusion model hooks."""
+
+import pytest
+import torch
+from tensordict import TensorDict
+from tensordict.tensorclass import NonTensorData, NonTensorStack
+
+from verl_omni.pipelines.model_base import DiffusionI2IModelBase, DiffusionModelBase
+from verl_omni.pipelines.utils import prepare_model_inputs
+from verl_omni.workers.config.diffusion.model import DiffusionModelConfig
+
+
+def _model_config(architecture: str) -> DiffusionModelConfig:
+    config = object.__new__(DiffusionModelConfig)
+    object.__setattr__(config, "architecture", architecture)
+    object.__setattr__(config, "external_lib", None)
+    object.__setattr__(config, "algorithm", "flow_grpo")
+    return config
+
+
+def _non_tensor_stack(values):
+    return NonTensorStack.from_list([NonTensorData(value) for value in values])
+
+
+class _EchoModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.last_kwargs = None
+
+    def forward(self, **kwargs):
+        self.last_kwargs = kwargs
+        return (kwargs["hidden_states"],)
+
+
+class TestDiffusionI2IModelBase:
+    def test_forward_slices_condition_predictions(self):
+        module = _EchoModule()
+        hidden_states = torch.arange(12, dtype=torch.float32).view(1, 3, 4)
+
+        prediction = DiffusionModelBase.forward(
+            module,
+            model_config=None,
+            model_inputs={"hidden_states": hidden_states, "_target_seq_len": 2},
+        )
+
+        assert prediction.shape == (1, 2, 4)
+        assert "_target_seq_len" not in module.last_kwargs
+
+    def test_inject_condition_is_noop_without_condition(self):
+        model_inputs = {"hidden_states": torch.zeros(1, 2, 4)}
+
+        output, negative_output = DiffusionI2IModelBase.inject_condition(model_inputs, None, None)
+
+        assert output is model_inputs
+        assert negative_output is None
+
+    def test_inject_condition_concatenates_positive_and_negative_inputs(self):
+        model_inputs = {"hidden_states": torch.zeros(1, 2, 4)}
+        negative_inputs = {"hidden_states": torch.ones(1, 2, 4)}
+        condition = {"image_latents": torch.full((1, 3, 4), 2.0)}
+
+        output, negative_output = DiffusionI2IModelBase.inject_condition(model_inputs, negative_inputs, condition)
+
+        assert output["hidden_states"].shape == (1, 5, 4)
+        assert negative_output["hidden_states"].shape == (1, 5, 4)
+        assert output["_target_seq_len"] == 2
+        assert negative_output["_target_seq_len"] == 2
+
+    def test_inject_condition_rejects_mismatched_batch_size(self):
+        model_inputs = {"hidden_states": torch.zeros(2, 2, 4)}
+        condition = {"image_latents": torch.zeros(1, 3, 4)}
+
+        with pytest.raises(ValueError, match="batch size"):
+            DiffusionI2IModelBase.inject_condition(model_inputs, None, condition)
+
+    def test_inject_condition_rejects_non_tensor_sequence(self):
+        model_inputs = {"hidden_states": torch.zeros(1, 2, 4)}
+        condition = {"image_latents": torch.zeros(1, 2, 2, 4)}
+
+        with pytest.raises(ValueError, match="must be 3-D"):
+            DiffusionI2IModelBase.inject_condition(model_inputs, None, condition)
+
+    def test_inject_condition_validates_sequence_parallel_alignment(self):
+        model_inputs = {"hidden_states": torch.zeros(1, 2, 4)}
+
+        with pytest.raises(ValueError, match="sequence-parallel size"):
+            DiffusionI2IModelBase.inject_condition(
+                model_inputs,
+                None,
+                {"image_latents": torch.zeros(1, 3, 4), "sp_size": 2},
+            )
+
+    def test_metadata_helpers_unwrap_non_tensor_values(self):
+        image_shapes = [[(1, 16, 16)], [(1, 16, 16)]]
+        micro_batch = TensorDict(
+            {
+                "img_shapes": _non_tensor_stack(image_shapes),
+                "sp_size": _non_tensor_stack([2, 2]),
+            },
+            batch_size=[2],
+        )
+
+        assert DiffusionI2IModelBase.get_i2i_metadata(micro_batch, "img_shapes") == image_shapes
+        assert DiffusionI2IModelBase.get_i2i_scalar_metadata(micro_batch, "sp_size") == 2
+
+    def test_scalar_metadata_rejects_mixed_micro_batch_values(self):
+        micro_batch = TensorDict(
+            {"sp_size": _non_tensor_stack([1, 2])},
+            batch_size=[2],
+        )
+
+        with pytest.raises(ValueError, match="differs across the micro-batch"):
+            DiffusionI2IModelBase.get_i2i_scalar_metadata(micro_batch, "sp_size")
+
+
+class TestPrepareModelInputsConditionDispatch:
+    def test_t2i_adapter_keeps_existing_dispatch_behavior(self):
+        @DiffusionModelBase.register("_GeneralInterfaceT2I", algorithm="flow_grpo")
+        class _T2I(DiffusionModelBase):
+            @classmethod
+            def build_scheduler(cls, model_config):
+                pass
+
+            @classmethod
+            def set_timesteps(cls, scheduler, model_config, device):
+                pass
+
+            @classmethod
+            def prepare_model_inputs(cls, *args, **kwargs):
+                return {"hidden_states": torch.zeros(1, 2, 4)}, None
+
+            @classmethod
+            def forward_and_sample_previous_step(cls, *args, **kwargs):
+                pass
+
+        model_inputs, negative_model_inputs = prepare_model_inputs(
+            module=None,
+            model_config=_model_config("_GeneralInterfaceT2I"),
+            latents=torch.zeros(1, 2, 4),
+            timesteps=torch.zeros(1),
+            prompt_embeds=torch.zeros(1, 1, 4),
+            prompt_embeds_mask=None,
+            negative_prompt_embeds=None,
+            negative_prompt_embeds_mask=None,
+            micro_batch={},
+            step=0,
+        )
+
+        assert model_inputs["hidden_states"].shape == (1, 2, 4)
+        assert negative_model_inputs is None
+
+    def test_i2i_adapter_injects_condition_after_base_inputs(self):
+        @DiffusionModelBase.register("_GeneralInterfaceI2I", algorithm="flow_grpo")
+        class _I2I(DiffusionI2IModelBase):
+            @classmethod
+            def build_scheduler(cls, model_config):
+                pass
+
+            @classmethod
+            def set_timesteps(cls, scheduler, model_config, device):
+                pass
+
+            @classmethod
+            def prepare_model_inputs(cls, *args, **kwargs):
+                return {"hidden_states": torch.zeros(1, 2, 4)}, None
+
+            @classmethod
+            def forward_and_sample_previous_step(cls, *args, **kwargs):
+                pass
+
+            @classmethod
+            def prepare_condition(cls, micro_batch, latents, step):
+                return {"image_latents": micro_batch["condition_image_latents"]}
+
+        model_inputs, negative_model_inputs = prepare_model_inputs(
+            module=None,
+            model_config=_model_config("_GeneralInterfaceI2I"),
+            latents=torch.zeros(1, 2, 4),
+            timesteps=torch.zeros(1),
+            prompt_embeds=torch.zeros(1, 1, 4),
+            prompt_embeds_mask=None,
+            negative_prompt_embeds=None,
+            negative_prompt_embeds_mask=None,
+            micro_batch={"condition_image_latents": torch.ones(1, 3, 4)},
+            step=0,
+        )
+
+        assert model_inputs["hidden_states"].shape == (1, 5, 4)
+        assert model_inputs["_target_seq_len"] == 2
+        assert negative_model_inputs is None
+
+    def test_i2i_adapter_fails_when_condition_is_missing(self):
+        @DiffusionModelBase.register("_GeneralInterfaceMissingI2I", algorithm="flow_grpo")
+        class _MissingI2I(DiffusionI2IModelBase):
+            @classmethod
+            def build_scheduler(cls, model_config):
+                pass
+
+            @classmethod
+            def set_timesteps(cls, scheduler, model_config, device):
+                pass
+
+            @classmethod
+            def prepare_model_inputs(cls, *args, **kwargs):
+                return {"hidden_states": torch.zeros(1, 2, 4)}, None
+
+            @classmethod
+            def forward_and_sample_previous_step(cls, *args, **kwargs):
+                pass
+
+        with pytest.raises(ValueError, match="prepare_condition returned None"):
+            prepare_model_inputs(
+                module=None,
+                model_config=_model_config("_GeneralInterfaceMissingI2I"),
+                latents=torch.zeros(1, 2, 4),
+                timesteps=torch.zeros(1),
+                prompt_embeds=torch.zeros(1, 1, 4),
+                prompt_embeds_mask=None,
+                negative_prompt_embeds=None,
+                negative_prompt_embeds_mask=None,
+                micro_batch={},
+                step=0,
+            )

--- a/tests/pipelines/test_i2i_model_base_on_cpu.py
+++ b/tests/pipelines/test_i2i_model_base_on_cpu.py
@@ -53,6 +53,31 @@ class TestDiffusionI2IModelBase:
         assert prediction.shape == (1, 2, 4)
         assert "_target_seq_len" not in module.last_kwargs
 
+    def test_forward_strips_private_keys_from_positive_and_negative_inputs(self):
+        class _StrictModule(torch.nn.Module):
+            def forward(self, hidden_states):
+                return (hidden_states,)
+
+        class _CfgAdapter(DiffusionModelBase):
+            @classmethod
+            def forward(cls, module, model_config, model_inputs, negative_model_inputs=None):
+                positive = module(**model_inputs)[0]
+                negative = module(**negative_model_inputs)[0]
+                return negative + 2 * (positive - negative)
+
+        class _I2ICfgAdapter(DiffusionI2IModelBase, _CfgAdapter):
+            pass
+
+        prediction = _I2ICfgAdapter.forward(
+            _StrictModule(),
+            model_config=None,
+            model_inputs={"hidden_states": torch.ones(1, 5, 4), "_target_seq_len": 2},
+            negative_model_inputs={"hidden_states": torch.zeros(1, 5, 4), "_target_seq_len": 2},
+        )
+
+        assert prediction.shape == (1, 2, 4)
+        torch.testing.assert_close(prediction, torch.full((1, 2, 4), 2.0))
+
     def test_inject_condition_is_noop_without_condition(self):
         model_inputs = {"hidden_states": torch.zeros(1, 2, 4)}
 
@@ -92,16 +117,6 @@ class TestDiffusionI2IModelBase:
 
         with pytest.raises(ValueError, match=r"requires condition\['image_latents'\]"):
             DiffusionI2IModelBase.inject_condition(model_inputs, None, {"img_shapes": [[(1, 2, 2)]]})
-
-    def test_inject_condition_validates_sequence_parallel_alignment(self):
-        model_inputs = {"hidden_states": torch.zeros(1, 2, 4)}
-
-        with pytest.raises(ValueError, match="sequence-parallel size"):
-            DiffusionI2IModelBase.inject_condition(
-                model_inputs,
-                None,
-                {"image_latents": torch.zeros(1, 3, 4), "sp_size": 2},
-            )
 
 
 class TestPrepareModelInputsConditionDispatch:
@@ -199,7 +214,22 @@ class TestPrepareModelInputsConditionDispatch:
             def forward_and_sample_previous_step(cls, *args, **kwargs):
                 pass
 
-        with pytest.raises(ValueError, match="prepare_condition returned None"):
+        with pytest.raises(ValueError, match=r"Available micro-batch keys: \['other'\]"):
+            prepare_model_inputs(
+                module=None,
+                model_config=_model_config("_GeneralInterfaceMissingI2I"),
+                latents=torch.zeros(1, 2, 4),
+                timesteps=torch.zeros(1),
+                prompt_embeds=torch.zeros(1, 1, 4),
+                prompt_embeds_mask=None,
+                negative_prompt_embeds=None,
+                negative_prompt_embeds_mask=None,
+                micro_batch={"other": torch.zeros(1)},
+                step=0,
+            )
+
+        _MissingI2I.prepare_condition = classmethod(lambda cls, micro_batch, latents, step: torch.ones(1024))
+        with pytest.raises(TypeError, match="keys=None") as exc_info:
             prepare_model_inputs(
                 module=None,
                 model_config=_model_config("_GeneralInterfaceMissingI2I"),
@@ -212,3 +242,4 @@ class TestPrepareModelInputsConditionDispatch:
                 micro_batch={},
                 step=0,
             )
+        assert "tensor(" not in str(exc_info.value)

--- a/tests/pipelines/test_i2i_model_base_on_cpu.py
+++ b/tests/pipelines/test_i2i_model_base_on_cpu.py
@@ -15,8 +15,6 @@
 
 import pytest
 import torch
-from tensordict import TensorDict
-from tensordict.tensorclass import NonTensorData, NonTensorStack
 
 from verl_omni.pipelines.model_base import DiffusionI2IModelBase, DiffusionModelBase
 from verl_omni.pipelines.utils import prepare_model_inputs
@@ -29,10 +27,6 @@ def _model_config(architecture: str) -> DiffusionModelConfig:
     object.__setattr__(config, "external_lib", None)
     object.__setattr__(config, "algorithm", "flow_grpo")
     return config
-
-
-def _non_tensor_stack(values):
-    return NonTensorStack.from_list([NonTensorData(value) for value in values])
 
 
 class _EchoModule(torch.nn.Module):
@@ -50,7 +44,7 @@ class TestDiffusionI2IModelBase:
         module = _EchoModule()
         hidden_states = torch.arange(12, dtype=torch.float32).view(1, 3, 4)
 
-        prediction = DiffusionModelBase.forward(
+        prediction = DiffusionI2IModelBase.forward(
             module,
             model_config=None,
             model_inputs={"hidden_states": hidden_states, "_target_seq_len": 2},
@@ -108,28 +102,6 @@ class TestDiffusionI2IModelBase:
                 None,
                 {"image_latents": torch.zeros(1, 3, 4), "sp_size": 2},
             )
-
-    def test_metadata_helpers_unwrap_non_tensor_values(self):
-        image_shapes = [[(1, 16, 16)], [(1, 16, 16)]]
-        micro_batch = TensorDict(
-            {
-                "img_shapes": _non_tensor_stack(image_shapes),
-                "sp_size": _non_tensor_stack([2, 2]),
-            },
-            batch_size=[2],
-        )
-
-        assert DiffusionI2IModelBase.get_i2i_metadata(micro_batch, "img_shapes") == image_shapes
-        assert DiffusionI2IModelBase.get_i2i_scalar_metadata(micro_batch, "sp_size") == 2
-
-    def test_scalar_metadata_rejects_mixed_micro_batch_values(self):
-        micro_batch = TensorDict(
-            {"sp_size": _non_tensor_stack([1, 2])},
-            batch_size=[2],
-        )
-
-        with pytest.raises(ValueError, match="differs across the micro-batch"):
-            DiffusionI2IModelBase.get_i2i_scalar_metadata(micro_batch, "sp_size")
 
 
 class TestPrepareModelInputsConditionDispatch:

--- a/tests/pipelines/test_image_edit_interface_on_cpu.py
+++ b/tests/pipelines/test_image_edit_interface_on_cpu.py
@@ -1,0 +1,179 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from verl_omni.pipelines.model_base import DiffusionModelBase
+from verl_omni.pipelines.utils import ImageGenerationRequest
+from verl_omni.workers.config.diffusion.model import DiffusionModelConfig
+
+
+class TestImageGenerationRequest:
+    def test_request_stores_image_generation_fields(self):
+        request = ImageGenerationRequest(
+            prompt="make it brighter", images=["image"], negative_prompt="", metadata={"id": 1}
+        )
+
+        assert request.prompt == "make it brighter"
+        assert request.images == ["image"]
+        assert request.negative_prompt == ""
+        assert request.metadata == {"id": 1}
+
+    def test_request_defaults_to_t2i_without_images(self):
+        request = ImageGenerationRequest(prompt="draw a cat")
+
+        assert request.images == []
+
+    def test_request_supports_multi_image_conditioning(self):
+        request = ImageGenerationRequest(prompt="combine them", images=["img0", "img1"])
+
+        assert request.images == ["img0", "img1"]
+
+    def test_from_request_payload_resolves_top_level_images_first(self):
+        custom_prompt = {
+            "prompt": "edit instruction",
+            "negative_prompt": "",
+            "images": ["top-level"],
+            "image": "single",
+            "multi_modal_data": {"image": ["raw"]},
+            "extra_args": {"multi_modal_data": {"image": ["extra"]}},
+            "additional_information": {"condition_images": ["fallback"]},
+        }
+
+        request = ImageGenerationRequest.from_request_payload(custom_prompt)
+
+        assert request.prompt == "edit instruction"
+        assert request.images == ["top-level"]
+        assert request.negative_prompt == ""
+        assert request.metadata == {"condition_images": ["fallback"]}
+
+    def test_from_request_payload_resolves_single_image_key(self):
+        request = ImageGenerationRequest.from_request_payload({"prompt": "edit", "image": "img"})
+
+        assert request.images == ["img"]
+
+    def test_from_request_payload_resolves_multimodal_images(self):
+        custom_prompt = {"prompt": "edit", "multi_modal_data": {"image": ["raw"]}}
+
+        request = ImageGenerationRequest.from_request_payload(custom_prompt)
+
+        assert request.images == ["raw"]
+
+    def test_from_request_payload_resolves_extra_args_multimodal_images(self):
+        custom_prompt = {"prompt": "edit", "extra_args": {"multi_modal_data": {"image": ("img0", "img1")}}}
+
+        request = ImageGenerationRequest.from_request_payload(custom_prompt)
+
+        assert request.images == ["img0", "img1"]
+
+    def test_from_request_payload_resolves_additional_information_fallback(self):
+        custom_prompt = {"prompt": "edit", "additional_information": {"condition_images": "img"}}
+
+        request = ImageGenerationRequest.from_request_payload(custom_prompt)
+
+        assert request.images == ["img"]
+
+    def test_from_request_payload_allows_t2i_without_images(self):
+        request = ImageGenerationRequest.from_request_payload({"prompt": "draw a cat"})
+
+        assert request.prompt == "draw a cat"
+        assert request.images == []
+
+        request = ImageGenerationRequest.from_request_payload(
+            {"prompt": "draw a cat", "extra_args": {"multi_modal_data": {"image": []}}}
+        )
+
+        assert request.images == []
+
+    def test_from_request_payload_allows_prompt_token_ids_without_prompt_text(self):
+        request = ImageGenerationRequest.from_request_payload({"prompt_token_ids": [1, 2], "images": ["img"]})
+
+        assert request.prompt == [1, 2]
+        assert request.images == ["img"]
+
+    def test_from_request_payload_uses_token_ids_when_prompt_is_none(self):
+        request = ImageGenerationRequest.from_request_payload(
+            {"prompt": None, "prompt_token_ids": [1, 2], "images": ["img"]}
+        )
+
+        assert request.prompt == [1, 2]
+
+    def test_from_request_payload_requires_prompt_or_prompt_token_ids(self):
+        with pytest.raises(ValueError, match="missing required 'prompt' or 'prompt_token_ids'"):
+            ImageGenerationRequest.from_request_payload({"images": ["img"]})
+
+    def test_from_request_payload_preserves_empty_metadata(self):
+        request = ImageGenerationRequest.from_request_payload(
+            {
+                "prompt": "edit",
+                "metadata": {},
+                "extra_info": {"id": 1},
+                "additional_information": {"condition_images": "img"},
+            }
+        )
+
+        assert request.metadata == {}
+
+
+class TestProcessorPreparationHook:
+    def test_diffusion_model_config_calls_registered_processor_hook(self, tmp_path):
+        model_dir = tmp_path / "model"
+        processor_dir = model_dir / "processor"
+        processor_dir.mkdir(parents=True)
+        (model_dir / "model_index.json").write_text(json.dumps({"_class_name": "_ImageGenerationHookPipeline"}))
+        events = []
+
+        @DiffusionModelBase.register("_ImageGenerationHookPipeline", algorithm="flow_grpo")
+        class _HookModel(DiffusionModelBase):
+            @classmethod
+            def prepare_processor_files(cls, model_path: str) -> None:
+                events.append(("hook", model_path))
+
+            @classmethod
+            def build_scheduler(cls, model_config):
+                pass
+
+            @classmethod
+            def set_timesteps(cls, scheduler, model_config, device):
+                pass
+
+            @classmethod
+            def prepare_model_inputs(cls, module, model_config, *args, **kwargs):
+                pass
+
+            @classmethod
+            def forward_and_sample_previous_step(cls, *args, **kwargs):
+                pass
+
+        def _fake_hf_processor(path, **kwargs):
+            events.append(("processor", path))
+            return "processor"
+
+        with (
+            patch("verl_omni.workers.config.diffusion.model.copy_to_local", return_value=str(model_dir)),
+            patch("verl_omni.workers.config.diffusion.model.hf_tokenizer", return_value="tokenizer"),
+            patch("verl_omni.workers.config.diffusion.model.hf_processor", side_effect=_fake_hf_processor),
+        ):
+            cfg = DiffusionModelConfig(
+                path=str(model_dir),
+                tokenizer_path=str(model_dir),
+                algorithm="flow_grpo",
+                attn_backend="native",
+            )
+
+        assert cfg.processor == "processor"
+        assert events == [("hook", str(model_dir)), ("processor", str(processor_dir))]

--- a/tests/pipelines/test_image_edit_interface_on_cpu.py
+++ b/tests/pipelines/test_image_edit_interface_on_cpu.py
@@ -16,6 +16,7 @@ import json
 from unittest.mock import patch
 
 import pytest
+from omegaconf import OmegaConf
 
 from verl_omni.pipelines.model_base import DiffusionModelBase
 from verl_omni.pipelines.utils import ImageGenerationRequest
@@ -177,3 +178,42 @@ class TestProcessorPreparationHook:
 
         assert cfg.processor == "processor"
         assert events == [("hook", str(model_dir)), ("processor", str(processor_dir))]
+
+    def test_driver_prepares_processor_before_loading_it(self, tmp_path):
+        from verl_omni.trainer.main_diffusion import _prepare_processor_files
+
+        model_dir = tmp_path / "model"
+        model_dir.mkdir()
+        (model_dir / "model_index.json").write_text(json.dumps({"_class_name": "_DriverHookPipeline"}))
+        events = []
+
+        @DiffusionModelBase.register("_DriverHookPipeline", algorithm="flow_grpo")
+        class _DriverHookModel(DiffusionModelBase):
+            @classmethod
+            def prepare_processor_files(cls, model_path: str) -> None:
+                events.append(("hook", model_path))
+
+            @classmethod
+            def build_scheduler(cls, model_config):
+                pass
+
+            @classmethod
+            def set_timesteps(cls, scheduler, model_config, device):
+                pass
+
+            @classmethod
+            def prepare_model_inputs(cls, module, model_config, *args, **kwargs):
+                pass
+
+            @classmethod
+            def forward_and_sample_previous_step(cls, *args, **kwargs):
+                pass
+
+        model_config = OmegaConf.create({"architecture": None, "algorithm": "flow_grpo", "external_lib": None})
+        _prepare_processor_files(str(model_dir), model_config)
+        events.append(("processor", str(model_dir / "processor")))
+
+        assert events == [
+            ("hook", str(model_dir)),
+            ("processor", str(model_dir / "processor")),
+        ]

--- a/tests/pipelines/test_image_edit_interface_on_cpu.py
+++ b/tests/pipelines/test_image_edit_interface_on_cpu.py
@@ -217,3 +217,37 @@ class TestProcessorPreparationHook:
             ("hook", str(model_dir)),
             ("processor", str(model_dir / "processor")),
         ]
+
+    def test_driver_accepts_alternate_processor_path(self, tmp_path):
+        from verl_omni.trainer.main_diffusion import _prepare_processor_files
+
+        model_dir = tmp_path / "model"
+        model_dir.mkdir()
+        alternate_processor = tmp_path / "prepared-processor"
+        (model_dir / "model_index.json").write_text(json.dumps({"_class_name": "_AlternateProcessorPipeline"}))
+
+        @DiffusionModelBase.register("_AlternateProcessorPipeline", algorithm="flow_grpo")
+        class _AlternateProcessorModel(DiffusionModelBase):
+            @classmethod
+            def prepare_processor_files(cls, model_path: str) -> str:
+                return str(alternate_processor)
+
+            @classmethod
+            def build_scheduler(cls, model_config):
+                pass
+
+            @classmethod
+            def set_timesteps(cls, scheduler, model_config, device):
+                pass
+
+            @classmethod
+            def prepare_model_inputs(cls, module, model_config, *args, **kwargs):
+                pass
+
+            @classmethod
+            def forward_and_sample_previous_step(cls, *args, **kwargs):
+                pass
+
+        model_config = OmegaConf.create({"architecture": None, "algorithm": "flow_grpo", "external_lib": None})
+
+        assert _prepare_processor_files(str(model_dir), model_config) == str(alternate_processor)

--- a/tests/pipelines/test_image_edit_interface_on_cpu.py
+++ b/tests/pipelines/test_image_edit_interface_on_cpu.py
@@ -131,6 +131,27 @@ class TestImageGenerationRequest:
 
 
 class TestProcessorPreparationHook:
+    def test_external_library_can_override_registered_adapter(self):
+        @DiffusionModelBase.register("_ExternalOverridePipeline", algorithm="flow_grpo")
+        class _BuiltinModel(DiffusionModelBase):
+            pass
+
+        class _ExternalModel(DiffusionModelBase):
+            pass
+
+        def import_external(_external_lib):
+            DiffusionModelBase._registry[("_ExternalOverridePipeline", "flow_grpo")] = _ExternalModel
+
+        with patch("verl.utils.import_utils.import_external_libs", side_effect=import_external) as import_mock:
+            model_cls = DiffusionModelBase.get_class_by_name(
+                "_ExternalOverridePipeline",
+                "flow_grpo",
+                "external_adapter",
+            )
+
+        assert model_cls is _ExternalModel
+        import_mock.assert_called_once_with("external_adapter")
+
     def test_diffusion_model_config_calls_registered_processor_hook(self, tmp_path):
         model_dir = tmp_path / "model"
         processor_dir = model_dir / "processor"

--- a/tests/pipelines/test_image_edit_interface_on_cpu.py
+++ b/tests/pipelines/test_image_edit_interface_on_cpu.py
@@ -189,16 +189,19 @@ class TestProcessorPreparationHook:
             patch("verl_omni.workers.config.diffusion.model.copy_to_local", return_value=str(model_dir)),
             patch("verl_omni.workers.config.diffusion.model.hf_tokenizer", return_value="tokenizer"),
             patch("verl_omni.workers.config.diffusion.model.hf_processor", side_effect=_fake_hf_processor),
+            patch("verl_omni.workers.config.diffusion.model.import_external_libs") as import_external_mock,
         ):
             cfg = DiffusionModelConfig(
                 path=str(model_dir),
                 tokenizer_path=str(model_dir),
                 algorithm="flow_grpo",
                 attn_backend="native",
+                external_lib="external_adapter",
             )
 
         assert cfg.processor == "processor"
         assert events == [("hook", str(model_dir)), ("processor", str(processor_dir))]
+        import_external_mock.assert_called_once_with("external_adapter")
 
     def test_driver_prepares_processor_before_loading_alternate_path(self, tmp_path):
         from verl_omni.trainer.main_diffusion import TaskRunner

--- a/tests/pipelines/test_image_edit_interface_on_cpu.py
+++ b/tests/pipelines/test_image_edit_interface_on_cpu.py
@@ -200,57 +200,24 @@ class TestProcessorPreparationHook:
         assert cfg.processor == "processor"
         assert events == [("hook", str(model_dir)), ("processor", str(processor_dir))]
 
-    def test_driver_prepares_processor_before_loading_it(self, tmp_path):
-        from verl_omni.trainer.main_diffusion import _prepare_processor_files
+    def test_driver_prepares_processor_before_loading_alternate_path(self, tmp_path):
+        from verl_omni.trainer.main_diffusion import TaskRunner
 
-        model_dir = tmp_path / "model"
-        model_dir.mkdir()
-        (model_dir / "model_index.json").write_text(json.dumps({"_class_name": "_DriverHookPipeline"}))
-        events = []
-
-        @DiffusionModelBase.register("_DriverHookPipeline", algorithm="flow_grpo")
-        class _DriverHookModel(DiffusionModelBase):
-            @classmethod
-            def prepare_processor_files(cls, model_path: str) -> None:
-                events.append(("hook", model_path))
-
-            @classmethod
-            def build_scheduler(cls, model_config):
-                pass
-
-            @classmethod
-            def set_timesteps(cls, scheduler, model_config, device):
-                pass
-
-            @classmethod
-            def prepare_model_inputs(cls, module, model_config, *args, **kwargs):
-                pass
-
-            @classmethod
-            def forward_and_sample_previous_step(cls, *args, **kwargs):
-                pass
-
-        model_config = OmegaConf.create({"architecture": None, "algorithm": "flow_grpo", "external_lib": None})
-        _prepare_processor_files(str(model_dir), model_config)
-        events.append(("processor", str(model_dir / "processor")))
-
-        assert events == [
-            ("hook", str(model_dir)),
-            ("processor", str(model_dir / "processor")),
-        ]
-
-    def test_driver_accepts_alternate_processor_path(self, tmp_path):
-        from verl_omni.trainer.main_diffusion import _prepare_processor_files
+        class _StopAfterProcessor(Exception):
+            pass
 
         model_dir = tmp_path / "model"
         model_dir.mkdir()
         alternate_processor = tmp_path / "prepared-processor"
+        alternate_processor.mkdir()
         (model_dir / "model_index.json").write_text(json.dumps({"_class_name": "_AlternateProcessorPipeline"}))
+        events = []
 
         @DiffusionModelBase.register("_AlternateProcessorPipeline", algorithm="flow_grpo")
         class _AlternateProcessorModel(DiffusionModelBase):
             @classmethod
             def prepare_processor_files(cls, model_path: str) -> str:
+                events.append(("hook", model_path))
                 return str(alternate_processor)
 
             @classmethod
@@ -269,6 +236,40 @@ class TestProcessorPreparationHook:
             def forward_and_sample_previous_step(cls, *args, **kwargs):
                 pass
 
-        model_config = OmegaConf.create({"architecture": None, "algorithm": "flow_grpo", "external_lib": None})
+        config = OmegaConf.create(
+            {
+                "actor_rollout_ref": {
+                    "model": {
+                        "path": str(model_dir),
+                        "tokenizer_path": str(model_dir),
+                        "architecture": None,
+                        "algorithm": "flow_grpo",
+                        "external_lib": None,
+                        "use_shm": False,
+                    }
+                },
+                "data": {"trust_remote_code": False},
+            }
+        )
 
-        assert _prepare_processor_files(str(model_dir), model_config) == str(alternate_processor)
+        def _fake_hf_processor(path, **kwargs):
+            events.append(("processor", path))
+            return "processor"
+
+        runner = TaskRunner()
+        with (
+            patch.object(runner, "add_actor_rollout_worker", return_value=(object(), object())),
+            patch.object(runner, "add_reward_model_resource_pool"),
+            patch.object(runner, "add_ref_policy_worker"),
+            patch.object(runner, "init_resource_pool_mgr", side_effect=_StopAfterProcessor),
+            patch("verl_omni.utils.fs.resolve_model_local_dir", return_value=str(model_dir)),
+            patch("verl.utils.hf_tokenizer", return_value="tokenizer"),
+            patch("verl.utils.hf_processor", side_effect=_fake_hf_processor),
+            pytest.raises(_StopAfterProcessor),
+        ):
+            runner.run(config)
+
+        assert events == [
+            ("hook", str(model_dir)),
+            ("processor", str(alternate_processor)),
+        ]

--- a/verl_omni/pipelines/model_base.py
+++ b/verl_omni/pipelines/model_base.py
@@ -84,7 +84,7 @@ class DiffusionModelBase(ABC):
     ) -> type["DiffusionModelBase"]:
         """Resolve an adapter before a full ``DiffusionModelConfig`` exists."""
         key = (architecture, algorithm)
-        if key not in cls._registry and external_lib is not None:
+        if external_lib is not None:
             from verl.utils.import_utils import import_external_libs
 
             import_external_libs(external_lib)

--- a/verl_omni/pipelines/model_base.py
+++ b/verl_omni/pipelines/model_base.py
@@ -243,7 +243,6 @@ class DiffusionModelBase(ABC):
         reverse-sampling algorithms (FlowGRPO et al.). Model adapters only need to
         override this when prediction requires extra handling such as CFG, negative
         inputs, or output conversion.
-
         """
         return module(**model_inputs)[0]
 
@@ -264,7 +263,7 @@ class DiffusionI2IModelBase(DiffusionModelBase):
     The default ``inject_condition`` implements a common concat-crop pattern:
     concatenate ``image_latents`` onto ``hidden_states``
     along the token dimension and set ``_target_seq_len`` so that
-    :meth:`DiffusionModelBase.forward` slices the prediction back to the
+    :meth:`DiffusionI2IModelBase.forward` slices the prediction back to the
     noise segment. Models with non-concat conditioning (Wan I2V, LTX2 I2AV)
     override ``inject_condition``.
     """
@@ -280,6 +279,16 @@ class DiffusionI2IModelBase(DiffusionModelBase):
         """Run concat-conditioned I2I prediction and keep the target-token prefix."""
         model_inputs = dict(model_inputs)
         target_seq_len = model_inputs.pop("_target_seq_len", None)
+        if negative_model_inputs is not None:
+            negative_model_inputs = dict(negative_model_inputs)
+            negative_target_seq_len = negative_model_inputs.pop("_target_seq_len", None)
+            if target_seq_len is None:
+                target_seq_len = negative_target_seq_len
+            elif negative_target_seq_len is not None and negative_target_seq_len != target_seq_len:
+                raise ValueError(
+                    "Positive and negative I2I inputs have different target sequence lengths: "
+                    f"{target_seq_len} and {negative_target_seq_len}."
+                )
         noise_pred = super().forward(module, model_config, model_inputs, negative_model_inputs)
         if target_seq_len is None:
             return noise_pred
@@ -337,20 +346,12 @@ class DiffusionI2IModelBase(DiffusionModelBase):
         Default implementation: concatenate ``image_latents`` onto
         ``hidden_states`` along the token dimension and set
         ``_target_seq_len`` so that
-        :meth:`DiffusionModelBase.forward` slices the prediction back.
+        :meth:`DiffusionI2IModelBase.forward` slices the prediction back.
 
         When ``condition`` is ``None`` or empty, this is a no-op (T2I
         degenerate path). Models with non-concat conditioning (Wan I2V,
         LTX2 I2AV) override this method.
 
-        Sequence-parallel note: Ulysses SP splits ``hidden_states`` along the
-        token dimension with ``chunk(sp_size)``, so the concatenated
-        ``noise + condition`` token count must be divisible by ``sp_size``.
-        When ``condition`` carries ``sp_size`` (> 1), this method asserts the
-        combined sequence length is aligned and raises otherwise, so the
-        condition latent resolution must be chosen upstream (rollout-side VAE
-        encode) rather than zero-padded here (padding would inject unmasked
-        condition tokens).
         """
         if not condition:
             return model_inputs, negative_model_inputs
@@ -383,20 +384,7 @@ class DiffusionI2IModelBase(DiffusionModelBase):
                 f"(batch, seq, dim), got shape {image_latents.shape}"
             )
 
-        # SP alignment: combined seq_len must be divisible by sp_size.
         target_seq_len = hidden_states.shape[1]
-        combined_seq_len = target_seq_len + image_latents.shape[1]
-        sp_size = condition.get("sp_size")
-        if isinstance(sp_size, int) and sp_size > 1 and combined_seq_len % sp_size != 0:
-            raise ValueError(
-                "inject_condition: combined noise+condition token length "
-                f"({combined_seq_len} = {target_seq_len} + {image_latents.shape[1]}) "
-                f"is not divisible by sequence-parallel size ({sp_size}). "
-                "Choose a condition image resolution whose packed latent length keeps "
-                "the combined sequence divisible by sp_size (align at rollout-side VAE "
-                "encode); do not zero-pad the condition here."
-            )
-
         for inputs in (model_inputs, negative_model_inputs):
             if inputs is None:
                 continue

--- a/verl_omni/pipelines/model_base.py
+++ b/verl_omni/pipelines/model_base.py
@@ -14,11 +14,12 @@
 
 import logging
 from abc import ABC, abstractmethod
-from typing import Optional
+from typing import Any, Optional
 
 import torch
 from diffusers import ModelMixin, SchedulerMixin
 from tensordict import TensorDict
+from verl.utils import tensordict_utils as tu
 
 from verl_omni.workers.config import DiffusionModelConfig
 
@@ -100,6 +101,15 @@ class DiffusionModelBase(ABC):
     @classmethod
     def configure_train_mode(cls, module: torch.nn.Module) -> None:
         """Hook called after ``module.train()`` for architecture-specific overrides."""
+        return
+
+    @classmethod
+    def prepare_processor_files(cls, model_path: str) -> None:
+        """Prepare model-specific processor files before ``hf_processor()`` loads them.
+
+        Override this when a model ships a ``processor`` directory that needs
+        adapter-owned config fixes before Hugging Face can load it.
+        """
         return
 
     @classmethod
@@ -223,8 +233,203 @@ class DiffusionModelBase(ABC):
         reverse-sampling algorithms (FlowGRPO et al.). Model adapters only need to
         override this when prediction requires extra handling such as CFG, negative
         inputs, or output conversion.
+
+        When ``_target_seq_len`` is present in ``model_inputs`` (set by
+        :meth:`DiffusionI2IModelBase.inject_condition`), it is popped before
+        the forward call and used to slice the output back to the noise
+        segment, dropping the condition-image token predictions.
         """
-        return module(**model_inputs)[0]
+        model_inputs = dict(model_inputs)
+        target_seq_len = model_inputs.pop("_target_seq_len", None)
+        noise_pred = module(**model_inputs)[0]
+        if target_seq_len is not None:
+            if noise_pred.shape[1] < target_seq_len:
+                raise ValueError(
+                    f"forward: model output seq_len ({noise_pred.shape[1]}) < "
+                    f"target_seq_len ({target_seq_len}). The condition concat may "
+                    f"have been dropped or the model truncated the output."
+                )
+            noise_pred = noise_pred[:, :target_seq_len]
+        return noise_pred
+
+
+class DiffusionI2IModelBase(DiffusionModelBase):
+    """Base class for image-conditioned diffusion model training helpers.
+
+    Inherits all T2I logic from :class:`DiffusionModelBase`. Adds a two-step
+    condition injection hook:
+
+    1. ``prepare_condition`` extracts condition tensors from ``micro_batch``.
+    2. ``inject_condition`` merges condition tensors into ``model_inputs``.
+
+    The training dispatcher requires I2I adapters to return a non-empty
+    condition. ``inject_condition`` itself remains a no-op for direct callers
+    that pass ``None``.
+
+    The default ``inject_condition`` implements a common concat-crop pattern:
+    concatenate ``image_latents`` onto ``hidden_states``
+    along the token dimension and set ``_target_seq_len`` so that
+    :meth:`DiffusionModelBase.forward` slices the prediction back to the
+    noise segment. Models with non-concat conditioning (Wan I2V, LTX2 I2AV)
+    override ``inject_condition``.
+    """
+
+    @staticmethod
+    def unwrap_i2i_metadata(value: Any) -> Any:
+        """Convert TensorDict non-tensor wrappers back to plain Python metadata."""
+        if hasattr(value, "tolist"):
+            return value.tolist()
+        return value
+
+    @classmethod
+    def get_i2i_metadata(cls, micro_batch: TensorDict, key: str, default: Any = None) -> Any:
+        """Read and unwrap I2I metadata carried through ``DataProto.non_tensor_batch``."""
+        value = tu.get_non_tensor_data(micro_batch, key, default=default)
+        return cls.unwrap_i2i_metadata(value)
+
+    @classmethod
+    def get_i2i_scalar_metadata(cls, micro_batch: TensorDict, key: str, default: Any = None) -> Any:
+        """Read scalar I2I metadata, requiring it to be constant across the micro-batch."""
+        value = cls.get_i2i_metadata(micro_batch, key, default=default)
+        if value is None:
+            return default
+
+        def _to_scalar(item):
+            if hasattr(item, "item") and not isinstance(item, str | bytes):
+                return item.item()
+            return item
+
+        if isinstance(value, list | tuple):
+            if len(value) == 0:
+                return default
+            values = [_to_scalar(item) for item in value]
+            first = values[0]
+            if any(item != first for item in values[1:]):
+                raise ValueError(f"I2I metadata {key!r} differs across the micro-batch: {values!r}")
+            return first
+
+        return _to_scalar(value)
+
+    @classmethod
+    def prepare_condition(
+        cls,
+        micro_batch: TensorDict,
+        latents: torch.Tensor,
+        step: int,
+    ) -> Optional[dict]:
+        """Extract condition fields from ``micro_batch``.
+
+        T2I default returns ``None``. I2I adapters override this to pull
+        model-specific condition tensors from the micro-batch and return them
+        under the keys that :meth:`inject_condition` expects (e.g.
+        ``image_latents``, ``image_latent_ids``, ``img_shapes``).
+
+        Note: the *micro-batch* keys carrying condition tensors must not
+        collide with keys the MFU FLOPs counter interprets as the denoised
+        latent (``image_latents``, ``latents_clean``, ``all_latents``,
+        ``audio_latents``). Use a distinct key such as
+        ``condition_image_latents`` on the micro-batch, then map it to the
+        ``image_latents`` slot in the returned condition dict.
+
+        Args:
+            micro_batch (TensorDict): the full micro-batch.
+            latents (torch.Tensor): the latent tensor for the current step.
+            step (int): the current denoising step index.
+
+        Returns:
+            Optional[dict]: a flat dict of condition tensors, or ``None``
+            when no condition is present (T2I degenerate path).
+        """
+        return None
+
+    @classmethod
+    def inject_condition(
+        cls,
+        model_inputs: dict,
+        negative_model_inputs: Optional[dict],
+        condition: Optional[dict],
+    ) -> tuple[dict, Optional[dict]]:
+        """Merge condition tensors into ``model_inputs``.
+
+        Default implementation: concatenate ``image_latents`` onto
+        ``hidden_states`` along the token dimension and set
+        ``_target_seq_len`` so that
+        :meth:`DiffusionModelBase.forward` slices the prediction back.
+
+        When ``condition`` is ``None`` or empty, this is a no-op (T2I
+        degenerate path). Models with non-concat conditioning (Wan I2V,
+        LTX2 I2AV) override this method.
+
+        Sequence-parallel note: Ulysses SP splits ``hidden_states`` along the
+        token dimension with ``chunk(sp_size)``, so the concatenated
+        ``noise + condition`` token count must be divisible by ``sp_size``.
+        When ``condition`` carries ``sp_size`` (> 1), this method asserts the
+        combined sequence length is aligned and raises otherwise, so the
+        condition latent resolution must be chosen upstream (rollout-side VAE
+        encode) rather than zero-padded here (padding would inject unmasked
+        condition tokens).
+        """
+        if not condition:
+            return model_inputs, negative_model_inputs
+
+        image_latents = condition.get("image_latents")
+        if image_latents is None:
+            return model_inputs, negative_model_inputs
+
+        # Guard: "image_latents" is reserved by the MFU FLOPs counter.
+        if "image_latents" in model_inputs:
+            raise ValueError(
+                "inject_condition: 'image_latents' found in model_inputs; "
+                "this key is reserved by the MFU FLOPs counter for the denoised "
+                "latent. The rollout adapter likely output 'image_latents' instead "
+                "of 'condition_image_latents'. Check the rollout adapter's "
+                "custom_output keys."
+            )
+
+        hidden_states = model_inputs["hidden_states"]
+        if image_latents.shape[0] != hidden_states.shape[0]:
+            raise ValueError(
+                "inject_condition: condition image_latents batch size "
+                f"({image_latents.shape[0]}) does not match hidden_states batch size "
+                f"({hidden_states.shape[0]})."
+            )
+
+        if image_latents.dim() != 3:
+            raise ValueError(
+                f"inject_condition: condition image_latents must be 3-D "
+                f"(batch, seq, dim), got shape {image_latents.shape}"
+            )
+
+        # SP alignment: combined seq_len must be divisible by sp_size.
+        target_seq_len = hidden_states.shape[1]
+        combined_seq_len = target_seq_len + image_latents.shape[1]
+        sp_size = condition.get("sp_size")
+        if isinstance(sp_size, int) and sp_size > 1 and combined_seq_len % sp_size != 0:
+            raise ValueError(
+                "inject_condition: combined noise+condition token length "
+                f"({combined_seq_len} = {target_seq_len} + {image_latents.shape[1]}) "
+                f"is not divisible by sequence-parallel size ({sp_size}). "
+                "Choose a condition image resolution whose packed latent length keeps "
+                "the combined sequence divisible by sp_size (align at rollout-side VAE "
+                "encode); do not zero-pad the condition here."
+            )
+
+        for inputs in (model_inputs, negative_model_inputs):
+            if inputs is None:
+                continue
+            inputs["hidden_states"] = torch.cat(
+                [
+                    inputs["hidden_states"],
+                    image_latents.to(
+                        device=inputs["hidden_states"].device,
+                        dtype=inputs["hidden_states"].dtype,
+                    ),
+                ],
+                dim=1,
+            )
+            inputs["_target_seq_len"] = target_seq_len
+
+        return model_inputs, negative_model_inputs
 
 
 class VllmOmniPipelineBase:

--- a/verl_omni/pipelines/model_base.py
+++ b/verl_omni/pipelines/model_base.py
@@ -63,23 +63,32 @@ class DiffusionModelBase(ABC):
         """Return the registered subclass for ``(architecture, algorithm)``."""
         architecture = model_config.architecture
         algorithm = model_config.algorithm
-        key = (architecture, algorithm)
 
-        if key not in cls._registry and model_config.external_lib is not None:
+        if architecture == "QwenImagePipeline":
+            logger.info(
+                "Applying monkey-patch for QwenImageTransformer2DModel Ulysses SP "
+                "This workaround will be removed once we upgrade to a diffusers release that "
+                "includes the upstream fix."
+            )
+            from verl_omni.models.diffusers.qwen_image import apply_qwen_image_ulysses_mask_fix
+
+            apply_qwen_image_ulysses_mask_fix()
+        return cls.get_class_by_name(architecture, algorithm, model_config.external_lib)
+
+    @classmethod
+    def get_class_by_name(
+        cls,
+        architecture: str,
+        algorithm: str,
+        external_lib: Optional[str] = None,
+    ) -> type["DiffusionModelBase"]:
+        """Resolve an adapter before a full ``DiffusionModelConfig`` exists."""
+        key = (architecture, algorithm)
+        if key not in cls._registry and external_lib is not None:
             from verl.utils.import_utils import import_external_libs
 
-            import_external_libs(model_config.external_lib)
-
+            import_external_libs(external_lib)
         try:
-            if architecture == "QwenImagePipeline":
-                logger.info(
-                    "Applying monkey-patch for QwenImageTransformer2DModel Ulysses SP "
-                    "This workaround will be removed once we upgrade to a diffusers release that "
-                    "includes the upstream fix."
-                )
-                from verl_omni.models.diffusers.qwen_image import apply_qwen_image_ulysses_mask_fix
-
-                apply_qwen_image_ulysses_mask_fix()
             return cls._registry[key]
         except KeyError:
             registered = sorted(cls._registry.keys())
@@ -321,8 +330,10 @@ class DiffusionI2IModelBase(DiffusionModelBase):
 
         T2I default returns ``None``. I2I adapters override this to pull
         model-specific condition tensors from the micro-batch and return them
-        under the keys that :meth:`inject_condition` expects (e.g.
-        ``image_latents``, ``image_latent_ids``, ``img_shapes``).
+        under the keys that :meth:`inject_condition` expects. The default
+        concat-crop implementation requires ``image_latents``. Adapters that
+        need position metadata or non-concat conditioning must override
+        :meth:`inject_condition`.
 
         Note: the *micro-batch* keys carrying condition tensors must not
         collide with keys the MFU FLOPs counter interprets as the denoised
@@ -374,7 +385,7 @@ class DiffusionI2IModelBase(DiffusionModelBase):
 
         image_latents = condition.get("image_latents")
         if image_latents is None:
-            return model_inputs, negative_model_inputs
+            raise ValueError("inject_condition requires condition['image_latents']")
 
         # Guard: "image_latents" is reserved by the MFU FLOPs counter.
         if "image_latents" in model_inputs:

--- a/verl_omni/pipelines/model_base.py
+++ b/verl_omni/pipelines/model_base.py
@@ -14,12 +14,11 @@
 
 import logging
 from abc import ABC, abstractmethod
-from typing import Any, Optional
+from typing import Optional
 
 import torch
 from diffusers import ModelMixin, SchedulerMixin
 from tensordict import TensorDict
-from verl.utils import tensordict_utils as tu
 
 from verl_omni.workers.config import DiffusionModelConfig
 
@@ -245,23 +244,8 @@ class DiffusionModelBase(ABC):
         override this when prediction requires extra handling such as CFG, negative
         inputs, or output conversion.
 
-        When ``_target_seq_len`` is present in ``model_inputs`` (set by
-        :meth:`DiffusionI2IModelBase.inject_condition`), it is popped before
-        the forward call and used to slice the output back to the noise
-        segment, dropping the condition-image token predictions.
         """
-        model_inputs = dict(model_inputs)
-        target_seq_len = model_inputs.pop("_target_seq_len", None)
-        noise_pred = module(**model_inputs)[0]
-        if target_seq_len is not None:
-            if noise_pred.shape[1] < target_seq_len:
-                raise ValueError(
-                    f"forward: model output seq_len ({noise_pred.shape[1]}) < "
-                    f"target_seq_len ({target_seq_len}). The condition concat may "
-                    f"have been dropped or the model truncated the output."
-                )
-            noise_pred = noise_pred[:, :target_seq_len]
-        return noise_pred
+        return module(**model_inputs)[0]
 
 
 class DiffusionI2IModelBase(DiffusionModelBase):
@@ -285,41 +269,27 @@ class DiffusionI2IModelBase(DiffusionModelBase):
     override ``inject_condition``.
     """
 
-    @staticmethod
-    def unwrap_i2i_metadata(value: Any) -> Any:
-        """Convert TensorDict non-tensor wrappers back to plain Python metadata."""
-        if hasattr(value, "tolist"):
-            return value.tolist()
-        return value
-
     @classmethod
-    def get_i2i_metadata(cls, micro_batch: TensorDict, key: str, default: Any = None) -> Any:
-        """Read and unwrap I2I metadata carried through ``DataProto.non_tensor_batch``."""
-        value = tu.get_non_tensor_data(micro_batch, key, default=default)
-        return cls.unwrap_i2i_metadata(value)
-
-    @classmethod
-    def get_i2i_scalar_metadata(cls, micro_batch: TensorDict, key: str, default: Any = None) -> Any:
-        """Read scalar I2I metadata, requiring it to be constant across the micro-batch."""
-        value = cls.get_i2i_metadata(micro_batch, key, default=default)
-        if value is None:
-            return default
-
-        def _to_scalar(item):
-            if hasattr(item, "item") and not isinstance(item, str | bytes):
-                return item.item()
-            return item
-
-        if isinstance(value, list | tuple):
-            if len(value) == 0:
-                return default
-            values = [_to_scalar(item) for item in value]
-            first = values[0]
-            if any(item != first for item in values[1:]):
-                raise ValueError(f"I2I metadata {key!r} differs across the micro-batch: {values!r}")
-            return first
-
-        return _to_scalar(value)
+    def forward(
+        cls,
+        module: ModelMixin,
+        model_config: DiffusionModelConfig,
+        model_inputs: dict[str, torch.Tensor],
+        negative_model_inputs: Optional[dict[str, torch.Tensor]] = None,
+    ) -> torch.Tensor:
+        """Run concat-conditioned I2I prediction and keep the target-token prefix."""
+        model_inputs = dict(model_inputs)
+        target_seq_len = model_inputs.pop("_target_seq_len", None)
+        noise_pred = super().forward(module, model_config, model_inputs, negative_model_inputs)
+        if target_seq_len is None:
+            return noise_pred
+        if noise_pred.shape[1] < target_seq_len:
+            raise ValueError(
+                f"forward: model output seq_len ({noise_pred.shape[1]}) < "
+                f"target_seq_len ({target_seq_len}). The condition concat may "
+                f"have been dropped or the model truncated the output."
+            )
+        return noise_pred[:, :target_seq_len]
 
     @classmethod
     def prepare_condition(

--- a/verl_omni/pipelines/model_base.py
+++ b/verl_omni/pipelines/model_base.py
@@ -113,13 +113,15 @@ class DiffusionModelBase(ABC):
         return
 
     @classmethod
-    def prepare_processor_files(cls, model_path: str) -> None:
+    def prepare_processor_files(cls, model_path: str) -> Optional[str]:
         """Prepare model-specific processor files before ``hf_processor()`` loads them.
 
         Override this when a model ships a ``processor`` directory that needs
-        adapter-owned config fixes before Hugging Face can load it.
+        adapter-owned config fixes before Hugging Face can load it. Return an
+        alternate processor path when the model directory should not be
+        modified in place.
         """
-        return
+        return None
 
     @classmethod
     def configure_trainable_params(

--- a/verl_omni/pipelines/utils.py
+++ b/verl_omni/pipelines/utils.py
@@ -27,6 +27,18 @@ from verl_omni.workers.config import DiffusionModelConfig
 
 from .model_base import DiffusionI2IModelBase, DiffusionModelBase
 
+__all__ = [
+    "ImageGenerationRequest",
+    "build_scheduler",
+    "forward",
+    "forward_and_sample_previous_step",
+    "get_sigmas",
+    "prepare_model_inputs",
+    "prepare_noisy_latents",
+    "sample_noise_and_timesteps",
+    "set_timesteps",
+]
+
 
 @dataclass
 class ImageGenerationRequest:
@@ -70,6 +82,7 @@ class ImageGenerationRequest:
             additional_information.get("condition_images") if isinstance(additional_information, Mapping) else None,
         ]
         images = []
+        # Select the first image source explicitly present in the request.
         for candidate in image_candidates:
             if candidate is not None:
                 images = candidate
@@ -85,6 +98,7 @@ class ImageGenerationRequest:
             additional_information,
         ]
         metadata = None
+        # Select the first metadata source explicitly present in the request.
         for candidate in metadata_candidates:
             if candidate is not None:
                 metadata = candidate
@@ -98,19 +112,6 @@ class ImageGenerationRequest:
             negative_prompt=request_payload.get("negative_prompt"),
             metadata=metadata,
         )
-
-
-__all__ = [
-    "ImageGenerationRequest",
-    "build_scheduler",
-    "forward",
-    "forward_and_sample_previous_step",
-    "get_sigmas",
-    "prepare_model_inputs",
-    "prepare_noisy_latents",
-    "sample_noise_and_timesteps",
-    "set_timesteps",
-]
 
 
 def prepare_model_inputs(

--- a/verl_omni/pipelines/utils.py
+++ b/verl_omni/pipelines/utils.py
@@ -170,19 +170,17 @@ def prepare_model_inputs(
     if issubclass(model_cls, DiffusionI2IModelBase):
         condition = model_cls.prepare_condition(micro_batch, latents, step)
         if condition is None:
-            # I2I adapter must have condition; None means rollout didn't forward it.
+            available_keys = [str(key) for key in micro_batch.keys()]
             raise ValueError(
-                f"{model_cls.__name__}.prepare_condition returned None: "
-                "no 'condition_image_latents' found in micro_batch. The rollout "
-                "adapter likely did not output this field, or it was dropped "
-                "during data transport. I2I training requires condition images; "
-                "check the rollout adapter's custom_output keys and the "
-                "async_server extra_fields forwarding."
+                f"{model_cls.__name__}.prepare_condition returned None. "
+                f"Available micro-batch keys: {available_keys}. Check that the "
+                "rollout output contains the condition fields expected by this adapter."
             )
         if not isinstance(condition, dict) or len(condition) == 0:
+            condition_keys = list(condition) if isinstance(condition, dict) else None
             raise TypeError(
-                f"prepare_condition returned {type(condition).__name__} "
-                f"(value={condition!r}); I2I adapters must return a non-empty dict."
+                f"prepare_condition returned {type(condition).__name__}; "
+                f"expected a non-empty dict, keys={condition_keys}."
             )
         model_inputs, negative_model_inputs = model_cls.inject_condition(model_inputs, negative_model_inputs, condition)
 
@@ -246,6 +244,7 @@ def _validate_adjacent_pair_values(values: torch.Tensor, name: str) -> None:
 
 
 def get_sigmas(noise_scheduler, timesteps, device, n_dim=4, dtype=torch.float32):
+    """Gather scheduler sigmas for the requested timesteps and output rank."""
     sigmas = noise_scheduler.sigmas.to(device=device, dtype=dtype)
     schedule_timesteps = noise_scheduler.timesteps.to(device)
     timesteps = timesteps.to(device)

--- a/verl_omni/pipelines/utils.py
+++ b/verl_omni/pipelines/utils.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Optional
 
 import torch
 from diffusers import ModelMixin, SchedulerMixin
@@ -22,7 +25,92 @@ from verl.utils.device import get_device_name
 
 from verl_omni.workers.config import DiffusionModelConfig
 
-from .model_base import DiffusionModelBase
+from .model_base import DiffusionI2IModelBase, DiffusionModelBase
+
+
+@dataclass
+class ImageGenerationRequest:
+    """Image generation request shared by t2i and image-conditioned backends.
+
+    Parses prompt / prompt token ids and condition images from verl-omni's
+    rollout request payload (``custom_prompt`` dict), checking multiple image
+    candidate keys: ``images``, ``image``, ``multi_modal_data.image``,
+    ``extra_args.multi_modal_data.image``, ``additional_information.condition_images``.
+    """
+
+    prompt: Any
+    images: list[Any] = field(default_factory=list)
+    """Condition images: empty for t2i, single-element for image editing, multi-element for multi-image conditioning."""
+
+    negative_prompt: Any | None = None
+    metadata: Mapping[str, Any] | None = None
+
+    @classmethod
+    def from_request_payload(cls, request_payload: Mapping[str, Any]) -> ImageGenerationRequest:
+        """Build a request from verl-omni's rollout request payload (``custom_prompt``)."""
+        prompt = request_payload.get("prompt")
+        if prompt is None:
+            prompt = request_payload.get("prompt_token_ids")
+        if prompt is None:
+            raise ValueError(
+                "ImageGenerationRequest missing required 'prompt' or 'prompt_token_ids' field. "
+                "The rollout request payload must carry one of them in custom_prompt."
+            )
+
+        multi_modal_data = request_payload.get("multi_modal_data")
+        extra_args = request_payload.get("extra_args")
+        extra_multi_modal_data = extra_args.get("multi_modal_data") if isinstance(extra_args, Mapping) else None
+        additional_information = request_payload.get("additional_information")
+
+        image_candidates = [
+            request_payload.get("images"),
+            request_payload.get("image"),
+            multi_modal_data.get("image") if isinstance(multi_modal_data, Mapping) else None,
+            extra_multi_modal_data.get("image") if isinstance(extra_multi_modal_data, Mapping) else None,
+            additional_information.get("condition_images") if isinstance(additional_information, Mapping) else None,
+        ]
+        images = []
+        for candidate in image_candidates:
+            if candidate is not None:
+                images = candidate
+                break
+        if isinstance(images, tuple):
+            images = list(images)
+        elif not isinstance(images, list):
+            images = [images]
+
+        metadata_candidates = [
+            request_payload.get("metadata"),
+            request_payload.get("extra_info"),
+            additional_information,
+        ]
+        metadata = None
+        for candidate in metadata_candidates:
+            if candidate is not None:
+                metadata = candidate
+                break
+        if not isinstance(metadata, Mapping):
+            metadata = None
+
+        return cls(
+            prompt=prompt,
+            images=images,
+            negative_prompt=request_payload.get("negative_prompt"),
+            metadata=metadata,
+        )
+
+
+__all__ = [
+    "ImageGenerationRequest",
+    "build_scheduler",
+    "forward",
+    "forward_and_sample_previous_step",
+    "get_sigmas",
+    "prepare_model_inputs",
+    "prepare_noisy_latents",
+    "sample_noise_and_timesteps",
+    "set_timesteps",
+]
 
 
 def prepare_model_inputs(
@@ -54,8 +142,17 @@ def prepare_model_inputs(
         micro_batch (TensorDict): the full micro-batch, available for architecture-specific
             metadata (e.g. height, width, vae_scale_factor).
         step (int): the current denoising step index.
+
+    Returns:
+        tuple[dict, Optional[dict]]: A pair of ``(model_inputs, negative_model_inputs)``
+        dicts ready to be unpacked into the transformer forward call. When the
+        registered adapter is an I2I subclass, condition tensors are injected
+        after the T2I ``prepare_model_inputs`` call.
     """
-    return DiffusionModelBase.get_class(model_config).prepare_model_inputs(
+    model_cls = DiffusionModelBase.get_class(model_config)
+
+    # T2I original logic (unchanged)
+    model_inputs, negative_model_inputs = model_cls.prepare_model_inputs(
         module,
         model_config,
         latents,
@@ -67,6 +164,28 @@ def prepare_model_inputs(
         micro_batch,
         step,
     )
+
+    # I2I adapters prepare and inject their model-specific condition tensors.
+    if issubclass(model_cls, DiffusionI2IModelBase):
+        condition = model_cls.prepare_condition(micro_batch, latents, step)
+        if condition is None:
+            # I2I adapter must have condition; None means rollout didn't forward it.
+            raise ValueError(
+                f"{model_cls.__name__}.prepare_condition returned None: "
+                "no 'condition_image_latents' found in micro_batch. The rollout "
+                "adapter likely did not output this field, or it was dropped "
+                "during data transport. I2I training requires condition images; "
+                "check the rollout adapter's custom_output keys and the "
+                "async_server extra_fields forwarding."
+            )
+        if not isinstance(condition, dict) or len(condition) == 0:
+            raise TypeError(
+                f"prepare_condition returned {type(condition).__name__} "
+                f"(value={condition!r}); I2I adapters must return a non-empty dict."
+            )
+        model_inputs, negative_model_inputs = model_cls.inject_condition(model_inputs, negative_model_inputs, condition)
+
+    return model_inputs, negative_model_inputs
 
 
 def build_scheduler(model_config: DiffusionModelConfig) -> SchedulerMixin:

--- a/verl_omni/trainer/main_diffusion.py
+++ b/verl_omni/trainer/main_diffusion.py
@@ -31,7 +31,7 @@ from verl_omni.trainer.diffusion.ray_diffusion_trainer import (
 from verl_omni.utils.diffusion_attention import fallback_fa3_if_unavailable, validate_attention_consistency
 
 
-def _prepare_processor_files(local_path: str, model_config) -> None:
+def _prepare_processor_files(local_path: str, model_config) -> str | None:
     """Run the registered model hook before the driver loads its processor."""
     architecture = model_config.get("architecture")
     if architecture is None:
@@ -40,7 +40,7 @@ def _prepare_processor_files(local_path: str, model_config) -> None:
 
     from verl_omni.pipelines.model_base import DiffusionModelBase
 
-    DiffusionModelBase.get_class_by_name(
+    return DiffusionModelBase.get_class_by_name(
         architecture,
         model_config.algorithm,
         model_config.get("external_lib"),
@@ -259,8 +259,10 @@ class TaskRunner:
         trust_remote_code = config.data.get("trust_remote_code", False)
         tokenizer = hf_tokenizer(config.actor_rollout_ref.model.tokenizer_path, trust_remote_code=trust_remote_code)
         # Used for multimodal LLM, could be None
-        _prepare_processor_files(local_path, config.actor_rollout_ref.model)
+        prepared_processor_path = _prepare_processor_files(local_path, config.actor_rollout_ref.model)
         processor_path = os.path.join(local_path, "processor")
+        if prepared_processor_path is not None:
+            processor_path = prepared_processor_path
         if not os.path.exists(processor_path):
             processor_path = local_path
         processor = hf_processor(processor_path, trust_remote_code=trust_remote_code, use_fast=True)

--- a/verl_omni/trainer/main_diffusion.py
+++ b/verl_omni/trainer/main_diffusion.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Entrypoint for diffusion model RL training."""
 
+import json
 import os
 import socket
 
@@ -28,6 +29,22 @@ from verl_omni.trainer.diffusion.ray_diffusion_trainer import (
     PolicyGradientRayTrainer,
 )
 from verl_omni.utils.diffusion_attention import fallback_fa3_if_unavailable, validate_attention_consistency
+
+
+def _prepare_processor_files(local_path: str, model_config) -> None:
+    """Run the registered model hook before the driver loads its processor."""
+    architecture = model_config.get("architecture")
+    if architecture is None:
+        with open(os.path.join(local_path, "model_index.json")) as model_index_file:
+            architecture = json.load(model_index_file)["_class_name"]
+
+    from verl_omni.pipelines.model_base import DiffusionModelBase
+
+    DiffusionModelBase.get_class_by_name(
+        architecture,
+        model_config.algorithm,
+        model_config.get("external_lib"),
+    ).prepare_processor_files(local_path)
 
 
 @hydra.main(config_path="./config", config_name="diffusion_trainer", version_base=None)
@@ -242,6 +259,7 @@ class TaskRunner:
         trust_remote_code = config.data.get("trust_remote_code", False)
         tokenizer = hf_tokenizer(config.actor_rollout_ref.model.tokenizer_path, trust_remote_code=trust_remote_code)
         # Used for multimodal LLM, could be None
+        _prepare_processor_files(local_path, config.actor_rollout_ref.model)
         processor_path = os.path.join(local_path, "processor")
         if not os.path.exists(processor_path):
             processor_path = local_path

--- a/verl_omni/trainer/main_diffusion.py
+++ b/verl_omni/trainer/main_diffusion.py
@@ -31,22 +31,6 @@ from verl_omni.trainer.diffusion.ray_diffusion_trainer import (
 from verl_omni.utils.diffusion_attention import fallback_fa3_if_unavailable, validate_attention_consistency
 
 
-def _prepare_processor_files(local_path: str, model_config) -> str | None:
-    """Run the registered model hook before the driver loads its processor."""
-    architecture = model_config.get("architecture")
-    if architecture is None:
-        with open(os.path.join(local_path, "model_index.json")) as model_index_file:
-            architecture = json.load(model_index_file)["_class_name"]
-
-    from verl_omni.pipelines.model_base import DiffusionModelBase
-
-    return DiffusionModelBase.get_class_by_name(
-        architecture,
-        model_config.algorithm,
-        model_config.get("external_lib"),
-    ).prepare_processor_files(local_path)
-
-
 @hydra.main(config_path="./config", config_name="diffusion_trainer", version_base=None)
 def main(config):
     """Main entry point for diffusion model training with Hydra configuration management.
@@ -259,7 +243,19 @@ class TaskRunner:
         trust_remote_code = config.data.get("trust_remote_code", False)
         tokenizer = hf_tokenizer(config.actor_rollout_ref.model.tokenizer_path, trust_remote_code=trust_remote_code)
         # Used for multimodal LLM, could be None
-        prepared_processor_path = _prepare_processor_files(local_path, config.actor_rollout_ref.model)
+        model_config = config.actor_rollout_ref.model
+        architecture = model_config.get("architecture")
+        if architecture is None:
+            with open(os.path.join(local_path, "model_index.json")) as model_index_file:
+                architecture = json.load(model_index_file)["_class_name"]
+
+        from verl_omni.pipelines.model_base import DiffusionModelBase
+
+        prepared_processor_path = DiffusionModelBase.get_class_by_name(
+            architecture,
+            model_config.algorithm,
+            model_config.get("external_lib"),
+        ).prepare_processor_files(local_path)
         processor_path = os.path.join(local_path, "processor")
         if prepared_processor_path is not None:
             processor_path = prepared_processor_path

--- a/verl_omni/trainer/main_diffusion.py
+++ b/verl_omni/trainer/main_diffusion.py
@@ -246,8 +246,15 @@ class TaskRunner:
         model_config = config.actor_rollout_ref.model
         architecture = model_config.get("architecture")
         if architecture is None:
-            with open(os.path.join(local_path, "model_index.json")) as model_index_file:
-                architecture = json.load(model_index_file)["_class_name"]
+            model_index_path = os.path.join(local_path, "model_index.json")
+            try:
+                with open(model_index_path) as model_index_file:
+                    architecture = json.load(model_index_file)["_class_name"]
+            except (OSError, KeyError, json.JSONDecodeError) as exc:
+                raise ValueError(
+                    f"Unable to infer the diffusion architecture from {model_index_path}. "
+                    "Set actor_rollout_ref.model.architecture explicitly."
+                ) from exc
 
         from verl_omni.pipelines.model_base import DiffusionModelBase
 

--- a/verl_omni/workers/config/diffusion/model.py
+++ b/verl_omni/workers/config/diffusion/model.py
@@ -156,10 +156,12 @@ class DiffusionModelConfig(BaseConfig):
             self.tokenizer = hf_tokenizer(
                 self.local_tokenizer_path, trust_remote_code=self.trust_remote_code, use_fast=True
             )
-            if os.path.exists(os.path.join(self.local_path, "processor")):
-                self.processor = hf_processor(
-                    os.path.join(self.local_path, "processor"), trust_remote_code=self.trust_remote_code
-                )
+            processor_path = os.path.join(self.local_path, "processor")
+            if os.path.exists(processor_path):
+                from verl_omni.pipelines.model_base import DiffusionModelBase
+
+                DiffusionModelBase.get_class(self).prepare_processor_files(self.local_path)
+                self.processor = hf_processor(processor_path, trust_remote_code=self.trust_remote_code)
             else:
                 self.processor = None
 

--- a/verl_omni/workers/config/diffusion/model.py
+++ b/verl_omni/workers/config/diffusion/model.py
@@ -160,11 +160,13 @@ class DiffusionModelConfig(BaseConfig):
             if os.path.exists(processor_path):
                 from verl_omni.pipelines.model_base import DiffusionModelBase
 
-                DiffusionModelBase.get_class_by_name(
+                prepared_processor_path = DiffusionModelBase.get_class_by_name(
                     self.architecture,
                     self.algorithm,
                     self.external_lib,
                 ).prepare_processor_files(self.local_path)
+                if prepared_processor_path is not None:
+                    processor_path = prepared_processor_path
                 self.processor = hf_processor(processor_path, trust_remote_code=self.trust_remote_code)
             else:
                 self.processor = None

--- a/verl_omni/workers/config/diffusion/model.py
+++ b/verl_omni/workers/config/diffusion/model.py
@@ -160,7 +160,11 @@ class DiffusionModelConfig(BaseConfig):
             if os.path.exists(processor_path):
                 from verl_omni.pipelines.model_base import DiffusionModelBase
 
-                DiffusionModelBase.get_class(self).prepare_processor_files(self.local_path)
+                DiffusionModelBase.get_class_by_name(
+                    self.architecture,
+                    self.algorithm,
+                    self.external_lib,
+                ).prepare_processor_files(self.local_path)
                 self.processor = hf_processor(processor_path, trust_remote_code=self.trust_remote_code)
             else:
                 self.processor = None

--- a/verl_omni/workers/config/diffusion/model.py
+++ b/verl_omni/workers/config/diffusion/model.py
@@ -163,7 +163,6 @@ class DiffusionModelConfig(BaseConfig):
                 prepared_processor_path = DiffusionModelBase.get_class_by_name(
                     self.architecture,
                     self.algorithm,
-                    self.external_lib,
                 ).prepare_processor_files(self.local_path)
                 if prepared_processor_path is not None:
                     processor_path = prepared_processor_path


### PR DESCRIPTION
## Summary

This PR adds the model-agnostic pieces needed by image-editing pipelines:

- `ImageGenerationRequest` normalizes text-to-image and image-conditioned rollout payloads.
- `DiffusionI2IModelBase` defines condition preparation, concat/crop injection, metadata unwrapping, and sequence-parallel validation.
- `prepare_processor_files()` runs before both driver-side and worker-side processor loading and may return a writable prepared path for read-only model mounts.
- CPU tests cover request parsing, T2I compatibility, I2I condition dispatch, processor load order, and external adapter overrides.

The branch was rebuilt from `upstream/main` at `f81ee27`. It contains no Qwen-Image-Edit, FLUX, reward-service, training-recipe, or long-form documentation changes. The Qwen implementation is isolated on `NancyFyong/pr/qwen-image-edit` and will be opened against `main` after this PR merges.

## Compatibility

Existing T2I adapters keep the original `prepare_model_inputs` path. I2I adapters opt in by subclassing `DiffusionI2IModelBase`; missing or malformed condition latents fail before model execution. Driver and worker processor resolution use the same registry and external-library override order.

## Duplicate-work check

Checked before rebuilding:

- `gh issue view 237 --repo verl-project/verl-omni --comments`
- `gh pr list --repo verl-project/verl-omni --state open --search "237 in:body"`
- `gh pr list --repo verl-project/verl-omni --state open --search "image editing interface in:title,body"`
- `gh pr list --repo verl-project/verl-omni --state open --search "Qwen Image Edit FlowGRPO in:title,body"`

No separate open PR implements this interface.

## Tests

- `PYTHONPATH=/tmp/kilo/verl-omni-general pytest -q tests/pipelines/test_image_edit_interface_on_cpu.py tests/pipelines/test_i2i_model_base_on_cpu.py tests/pipelines/test_diffusion_model_base_on_cpu.py tests/workers/config/test_diffusion_config_on_cpu.py` - 59 passed
- `ruff check` and `ruff format --check` on all changed Python files - passed
- full pre-commit hooks on every commit - passed
- `git diff --check upstream/main..HEAD` - passed

## AI assistance

AI assistance was used while restructuring and testing this change. I reviewed the final diff and test results.