### PR TITLE
[misc] fix: resolve verl-omni and vllm-omni accelerate dependency conflict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,3 +156,12 @@ verl_omni = [
   "trainer/config/*/*.yaml",
   "trainer/config/*/*/*.yaml",
 ]
+
+# -------------------------------
+# tool.uv - Package resolution overrides
+# -------------------------------
+[tool.uv]
+override-dependencies = [
+    "accelerate>=1.14.0",
+]
+


### PR DESCRIPTION
### What does this PR do?
Fix #234 

- Resolves the dependency resolution conflict between `verl-omni` and `vllm-omni` (#234) where `verl-omni` requires `accelerate>=1.14.0` for Qwen3-Omni training while `vllm-omni`
  strictly pins `accelerate==1.12.0`.
- Utilizes `tool.uv.override-dependencies` to override `vllm-omni`'s strict requirement and forces the installation of `accelerate>=1.14.0` when resolving dependencies.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `vllm_omni`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `diffusion`, `omni`, `tests`, `docker`
  - If this PR involves multiple modules, separate them with `,` like `[diffusion, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][diffusion, fsdp] feat: new rollout scheduler`

### Test

  - Run `uv pip install -e ".[vllm-omni,train]" --dry-run` and verify that the package manager completes resolution successfully with `accelerate>=1.14.0` without errors.
  - Run `uv pip install -e ".[gpu]" --dry-run` and verify that `accelerate>=1.14.0` is still selected.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update the documentation.
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl-omni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
