### PR TITLE
[reward] fix: drop duplicate critic/score metric for single-reward training

### DIFF
--- a/verl_omni/reward_loop/reward_manager/visual.py
+++ b/verl_omni/reward_loop/reward_manager/visual.py
@@ -93,6 +93,8 @@ class VisualRewardManager(RewardManagerBase):
         if isinstance(result, dict):
             score = result["score"]
             for key, value in result.items():
+                if key == "score":
+                    continue
                 reward_extra_info[key] = value
         else:
             score = result


### PR DESCRIPTION
## What

Fixes #121. For single-reward flow-grpo training, `critic/score/mean` was always identical to `critic/rewards/mean`.

Root cause: `VisualRewardManager.run_single` copies **every** field of a dict reward result into `reward_extra_info`, including the primary `score`. Since `score` is the reward itself (already reported as `critic/rewards/mean` by `compute_data_metrics_diffusion`), re-exporting it made `compute_reward_extra_metrics_diffusion` emit a duplicate `critic/score/mean`. The fix skips the `score` key.

## Not duplicating existing work

No open PR touches `visual.py` / `diffusion_metric_utils.py`, and no PR references #121. Since the issue was filed, the only change to those files (#106) did not address the duplication.

## Testing

- Ran `ruff check` on both changed files — passed.
- A/B verification against the real code (git HEAD vs this branch), driving the real `run_single` -> real `compute_reward_extra_metrics_diffusion`:
  - **before:** `critic/score/mean` present and equal to `critic/rewards/mean` (duplicate)
  - **after:** `critic/score/mean` no longer produced; `critic/rewards/mean` unchanged

## Related but not addressed (kept out of scope)

- Non-dict branch sets `reward_extra_info["acc"] = score`, which similarly duplicates `critic/rewards/mean`. Left as-is because `acc` is used as the validation core variable (`ray_diffusion_trainer.py`); changing it risks a validation regression.
- `MultiVisualRewardManager` emits `reward/combined` == `reward/{key}` for a single sub-reward — same class of issue, better as a follow-up.
