### PR TITLE
[reward] fix: drop duplicate reward/<key>/score metric for multi-reward training

### DIFF
--- a/tests/reward_loop/test_multi_reward_manager_on_cpu.py
+++ b/tests/reward_loop/test_multi_reward_manager_on_cpu.py
@@ -135,6 +135,7 @@ class TestMultiVisualRewardManagerRunSingle:
         assert result["reward_extra_info"]["reward/fixed"] == pytest.approx(0.5)
         assert result["reward_extra_info"]["reward/dict_result"] == pytest.approx(1.0)
         assert result["reward_extra_info"]["reward/dict_result/detail"] == "perfect"
+        assert "reward/dict_result/score" not in result["reward_extra_info"]
         assert result["reward_extra_info"]["reward/combined"] == pytest.approx(2.0)
 
     def test_exception_contributes_zero(self):

--- a/tests/reward_loop/test_visual_reward_manager.py
+++ b/tests/reward_loop/test_visual_reward_manager.py
@@ -102,7 +102,7 @@ def test_reward_model_genrm():
 
     for idx, output in enumerate(outputs):
         print(f"GRM Response {idx}:\n{output.non_tensor_batch['genrm_response']}\n")
-        print(f"Score:\n{output.non_tensor_batch['score']}\n")
+        print(f"Score:\n{output.batch['rm_scores']}\n")
         print("=" * 50 + "\n")
 
     ray.shutdown()

--- a/verl_omni/reward_loop/reward_manager/multi.py
+++ b/verl_omni/reward_loop/reward_manager/multi.py
@@ -158,8 +158,9 @@ class MultiVisualRewardManager(VisualRewardManager):
 
                 if isinstance(result, dict):
                     score = float(result["score"])
-                    # Store all sub-result fields under the reward key namespace
                     for rk, rv in result.items():
+                        if rk == "score":
+                            continue
                         reward_extra_info[f"reward/{key}/{rk}"] = rv
                 else:
                     score = float(result)


### PR DESCRIPTION
# [reward] fix: drop duplicate reward/<key>/score metric for multi-reward training

Follow-up to #242

## What & why

#242 removed the duplicate `critic/score/mean` metric in
`VisualRewardManager` by not copying a dict reward's primary `score` field into
`reward_extra_info`. `MultiVisualRewardManager.run_single` has the same issue:
for a dict sub-reward it copies **every** field — including `score` — into the
per-reward namespace, so it emits both

- `reward/<key>/score` (from the field-copy loop), and
- `reward/<key>` (the primary score, set explicitly right after)

which are identical. This mirrors #121/#242 exactly, so the fix mirrors it:
skip `score` when copying the auxiliary fields.

## Testing
- Ran a local cpu end-to-end test that drives the real `run_single`
  output through the real `compute_reward_extra_metrics_diffusion`, asserting the
  logged metrics contain no `critic/reward/ocr/score/mean` (the duplicate) while
  `critic/reward/ocr/mean` and the auxiliary `reward/ocr/genrm_response` field
  are intact — end-to-end proof that the duplicate metric is gone.
- `ruff check` and `ruff format --check` pass on all changed files.

## Not duplicating existing work

This is the multi-reward counterpart explicitly requested on #242; no open PR
addresses multi-reward metric deduplication.
