### PR TITLE
[1/N][omni] feat: Omni model refactor

### DIFF
--- a/tests/pipelines/test_qwen3_omni_thinker_adapter.py
+++ b/tests/pipelines/test_qwen3_omni_thinker_adapter.py
@@ -1,0 +1,120 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Regression: upstream fixes that made patches unnecessary for Qwen3-Omni.
+
+Patches dropped from the adapter:
+- ``_apply_tie_embeddings_fix``   → v5 default is ``False``
+- ``_install_moe_unfuse_hook``    → PEFT handles MoE natively
+- ``module._no_split_modules``    → thinker class already correct
+"""
+
+import pytest
+import torch
+import torch.nn as nn
+
+
+def _has_lora(module: nn.Module) -> bool:
+    """Return True if *module* was wrapped with LoRA by PEFT."""
+    return hasattr(module, "lora_A") and hasattr(module, "lora_B")
+
+
+class _FusedMoEExperts(nn.Module):
+    """Minimal Qwen3-Omni-style fused expert group.
+
+    ``gate_up_proj`` is a 3D ``nn.Parameter``, not ``nn.Linear``.
+    """
+
+    def __init__(self, num_experts=4, hidden=64, intermediate=128):
+        super().__init__()
+        self.gate_up_proj = nn.Parameter(torch.randn(num_experts, 2 * intermediate, hidden))
+        self.down_proj = nn.Parameter(torch.randn(num_experts, hidden, intermediate))
+
+
+class _MoEModel(nn.Module):
+    """Minimal model with ``config.model_type`` for PEFT conversion routing.
+
+    Contains one dense ``nn.Linear`` block and one fused MoE expert
+    block so we can verify PEFT correctly routes LoRA to both.
+    """
+
+    def __init__(self, hidden=64, intermediate=128, num_experts=4):
+        super().__init__()
+        self.config = type("C", (), {"model_type": "qwen3_omni_moe"})()
+
+        # Dense layers — standard nn.Linear, PEFT wraps these directly.
+        self.dense = nn.Module()
+        self.dense.q_proj = nn.Linear(hidden, hidden, bias=False)
+        self.dense.k_proj = nn.Linear(hidden, hidden, bias=False)
+        self.dense.v_proj = nn.Linear(hidden, hidden, bias=False)
+        self.dense.o_proj = nn.Linear(hidden, hidden, bias=False)
+
+        # MoE experts — fused parameters, PEFT maps via target_parameters
+        # with doubled rank.
+        self.experts = _FusedMoEExperts(num_experts, hidden, intermediate)
+
+
+def test_peft_lora_attaches_to_fused_moe_natively():
+    """PEFT converts gate_proj+up_proj → gate_up_proj with doubled rank."""
+    pytest.importorskip("peft")
+    from peft import LoraConfig, get_peft_model
+
+    model = _MoEModel()
+    lora_config = LoraConfig(
+        r=8,
+        lora_alpha=16,
+        target_modules=["q_proj", "k_proj", "v_proj", "o_proj", "gate_proj", "up_proj", "down_proj"],
+    )
+    peft_model = get_peft_model(model, lora_config)
+
+    # 1. Dense nn.Linear layers get standard LoRA.
+    assert _has_lora(peft_model.dense.q_proj), "dense q_proj missing LoRA"
+    assert _has_lora(peft_model.dense.k_proj), "dense k_proj missing LoRA"
+
+    # 2. PEFT doubled the rank — gate_proj + up_proj fused into gate_up_proj.
+    cur_r = peft_model.peft_config["default"].r
+    assert cur_r != 8, f"PEFT should have doubled LoRA rank (8 → 16) for fused gate_up_proj, got r={cur_r}"
+
+    # 3. gate_up_proj parameter exists and is not an nn.Linear module.
+    assert hasattr(peft_model.experts, "gate_up_proj"), "gate_up_proj parameter should still exist after PEFT wrapping"
+
+
+def test_adapter_source_has_no_peft_references():
+    """The adapter source must not import or reference ``peft``."""
+    import verl_omni.pipelines.qwen3_omni.thinker_training_adapter as ta
+
+    source = open(ta.__file__).read()
+    err = "adapter source references 'peft' — PEFT handles MoE natively"
+    assert "peft" not in source, err
+    assert "get_peft_model" not in source, err
+
+
+def test_tie_word_embeddings_is_false_by_default():
+    """v5 config defaults ``tie_word_embeddings=False``."""
+    pytest.importorskip("transformers")
+    from transformers.models.qwen3_omni_moe import Qwen3OmniMoeConfig
+
+    cfg = Qwen3OmniMoeConfig()
+    assert cfg.tie_word_embeddings is False, "tie_word_embeddings should default to False in transformers >= 5.0"
+
+
+def test_thinker_class_no_split_modules_is_correct():
+    """Thinker subclass already uses the right FSDP layer class name."""
+    pytest.importorskip("transformers")
+    from transformers.models.qwen3_omni_moe import (
+        Qwen3OmniMoeThinkerForConditionalGeneration,
+    )
+
+    expected = ["Qwen3OmniMoeThinkerTextDecoderLayer"]
+    actual = Qwen3OmniMoeThinkerForConditionalGeneration._no_split_modules
+    assert actual == expected, f"_no_split_modules should be {expected} in transformers >= 5.0, got {actual}"

--- a/verl_omni/pipelines/__init__.py
+++ b/verl_omni/pipelines/__init__.py
@@ -14,6 +14,7 @@
 
 from . import (
     bagel_flow_grpo,
+    qwen3_omni,
     qwen_image_diffusion_nft,
     qwen_image_dpo,
     qwen_image_flow_grpo,
@@ -23,6 +24,7 @@ from . import (
     wan22_dance_grpo,
 )
 from .bagel_flow_grpo import *  # noqa: F401, F403
+from .qwen3_omni import *  # noqa: F401, F403
 from .qwen_image_diffusion_nft import *  # noqa: F401, F403
 from .qwen_image_dpo import *  # noqa: F401, F403
 from .qwen_image_flow_grpo import *  # noqa: F401, F403
@@ -31,7 +33,8 @@ from .sd3_dpo import *  # noqa: F401, F403
 from .sd3_flow_grpo import *  # noqa: F401, F403
 from .wan22_dance_grpo import *  # noqa: F401, F403
 
-__all__ = list(qwen_image_flow_grpo.__all__)
+__all__ = list(qwen3_omni.__all__)
+__all__ += list(qwen_image_flow_grpo.__all__)
 __all__ += list(qwen_image_diffusion_nft.__all__)
 __all__ += list(qwen_image_mix_grpo.__all__)
 __all__ += list(bagel_flow_grpo.__all__)

--- a/verl_omni/pipelines/model_base.py
+++ b/verl_omni/pipelines/model_base.py
@@ -14,7 +14,7 @@
 
 import logging
 from abc import ABC, abstractmethod
-from typing import Optional
+from typing import Any, Optional
 
 import torch
 from diffusers import ModelMixin, SchedulerMixin
@@ -267,3 +267,197 @@ class VllmOmniPipelineBase:
         if pipeline_cls is None:
             return None
         return f"{pipeline_cls.__module__}.{pipeline_cls.__qualname__}"
+
+
+class OmniModelBase(ABC):
+    """Abstract base class for omni model training adapters.
+
+    Different omni models (Qwen3-Omni, future models) have multi-stage
+    architectures with thinker, talker, and codec components.  Subclass
+    this ABC and implement the abstract methods to plug your model into
+    the verl RL training loop.
+
+    Unlike diffusion models, omni models are AR language models — the
+    adapter is **algorithm-agnostic**.  RL algorithm selection (GSPO,
+    GRPO, RLOO, etc.) is handled by verl's existing config fields
+    ``actor.policy_loss.loss_mode`` and ``algorithm.adv_estimator``.
+
+    To register, decorate your subclass with::
+
+        @OmniModelBase.register("Qwen3OmniMoeForConditionalGeneration", stage="thinker")
+        class Qwen3OmniThinkerAdapter(OmniModelBase):
+            ...
+
+    The registry key is ``(architecture, stage)`` where *architecture*
+    matches the HF config ``architectures[0]`` and *stage* is
+    ``"thinker"``, ``"talker"``, or ``"all"``.
+    """
+
+    _registry: dict[tuple[str, str], type["OmniModelBase"]] = {}
+
+    @classmethod
+    def register(cls, architecture: str, stage: str = "thinker"):
+        """Class decorator that registers a subclass for ``(architecture, stage)``."""
+
+        def decorator(subclass: type["OmniModelBase"]) -> type["OmniModelBase"]:
+            cls._registry[(architecture, stage)] = subclass
+            return subclass
+
+        return decorator
+
+    @classmethod
+    def get_class(cls, model_config) -> type["OmniModelBase"]:
+        """Return the registered subclass for ``(architecture, model_stage)``.
+
+        Args:
+            model_config: An ``OmniModelConfig`` instance (or any config object
+                with ``architecture`` and ``model_stage`` attributes).
+        """
+        key = (model_config.architecture, model_config.model_stage)
+        if key not in cls._registry and getattr(model_config, "external_lib", None) is not None:
+            from verl.utils.import_utils import import_external_libs
+
+            import_external_libs(model_config.external_lib)
+
+        try:
+            return cls._registry[key]
+        except KeyError:
+            registered = sorted(cls._registry.keys())
+            raise NotImplementedError(
+                f"No omni model registered for (architecture={model_config.architecture!r}, "
+                f"stage={model_config.model_stage!r}). Registered: {registered}. "
+                f"Set ``external_lib`` to load your training adapter."
+            ) from None
+
+    @classmethod
+    @abstractmethod
+    def get_strip_modules(cls, model_config) -> list[str]:
+        """Return submodule prefixes to strip before FSDP init.
+
+        Multi-stage omni models contain components that are not trained
+        in every run (e.g. the talker and codec are dead weight during
+        thinker-only training).  Stripping them before FSDP wrapping
+        saves memory and avoids sharding unused parameters.
+
+        Args:
+            model_config: The ``OmniModelConfig``.
+
+        Returns:
+            list[str]: Submodule attribute names to delete.  For
+            thinker-only training this is typically ``["talker",
+            "code2wav", "code_predictor"]``; for all-stage training an
+            empty list.
+        """
+        pass
+
+    @classmethod
+    @abstractmethod
+    def configure_processor(cls, model_path: str, model_config) -> Any:
+        """Load and configure the multimodal processor.
+
+        Returns a processor object that handles text, image, audio, and
+        video inputs.  Must provide ``apply_chat_template``, ``__call__``,
+        ``tokenizer``, and ``chat_template``.
+
+        Called by the omni trainer at init time instead of verl's
+        default ``hf_processor`` helper.
+
+        Args:
+            model_path: Local path to the model checkpoint.
+            model_config: The ``OmniModelConfig``.
+        """
+        pass
+
+    @classmethod
+    @abstractmethod
+    def configure_tokenizer(cls, model_path: str, model_config) -> Any:
+        """Load and configure the tokenizer.
+
+        Handles model-specific setup such as loading ``chat_template``
+        from a separate JSON file.
+
+        Called by the omni trainer at init time instead of verl's
+        default ``hf_tokenizer`` helper.
+
+        Args:
+            model_path: Local path to the model checkpoint.
+            model_config: The ``OmniModelConfig``.
+        """
+        pass
+
+    @classmethod
+    def configure_model(cls, module, model_config):
+        """Configure the model after loading and before FSDP wrapping.
+
+        Default implementation strips the submodules returned by
+        :meth:`get_strip_modules`.  Override to also:
+
+        - Register the model class with ``AutoModelForCausalLM``.
+        - Redirect ``forward()`` and embedding accessors to the
+          trainable sub-component.
+        - Force ``tie_word_embeddings=False`` for FSDP compatibility.
+        - Unfuse MoE experts for PEFT / LoRA.
+
+        Args:
+            module: The loaded model (before FSDP wrapping).
+            model_config: The ``OmniModelConfig``.
+
+        Returns:
+            The configured module.
+        """
+        for submod_name in cls.get_strip_modules(model_config):
+            if hasattr(module, submod_name):
+                delattr(module, submod_name)
+
+        return module
+
+
+class OmniRolloutPipelineBase:
+    """Registry for omni model vLLM-Omni pipeline topologies.
+
+    Each registered entry provides model-specific topology defaults for
+    running the model as a multi-stage pipeline in vLLM-Omni.
+
+    To register, decorate your subclass with::
+
+        @OmniRolloutPipelineBase.register("qwen3_omni_moe")
+        class Qwen3OmniRolloutAdapter(OmniRolloutPipelineBase):
+            ...
+
+    Registration uses a ``model_type`` key matching vLLM-Omni's pipeline
+    registry names (e.g. ``"qwen3_omni_moe"``).
+    """
+
+    _registry: dict[str, type["OmniRolloutPipelineBase"]] = {}
+
+    @classmethod
+    def register(cls, model_type: str):
+        """Class decorator that registers a rollout adapter for ``model_type``."""
+
+        def decorator(subclass: type["OmniRolloutPipelineBase"]) -> type["OmniRolloutPipelineBase"]:
+            cls._registry[model_type] = subclass
+            return subclass
+
+        return decorator
+
+    @classmethod
+    def get_class(cls, model_type: str) -> type | None:
+        """Return the registered rollout adapter for ``model_type``, or ``None``."""
+        return cls._registry.get(model_type)
+
+    @classmethod
+    @abstractmethod
+    def build_stage_configs(cls, pipeline_mode: str = "thinker_only") -> list[dict]:
+        """Return per-stage topology defaults for a vLLM-Omni stage config.
+
+        Each dict is the model-specific starting point for one stage's
+        ``engine_args`` (``model_stage``, ``model_arch``,
+        ``worker_type``, ``hf_config_name``, etc.).
+
+        Args:
+            pipeline_mode: ``"thinker_only"`` | ``"thinker_talker"`` | ``"full"``.
+
+        Returns:
+            list[dict]: One topology dict per pipeline stage.
+        """
+        pass

--- a/verl_omni/pipelines/qwen3_omni/__init__.py
+++ b/verl_omni/pipelines/qwen3_omni/__init__.py
@@ -11,9 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Qwen3-Omni pipeline adapters (Thinker training + rollout pipeline topology)."""
 
-from . import diffusion, omni
-from .diffusion import *  # noqa: F401,F403
-from .omni import *  # noqa: F401,F403
+from .omni_rollout_adapter import Qwen3OmniRolloutAdapter
+from .thinker_training_adapter import Qwen3OmniThinkerAdapter
 
-__all__ = list(diffusion.__all__) + list(omni.__all__)
+__all__ = [
+    "Qwen3OmniThinkerAdapter",
+    "Qwen3OmniRolloutAdapter",
+]

--- a/verl_omni/pipelines/qwen3_omni/omni_rollout_adapter.py
+++ b/verl_omni/pipelines/qwen3_omni/omni_rollout_adapter.py
@@ -1,0 +1,98 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Qwen3-Omni rollout pipeline adapter.
+
+Generates per-stage ``engine_args`` topology defaults for running
+Qwen3-Omni as a multi-stage pipeline in vLLM-Omni.
+"""
+
+import logging
+
+from verl_omni.pipelines.model_base import OmniRolloutPipelineBase
+
+logger = logging.getLogger(__name__)
+
+
+@OmniRolloutPipelineBase.register("qwen3_omni_moe")
+class Qwen3OmniRolloutAdapter(OmniRolloutPipelineBase):
+    """Rollout pipeline topology adapter for Qwen3-Omni.
+
+    Registered under ``model_type="qwen3_omni_moe"``.  Supports three
+    pipeline modes: ``"thinker_only"`` (AR text), ``"thinker_talker"``
+    (speech codec tokens), and ``"full"`` (audio waveform).
+    """
+
+    @classmethod
+    def build_stage_configs(cls, pipeline_mode: str = "thinker_only") -> list[dict]:
+        """Return per-stage model-topology defaults for vLLM-Omni.
+
+        Args:
+            pipeline_mode: ``"thinker_only"`` | ``"thinker_talker"`` | ``"full"``.
+
+        Returns:
+            list[dict]: One topology dict per pipeline stage.
+        """
+        thinker_engine = {
+            "model_stage": "thinker",
+            "model_arch": "Qwen3OmniMoeThinkerForConditionalGeneration",
+            "worker_type": "ar",
+            "scheduler_cls": "vllm_omni.core.sched.omni_ar_scheduler.OmniARScheduler",
+            "hf_config_name": "thinker_config",
+        }
+        thinker = {
+            "stage_id": 0,
+            "engine_args": thinker_engine,
+            "final_output": True,
+            "final_output_type": "text",
+        }
+        thinker_with_hidden = {
+            "stage_id": 0,
+            "engine_args": {**thinker_engine, "return_hidden_states": True},
+            "final_output": False,
+        }
+        talker = {
+            "stage_id": 1,
+            "engine_args": {
+                "model_stage": "talker",
+                "model_arch": "Qwen3OmniMoeTalkerForConditionalGeneration",
+                "worker_type": "codec",
+                "hf_config_name": "talker_config",
+            },
+        }
+        code2wav = {
+            "stage_id": 2,
+            "engine_args": {
+                "model_stage": "code2wav",
+                "model_arch": "Qwen3OmniMoeCode2WavForConditionalGeneration",
+                "worker_type": "waveform",
+            },
+        }
+
+        if pipeline_mode == "thinker_only":
+            return [thinker]
+        elif pipeline_mode == "thinker_talker":
+            return [
+                thinker_with_hidden,
+                {**talker, "final_output": True, "final_output_type": "codec"},
+            ]
+        elif pipeline_mode == "full":
+            return [
+                thinker_with_hidden,
+                talker,
+                {**code2wav, "final_output": True, "final_output_type": "waveform"},
+            ]
+        else:
+            raise ValueError(
+                f"Unknown pipeline_mode={pipeline_mode!r}. Expected one of: 'thinker_only', 'thinker_talker', 'full'."
+            )

--- a/verl_omni/pipelines/qwen3_omni/thinker_training_adapter.py
+++ b/verl_omni/pipelines/qwen3_omni/thinker_training_adapter.py
@@ -1,0 +1,98 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Qwen3-Omni Thinker training adapter.
+
+Implements ``OmniModelBase`` for thinker-stage training of
+Qwen3-Omni: sub-module stripping, forward redirection, and
+processor/tokenizer configuration.
+"""
+
+import json
+import logging
+import os
+from typing import Any
+
+from verl_omni.pipelines.model_base import OmniModelBase
+
+logger = logging.getLogger(__name__)
+
+
+@OmniModelBase.register("Qwen3OmniMoeForConditionalGeneration", stage="thinker")
+class Qwen3OmniThinkerAdapter(OmniModelBase):
+    """Thinker-stage training adapter for Qwen3-Omni.
+
+    Handles model setup that is required before verl's FSDP engine
+    loads and wraps the model: sub-module stripping, forward redirection
+    to the thinker component, and processor/tokenizer configuration.
+    """
+
+    @classmethod
+    def get_strip_modules(cls, model_config) -> list[str]:
+        return ["talker", "code2wav", "code_predictor"]
+
+    @classmethod
+    def configure_model(cls, module, model_config):
+        """Strip non-training stages and redirect forward to thinker."""
+        for submod_name in cls.get_strip_modules(model_config):
+            if hasattr(module, submod_name):
+                delattr(module, submod_name)
+
+        module.forward = module.thinker.forward
+        module.get_input_embeddings = module.thinker.get_input_embeddings
+        module.set_input_embeddings = module.thinker.set_input_embeddings
+        return module
+
+    @classmethod
+    def configure_processor(cls, model_path: str, model_config) -> Any:
+        """Load the Qwen3-Omni multimodal processor with RoPE helpers.
+
+        Swaps ``processor.config`` to ``thinker_config`` (Qwen3-Omni
+        nests multimodal settings under sub-configs).  Binds
+        ``get_rope_index`` and ``get_llm_pos_ids_for_vision`` to the
+        processor — the omni agent loop calls these on the processor,
+        but they are model methods.
+        """
+        import types
+
+        from transformers import AutoConfig, AutoProcessor
+        from transformers.models.qwen3_omni_moe import Qwen3OmniMoeThinkerForConditionalGeneration
+
+        processor = AutoProcessor.from_pretrained(model_path)
+        config = AutoConfig.from_pretrained(model_path)
+
+        processor.config = config.thinker_config
+        processor.spatial_merge_size = config.thinker_config.vision_config.spatial_merge_size
+        processor.config.vision_start_token_id = config.talker_config.vision_start_token_id
+
+        model_cls = Qwen3OmniMoeThinkerForConditionalGeneration
+        processor.get_rope_index = types.MethodType(model_cls.get_rope_index, processor)
+        processor.get_llm_pos_ids_for_vision = types.MethodType(model_cls.get_llm_pos_ids_for_vision, processor)
+        return processor
+
+    @classmethod
+    def configure_tokenizer(cls, model_path: str, model_config) -> Any:
+        """Load the tokenizer. Qwen3-Omni stores its chat template in
+        ``chat_template.json`` instead of ``tokenizer_config.json``."""
+        from transformers import AutoTokenizer
+
+        tokenizer = AutoTokenizer.from_pretrained(model_path)
+        chat_template_path = os.path.join(model_path, "chat_template.json")
+        if not os.path.isfile(chat_template_path):
+            raise FileNotFoundError(
+                f"Qwen3-Omni chat template not found at {chat_template_path}. "
+                f"Ensure the model checkpoint includes chat_template.json."
+            )
+        with open(chat_template_path) as f:
+            tokenizer.chat_template = json.load(f)["chat_template"]
+        return tokenizer

--- a/verl_omni/trainer/config/omni_trainer.yaml
+++ b/verl_omni/trainer/config/omni_trainer.yaml
@@ -1,0 +1,19 @@
+# Format checks enforced on CI:
+# 1. Comments must appear above each field.
+# 2. There must be a blank line between each field.
+# 3. Inline comments (after a field on the same line) are not allowed.
+# 4. Indentation level is respected for nested fields.
+
+hydra:
+  searchpath:
+    - pkg://verl.trainer.config
+
+defaults:
+  - ppo_trainer
+  - _self_
+
+actor_rollout_ref:
+  model:
+    model_type: language_model
+    architecture: ???
+    model_stage: thinker

--- a/verl_omni/workers/config/omni/__init__.py
+++ b/verl_omni/workers/config/omni/__init__.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from . import diffusion, omni
-from .diffusion import *  # noqa: F401,F403
-from .omni import *  # noqa: F401,F403
+from . import model
+from .model import *  # noqa: F401
 
-__all__ = list(diffusion.__all__) + list(omni.__all__)
+__all__ = model.__all__

--- a/verl_omni/workers/config/omni/model.py
+++ b/verl_omni/workers/config/omni/model.py
@@ -1,0 +1,120 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Configuration dataclass for omni (thinker/talker) model training."""
+
+import json
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from omegaconf import MISSING
+from verl.base_config import BaseConfig
+from verl.utils.fs import copy_to_local
+from verl.utils.import_utils import import_external_libs
+
+from verl_omni.utils.fs import resolve_model_local_dir
+
+__all__ = ["OmniModelConfig"]
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class OmniModelConfig(BaseConfig):
+    """Configuration for omni (thinker/talker) model training.
+
+    Provides the fields that verl's FSDP engine needs for model loading
+    (``path``, ``hf_config_name``, ``no_split_modules``, etc.) plus
+    omni-specific fields (``architecture``, ``model_stage``).
+
+    RL algorithm selection (GSPO, GRPO, RLOO, etc.) is handled by
+    verl's ``actor.policy_loss.loss_mode`` and ``algorithm.adv_estimator``
+    config — the config is algorithm-agnostic.
+    """
+
+    _mutable_fields = {
+        "model_type",
+        "architecture",
+        "model_stage",
+        "tokenizer_path",
+        "tokenizer",
+        "processor",
+        "local_path",
+        "local_tokenizer_path",
+        "no_split_modules",
+    }
+
+    path: str = MISSING
+    tokenizer_path: Optional[str] = None
+    trust_remote_code: bool = False
+    override_config: dict = field(default_factory=dict)
+    lora_rank: int = 0
+    lora_alpha: int = 16
+    target_modules: str = "q_proj,k_proj,v_proj,o_proj,gate_proj,up_proj,down_proj"
+    exclude_modules: Optional[str] = None
+    enable_gradient_checkpointing: bool = True
+    use_remove_padding: bool = True
+    external_lib: Optional[str] = None
+    custom_chat_template: Optional[str] = None
+
+    model_type: str = "language_model"
+    local_path: Optional[str] = None
+    local_tokenizer_path: Optional[str] = None
+
+    tokenizer: Any = None
+    processor: Any = None
+
+    load_tokenizer: bool = True
+    use_shm: bool = False
+
+    # HF config architectures[0].
+    architecture: str = MISSING
+
+    # Which stage to train: "thinker", "talker", or "all".
+    model_stage: str = "thinker"
+
+    # Sub-config key for the trainable component
+    # (e.g. "thinker_config", "talker_config").
+    hf_config_name: Optional[str] = None
+
+    # FSDP layer class names.
+    no_split_modules: list[str] = field(default_factory=list)
+
+    # Force ``tie_word_embeddings=False`` for FSDP compatibility.
+    tie_word_embeddings_override: Optional[bool] = None
+
+    # Multimodal token budget.
+    max_image_tokens: int = 1024
+    max_audio_tokens: int = 1500
+    max_video_tokens: int = 2304
+
+    def __post_init__(self):
+        import_external_libs(self.external_lib)
+
+        self.local_path = resolve_model_local_dir(self.path, use_shm=self.use_shm)
+
+        if self.tokenizer_path is None:
+            tokenizer_path = os.path.join(self.local_path, "tokenizer")
+            self.tokenizer_path = tokenizer_path if os.path.exists(tokenizer_path) else self.local_path
+
+        if self.architecture is MISSING:
+            config_path = os.path.join(self.local_path, "config.json")
+            with open(config_path) as f:
+                self.architecture = json.load(f)["architectures"][0]
+
+        if self.load_tokenizer:
+            self.local_tokenizer_path = copy_to_local(self.tokenizer_path, use_shm=self.use_shm)
+            # Tokenizer/processor are loaded by the omni trainer via
+            # OmniModelBase.configure_tokenizer / configure_processor.


### PR DESCRIPTION
## Summary

Phase 1 of [#232] — formal omni-model plug-in architecture (core interfaces + Qwen3-Omni adapters). No behavioural change to existing training recipes; all new code is additive.

## What was added

#### Core interfaces (`verl_omni/pipelines/model_base.py`)
- `OmniModelBase` — pluggable training adapter base class, registered by `(architecture, stage)`. Three abstract methods: `get_strip_modules`, `configure_processor`, `configure_tokenizer`. One optional hook: `configure_model`.
- `OmniRolloutPipelineBase` — registry for vLLM-Omni pipeline topologies, keyed by `model_type`. One abstract method: `build_stage_configs`.

#### Configuration (`verl_omni/workers/config/omni/`)
- `OmniModelConfig` — dataclass for omni model training. Fields needed by verl's FSDP engine plus omni-specific fields (`architecture`, `model_stage`, `hf_config_name`, `no_split_modules`, `tie_word_embeddings_override`).
- `omni_trainer.yaml` — minimal Hydra config inheriting verl's `ppo_trainer`.

#### Qwen3-Omni thinker training adapter (`thinker_training_adapter.py`)
- Strips talker/code2wav sub-modules before FSDP wrapping via `configure_model`.
- Redirects `forward` / embedding accessors to the thinker sub-component.
- Configures the multimodal processor: routes `thinker_config` / `talker_config` fields, binds `get_rope_index` and `get_llm_pos_ids_for_vision`.
- Loads chat template from `chat_template.json`.

#### Qwen3-Omni rollout adapter (`omni_rollout_adapter.py`)
- `build_stage_configs` generates per-stage model-topology defaults for `thinker_only`, `thinker_talker`, and `full` pipeline modes.
- Only sets model-specific fields (`model_arch`, `worker_type`, `scheduler_cls`, `hf_config_name`). GPU allocation and `engine_output_type` are left to the user / vLLM-Omni pipeline defaults.

#### Monkey-patches removed from the adapter
All removed patches are validated by regression tests against transformers >= 5.0:
- `tie_word_embeddings=False` — already the default in v5.
- `_no_split_modules` override — thinker subclass already correct in v5.
- MoE expert unfusing hook — PEFT's v4→v5 conversion handles fused `gate_up_proj` natively (doubles LoRA rank).
- `AutoModelForCausalLM.register()` — replaced by `AutoModelForMultimodalLM` in a follow-up.

#### Tests (`tests/pipelines/test_qwen3_omni_thinker_adapter.py`)
- PEFT attaches LoRA to fused MoE experts without any manual unfusing hook.
- Adapter source has zero `peft` references.
- `tie_word_embeddings` defaults to `False` and `_no_split_modules` is correct on the thinker class.

## What's next (Phase 2)
- `main_omni.py` — thin Hydra wrapper around verl's `main_ppo`.
- `OmniPPOTrainerSync` — V1 trainer subclass overriding `_init_tokenizer` to use `OmniModelBase.configure_processor` / `configure_tokenizer`.
- `OmniAgentLoopWorkerTQ` — V1 agent loop loading the processor via the omni adapter.
- Route model loading through `AutoModelForMultimodalLM` instead of `AutoModelForCausalLM`.
- Update the GSPO recipe to use `main_omni` instead of `main_ppo` + `external_lib`.

[#232]: https://github.com/verl-project/verl-omni/issues/232
