### PR TITLE
[trainer, reward, cfg, doc] feat: profile reward-model rollout servers

### DIFF
--- a/docs/perf/profiler.md
+++ b/docs/perf/profiler.md
@@ -176,6 +176,29 @@ actor_rollout_ref.rollout.profiler.tool_config.torch.discrete=True
 Combine with recipe 1 to capture the actor train phase and the rollout in the
 same step.
 
+### 6. Reward-model servers
+
+When `reward.reward_model.enable=True`, the reward model runs in its own
+vLLM server processes — the same server stack as recipe 5, driven by
+`reward.reward_model.rollout.profiler`:
+
+```bash
+global_profiler.tool=torch \
+global_profiler.steps=[1] \
+reward.reward_model.rollout.profiler.enable=True \
+reward.reward_model.rollout.profiler.ranks=[0] \
+reward.reward_model.rollout.profiler.tool=torch \
+reward.reward_model.rollout.profiler.tool_config.torch.contents=[cpu,cuda] \
+reward.reward_model.rollout.profiler.tool_config.torch.discrete=True
+```
+
+The trainer starts/stops it around the phase where the servers actually
+score: the generation phase when reward computation streams with the rollout
+(`reward.reward_model.enable_resource_pool=True`), or the reward phase in
+colocate mode. Each profiled replica writes to
+`{save_path}/reward_model/agent_loop_rollout_replica_{rank}`, keeping reward
+traces apart from the actor rollout ones.
+
 ## Lightweight profiling recipe
 
 Profiling a full FlowGRPO step produces a large trace that is slow to open.
@@ -185,7 +208,8 @@ last-wins — so appending overrides to any recipe shrinks its footprint
 without editing the script. The following profiles a single lightweight step
 of the SD3.5 OCR recipe (2 rollouts instead of 8, 4 denoising steps instead
 of 10, 256px instead of 384px, train batch 4 instead of 8), capturing the
-actor train phase and the rollout servers (recipes 1 and 5 combined):
+actor train phase, the rollout servers and the reward-model servers
+(recipes 1, 5 and 6 combined):
 
 ```bash
 bash examples/flowgrpo_trainer/sd35/run_sd35_medium_ocr_lora.sh \
@@ -215,7 +239,12 @@ bash examples/flowgrpo_trainer/sd35/run_sd35_medium_ocr_lora.sh \
     actor_rollout_ref.rollout.profiler.ranks=[0] \
     actor_rollout_ref.rollout.profiler.tool=torch \
     actor_rollout_ref.rollout.profiler.tool_config.torch.contents=[cpu,cuda] \
-    actor_rollout_ref.rollout.profiler.tool_config.torch.discrete=True
+    actor_rollout_ref.rollout.profiler.tool_config.torch.discrete=True \
+    reward.reward_model.rollout.profiler.enable=True \
+    reward.reward_model.rollout.profiler.ranks=[0] \
+    reward.reward_model.rollout.profiler.tool=torch \
+    reward.reward_model.rollout.profiler.tool_config.torch.contents=[cpu,cuda] \
+    reward.reward_model.rollout.profiler.tool_config.torch.discrete=True
 ```
 
 Measured on 3×RTX 4090 against the recipe defaults: traces 163 MB → 32 MB,
@@ -255,7 +284,8 @@ recipe's own values, minding two couplings:
 * For the rollout servers, the trainer calls
   `llm_server_manager.start_profile()`/`stop_profile()` around the generation
   phase of profiled steps; the servers record through vLLM's built-in torch
-  profiler (recipe 5).
+  profiler (recipe 5). The reward-model servers are driven the same way
+  through `verl_omni.reward_loop.OmniRewardLoopManager` (recipe 6).
 
 ## Further reading
 

--- a/verl_omni/reward_loop/__init__.py
+++ b/verl_omni/reward_loop/__init__.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from .reward_loop import OmniRewardLoopManager  # noqa: F401
 from .reward_manager import VisualRewardManager  # noqa: F401
 
-__all__ = ["VisualRewardManager"]
+__all__ = ["OmniRewardLoopManager", "VisualRewardManager"]

--- a/verl_omni/reward_loop/reward_loop.py
+++ b/verl_omni/reward_loop/reward_loop.py
@@ -1,0 +1,46 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import asyncio
+
+from verl.experimental.reward_loop import RewardLoopManager
+
+
+class OmniRewardLoopManager(RewardLoopManager):
+    """RewardLoopManager that can start/stop the profiler on the reward-model rollout servers.
+
+    The reward-model servers are the same ``RolloutReplica`` stack as the actor rollout
+    servers, whose per-server profiler fan-out already exists (``RolloutReplica.start_profile``);
+    upstream ``RewardLoopManager`` just exposes no caller for it. The trainer invokes these
+    around the phase where the servers actually score: the generation phase when reward
+    computation streams with rollout, or ``compute_rm_score`` in colocate mode. Configured
+    via ``reward.reward_model.rollout.profiler``.
+    """
+
+    def start_profile(self, **kwargs) -> None:
+        """Start profiling on all reward-model rollout servers. No-op without a reward model."""
+        self._run_on_replicas("start_profile", **kwargs)
+
+    def stop_profile(self) -> None:
+        """Stop profiling on all reward-model rollout servers. No-op without a reward model."""
+        self._run_on_replicas("stop_profile")
+
+    def _run_on_replicas(self, method: str, **kwargs) -> None:
+        if self.reward_model_manager is None:
+            return
+        replicas = self.reward_model_manager.rollout_replicas
+
+        async def run_all():
+            await asyncio.gather(*[getattr(replica, method)(**kwargs) for replica in replicas])
+
+        asyncio.run(run_all())

--- a/verl_omni/trainer/config/_generated_diffusion_trainer.yaml
+++ b/verl_omni/trainer/config/_generated_diffusion_trainer.yaml
@@ -354,26 +354,30 @@ data:
     name: null
   apply_chat_template_kwargs: {}
 reward:
-  num_workers: 8
-  custom_reward_function:
-    path: null
-    name: compute_score
-  reward_functions: {}
-  aggregation: weighted_sum
-  reward_manager:
-    _target_: verl.workers.config.reward_model.RewardManagerConfig
-    source: importlib
-    name: VisualRewardManager
-    module:
-      _target_: verl.trainer.config.config.ModuleConfig
-      path: pkg://verl_omni.reward_loop.reward_manager
   reward_model:
-    enable: false
-    enable_resource_pool: false
-    n_gpus_per_node: 8
-    nnodes: 0
-    model_path: null
     rollout:
+      profiler:
+        _target_: verl.utils.profiler.ProfilerConfig
+        tool: torch
+        enable: false
+        all_ranks: false
+        ranks: []
+        save_path: ${oc.select:global_profiler.save_path,outputs/profile}/reward_model
+        tool_config:
+          nsys:
+            _target_: verl.utils.profiler.config.NsightToolConfig
+            discrete: ${oc.select:global_profiler.global_tool_config.nsys.discrete,false}
+            name: nsight
+          torch:
+            _target_: verl.utils.profiler.config.TorchProfilerToolConfig
+            contents: []
+            discrete: false
+            name: torch
+          torch_memory:
+            _target_: verl.utils.profiler.config.TorchMemoryToolConfig
+            trace_alloc_max_entries: ${oc.select:global_profiler.global_tool_config.torch_memory.trace_alloc_max_entries,100000}
+            stack_depth: ${oc.select:global_profiler.global_tool_config.torch_memory.stack_depth,32}
+            name: torch_memory
       _target_: verl.workers.config.RolloutConfig
       name: ???
       dtype: bfloat16
@@ -417,6 +421,24 @@ reward:
         transfer_backend: nixl
         bootstrap_port: null
         ib_device: null
+    enable: false
+    enable_resource_pool: false
+    n_gpus_per_node: 8
+    nnodes: 0
+    model_path: null
+  num_workers: 8
+  custom_reward_function:
+    path: null
+    name: compute_score
+  reward_functions: {}
+  aggregation: weighted_sum
+  reward_manager:
+    _target_: verl.workers.config.reward_model.RewardManagerConfig
+    source: importlib
+    name: VisualRewardManager
+    module:
+      _target_: verl.trainer.config.config.ModuleConfig
+      path: pkg://verl_omni.reward_loop.reward_manager
   sandbox_fusion:
     url: null
     max_concurrent: 64

--- a/verl_omni/trainer/config/_generated_diffusion_veomni_trainer.yaml
+++ b/verl_omni/trainer/config/_generated_diffusion_veomni_trainer.yaml
@@ -395,26 +395,30 @@ data:
     name: null
   apply_chat_template_kwargs: {}
 reward:
-  num_workers: 8
-  custom_reward_function:
-    path: null
-    name: compute_score
-  reward_functions: {}
-  aggregation: weighted_sum
-  reward_manager:
-    _target_: verl.workers.config.reward_model.RewardManagerConfig
-    source: importlib
-    name: VisualRewardManager
-    module:
-      _target_: verl.trainer.config.config.ModuleConfig
-      path: pkg://verl_omni.reward_loop.reward_manager
   reward_model:
-    enable: false
-    enable_resource_pool: false
-    n_gpus_per_node: 8
-    nnodes: 0
-    model_path: null
     rollout:
+      profiler:
+        _target_: verl.utils.profiler.ProfilerConfig
+        tool: torch
+        enable: false
+        all_ranks: false
+        ranks: []
+        save_path: ${oc.select:global_profiler.save_path,outputs/profile}/reward_model
+        tool_config:
+          nsys:
+            _target_: verl.utils.profiler.config.NsightToolConfig
+            discrete: ${oc.select:global_profiler.global_tool_config.nsys.discrete,false}
+            name: nsight
+          torch:
+            _target_: verl.utils.profiler.config.TorchProfilerToolConfig
+            contents: []
+            discrete: false
+            name: torch
+          torch_memory:
+            _target_: verl.utils.profiler.config.TorchMemoryToolConfig
+            trace_alloc_max_entries: ${oc.select:global_profiler.global_tool_config.torch_memory.trace_alloc_max_entries,100000}
+            stack_depth: ${oc.select:global_profiler.global_tool_config.torch_memory.stack_depth,32}
+            name: torch_memory
       _target_: verl.workers.config.RolloutConfig
       name: ???
       dtype: bfloat16
@@ -458,6 +462,24 @@ reward:
         transfer_backend: nixl
         bootstrap_port: null
         ib_device: null
+    enable: false
+    enable_resource_pool: false
+    n_gpus_per_node: 8
+    nnodes: 0
+    model_path: null
+  num_workers: 8
+  custom_reward_function:
+    path: null
+    name: compute_score
+  reward_functions: {}
+  aggregation: weighted_sum
+  reward_manager:
+    _target_: verl.workers.config.reward_model.RewardManagerConfig
+    source: importlib
+    name: VisualRewardManager
+    module:
+      _target_: verl.trainer.config.config.ModuleConfig
+      path: pkg://verl_omni.reward_loop.reward_manager
   sandbox_fusion:
     url: null
     max_concurrent: 64

--- a/verl_omni/trainer/config/reward/reward.yaml
+++ b/verl_omni/trainer/config/reward/reward.yaml
@@ -1,5 +1,15 @@
 # configs for the reward computation
 
+# specify the default per-component configs
+defaults:
+
+  # per-role profiler config for the reward-model rollout servers,
+  # inheriting from trainer/config/profiler/profiler.yaml
+  - ../profiler@reward_model.rollout.profiler: profiler
+
+  # load the reference default config, then apply the fields in the current yaml
+  - _self_
+
 # we launch num_workers reward managers to parallelize the reward computation
 num_workers: 8
 
@@ -42,6 +52,12 @@ reward_model:
   model_path: null
   rollout:
     _target_: verl.workers.config.RolloutConfig
+
+    # Keep reward-server traces out of the actor rollout replicas' directories:
+    # the trace subdirectory is named agent_loop_rollout_replica_{rank} for both.
+    profiler:
+      save_path: ${oc.select:global_profiler.save_path,outputs/profile}/reward_model
+
     name: ???
     dtype: bfloat16
     gpu_memory_utilization: 0.5

--- a/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
+++ b/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
@@ -638,13 +638,13 @@ class BaseRayDiffusionTrainer(ABC):
     def _init_online_rollout_stack(self, actor_rollout_resource_pool):
         """Initialize rollout, reward, and checkpoint engines (online sampling only)."""
         # create reward loop manager
-        from verl.experimental.reward_loop import RewardLoopManager
+        from verl_omni.reward_loop import OmniRewardLoopManager
 
         # initalize reward loop manager
         # reward model (colocate or standalone): get resource_pool
         # no reward model: resource_pool = None
         resource_pool = self.resource_pool_manager.get_resource_pool(Role.RewardModel) if self.use_rm else None
-        self.reward_loop_manager = RewardLoopManager(
+        self.reward_loop_manager = OmniRewardLoopManager(
             config=self.config,
             rm_resource_pool=resource_pool,
         )
@@ -667,11 +667,13 @@ class BaseRayDiffusionTrainer(ABC):
         # infrastructure overview: https://verl.readthedocs.io/en/latest/advance/reward_loop.html#architecture-design
         # agent_reward_loop: streaming reward computation with actor rollout
         # two conditions satisfied: (1) no reward model, or (2) reward model with extra resource pool
-        enable_agent_reward_loop = not self.use_rm or self.config.reward.reward_model.enable_resource_pool
+        self.enable_agent_reward_loop = not self.use_rm or self.config.reward.reward_model.enable_resource_pool
 
         # if enable_agent_reward_loop, we directly pass reward_loop_workers to agent loop manager
         # to stream reward computation with actor rollout
-        reward_loop_worker_handles = self.reward_loop_manager.reward_loop_workers if enable_agent_reward_loop else None
+        reward_loop_worker_handles = (
+            self.reward_loop_manager.reward_loop_workers if self.enable_agent_reward_loop else None
+        )
 
         self.llm_server_manager = LLMServerManager.create(
             config=self.config,
@@ -987,10 +989,15 @@ class PolicyGradientRayTrainer(BaseRayDiffusionTrainer):
                     with marked_timer("gen", timing_raw, color="red"):
                         if curr_step_profile:
                             self.llm_server_manager.start_profile()
+                            # streaming reward scores inside the gen window; colocate in the reward phase
+                            if self.enable_agent_reward_loop:
+                                self.reward_loop_manager.start_profile()
                         gen_batch_output = self.async_rollout_manager.generate_sequences(gen_batch_output)
                         self.checkpoint_manager.sleep_replicas()
                         if curr_step_profile:
                             self.llm_server_manager.stop_profile()
+                            if self.enable_agent_reward_loop:
+                                self.reward_loop_manager.stop_profile()
 
                         timing_raw.update(gen_batch_output.meta_info["timing"])
                         gen_batch_output.meta_info.pop("timing", None)
@@ -1002,7 +1009,11 @@ class PolicyGradientRayTrainer(BaseRayDiffusionTrainer):
                     with marked_timer("reward", timing_raw, color="yellow"):
                         # compute reward model score
                         if self.use_rm and "rm_scores" not in batch.batch.keys():
+                            if curr_step_profile:
+                                self.reward_loop_manager.start_profile()
                             batch_reward = self._compute_reward_colocate(batch)
+                            if curr_step_profile:
+                                self.reward_loop_manager.stop_profile()
                             batch = batch.union(batch_reward)
 
                         # extract reward_tensor and reward_extra_infos_dict for training
@@ -1203,6 +1214,7 @@ class DirectPreferenceRayTrainer(BaseRayDiffusionTrainer):
         if self.is_offline:
             self.reward_loop_manager = None
             self.llm_server_manager = None
+            self.enable_agent_reward_loop = False
             self.checkpoint_manager = NoOpCheckpointManager()
             return
         self._init_online_rollout_stack(actor_rollout_resource_pool)
@@ -1424,10 +1436,15 @@ class DirectPreferenceRayTrainer(BaseRayDiffusionTrainer):
                         with marked_timer("gen", timing_raw, color="red"):
                             if curr_step_profile:
                                 self.llm_server_manager.start_profile()
+                                # streaming reward scores inside the gen window; colocate in the reward phase
+                                if self.enable_agent_reward_loop:
+                                    self.reward_loop_manager.start_profile()
                             gen_batch_output = self.async_rollout_manager.generate_sequences(gen_batch_output)
                             self.checkpoint_manager.sleep_replicas()
                             if curr_step_profile:
                                 self.llm_server_manager.stop_profile()
+                                if self.enable_agent_reward_loop:
+                                    self.reward_loop_manager.stop_profile()
                             timing_raw.update(gen_batch_output.meta_info["timing"])
                             gen_batch_output.meta_info.pop("timing", None)
 
@@ -1436,7 +1453,11 @@ class DirectPreferenceRayTrainer(BaseRayDiffusionTrainer):
 
                         with marked_timer("reward", timing_raw, color="yellow"):
                             if self.use_rm and "rm_scores" not in batch.batch.keys():
+                                if curr_step_profile:
+                                    self.reward_loop_manager.start_profile()
                                 batch_reward = self._compute_reward_colocate(batch)
+                                if curr_step_profile:
+                                    self.reward_loop_manager.stop_profile()
                                 batch = batch.union(batch_reward)
                             reward_tensor, reward_extra_infos_dict = extract_reward(batch)
 


### PR DESCRIPTION
Closes #219 — completes the reward half of the issue; the footprint and
rollout halves were merged in #252.

## What & why

Issue #219 asks for profiling results that also cover reward. The
reward-model servers are the same `RolloutReplica`/`vLLMHttpServer` stack as
the actor rollout servers, so the per-server profiler plumbing (vLLM's
built-in torch profiler, `--profiler_config` injection, per-replica
`start_profile` fan-out) already exists — what was missing is a config
surface and a caller. Design was posted in #219 before implementing.

### Config surface (`verl_omni/trainer/config/reward/reward.yaml`)

`reward.reward_model.rollout` previously had no `profiler` key: it silently
fell back to the `RolloutConfig` dataclass default (`None`, profiler
disabled) and rejected plain CLI overrides. The shared per-role profiler
group is now imported under `reward.reward_model.rollout.profiler`
(disabled by default — no behavior change for existing users), mirroring
how `diffusion_rollout.yaml` imports it. Its `save_path` defaults to a
`reward_model/` subdirectory because vLLM's trace directory is named
`agent_loop_rollout_replica_{rank}` for reward and actor rollout replicas
alike — without the subdirectory, replica 0 of both would write into the
same place.

### Caller (`verl_omni/reward_loop/reward_loop.py`, new)

`OmniRewardLoopManager(RewardLoopManager)` adds `start_profile`/
`stop_profile` fan-out over the reward-model rollout replicas (no-op
without a reward model). Subclassing keeps the change inside verl-omni.

### Trainer windows (`ray_diffusion_trainer.py`, both `fit()` variants)

Reward computation has two homes, so the profiling window follows it:

- **streaming** (`enable_resource_pool=True`): scoring runs inside the
  agent loop, concurrent with generation — start/stop next to the existing
  `llm_server_manager` calls in the gen block;
- **colocate** (default for most recipes): scoring runs in
  `compute_rm_score` after generation — start/stop around
  `_compute_reward_colocate` in the reward block.

The two windows are mutually exclusive by construction (the colocate branch
is skipped when `rm_scores` already streamed in, and the gen-block calls are
gated on the streaming flag).

### Docs (`docs/perf/profiler.md`)

New recipe 6 (reward-model servers), reward overrides added to the
lightweight profiling command, implementation note.

`_generated_*.yaml` regenerated via `scripts/generate_trainer_config.sh`.

## Not duplicating existing work

At the time of writing, #219 has no assignee and no other linked PR;
`gh pr list --search "219 in:body"` / `--search "reward profil"` /
`--search "profiler"` return nothing open.

## Testing

Local (no GPU):
- Full Hydra composition of the documented lightweight command (102
  overrides captured from the recipe's real emitted command line):
  `reward.reward_model.rollout.profiler` resolves to `enable=True,
  discrete=True, save_path=./outputs/profile_sd35/reward_model`; plain
  overrides accepted.
- Replicated the exact server-side consumption
  (`omega_conf_to_dataclass(rollout)` → `RolloutConfig` with
  `ProfilerConfig`, then the `vLLMHttpServer.__init__` tool-config lookup →
  `TorchProfilerToolConfig(discrete=True, contents=[cpu, cuda])`).
- Fan-out smoke test with fake replicas: start (kwargs forwarded) / stop
  broadcast to all replicas; no-op without a reward model.
- Regression: the colocate `qwen_image` recipe composes unchanged
  (profiler present, disabled).
- `pre-commit run` passes (ruff, ruff format, mypy, generated-config
  verification, license, doc checks).

On 3×RTX 4090 (24GB; SD3.5-Medium LoRA OCR + Qwen2.5-VL-3B GenRM reward),
lightweight footprint from the profiler doc plus the recipe-6 overrides:

**Streaming run** (`enable_resource_pool=True`, the recipe default):
- Three traces, each in its own directory under the save path: actor e2e
  (24.8 MB), rollout replica (8.1 MB), reward replica
  (`reward_model/agent_loop_rollout_replica_0`, 4.5 MB).
- The reward trace contains the scoring compute: vLLM decode iterations
  (`execute_context_*_generation_*`), gemv/cutlass bf16 GEMMs,
  `_vllm_fa2_C::varlen_fwd`, `fused_add_rms_norm`,
  `reshape_and_cache_flash` — the VL reward model's forward, distinct from
  the diffusion `pipeline_forward` in the rollout trace.
- Timings confirm the window choice: `gen` 100 s vs a `reward` phase of
  ~0.1 ms — scoring streams inside the gen window, and the reward trace
  still captures it.

**Colocate run** (`enable_resource_pool=False`,
`gpu_memory_utilization=0.25`, `free_cache_engine=True`): completes
normally and writes the same three trace directories, confirming the
reward-phase window and that `start_profile` is safe on a slept reward
server (scoring wakes it inside `compute_rm_score`).
