### PR TITLE
[docker] read NPU vLLM backend refs from pins

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,8 @@
 .git
 .github
 !.github/verl_pin.txt
+!.github/vllm_ascend_pin.txt
+!.github/vllm_omni_pin.txt
 .cursor
 .vscode
 .idea
@@ -45,5 +47,4 @@ playground
 # Hugging Face / model caches
 .huggingface
 **/huggingface
-
 

--- a/docker/Dockerfile.a2.npu
+++ b/docker/Dockerfile.a2.npu
@@ -5,13 +5,13 @@ ARG ASCEND_PIP_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pypi"
 ARG PYTORCH_CPU_INDEX_URL="https://download.pytorch.org/whl/cpu/"
 
 ARG VLLM_REPO="https://github.com/vllm-project/vllm.git"
-ARG VLLM_REF="v0.22.0"
+ARG VLLM_REF="v0.24.0"
 
 ARG VLLM_ASCEND_REPO="https://github.com/vllm-project/vllm-ascend.git"
-ARG VLLM_ASCEND_REF="bb4d0776eee8fc45c3484a45c971a7049f1a2bbf"
+ARG VLLM_ASCEND_REF=""
 
 ARG VLLM_OMNI_REPO="https://github.com/vllm-project/vllm-omni.git"
-ARG VLLM_OMNI_REF="v0.22.0"
+ARG VLLM_OMNI_REF=""
 
 ARG VERL_REPO="https://github.com/verl-project/verl.git"
 # Default: read from .github/verl_pin.txt at build time.
@@ -40,8 +40,7 @@ WORKDIR /workspace
 
 RUN mkdir -p /workspace/src /workspace/pins
 
-# .dockerignore only allows .github/verl_pin.txt, matching Dockerfile.cuda behavior.
-COPY .github/verl_pin.txt /workspace/pins/verl_pin.txt
+COPY .github/verl_pin.txt .github/vllm_ascend_pin.txt .github/vllm_omni_pin.txt /workspace/pins/
 
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
@@ -97,7 +96,9 @@ RUN git clone --depth 1 -b ${VLLM_REF} ${VLLM_REPO} /workspace/src/vllm && \
     python3 -m pip uninstall -y triton || true
 
 # Install vLLM-Ascend.
-RUN git clone ${VLLM_ASCEND_REPO} /workspace/src/vllm-ascend && \
+RUN VLLM_ASCEND_REF="${VLLM_ASCEND_REF:-$(tr -d '[:space:]' < /workspace/pins/vllm_ascend_pin.txt)}" && \
+    echo "Installing vLLM-Ascend from ${VLLM_ASCEND_REPO}@${VLLM_ASCEND_REF}" && \
+    git clone ${VLLM_ASCEND_REPO} /workspace/src/vllm-ascend && \
     cd /workspace/src/vllm-ascend && \
     git checkout ${VLLM_ASCEND_REF} && \
     git submodule update --init --recursive && \
@@ -113,8 +114,11 @@ RUN git clone ${VLLM_ASCEND_REPO} /workspace/src/vllm-ascend && \
         --extra-index-url ${ASCEND_PIP_INDEX_URL}
 
 # Install vLLM-Omni.
-RUN git clone --depth 1 -b ${VLLM_OMNI_REF} ${VLLM_OMNI_REPO} /workspace/src/vllm-omni && \
+RUN VLLM_OMNI_REF="${VLLM_OMNI_REF:-$(tr -d '[:space:]' < /workspace/pins/vllm_omni_pin.txt)}" && \
+    echo "Installing vLLM-Omni from ${VLLM_OMNI_REPO}@${VLLM_OMNI_REF}" && \
+    git clone ${VLLM_OMNI_REPO} /workspace/src/vllm-omni && \
     cd /workspace/src/vllm-omni && \
+    git checkout ${VLLM_OMNI_REF} && \
     VLLM_OMNI_TARGET_DEVICE=npu python3 -m pip install -e . \
         --extra-index-url ${ASCEND_PIP_INDEX_URL} \
         --extra-index-url ${PYTORCH_CPU_INDEX_URL}

--- a/docker/Dockerfile.a3.npu
+++ b/docker/Dockerfile.a3.npu
@@ -5,13 +5,13 @@ ARG ASCEND_PIP_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pypi"
 ARG PYTORCH_CPU_INDEX_URL="https://download.pytorch.org/whl/cpu/"
 
 ARG VLLM_REPO="https://github.com/vllm-project/vllm.git"
-ARG VLLM_REF="v0.22.0"
+ARG VLLM_REF="v0.24.0"
 
 ARG VLLM_ASCEND_REPO="https://github.com/vllm-project/vllm-ascend.git"
-ARG VLLM_ASCEND_REF="bb4d0776eee8fc45c3484a45c971a7049f1a2bbf"
+ARG VLLM_ASCEND_REF=""
 
 ARG VLLM_OMNI_REPO="https://github.com/vllm-project/vllm-omni.git"
-ARG VLLM_OMNI_REF="v0.22.0"
+ARG VLLM_OMNI_REF=""
 
 ARG VERL_REPO="https://github.com/verl-project/verl.git"
 # Default: read from .github/verl_pin.txt at build time.
@@ -40,8 +40,7 @@ WORKDIR /workspace
 
 RUN mkdir -p /workspace/src /workspace/pins
 
-# .dockerignore only allows .github/verl_pin.txt, matching Dockerfile.cuda behavior.
-COPY .github/verl_pin.txt /workspace/pins/verl_pin.txt
+COPY .github/verl_pin.txt .github/vllm_ascend_pin.txt .github/vllm_omni_pin.txt /workspace/pins/
 
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
@@ -97,7 +96,9 @@ RUN git clone --depth 1 -b ${VLLM_REF} ${VLLM_REPO} /workspace/src/vllm && \
     python3 -m pip uninstall -y triton || true
 
 # Install vLLM-Ascend.
-RUN git clone ${VLLM_ASCEND_REPO} /workspace/src/vllm-ascend && \
+RUN VLLM_ASCEND_REF="${VLLM_ASCEND_REF:-$(tr -d '[:space:]' < /workspace/pins/vllm_ascend_pin.txt)}" && \
+    echo "Installing vLLM-Ascend from ${VLLM_ASCEND_REPO}@${VLLM_ASCEND_REF}" && \
+    git clone ${VLLM_ASCEND_REPO} /workspace/src/vllm-ascend && \
     cd /workspace/src/vllm-ascend && \
     git checkout ${VLLM_ASCEND_REF} && \
     git submodule update --init --recursive && \
@@ -113,8 +114,11 @@ RUN git clone ${VLLM_ASCEND_REPO} /workspace/src/vllm-ascend && \
         --extra-index-url ${ASCEND_PIP_INDEX_URL}
 
 # Install vLLM-Omni.
-RUN git clone --depth 1 -b ${VLLM_OMNI_REF} ${VLLM_OMNI_REPO} /workspace/src/vllm-omni && \
+RUN VLLM_OMNI_REF="${VLLM_OMNI_REF:-$(tr -d '[:space:]' < /workspace/pins/vllm_omni_pin.txt)}" && \
+    echo "Installing vLLM-Omni from ${VLLM_OMNI_REPO}@${VLLM_OMNI_REF}" && \
+    git clone ${VLLM_OMNI_REPO} /workspace/src/vllm-omni && \
     cd /workspace/src/vllm-omni && \
+    git checkout ${VLLM_OMNI_REF} && \
     VLLM_OMNI_TARGET_DEVICE=npu python3 -m pip install -e . \
         --extra-index-url ${ASCEND_PIP_INDEX_URL} \
         --extra-index-url ${PYTORCH_CPU_INDEX_URL}


### PR DESCRIPTION
### What does this PR do?

Update the NPU Dockerfiles to make the vLLM backend source revisions reproducible.

- Keep vLLM explicitly on `v0.24.0`.
- Read the default vLLM-Ascend and vLLM-Omni revisions from `.github/vllm_ascend_pin.txt` and `.github/vllm_omni_pin.txt`.
- Apply the same behavior to both `docker/Dockerfile.a2.npu` and `docker/Dockerfile.a3.npu`.
- Preserve `VLLM_ASCEND_REF` and `VLLM_OMNI_REF` build-arg overrides.

This aligns the NPU image source selection with the existing `verl_pin.txt` pattern and with the vLLM-Omni pin introduced in #257.

### Checklist Before Starting

- [x] Search for similar PRs. [Query: NPU Dockerfile pins](https://github.com/verl-project/verl-omni/pulls?q=is%3Apr+Dockerfile.a2.npu)
- [x] Format the PR title as `[{modules}] {type}: {description}`

Suggested title:

`[docker] chore: pin NPU vLLM backend source revisions`

### Test

- [x] `git diff --check`

A full Docker build was not run because it requires the Ascend NPU base image and its external package/source dependencies.

### API and Usage Example

No user-facing API changes.

The default revisions come from the repository pin files. They can still be overridden at build time:

```bash
docker build -f docker/Dockerfile.a3.npu . \
  --build-arg VLLM_ASCEND_REF=<commit-or-tag> \
  --build-arg VLLM_OMNI_REF=<commit-or-tag>
```

### Design & Code Changes

- Allow the two NPU Dockerfiles to receive `vllm_ascend_pin.txt` and `vllm_omni_pin.txt` in the Docker build context.
- Change `VLLM_ASCEND_REF` and `VLLM_OMNI_REF` defaults to empty values.
- At build time, resolve an empty ref from the corresponding pin file; explicit build args take precedence.
- Clone and check out the resolved commit for vLLM-Ascend and vLLM-Omni.
- Update vLLM from `v0.22.0` to the explicitly requested `v0.24.0`.

### Checklist Before Submitting

- [x] Read the [[Contribute Guide](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md)](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md).
- [x] Apply [[pre-commit checks](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md#code-linting-and-formatting)](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md#code-linting-and-formatting).
- [x] Add / Update the documentation.
- [x] Add unit or end-to-end test(s) to CI.

No documentation, API, or runtime-code changes are needed for this Dockerfile-only revision-pinning update. No CI test was added because the change is build-time dependency source selection; `git diff --check` was run.
