### PR TITLE
[1/N][data, omni, tests] feat: add Omni-Preference offline MLLM DPO dataset pipeline

### DIFF
--- a/examples/dpo_trainer/data_process/omni_preference_dpo_dataset.md
+++ b/examples/dpo_trainer/data_process/omni_preference_dpo_dataset.md
@@ -224,8 +224,8 @@ python examples/dpo_trainer/data_process/omni_preference_dpo_multisource.py \
 
 ## 6. Offline DPO Parquet Schema
 
-Parquet rows follow the preference schema consumed by the Qwen3-Omni VeOmni
-VLM DPO smoke task.
+Parquet rows follow the preference schema consumed by verl-omni's offline MLLM
+DPO pipeline.
 
 ### 6.1 Columns
 
@@ -243,30 +243,23 @@ VLM DPO smoke task.
 
 ---
 
-## 7. Training Configuration (VeOmni)
+## 7. Training Configuration
 
-Point the VeOmni VLM DPO data config at the generated parquet files:
+Point the verl-omni offline MLLM DPO data config at the generated parquet
+files. For all three modalities:
 
-```yaml
-sources:
-  - /path/to/Omni-Preference/parquet_dpo/image/train.parquet
-  - /path/to/Omni-Preference/parquet_dpo/video/train.parquet
-  - /path/to/Omni-Preference/parquet_dpo/audio/train.parquet
-names:
-  - Omni-Preference-Image
-  - Omni-Preference-Video
-  - Omni-Preference-Audio
-schedule:
-  - schedule_type: const
-    weights: [0.34, 0.33, 0.33]
+```bash
+data.train_files="['/path/to/Omni-Preference/parquet_dpo/image/train.parquet','/path/to/Omni-Preference/parquet_dpo/video/train.parquet','/path/to/Omni-Preference/parquet_dpo/audio/train.parquet']"
+data.val_files="['/path/to/Omni-Preference/parquet_dpo/image/test.parquet','/path/to/Omni-Preference/parquet_dpo/video/test.parquet','/path/to/Omni-Preference/parquet_dpo/audio/test.parquet']"
+data.custom_cls.path=pkg://verl_omni.utils.dataset.offline_mllm_dpo_dataset
+data.custom_cls.name=OfflineMLLMDPODataset
+data.custom_cls.collate_fn=offline_mllm_dpo_collate_fn
 ```
 
-To train on a single modality, list only that modality's parquet path and set
-the corresponding source name/weight. Configure the custom dataset with
-`verl_omni.utils.dataset.offline_mllm_dpo_dataset.OfflineMLLMDPODataset` and
-`offline_mllm_dpo_collate_fn`; the dataset consumes the parquet schema above and
-uses `verl_omni.utils.dataset.qwen3_omni_transform` for Qwen3-Omni multimodal
-sample processing.
+To train on a single modality, list only that modality's parquet paths. The
+dataset consumes the parquet schema above and uses
+`verl_omni.utils.dataset.qwen3_omni_transform` for Qwen3-Omni multimodal sample
+processing.
 
 ---
 

--- a/examples/dpo_trainer/data_process/omni_preference_dpo_dataset.md
+++ b/examples/dpo_trainer/data_process/omni_preference_dpo_dataset.md
@@ -232,14 +232,32 @@ DPO pipeline.
 | Column | Type | Required | Description |
 |--------|------|----------|-------------|
 | `data_source` | `str` | Yes | `"omni_preference/image"`, `".../video"`, or `".../audio"` |
-| `prompt` | `list[dict]` | Yes | Chat messages: system + user (typed media + question text) |
-| `chosen` | `str` | Yes | Preferred candidate answer |
-| `rejected` | `str` | Yes | Less preferred candidate answer |
+| `prompt` | `list[dict]` | Yes | Chat messages. User content starts with `<image>`, `<video>`, or `<audio>` followed by the question text. |
+| `chosen` | `dict` | Yes | Preferred assistant message, e.g. `{"role": "assistant", "content": "..."}` |
+| `rejected` | `dict` | Yes | Less preferred assistant message, e.g. `{"role": "assistant", "content": "..."}` |
+| `images` / `videos` / `audios` | `list[str]` | Yes for that modality | Local media paths referenced by the prompt placeholder. |
 | `win_score` | `float` | No | Score of the chosen candidate (from `score_A` / `score_B`) |
 | `lose_score` | `float` | No | Score of the rejected candidate |
 | `ability` | `str` | Yes | `"image_qa"`, `"video_qa"`, or `"audio_qa"` |
 | `reward_model` | `dict` | Yes | `{"style": "preference"}` |
 | `extra_info` | `dict` | Yes | Metadata: `split`, `question`, `source_media`, `better`, `{modality}_path`, … |
+
+Example video row:
+
+```json
+{
+  "data_source": "omni_preference/video",
+  "prompt": [{"role": "user", "content": "<video>What is shown at the end?"}],
+  "chosen": {"role": "assistant", "content": "The preferred answer."},
+  "rejected": {"role": "assistant", "content": "The rejected answer."},
+  "videos": ["/abs/path/to/video.mp4"],
+  "win_score": 8.0,
+  "lose_score": 4.0,
+  "ability": "video_qa",
+  "reward_model": {"style": "preference"},
+  "extra_info": {"split": "train", "modality": "video"}
+}
+```
 
 ---
 

--- a/examples/dpo_trainer/data_process/omni_preference_dpo_dataset.md
+++ b/examples/dpo_trainer/data_process/omni_preference_dpo_dataset.md
@@ -1,0 +1,288 @@
+# Omni-Preference Dataset for verl-omni Offline MLLM DPO
+
+Last updated: 07/09/2026
+
+This document describes how to download, prepare, and convert the
+[Omni-Preference](https://huggingface.co/datasets/Omni-RRM/Omni-Preference)
+dataset into the parquet format required by verl-omni's offline MLLM DPO pipeline.
+
+Omni-Preference is the rubric-grounded preference dataset introduced in
+**Omni-RRM: Advancing Omni Reward Modeling via Automatic Rubric-Grounded Preference
+Synthesis** ([anonymous repo](https://anonymous.4open.science/r/Omni-RRM-CC08/readme.md),
+[Hugging Face dataset](https://huggingface.co/datasets/Omni-RRM/Omni-Preference)).
+It contains ~41K retained preference pairs across **image**, **video**, and **audio**
+modalities, with teacher-reconciled scores and verdicts.
+
+For verl-omni DPO training we convert `final_rl_data.jsonl` into multimodal
+parquet files: each row is a preference pair where the prompt is **media + question**
+and `chosen` / `rejected` are the two candidate answers.
+
+---
+
+## 1. Source Dataset Overview
+
+### 1.1 Modality breakdown
+
+| Modality | Source datasets | Retained samples (paper) | `final_rl_data.jsonl` rows (local clone) |
+|----------|-----------------|--------------------------|------------------------------------------|
+| Image | RLAIF-V | ~17.0K | 6,637 |
+| Video | ActivityNet, Charades, Ego4D, NextQA, YouCook2 | ~12.2K | 4,327 |
+| Audio | Clotho-AQA | ~11.8K | 5,707 |
+| **Total** | — | **~41.0K** | **~16.7K raw RL rows** |
+
+Each modality also ships an SFT JSONL (`final_sft_data.jsonl`) for reward-model
+SFT / GRPO in the original Omni-RRM repo. The verl-omni DPO converter reads
+**`final_rl_data.jsonl` only**.
+
+### 1.2 Preference construction (summary)
+
+1. **Candidate pair generation** — for each multimodal input, a stronger and a
+   weaker model produce Candidate A and Candidate B.
+2. **Rubric-grounded teacher reconciliation** — heterogeneous teachers assign
+   scalar scores, a categorical verdict, and five-criterion rationales.
+3. **Consensus filtering** — a pair is kept only when both teachers agree on a
+   non-tie verdict consistent with score ranking.
+
+Evaluation uses five shared criteria: fluency/coherence, relevance,
+accuracy/completeness, reasoning quality, and safety/ethical alignment.
+
+---
+
+## 2. Download
+
+Omni-Preference is hosted on Hugging Face and uses Git LFS for media files.
+
+### 2.1 Clone the full dataset
+
+```bash
+git lfs install
+git clone https://huggingface.co/datasets/Omni-RRM/Omni-Preference
+cd Omni-Preference
+```
+
+> **Note:** The full clone includes images, videos, and audio. Download size is
+> large; ensure sufficient disk space and a working Git LFS setup.
+
+### 2.2 Partial / resume download
+
+If the clone is interrupted, resume from inside the repo:
+
+```bash
+cd Omni-Preference
+git lfs pull
+```
+
+---
+
+## 3. Folder Structure
+
+After a full download, the dataset root looks like this:
+
+```text
+Omni-Preference/
+├── dataset_jsonl/
+│   ├── image/
+│   │   ├── final_rl_data.jsonl      # RL / DPO preference pairs (image)
+│   │   └── final_sft_data.jsonl       # SFT targets for Omni-RRM training
+│   ├── video/
+│   │   ├── final_rl_data.jsonl
+│   │   └── final_sft_data.jsonl
+│   └── audio/
+│       ├── final_rl_data.jsonl
+│       └── final_sft_data.jsonl
+├── rlaif-v-dataset/                   # Image media root
+│   ├── llava1.5_raw_images/
+│   ├── coco2017/
+│   ├── gqa/
+│   └── ...
+├── video-dataset/                     # Video media root
+│   └── academic_source/
+│       ├── Charades/
+│       ├── activitynet/
+│       ├── ego4d/
+│       ├── NextQA/
+│       └── youcook2/
+└── audio_files/                       # Audio media root
+    └── audio_files/                   # Flat WAV files (by basename)
+
+```
+
+### 3.1 Path mapping used by verl-omni
+
+JSONL media paths use a `/data/...` prefix. The converter resolves them as follows:
+
+| Modality | JSONL path example | Resolved on disk |
+|----------|-------------------|------------------|
+| Image | `/data/rlaif-v-dataset/llava1.5_raw_images/00013/000137479.jpg` | `{dataset_root}/rlaif-v-dataset/llava1.5_raw_images/...` |
+| Video | `/data/academic_source/Charades/2D98B.mp4` | `{dataset_root}/video-dataset/academic_source/Charades/...` |
+| Audio | `/data/audio/Lake_Wars_extract.wav` | `{dataset_root}/audio_files/**/{basename}.wav` |
+
+Rows whose media file cannot be resolved locally are **skipped** (logged as
+`skipped_missing_media`).
+
+## 4. Raw JSONL Schema
+
+### 4.1 RL row (`final_rl_data.jsonl`) — used for DPO
+
+Each line is one preference-evaluation record. Example (video):
+
+```json
+{
+  "videos": ["/data/academic_source/Charades/2D98B.mp4"],
+  "messages": [
+    {
+      "role": "user",
+      "content": "... ### Context\nVideo file: ...\nQuestion: ...\nCandidate A: ...\nCandidate B: ..."
+    }
+  ],
+  "solution": "{\"score_A\": 6, \"score_B\": 8, \"better\": \"B\", \"reasoning\": \"...\", \"final_verdict\": \"<answer>[[B]]</answer>\"}"
+}
+```
+
+Image rows use `"images": [...]` and `Image file:` in the Context block.
+Audio rows use `"audios": [...]` and `Audio file:` in the Context block.
+
+The converter parses the `### Context` section:
+
+```text
+{Image|Video|Audio} file: <media_path>
+Question: <question>
+Candidate A: <answer_a>
+Candidate B: <answer_b>
+```
+
+And the `solution` JSON:
+
+| Field | Description |
+|-------|-------------|
+| `score_A` / `score_B` | Teacher scores (0–10) for each candidate |
+| `better` | `"A"`, `"B"`, or `"equal"` |
+| `reasoning` | Rubric-grounded comparative rationale |
+| `final_verdict` | Parsed verdict tag, e.g. `<answer>[[B]]</answer>` |
+
+**DPO conversion rules:**
+
+- `better == "equal"` → row is **skipped** (no clear preference).
+- `better == "A"` → `chosen = Candidate A`, `rejected = Candidate B`.
+- `better == "B"` → `chosen = Candidate B`, `rejected = Candidate A`.
+- `win_score` / `lose_score` in parquet = scores of the chosen / rejected candidate.
+
+
+## 5. Preprocessing for verl-omni Offline DPO
+
+Script:
+[`omni_preference_dpo_multisource.py`](omni_preference_dpo_multisource.py)
+
+### 5.1 One-shot: all three modalities
+
+```bash
+export DATASET_ROOT=${DATASET_ROOT:-"$HOME/Omni-Preference"}
+export OUTPUT_DIR=${OUTPUT_DIR:-"$DATASET_ROOT/parquet_dpo"}
+
+python examples/dpo_trainer/data_process/omni_preference_dpo_multisource.py \
+  --dataset_root "$DATASET_ROOT" \
+  --output_dir "$OUTPUT_DIR" \
+  --modalities image video audio \
+  --test_ratio 0.10 \
+  --seed 42
+```
+
+
+### 5.2 CLI arguments
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| `--dataset_root` | *(required)* | Omni-Preference repo root |
+| `--output_dir` | `~/data/omni_preference_dpo/parquet` | Parquet output directory |
+| `--modalities` | `image video audio` | Modalities to convert |
+| `--test_ratio` | `0.10` | Target validation fraction |
+| `--seed` | `42` | Random seed for train/test split |
+| `--max_samples` | `-1` | Truncate per modality (debug) |
+
+### 5.3 Train / test split
+
+- Split unit: **media file name** (same image / video / audio never appears in
+  both train and test).
+- Target test size: `round(total_parsed_rows × test_ratio)`.
+- Because grouping is by media file, the actual row ratio may differ slightly
+  from `--test_ratio`.
+- Media-missing rows are dropped **after** split assignment, which can further
+  skew the final train/test ratio if many files are absent locally.
+
+### 5.4 Outputs
+
+| File | Description |
+|------|-------------|
+| `$OUTPUT_DIR/image/train.parquet` | Image + question DPO training split |
+| `$OUTPUT_DIR/image/test.parquet` | Image + question DPO validation split |
+| `$OUTPUT_DIR/video/train.parquet` | Video + question DPO training split |
+| `$OUTPUT_DIR/video/test.parquet` | Video + question DPO validation split |
+| `$OUTPUT_DIR/audio/train.parquet` | Audio + question DPO training split |
+| `$OUTPUT_DIR/audio/test.parquet` | Audio + question DPO validation split |
+
+---
+
+## 6. Offline DPO Parquet Schema
+
+Parquet rows follow the preference schema consumed by the Qwen3-Omni VeOmni
+VLM DPO smoke task.
+
+### 6.1 Columns
+
+| Column | Type | Required | Description |
+|--------|------|----------|-------------|
+| `data_source` | `str` | Yes | `"omni_preference/image"`, `".../video"`, or `".../audio"` |
+| `prompt` | `list[dict]` | Yes | Chat messages: system + user (typed media + question text) |
+| `chosen` | `str` | Yes | Preferred candidate answer |
+| `rejected` | `str` | Yes | Less preferred candidate answer |
+| `win_score` | `float` | No | Score of the chosen candidate (from `score_A` / `score_B`) |
+| `lose_score` | `float` | No | Score of the rejected candidate |
+| `ability` | `str` | Yes | `"image_qa"`, `"video_qa"`, or `"audio_qa"` |
+| `reward_model` | `dict` | Yes | `{"style": "preference"}` |
+| `extra_info` | `dict` | Yes | Metadata: `split`, `question`, `source_media`, `better`, `{modality}_path`, … |
+
+---
+
+## 7. Training Configuration (VeOmni)
+
+Point the VeOmni VLM DPO data config at the generated parquet files:
+
+```yaml
+sources:
+  - /path/to/Omni-Preference/parquet_dpo/image/train.parquet
+  - /path/to/Omni-Preference/parquet_dpo/video/train.parquet
+  - /path/to/Omni-Preference/parquet_dpo/audio/train.parquet
+names:
+  - Omni-Preference-Image
+  - Omni-Preference-Video
+  - Omni-Preference-Audio
+schedule:
+  - schedule_type: const
+    weights: [0.34, 0.33, 0.33]
+```
+
+To train on a single modality, list only that modality's parquet path and set
+the corresponding source name/weight. Configure the custom dataset with
+`verl_omni.utils.dataset.offline_mllm_dpo_dataset.OfflineMLLMDPODataset` and
+`offline_mllm_dpo_collate_fn`; the dataset consumes the parquet schema above and
+uses `verl_omni.utils.dataset.qwen3_omni_transform` for Qwen3-Omni multimodal
+sample processing.
+
+---
+
+## 8. Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| `skipped_missing_media` is large | Media not fully downloaded | Run `git lfs pull` inside `Omni-Preference` |
+| `skipped_parse > 0` | Context block doesn't match expected template | Inspect failing rows; check for format drift |
+| `skipped_equal` | Teacher verdict is tie | Expected; DPO requires a strict preference |
+| Test set much smaller than `--test_ratio` | Many test media files missing locally | Complete media download or lower `--test_ratio` |
+| Audio paths not found | WAVs stored flat under `audio_files/audio_files/` | Converter matches by **basename**; ensure LFS pull completed |
+
+---
+
+## 9. References
+
+- Omni-RRM paper repo (anonymous): https://anonymous.4open.science/r/Omni-RRM-CC08/readme.md
+- Omni-Preference on Hugging Face: https://huggingface.co/datasets/Omni-RRM/Omni-Preference

--- a/examples/dpo_trainer/data_process/omni_preference_dpo_multisource.py
+++ b/examples/dpo_trainer/data_process/omni_preference_dpo_multisource.py
@@ -35,7 +35,6 @@ from pathlib import Path
 
 import pandas as pd
 
-SYSTEM_PROMPT = "You are a helpful assistant."
 VIDEO_FILE_EXTENSIONS = (".mp4", ".webm", ".mkv", ".mov", ".avi")
 AUDIO_FILE_EXTENSIONS = (".wav", ".mp3", ".flac", ".ogg", ".m4a", ".aac")
 CONTEXT_PATTERN = re.compile(
@@ -67,10 +66,6 @@ MODALITY_CONFIGS = {
         "ability": "audio_qa",
     },
 }
-
-
-def _content_item(item_type: str, *, text: str | None = None, image="", video="", audio="") -> dict:
-    return {"type": item_type, "text": text, "image": image, "video": video, "audio": audio}
 
 
 def _media_key(media_rel: str) -> str:
@@ -268,8 +263,8 @@ def _base_row(record: dict, split: str, index: int) -> dict:
 
     return {
         "data_source": config["data_source"],
-        "chosen": record["chosen"],
-        "rejected": record["rejected"],
+        "chosen": {"role": "assistant", "content": record["chosen"]},
+        "rejected": {"role": "assistant", "content": record["rejected"]},
         "win_score": record["win_score"],
         "lose_score": record["lose_score"],
         "ability": config["ability"],
@@ -289,19 +284,16 @@ def _base_row(record: dict, split: str, index: int) -> dict:
 
 def _build_multimodal_row(record: dict, split: str, index: int, media_path: str) -> dict:
     modality = record["modality"]
+    config = MODALITY_CONFIGS[modality]
     question = record["question"]
     row = _base_row(record, split, index)
-    media_item = _content_item(modality, **{modality: media_path})
     row["prompt"] = [
-        {"role": "system", "content": [_content_item("text", text=SYSTEM_PROMPT)]},
         {
             "role": "user",
-            "content": [
-                media_item,
-                _content_item("text", text=question),
-            ],
+            "content": f"<{modality}>{question}",
         },
     ]
+    row[config["media_field"]] = [media_path]
     row["extra_info"][f"{modality}_path"] = media_path
     return row
 

--- a/examples/dpo_trainer/data_process/omni_preference_dpo_multisource.py
+++ b/examples/dpo_trainer/data_process/omni_preference_dpo_multisource.py
@@ -1,0 +1,454 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Build offline MLLM DPO parquet data from Omni-Preference RL preference pairs.
+
+Reads ``dataset_jsonl/{image,video,audio}/final_rl_data.jsonl`` and converts
+each row into multimodal offline DPO parquet (media + question as prompt,
+chosen/rejected as candidate answers).
+
+Train/test splitting is performed at media-file granularity so validation
+samples never share a source image/video/audio with training samples.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import random
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+import pandas as pd
+
+SYSTEM_PROMPT = "You are a helpful assistant."
+VIDEO_FILE_EXTENSIONS = (".mp4", ".webm", ".mkv", ".mov", ".avi")
+AUDIO_FILE_EXTENSIONS = (".wav", ".mp3", ".flac", ".ogg", ".m4a", ".aac")
+CONTEXT_PATTERN = re.compile(
+    r"(?:Image|Video|Audio) file:\s*(?P<media>.+?)\s+Question:\s*(?P<question>.+?)\s+"
+    r"Candidate A:\s*(?P<candidate_a>.+?)\s+Candidate B:\s*(?P<candidate_b>.+?)\s*\Z",
+    re.DOTALL,
+)
+
+MODALITY_CONFIGS = {
+    "image": {
+        "jsonl_relpath": "dataset_jsonl/image/final_rl_data.jsonl",
+        "media_field": "images",
+        "media_subdir": None,
+        "data_source": "omni_preference/image",
+        "ability": "image_qa",
+    },
+    "video": {
+        "jsonl_relpath": "dataset_jsonl/video/final_rl_data.jsonl",
+        "media_field": "videos",
+        "media_subdir": "video-dataset",
+        "data_source": "omni_preference/video",
+        "ability": "video_qa",
+    },
+    "audio": {
+        "jsonl_relpath": "dataset_jsonl/audio/final_rl_data.jsonl",
+        "media_field": "audios",
+        "media_subdir": "audio_files",
+        "data_source": "omni_preference/audio",
+        "ability": "audio_qa",
+    },
+}
+
+
+def _content_item(item_type: str, *, text: str | None = None, image="", video="", audio="") -> dict:
+    return {"type": item_type, "text": text, "image": image, "video": video, "audio": audio}
+
+
+def _media_key(media_rel: str) -> str:
+    return Path(media_rel.replace("\\", "/")).name or media_rel
+
+
+def _dataset_media_rel(media_path: str) -> str:
+    normalized = media_path.replace("\\", "/").strip().rstrip("_")
+    if normalized.startswith("/data/"):
+        return normalized[len("/data/") :]
+    return normalized.lstrip("/")
+
+
+def _read_records(jsonl_path: str) -> list[dict]:
+    records: list[dict] = []
+    with open(jsonl_path, encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if line:
+                records.append(json.loads(line))
+    return records
+
+
+def _parse_context(content: str) -> dict[str, str] | None:
+    if "### Context" not in content:
+        return None
+    context = content.split("### Context", 1)[1].strip()
+    match = CONTEXT_PATTERN.search(context)
+    if match is None:
+        return None
+    return {
+        "media": match.group("media").strip().rstrip("_"),
+        "question": match.group("question").strip(),
+        "candidate_a": match.group("candidate_a").strip(),
+        "candidate_b": match.group("candidate_b").strip(),
+    }
+
+
+def _normalize_record(record: dict, modality: str, index: int) -> dict | None:
+    config = MODALITY_CONFIGS[modality]
+    media_items = record.get(config["media_field"]) or []
+    messages = record.get("messages") or []
+    if not media_items or not messages:
+        return None
+
+    try:
+        solution = json.loads(record["solution"])
+    except (KeyError, json.JSONDecodeError, TypeError):
+        return None
+
+    better = str(solution.get("better", "")).strip()
+    if better == "equal":
+        return None
+
+    context = _parse_context(str(messages[0].get("content", "")))
+    if context is None:
+        return None
+
+    candidate_a = context["candidate_a"]
+    candidate_b = context["candidate_b"]
+    if not candidate_a or not candidate_b:
+        return None
+
+    try:
+        score_a = float(solution.get("score_A", 0))
+        score_b = float(solution.get("score_B", 0))
+    except (TypeError, ValueError):
+        return None
+
+    if better == "A":
+        chosen, rejected = candidate_a, candidate_b
+        win_score, lose_score = score_a, score_b
+    elif better == "B":
+        chosen, rejected = candidate_b, candidate_a
+        win_score, lose_score = score_b, score_a
+    else:
+        return None
+
+    media_path = str(media_items[0]).strip()
+    dataset_media_rel = _dataset_media_rel(media_path)
+    question = context["question"]
+    if not question or not chosen or not rejected:
+        return None
+
+    return {
+        "modality": modality,
+        "media_path": media_path,
+        "dataset_media_rel": dataset_media_rel,
+        "question": question,
+        "chosen": chosen,
+        "rejected": rejected,
+        "win_score": win_score,
+        "lose_score": lose_score,
+        "better": better,
+        "sample_id": f"omni_pref_{modality}_{index}",
+    }
+
+
+def _build_audio_basename_index(audio_dir: str) -> dict[str, str]:
+    index: dict[str, str] = {}
+    for root, _, files in os.walk(audio_dir):
+        for filename in files:
+            if Path(filename).suffix.lower() not in AUDIO_FILE_EXTENSIONS:
+                continue
+            abs_path = os.path.abspath(os.path.join(root, filename))
+            existing = index.get(filename)
+            if existing is None or len(abs_path) < len(existing):
+                index[filename] = abs_path
+    return index
+
+
+def _resolve_image_or_video(dataset_root: str, media_subdir: str | None, media_rel: str) -> str | None:
+    candidates = []
+    if media_subdir:
+        candidates.append(os.path.join(dataset_root, media_subdir, media_rel))
+    candidates.append(os.path.join(dataset_root, media_rel))
+
+    rel = media_rel.lstrip("/").lstrip("\\")
+    if media_subdir:
+        candidates.append(os.path.join(dataset_root, media_subdir, rel))
+    candidates.append(os.path.join(dataset_root, rel))
+
+    for candidate in candidates:
+        if os.path.isfile(candidate):
+            return os.path.abspath(candidate)
+        if not Path(rel).suffix:
+            for extension in VIDEO_FILE_EXTENSIONS:
+                with_extension = candidate + extension
+                if os.path.isfile(with_extension):
+                    return os.path.abspath(with_extension)
+    return None
+
+
+def _resolve_audio(dataset_root: str, media_subdir: str, media_rel: str, basename_index: dict[str, str]) -> str | None:
+    filename = Path(_dataset_media_rel(media_rel)).name
+    indexed = basename_index.get(filename)
+    if indexed is not None:
+        return indexed
+
+    candidates = [
+        os.path.join(dataset_root, media_subdir, media_rel),
+        os.path.join(dataset_root, media_subdir, "audio", filename),
+        os.path.join(dataset_root, media_subdir, "audio_files", filename),
+        os.path.join(dataset_root, media_subdir, filename),
+    ]
+    for candidate in candidates:
+        if os.path.isfile(candidate):
+            return os.path.abspath(candidate)
+    return None
+
+
+def _resolve_media(
+    record: dict,
+    dataset_root: str,
+    audio_basename_index: dict[str, str],
+) -> str | None:
+    modality = record["modality"]
+    config = MODALITY_CONFIGS[modality]
+    media_rel = record["dataset_media_rel"]
+
+    if modality == "audio":
+        return _resolve_audio(dataset_root, config["media_subdir"] or "audio_files", media_rel, audio_basename_index)
+    return _resolve_image_or_video(dataset_root, config["media_subdir"], media_rel)
+
+
+def _split_media_keys(records: list[dict], test_ratio: float, seed: int) -> set[str]:
+    grouped: dict[str, list[dict]] = defaultdict(list)
+    for record in records:
+        grouped[_media_key(record["dataset_media_rel"])].append(record)
+
+    groups = list(grouped.items())
+    rng = random.Random(seed)
+    rng.shuffle(groups)
+
+    target_test_rows = max(1, round(len(records) * test_ratio))
+    test_keys: set[str] = set()
+    test_rows = 0
+
+    for key, group_records in groups:
+        if test_keys and test_rows >= target_test_rows:
+            break
+        test_keys.add(key)
+        test_rows += len(group_records)
+
+    if len(test_keys) == len(groups) and len(groups) > 1:
+        test_keys.remove(groups[-1][0])
+    return test_keys
+
+
+def _base_row(record: dict, split: str, index: int) -> dict:
+    modality = record["modality"]
+    config = MODALITY_CONFIGS[modality]
+    media_rel = record["dataset_media_rel"]
+    question = record["question"]
+
+    return {
+        "data_source": config["data_source"],
+        "chosen": record["chosen"],
+        "rejected": record["rejected"],
+        "win_score": record["win_score"],
+        "lose_score": record["lose_score"],
+        "ability": config["ability"],
+        "reward_model": {"style": "preference"},
+        "extra_info": {
+            "split": split,
+            "index": index,
+            "sample_id": record["sample_id"],
+            "question": question,
+            "modality": modality,
+            "source_media": media_rel,
+            "source_media_name": _media_key(media_rel),
+            "better": record["better"],
+        },
+    }
+
+
+def _build_multimodal_row(record: dict, split: str, index: int, media_path: str) -> dict:
+    modality = record["modality"]
+    question = record["question"]
+    row = _base_row(record, split, index)
+    media_item = _content_item(modality, **{modality: media_path})
+    row["prompt"] = [
+        {"role": "system", "content": [_content_item("text", text=SYSTEM_PROMPT)]},
+        {
+            "role": "user",
+            "content": [
+                media_item,
+                _content_item("text", text=question),
+            ],
+        },
+    ]
+    row["extra_info"][f"{modality}_path"] = media_path
+    return row
+
+
+def _write_split(rows: list[dict], output_dir: str) -> None:
+    train_rows = [row for row in rows if row["extra_info"]["split"] == "train"]
+    test_rows = [row for row in rows if row["extra_info"]["split"] == "test"]
+
+    os.makedirs(output_dir, exist_ok=True)
+    pd.DataFrame(train_rows).to_parquet(os.path.join(output_dir, "train.parquet"), index=False)
+    pd.DataFrame(test_rows).to_parquet(os.path.join(output_dir, "test.parquet"), index=False)
+    print(f"  train={len(train_rows):,}, test={len(test_rows):,}", flush=True)
+
+
+def _process_modality(
+    modality: str,
+    dataset_root: str,
+    output_dir: str,
+    test_ratio: float,
+    seed: int,
+    max_samples: int,
+    audio_basename_index: dict[str, str],
+) -> None:
+    config = MODALITY_CONFIGS[modality]
+    jsonl_path = os.path.join(dataset_root, config["jsonl_relpath"])
+    modality_output_dir = os.path.join(output_dir, modality)
+
+    if not os.path.isfile(jsonl_path):
+        print(f"WARNING: skipping {modality}; missing {jsonl_path}", flush=True)
+        return
+
+    print(f"\n=== {modality} ===", flush=True)
+    print(f"Loading {jsonl_path} ...", flush=True)
+    raw_records = _read_records(jsonl_path)
+    if max_samples > 0:
+        raw_records = raw_records[:max_samples]
+    print(f"  Loaded {len(raw_records):,} raw records.", flush=True)
+
+    records: list[dict] = []
+    skipped_equal = 0
+    skipped_parse = 0
+    for index, raw_record in enumerate(raw_records):
+        normalized = _normalize_record(raw_record, modality, index)
+        if normalized is None:
+            try:
+                solution = json.loads(raw_record["solution"])
+                if str(solution.get("better", "")).strip() == "equal":
+                    skipped_equal += 1
+                else:
+                    skipped_parse += 1
+            except (KeyError, json.JSONDecodeError, TypeError):
+                skipped_parse += 1
+            continue
+        records.append(normalized)
+
+    print(
+        f"  Parsed {len(records):,} preference pairs "
+        f"(skipped_equal={skipped_equal:,}, skipped_parse={skipped_parse:,}).",
+        flush=True,
+    )
+    if not records:
+        print(f"  WARNING: no valid {modality} preference pairs found.", flush=True)
+        return
+
+    test_keys = _split_media_keys(records, test_ratio=test_ratio, seed=seed)
+    train_keys = {_media_key(record["dataset_media_rel"]) for record in records} - test_keys
+    print(
+        f"  Split by media name: train_media={len(train_keys):,}, test_media={len(test_keys):,}",
+        flush=True,
+    )
+
+    rows: list[dict] = []
+    skipped_media = 0
+
+    for idx, record in enumerate(records):
+        split = "test" if _media_key(record["dataset_media_rel"]) in test_keys else "train"
+        media_path = _resolve_media(record, dataset_root, audio_basename_index)
+        if media_path is None:
+            skipped_media += 1
+            continue
+        rows.append(_build_multimodal_row(record, split, idx, media_path))
+
+    print("  Writing parquet files:", flush=True)
+    _write_split(rows, modality_output_dir)
+    if skipped_media:
+        print(f"  skipped_missing_media={skipped_media:,}", flush=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Convert Omni-Preference image/video/audio RL JSONL into offline DPO parquet.",
+    )
+    parser.add_argument(
+        "--dataset_root",
+        required=True,
+        help="Omni-Preference repo root containing dataset_jsonl/ and media folders.",
+    )
+    parser.add_argument(
+        "--output_dir",
+        default=os.path.expanduser("~/data/omni_preference_dpo/parquet"),
+        help="Directory to write {image,video,audio}/train.parquet.",
+    )
+    parser.add_argument(
+        "--modalities",
+        nargs="+",
+        choices=["image", "video", "audio"],
+        default=["image", "video", "audio"],
+        help="Modalities to convert.",
+    )
+    parser.add_argument("--test_ratio", type=float, default=0.10, help="Target test row ratio.")
+    parser.add_argument("--seed", type=int, default=42, help="Seed for media-name split.")
+    parser.add_argument("--max_samples", type=int, default=-1, help="Truncate each modality for quick tests.")
+    args = parser.parse_args()
+
+    if not 0 < args.test_ratio < 1:
+        raise ValueError("--test_ratio must be between 0 and 1")
+
+    dataset_root = os.path.abspath(os.path.expanduser(args.dataset_root))
+    output_dir = os.path.abspath(os.path.expanduser(args.output_dir))
+
+    if not os.path.isdir(dataset_root):
+        print(f"ERROR: dataset_root not found: {dataset_root}", file=sys.stderr)
+        sys.exit(1)
+
+    audio_basename_index: dict[str, str] = {}
+    if "audio" in args.modalities:
+        audio_dir = os.path.join(dataset_root, "audio_files")
+        if os.path.isdir(audio_dir):
+            audio_basename_index = _build_audio_basename_index(audio_dir)
+            print(f"Indexed {len(audio_basename_index):,} audio files under {audio_dir}.", flush=True)
+        else:
+            print(f"WARNING: audio_files not found under {dataset_root}; audio rows may be skipped.", flush=True)
+
+    os.makedirs(output_dir, exist_ok=True)
+    for modality in args.modalities:
+        _process_modality(
+            modality=modality,
+            dataset_root=dataset_root,
+            output_dir=output_dir,
+            test_ratio=args.test_ratio,
+            seed=args.seed,
+            max_samples=args.max_samples,
+            audio_basename_index=audio_basename_index,
+        )
+
+    print("\nDone.", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/special_e2e/create_dummy_omni_preference_dpo_data.py
+++ b/tests/special_e2e/create_dummy_omni_preference_dpo_data.py
@@ -34,8 +34,6 @@ import av
 import pandas as pd
 from PIL import Image
 
-SYSTEM_PROMPT = "You are a helpful assistant."
-
 MODALITY_SPECS = {
     "image": {
         "data_source": "omni_preference/image",
@@ -53,10 +51,6 @@ MODALITY_SPECS = {
         "source_media": "audio/dummy_audio.wav",
     },
 }
-
-
-def _content_item(item_type: str, *, text: str | None = None, image="", video="", audio="") -> dict:
-    return {"type": item_type, "text": text, "image": image, "video": video, "audio": audio}
 
 
 def _write_png(path: str, color: tuple[int, int, int]) -> str:
@@ -124,8 +118,14 @@ def _base_row(split: str, modality: str, index: int, question: str) -> dict:
     source_media = spec["source_media"]
     return {
         "data_source": spec["data_source"],
-        "chosen": "The preferred answer correctly describes the dummy content.",
-        "rejected": "The rejected answer gives an unrelated description.",
+        "chosen": {
+            "role": "assistant",
+            "content": "The preferred answer correctly describes the dummy content.",
+        },
+        "rejected": {
+            "role": "assistant",
+            "content": "The rejected answer gives an unrelated description.",
+        },
         "win_score": 8.0,
         "lose_score": 4.0,
         "ability": spec["ability"],
@@ -147,15 +147,12 @@ def _image_row(split: str, index: int, image_path: str) -> dict:
     question = "What is shown in this dummy image?"
     row = _base_row(split, "image", index, question)
     row["prompt"] = [
-        {"role": "system", "content": [_content_item("text", text=SYSTEM_PROMPT)]},
         {
             "role": "user",
-            "content": [
-                _content_item("image", image=image_path),
-                _content_item("text", text=question),
-            ],
+            "content": f"<image>{question}",
         },
     ]
+    row["images"] = [image_path]
     row["extra_info"]["image_path"] = image_path
     return row
 
@@ -164,15 +161,12 @@ def _video_row(split: str, index: int, video_path: str) -> dict:
     question = "What changes across the dummy video frames?"
     row = _base_row(split, "video", index, question)
     row["prompt"] = [
-        {"role": "system", "content": [_content_item("text", text=SYSTEM_PROMPT)]},
         {
             "role": "user",
-            "content": [
-                _content_item("video", video=video_path),
-                _content_item("text", text=question),
-            ],
+            "content": f"<video>{question}",
         },
     ]
+    row["videos"] = [video_path]
     row["extra_info"]["video_path"] = video_path
     return row
 
@@ -181,15 +175,12 @@ def _audio_row(split: str, index: int, audio_path: str) -> dict:
     question = "What sound is described in this dummy audio clip?"
     row = _base_row(split, "audio", index, question)
     row["prompt"] = [
-        {"role": "system", "content": [_content_item("text", text=SYSTEM_PROMPT)]},
         {
             "role": "user",
-            "content": [
-                _content_item("audio", audio=audio_path),
-                _content_item("text", text=question),
-            ],
+            "content": f"<audio>{question}",
         },
     ]
+    row["audios"] = [audio_path]
     row["extra_info"]["audio_path"] = audio_path
     return row
 

--- a/tests/special_e2e/create_dummy_omni_preference_dpo_data.py
+++ b/tests/special_e2e/create_dummy_omni_preference_dpo_data.py
@@ -1,0 +1,243 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Create a tiny Omni-Preference-style multimodal parquet dataset.
+
+The generated data mirrors the offline MLLM DPO schema produced by
+``omni_preference_dpo_multisource.py``:
+
+    prompt, chosen, rejected, win_score, lose_score, data_source, ability,
+    reward_model, extra_info
+
+It writes three modality folders (image/video/audio) so e2e smoke tests exercise
+mixed multimodal batches without downloading the real Omni-Preference dataset.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import struct
+import wave
+
+import av
+import pandas as pd
+from PIL import Image
+
+SYSTEM_PROMPT = "You are a helpful assistant."
+
+MODALITY_SPECS = {
+    "image": {
+        "data_source": "omni_preference/image",
+        "ability": "image_qa",
+        "source_media": "rlaif-v-dataset/dummy_images/dummy_image.png",
+    },
+    "video": {
+        "data_source": "omni_preference/video",
+        "ability": "video_qa",
+        "source_media": "academic_source/dummy_clip.mp4",
+    },
+    "audio": {
+        "data_source": "omni_preference/audio",
+        "ability": "audio_qa",
+        "source_media": "audio/dummy_audio.wav",
+    },
+}
+
+
+def _content_item(item_type: str, *, text: str | None = None, image="", video="", audio="") -> dict:
+    return {"type": item_type, "text": text, "image": image, "video": video, "audio": audio}
+
+
+def _write_png(path: str, color: tuple[int, int, int]) -> str:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    Image.new("RGB", (64, 64), color=color).save(path)
+    return os.path.abspath(path)
+
+
+def _write_video(
+    path: str,
+    colors: list[tuple[int, int, int]],
+    *,
+    fps: int = 2,
+    size: tuple[int, int] = (64, 64),
+) -> str:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    width, height = size
+    container = av.open(path, mode="w")
+    stream = container.add_stream("libx264", rate=fps)
+    stream.width = width
+    stream.height = height
+    stream.pix_fmt = "yuv420p"
+
+    for color in colors:
+        frame = av.VideoFrame.from_image(Image.new("RGB", size, color=color))
+        for packet in stream.encode(frame):
+            container.mux(packet)
+
+    for packet in stream.encode():
+        container.mux(packet)
+    container.close()
+    return os.path.abspath(path)
+
+
+def _write_wav(path: str, *, sample_rate: int = 16_000, duration_s: float = 1.0) -> str:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    num_frames = int(sample_rate * duration_s)
+    frames = bytearray()
+    for idx in range(num_frames):
+        sample = int(12_000 * (1 if idx % 80 < 40 else -1))
+        frames.extend(struct.pack("<h", sample))
+
+    with wave.open(path, "wb") as wav_file:
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(sample_rate)
+        wav_file.writeframes(frames)
+    return os.path.abspath(path)
+
+
+def _make_assets(root: str) -> dict[str, str]:
+    media_dir = os.path.join(root, "media")
+    image_path = _write_png(os.path.join(media_dir, "images", "dummy_image.png"), (240, 64, 64))
+    audio_path = _write_wav(os.path.join(media_dir, "audio", "dummy_audio.wav"))
+
+    video_path = _write_video(
+        os.path.join(media_dir, "videos", "dummy_clip.mp4"),
+        [(64, 128, 240), (64, 200, 120), (220, 180, 64)],
+    )
+    return {"image": image_path, "video": video_path, "audio": audio_path}
+
+
+def _base_row(split: str, modality: str, index: int, question: str) -> dict:
+    spec = MODALITY_SPECS[modality]
+    source_media = spec["source_media"]
+    return {
+        "data_source": spec["data_source"],
+        "chosen": "The preferred answer correctly describes the dummy content.",
+        "rejected": "The rejected answer gives an unrelated description.",
+        "win_score": 8.0,
+        "lose_score": 4.0,
+        "ability": spec["ability"],
+        "reward_model": {"style": "preference"},
+        "extra_info": {
+            "split": split,
+            "index": index,
+            "sample_id": f"omni_pref_{modality}_{split}_{index}",
+            "question": question,
+            "modality": modality,
+            "source_media": source_media,
+            "source_media_name": os.path.basename(source_media),
+            "better": "B",
+        },
+    }
+
+
+def _image_row(split: str, index: int, image_path: str) -> dict:
+    question = "What is shown in this dummy image?"
+    row = _base_row(split, "image", index, question)
+    row["prompt"] = [
+        {"role": "system", "content": [_content_item("text", text=SYSTEM_PROMPT)]},
+        {
+            "role": "user",
+            "content": [
+                _content_item("image", image=image_path),
+                _content_item("text", text=question),
+            ],
+        },
+    ]
+    row["extra_info"]["image_path"] = image_path
+    return row
+
+
+def _video_row(split: str, index: int, video_path: str) -> dict:
+    question = "What changes across the dummy video frames?"
+    row = _base_row(split, "video", index, question)
+    row["prompt"] = [
+        {"role": "system", "content": [_content_item("text", text=SYSTEM_PROMPT)]},
+        {
+            "role": "user",
+            "content": [
+                _content_item("video", video=video_path),
+                _content_item("text", text=question),
+            ],
+        },
+    ]
+    row["extra_info"]["video_path"] = video_path
+    return row
+
+
+def _audio_row(split: str, index: int, audio_path: str) -> dict:
+    question = "What sound is described in this dummy audio clip?"
+    row = _base_row(split, "audio", index, question)
+    row["prompt"] = [
+        {"role": "system", "content": [_content_item("text", text=SYSTEM_PROMPT)]},
+        {
+            "role": "user",
+            "content": [
+                _content_item("audio", audio=audio_path),
+                _content_item("text", text=question),
+            ],
+        },
+    ]
+    row["extra_info"]["audio_path"] = audio_path
+    return row
+
+
+def _build_rows(split: str, size: int, assets: dict[str, str]) -> dict[str, list[dict]]:
+    rows = {"image": [], "video": [], "audio": []}
+    image_path = str(assets["image"])
+    video_path = str(assets["video"])
+    audio_path = str(assets["audio"])
+    for idx in range(size):
+        rows["image"].append(_image_row(split, idx, image_path))
+        rows["video"].append(_video_row(split, idx, video_path))
+        rows["audio"].append(_audio_row(split, idx, audio_path))
+    return rows
+
+
+def _write_modality_parquet(root: str, modality: str, train_rows: list[dict], val_rows: list[dict]) -> None:
+    modality_dir = os.path.join(root, modality)
+    os.makedirs(modality_dir, exist_ok=True)
+    pd.DataFrame(train_rows).to_parquet(os.path.join(modality_dir, "train.parquet"), index=False)
+    pd.DataFrame(val_rows).to_parquet(os.path.join(modality_dir, "test.parquet"), index=False)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate dummy Omni-Preference parquet data for e2e testing")
+    parser.add_argument(
+        "--local_save_dir",
+        default=os.path.expanduser("~/data/dummy_omni_preference_dpo"),
+        help="Directory to write modality parquet folders and media files",
+    )
+    parser.add_argument("--train_size", type=int, default=4, help="Rows per modality for train split")
+    parser.add_argument("--val_size", type=int, default=2, help="Rows per modality for val split")
+    args = parser.parse_args()
+
+    root = os.path.abspath(os.path.expanduser(args.local_save_dir))
+    assets = _make_assets(root)
+    train_rows = _build_rows("train", args.train_size, assets)
+    val_rows = _build_rows("test", args.val_size, assets)
+
+    for modality in ("image", "video", "audio"):
+        _write_modality_parquet(root, modality, train_rows[modality], val_rows[modality])
+        print(
+            f"Wrote {len(train_rows[modality])} train and {len(val_rows[modality])} val rows for {modality}",
+            flush=True,
+        )
+
+    print(f"Dummy Omni-Preference data root: {root}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/utils/test_offline_mllm_dpo_dataset_on_cpu.py
+++ b/tests/utils/test_offline_mllm_dpo_dataset_on_cpu.py
@@ -1,0 +1,397 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU unit tests for offline MLLM DPO dataset helpers and Omni-Preference preprocessing."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+import torch
+from omegaconf import OmegaConf
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_dataset_module():
+    # Avoid importing verl_omni.__init__, which may pull optional rollout deps.
+    sys.modules.setdefault("verl_omni", types.ModuleType("verl_omni"))
+    sys.modules.setdefault("verl_omni.utils", types.ModuleType("verl_omni.utils"))
+    sys.modules.setdefault("verl_omni.utils.dataset", types.ModuleType("verl_omni.utils.dataset"))
+
+    dataset_dir = REPO_ROOT / "verl_omni" / "utils" / "dataset"
+    transform_spec = importlib.util.spec_from_file_location(
+        "verl_omni.utils.dataset.qwen3_omni_transform",
+        dataset_dir / "qwen3_omni_transform.py",
+    )
+    if transform_spec is None or transform_spec.loader is None:
+        raise ImportError("Cannot load qwen3_omni_transform module.")
+    transform_module = importlib.util.module_from_spec(transform_spec)
+    sys.modules[transform_spec.name] = transform_module
+    transform_spec.loader.exec_module(transform_module)
+
+    dataset_spec = importlib.util.spec_from_file_location(
+        "verl_omni.utils.dataset.offline_mllm_dpo_dataset",
+        dataset_dir / "offline_mllm_dpo_dataset.py",
+    )
+    if dataset_spec is None or dataset_spec.loader is None:
+        raise ImportError("Cannot load offline_mllm_dpo_dataset module.")
+    dataset_module = importlib.util.module_from_spec(dataset_spec)
+    sys.modules[dataset_spec.name] = dataset_module
+    dataset_spec.loader.exec_module(dataset_module)
+    return dataset_module
+
+
+dataset_mod = _load_dataset_module()
+
+
+def _load_multisource_module():
+    module_path = REPO_ROOT / "examples/dpo_trainer/data_process/omni_preference_dpo_multisource.py"
+    spec = importlib.util.spec_from_file_location("omni_preference_dpo_multisource", module_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load module from {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _content_item(item_type: str, *, text: str | None = None, image="", video="", audio="") -> dict:
+    return {"type": item_type, "text": text, "image": image, "video": video, "audio": audio}
+
+
+def _sample_prompt(modality: str = "image", media_path: str = "/tmp/dummy.png") -> list[dict]:
+    media_item = _content_item(modality, **{modality: media_path})
+    return [
+        {"role": "system", "content": [_content_item("text", text="You are a helpful assistant.")]},
+        {
+            "role": "user",
+            "content": [
+                media_item,
+                _content_item("text", text="What is shown?"),
+            ],
+        },
+    ]
+
+
+def _parquet_row(modality: str, index: int = 0) -> dict:
+    return {
+        "data_source": f"omni_preference/{modality}",
+        "prompt": _sample_prompt(modality, f"/tmp/{modality}_{index}.bin"),
+        "chosen": "preferred answer",
+        "rejected": "rejected answer",
+        "win_score": 8.0,
+        "lose_score": 4.0,
+        "ability": f"{modality}_qa",
+        "reward_model": {"style": "preference"},
+        "extra_info": {
+            "split": "train",
+            "index": index,
+            "modality": modality,
+            "question": "What is shown?",
+        },
+    }
+
+
+@pytest.fixture
+def mock_processor():
+    processor = MagicMock()
+    processor.get_rope_index = MagicMock(
+        return_value={"position_ids": torch.zeros(1, 3, 4), "mrope_position_deltas": torch.zeros(1)}
+    )
+    return processor
+
+
+@pytest.fixture
+def mixed_parquet_path(tmp_path):
+    rows = [
+        _parquet_row("image", 0),
+        _parquet_row("image", 1),
+        _parquet_row("video", 0),
+        _parquet_row("audio", 0),
+    ]
+    parquet_path = tmp_path / "train.parquet"
+    pd.DataFrame(rows).to_parquet(parquet_path, index=False)
+    return str(parquet_path)
+
+
+class FakeModalityDataset:
+    def __init__(self, modalities: list[str]):
+        self._modalities = modalities
+
+    def __len__(self) -> int:
+        return len(self._modalities)
+
+    def get_modality(self, index: int) -> str:
+        return self._modalities[index]
+
+
+def test_as_python_parses_json_string():
+    assert dataset_mod._as_python('{"a": 1}') == {"a": 1}
+    assert dataset_mod._as_python("[1, 2]") == [1, 2]
+    assert dataset_mod._as_python(b'{"k": "v"}') == {"k": "v"}
+
+
+def test_build_preference_branch_extracts_media_and_answer():
+    sample = {
+        "prompt": _sample_prompt("video", "/tmp/clip.mp4"),
+        "chosen": "answer A",
+        "data_source": "omni_preference/video",
+    }
+    branch = dataset_mod._build_preference_branch(sample, sample["chosen"])
+
+    assert branch["source_name"] == "omni_preference/video"
+    assert branch["videos"] == ["/tmp/clip.mp4"]
+    assert branch["conversations"][-1] == ["assistant", ("text", "answer A")]
+    assert branch["conversations"][0][0] == "user"
+
+
+def test_merge_chosen_rejected_concatenates_sequence_tensors():
+    chosen = {"input_ids": torch.tensor([1, 2]), "labels": torch.tensor([3, 4])}
+    rejected = {"input_ids": torch.tensor([5, 6]), "labels": torch.tensor([7, 8])}
+
+    merged = dataset_mod._merge_chosen_rejected(chosen, rejected)
+
+    torch.testing.assert_close(merged["input_ids"], torch.tensor([1, 2, 5, 6]))
+    torch.testing.assert_close(merged["labels"], torch.tensor([3, 4, 7, 8]))
+
+
+def test_collate_tensor_values_pads_variable_length_sequences():
+    values = [
+        torch.tensor([1, 2]),
+        torch.tensor([3, 4, 5]),
+    ]
+    collated = dataset_mod._collate_tensor_values("input_ids", values)
+
+    assert collated.shape == (2, 3)
+    torch.testing.assert_close(collated[0], torch.tensor([1, 2, 0]))
+    torch.testing.assert_close(collated[1], torch.tensor([3, 4, 5]))
+
+
+def test_offline_mllm_dpo_collate_fn_rejects_mixed_modalities():
+    features = [
+        {"modality": "image", "input_ids": torch.tensor([1])},
+        {"modality": "video", "input_ids": torch.tensor([2])},
+    ]
+    with pytest.raises(ValueError, match="single modality"):
+        dataset_mod.offline_mllm_dpo_collate_fn(features)
+
+
+def test_offline_mllm_dpo_collate_fn_batches_same_modality():
+    features = [
+        {
+            "modality": "image",
+            "input_ids": torch.tensor([1, 2]),
+            "labels": torch.tensor([3, 4]),
+            "extra_info": {"index": 0},
+        },
+        {
+            "modality": "image",
+            "input_ids": torch.tensor([5]),
+            "labels": torch.tensor([6]),
+            "extra_info": {"index": 1},
+        },
+    ]
+    batch = dataset_mod.offline_mllm_dpo_collate_fn(features)
+
+    assert batch["input_ids"].shape == (2, 2)
+    assert batch["labels"].shape == (2, 2)
+    assert batch["modality"].tolist() == ["image", "image"]
+    assert batch["extra_info"].tolist() == [{"index": 0}, {"index": 1}]
+
+
+def test_modality_grouped_batch_sampler_yields_same_modality_chunks():
+    dataset = FakeModalityDataset(["image", "image", "video", "audio", "video", "audio"])
+    sampler = dataset_mod.ModalityGroupedBatchSampler(
+        data_source=dataset,
+        batch_size=2,
+        seed=0,
+        num_batches=3,
+    )
+
+    batches: list[list[str]] = []
+    current: list[str] = []
+    for index in sampler:
+        current.append(dataset.get_modality(index))
+        if len(current) == sampler.batch_size:
+            batches.append(current)
+            current = []
+
+    assert len(batches) == 3
+    for batch_modalities in batches:
+        assert len(set(batch_modalities)) == 1
+
+
+def test_modality_grouped_batch_sampler_respects_weights(monkeypatch):
+    dataset = FakeModalityDataset(["image", "video", "audio"])
+    sampler = dataset_mod.ModalityGroupedBatchSampler(
+        data_source=dataset,
+        batch_size=1,
+        seed=0,
+        num_batches=6,
+        modality_sample_weights={"video": 100.0, "image": 0.0, "audio": 0.0},
+    )
+
+    sampled = [dataset.get_modality(index) for index in sampler]
+    assert sampled == ["video"] * 6
+
+
+def test_offline_mllm_dpo_dataset_init_and_get_modality(mock_processor, mixed_parquet_path):
+    config = OmegaConf.create({"train_batch_size": 2})
+    dataset = dataset_mod.OfflineMLLMDPODataset(
+        data_files=mixed_parquet_path,
+        tokenizer=None,
+        processor=mock_processor,
+        config=config,
+    )
+
+    assert len(dataset) == 4
+    assert dataset.get_modality(0) == "image"
+    assert dataset.get_modality(2) == "video"
+    assert dataset.get_modality(3) == "audio"
+
+
+def test_offline_mllm_dpo_dataset_getitem(monkeypatch, mock_processor, mixed_parquet_path):
+    def fake_transform(sample, **kwargs):
+        answer = sample["conversations"][-1][1][1]
+        token = 1 if answer == "preferred answer" else 2
+        return [{"input_ids": torch.tensor([token]), "labels": torch.tensor([token])}]
+
+    monkeypatch.setattr(dataset_mod, "process_qwen3_omni_sample", fake_transform)
+
+    config = OmegaConf.create({"train_batch_size": 2})
+    dataset = dataset_mod.OfflineMLLMDPODataset(
+        data_files=mixed_parquet_path,
+        tokenizer=None,
+        processor=mock_processor,
+        config=config,
+    )
+    item = dataset[0]
+
+    torch.testing.assert_close(item["input_ids"], torch.tensor([1, 2]))
+    torch.testing.assert_close(item["sample_level_scores"], torch.tensor([8.0, 4.0]))
+    assert item["modality"] == "image"
+    assert item["data_source"] == "omni_preference/image"
+    assert item["extra_info"]["modality"] == "image"
+
+
+def test_offline_mllm_dpo_dataset_requires_processor():
+    with pytest.raises(ValueError, match="requires a multimodal processor"):
+        dataset_mod.OfflineMLLMDPODataset(
+            data_files=[],
+            tokenizer=None,
+            processor=None,
+            config=OmegaConf.create({}),
+        )
+
+
+def test_multisource_parse_context_and_normalize_record():
+    multisource = _load_multisource_module()
+    content = (
+        "prefix ### Context\n"
+        "Image file: /data/rlaif-v-dataset/foo.jpg\n"
+        "Question: What color is the object?\n"
+        "Candidate A: red\n"
+        "Candidate B: blue"
+    )
+    parsed = multisource._parse_context(content)
+    assert parsed == {
+        "media": "/data/rlaif-v-dataset/foo.jpg",
+        "question": "What color is the object?",
+        "candidate_a": "red",
+        "candidate_b": "blue",
+    }
+
+    record = {
+        "images": ["/data/rlaif-v-dataset/foo.jpg"],
+        "messages": [{"role": "user", "content": content}],
+        "solution": json.dumps({"score_A": 5, "score_B": 8, "better": "B"}),
+    }
+    normalized = multisource._normalize_record(record, "image", 3)
+
+    assert normalized is not None
+    assert normalized["chosen"] == "blue"
+    assert normalized["rejected"] == "red"
+    assert normalized["win_score"] == 8.0
+    assert normalized["lose_score"] == 5.0
+    assert normalized["dataset_media_rel"] == "rlaif-v-dataset/foo.jpg"
+
+
+def test_multisource_skips_equal_verdict():
+    multisource = _load_multisource_module()
+    record = {
+        "images": ["/data/foo.jpg"],
+        "messages": [{"role": "user", "content": "no context"}],
+        "solution": json.dumps({"score_A": 5, "score_B": 5, "better": "equal"}),
+    }
+    assert multisource._normalize_record(record, "image", 0) is None
+
+
+def test_multisource_split_media_keys_keeps_train_and_test_disjoint():
+    multisource = _load_multisource_module()
+    records = [
+        {"dataset_media_rel": "a/img1.jpg"},
+        {"dataset_media_rel": "a/img1.jpg"},
+        {"dataset_media_rel": "b/img2.jpg"},
+        {"dataset_media_rel": "c/img3.jpg"},
+    ]
+    test_keys = multisource._split_media_keys(records, test_ratio=0.5, seed=42)
+    train_keys = {multisource._media_key(record["dataset_media_rel"]) for record in records} - test_keys
+
+    assert test_keys & train_keys == set()
+    assert test_keys
+
+
+def test_read_dataframe_supports_multiple_parquet_files(tmp_path):
+    first = tmp_path / "a.parquet"
+    second = tmp_path / "b.parquet"
+    pd.DataFrame([_parquet_row("image", 0)]).to_parquet(first, index=False)
+    pd.DataFrame([_parquet_row("video", 0)]).to_parquet(second, index=False)
+
+    frame = dataset_mod._read_dataframe([str(first), str(second)])
+
+    assert len(frame) == 2
+    assert set(frame["data_source"]) == {"omni_preference/image", "omni_preference/video"}
+
+
+def test_row_modality_prefers_extra_info():
+    row = {
+        "data_source": "omni_preference/image",
+        "extra_info": {"modality": "video"},
+    }
+    assert dataset_mod._row_modality(row, "data_source") == "video"
+
+
+def test_offline_mllm_dpo_collate_fn_squeezes_position_ids():
+    features = [
+        {
+            "modality": "image",
+            "position_ids": torch.ones(3, 1, 4),
+            "input_ids": torch.tensor([1]),
+        },
+        {
+            "modality": "image",
+            "position_ids": torch.ones(3, 1, 4),
+            "input_ids": torch.tensor([2]),
+        },
+    ]
+    batch = dataset_mod.offline_mllm_dpo_collate_fn(features)
+
+    assert batch["position_ids"].shape == (2, 3, 4)

--- a/tests/utils/test_offline_mllm_dpo_dataset_on_cpu.py
+++ b/tests/utils/test_offline_mllm_dpo_dataset_on_cpu.py
@@ -163,14 +163,40 @@ def test_build_preference_branch_extracts_media_and_answer():
     assert branch["conversations"][0][0] == "user"
 
 
-def test_merge_chosen_rejected_concatenates_sequence_tensors():
+def test_build_preference_branch_supports_compact_top_level_media_schema():
+    sample = {
+        "prompt": [{"role": "user", "content": "<video>What happens at the end?"}],
+        "chosen": {"role": "assistant", "content": "preferred answer"},
+        "videos": ["/tmp/clip.mp4"],
+        "data_source": "omni_preference/video",
+    }
+    branch = dataset_mod._build_preference_branch(sample, sample["chosen"])
+
+    assert branch["source_name"] == "omni_preference/video"
+    assert branch["videos"] == ["/tmp/clip.mp4"]
+    assert branch["conversations"][0] == ["user", ("video", None), ("text", "What happens at the end?")]
+    assert branch["conversations"][-1] == ["assistant", ("text", "preferred answer")]
+
+
+def test_build_preference_branch_rejects_missing_top_level_media():
+    sample = {
+        "prompt": [{"role": "user", "content": "<video>What happens at the end?"}],
+        "chosen": {"role": "assistant", "content": "preferred answer"},
+        "data_source": "omni_preference/video",
+    }
+
+    with pytest.raises(ValueError, match=r"Prompt contains 1 <video> token\(s\) but videos has 0 item\(s\)"):
+        dataset_mod._build_preference_branch(sample, sample["chosen"])
+
+
+def test_merge_chosen_rejected_stacks_branch_tensors():
     chosen = {"input_ids": torch.tensor([1, 2]), "labels": torch.tensor([3, 4])}
-    rejected = {"input_ids": torch.tensor([5, 6]), "labels": torch.tensor([7, 8])}
+    rejected = {"input_ids": torch.tensor([5]), "labels": torch.tensor([7])}
 
     merged = dataset_mod._merge_chosen_rejected(chosen, rejected)
 
-    torch.testing.assert_close(merged["input_ids"], torch.tensor([1, 2, 5, 6]))
-    torch.testing.assert_close(merged["labels"], torch.tensor([3, 4, 7, 8]))
+    torch.testing.assert_close(merged["input_ids"], torch.tensor([[1, 2], [5, 0]]))
+    torch.testing.assert_close(merged["labels"], torch.tensor([[3, 4], [7, -100]]))
 
 
 def test_collate_tensor_values_pads_variable_length_sequences():
@@ -215,6 +241,27 @@ def test_offline_mllm_dpo_collate_fn_batches_same_modality():
     assert batch["labels"].shape == (2, 2)
     assert batch["modality"].tolist() == ["image", "image"]
     assert batch["extra_info"].tolist() == [{"index": 0}, {"index": 1}]
+
+
+def test_offline_mllm_dpo_collate_fn_pads_branch_stacked_pairs():
+    features = [
+        {
+            "modality": "image",
+            "input_ids": torch.tensor([[1, 2], [3, 0]]),
+            "labels": torch.tensor([[-100, 2], [3, -100]]),
+        },
+        {
+            "modality": "image",
+            "input_ids": torch.tensor([[4, 5, 6], [7, 8, 0]]),
+            "labels": torch.tensor([[-100, 5, 6], [7, 8, -100]]),
+        },
+    ]
+    batch = dataset_mod.offline_mllm_dpo_collate_fn(features)
+
+    assert batch["input_ids"].shape == (2, 2, 3)
+    assert batch["labels"].shape == (2, 2, 3)
+    torch.testing.assert_close(batch["input_ids"][0], torch.tensor([[1, 2, 0], [3, 0, 0]]))
+    torch.testing.assert_close(batch["labels"][0], torch.tensor([[-100, 2, -100], [3, -100, -100]]))
 
 
 def test_modality_grouped_batch_sampler_yields_same_modality_chunks():
@@ -285,11 +332,52 @@ def test_offline_mllm_dpo_dataset_getitem(monkeypatch, mock_processor, mixed_par
     )
     item = dataset[0]
 
-    torch.testing.assert_close(item["input_ids"], torch.tensor([1, 2]))
+    torch.testing.assert_close(item["input_ids"], torch.tensor([[1], [2]]))
     torch.testing.assert_close(item["sample_level_scores"], torch.tensor([8.0, 4.0]))
     assert item["modality"] == "image"
     assert item["data_source"] == "omni_preference/image"
     assert item["extra_info"]["modality"] == "image"
+
+
+def test_offline_mllm_dpo_dataset_getitem_compact_top_level_media_schema(monkeypatch, mock_processor, tmp_path):
+    row = {
+        "prompt": [{"role": "user", "content": "<video>What visual is shown?"}],
+        "chosen": {"role": "assistant", "content": "preferred answer"},
+        "rejected": {"role": "assistant", "content": "rejected answer"},
+        "videos": ["/tmp/clip.mp4"],
+        "win_score": 9.0,
+        "lose_score": 2.0,
+        "extra_info": {"index": 0},
+    }
+    parquet_path = tmp_path / "compact.parquet"
+    pd.DataFrame([row]).to_parquet(parquet_path, index=False)
+
+    seen_samples = []
+
+    def fake_transform(sample, **kwargs):
+        seen_samples.append(sample)
+        answer = sample["conversations"][-1][1][1]
+        token = 1 if answer == "preferred answer" else 2
+        return [{"input_ids": torch.tensor([token]), "labels": torch.tensor([token])}]
+
+    monkeypatch.setattr(dataset_mod, "process_qwen3_omni_sample", fake_transform)
+
+    dataset = dataset_mod.OfflineMLLMDPODataset(
+        data_files=str(parquet_path),
+        tokenizer=None,
+        processor=mock_processor,
+        config=OmegaConf.create({"train_batch_size": 1}),
+    )
+    item = dataset[0]
+
+    assert dataset.get_modality(0) == "video"
+    assert seen_samples[0]["videos"] == ["/tmp/clip.mp4"]
+    assert seen_samples[0]["conversations"][0] == ["user", ("video", None), ("text", "What visual is shown?")]
+    assert seen_samples[0]["conversations"][-1] == ["assistant", ("text", "preferred answer")]
+    assert seen_samples[1]["conversations"][-1] == ["assistant", ("text", "rejected answer")]
+    torch.testing.assert_close(item["input_ids"], torch.tensor([[1], [2]]))
+    torch.testing.assert_close(item["sample_level_scores"], torch.tensor([9.0, 2.0]))
+    assert item["modality"] == "video"
 
 
 def test_offline_mllm_dpo_dataset_requires_processor():
@@ -334,6 +422,29 @@ def test_multisource_parse_context_and_normalize_record():
     assert normalized["dataset_media_rel"] == "rlaif-v-dataset/foo.jpg"
 
 
+def test_multisource_build_multimodal_row_uses_compact_schema():
+    multisource = _load_multisource_module()
+    record = {
+        "modality": "video",
+        "dataset_media_rel": "academic_source/clip.mp4",
+        "question": "What happens at the end?",
+        "chosen": "preferred answer",
+        "rejected": "rejected answer",
+        "win_score": 8.0,
+        "lose_score": 4.0,
+        "better": "A",
+        "sample_id": "sample-0",
+    }
+    row = multisource._build_multimodal_row(record, split="train", index=0, media_path="/tmp/clip.mp4")
+
+    assert row["prompt"] == [{"role": "user", "content": "<video>What happens at the end?"}]
+    assert row["chosen"] == {"role": "assistant", "content": "preferred answer"}
+    assert row["rejected"] == {"role": "assistant", "content": "rejected answer"}
+    assert row["videos"] == ["/tmp/clip.mp4"]
+    assert "images" not in row
+    assert "audios" not in row
+
+
 def test_multisource_skips_equal_verdict():
     multisource = _load_multisource_module()
     record = {
@@ -375,6 +486,13 @@ def test_row_modality_prefers_extra_info():
     row = {
         "data_source": "omni_preference/image",
         "extra_info": {"modality": "video"},
+    }
+    assert dataset_mod._row_modality(row, "data_source") == "video"
+
+
+def test_row_modality_falls_back_to_top_level_media_columns():
+    row = {
+        "videos": ["/tmp/clip.mp4"],
     }
     assert dataset_mod._row_modality(row, "data_source") == "video"
 

--- a/verl_omni/utils/dataset/offline_mllm_dpo_dataset.py
+++ b/verl_omni/utils/dataset/offline_mllm_dpo_dataset.py
@@ -34,7 +34,7 @@ from verl_omni.utils.dataset.qwen3_omni_transform import process_qwen3_omni_samp
 
 
 def _read_dataframe(data_files: str | Sequence[str]) -> pd.DataFrame:
-    paths = [data_files] if isinstance(data_files, str) else list(data_files)
+    paths = [data_files] if isinstance(data_files, (str, Path)) else list(data_files)
     frames = []
     for data_file in paths:
         path = Path(os.path.expanduser(data_file))

--- a/verl_omni/utils/dataset/offline_mllm_dpo_dataset.py
+++ b/verl_omni/utils/dataset/offline_mllm_dpo_dataset.py
@@ -460,6 +460,20 @@ class ModalityGroupedBatchSampler(Sampler[int]):
 
 
 def offline_mllm_dpo_collate_fn(features):
+    """Collate Offline MLLM DPO samples into a single-modality batch.
+
+    The collator requires every sample in the batch to share the same modality,
+    stacks tensor fields with modality-aware padding, and stores non-tensor
+    fields in object arrays.
+
+    Args:
+        features: Sequence of dataset samples produced by
+            ``OfflineMLLMDPODataset``.
+
+    Returns:
+        Batch dictionary containing collated tensor fields and object arrays for
+        non-tensor fields.
+    """
     modalities = {feature.get("modality") for feature in features}
     if len(modalities) != 1:
         raise ValueError(f"Offline MLLM DPO batches must contain a single modality, got {sorted(modalities)}")

--- a/verl_omni/utils/dataset/offline_mllm_dpo_dataset.py
+++ b/verl_omni/utils/dataset/offline_mllm_dpo_dataset.py
@@ -18,8 +18,8 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import uuid
-import warnings
 from collections import defaultdict
 from collections.abc import Sequence
 from pathlib import Path
@@ -33,9 +33,11 @@ from torch.utils.data import Dataset, Sampler
 
 from verl_omni.utils.dataset.qwen3_omni_transform import process_qwen3_omni_sample
 
+_MEDIA_TOKEN_PATTERN = re.compile(r"<(image|video|audio)>")
+
 
 def _read_dataframe(data_files: str | Sequence[str]) -> pd.DataFrame:
-    paths = [data_files] if isinstance(data_files, str | Path) else list(data_files)
+    paths = [data_files] if isinstance(data_files, (str | Path)) else list(data_files)
     frames = []
     for data_file in paths:
         path = Path(os.path.expanduser(data_file))
@@ -65,10 +67,87 @@ def _as_python(value: Any) -> Any:
     return value
 
 
+def _is_missing(value: Any) -> bool:
+    if value is None:
+        return True
+    if isinstance(value, float) and np.isnan(value):
+        return True
+    return value is pd.NA
+
+
+def _append_media_path(media: dict[str, list[Any]], key: str, value: Any) -> None:
+    if _is_missing(value):
+        return
+    if value not in media[key]:
+        media[key].append(value)
+
+
+def _normalise_media_list(value: Any) -> list[Any]:
+    value = _as_python(value)
+    if _is_missing(value):
+        return []
+    if isinstance(value, str):
+        return [value] if value else []
+    if isinstance(value, Sequence):
+        return [item for item in value if not _is_missing(item)]
+    return [value]
+
+
+def _initial_media(sample: dict[str, Any]) -> dict[str, list[Any]]:
+    return {
+        "images": _normalise_media_list(sample.get("images")),
+        "videos": _normalise_media_list(sample.get("videos")),
+        "audios": _normalise_media_list(sample.get("audios")),
+    }
+
+
+def _answer_text(answer: Any) -> str:
+    answer = _as_python(answer)
+    if isinstance(answer, dict):
+        if "content" in answer:
+            return _content_to_text(answer["content"])
+        if "text" in answer:
+            return str(answer["text"])
+    return _content_to_text(answer)
+
+
+def _content_to_text(content: Any) -> str:
+    content = _as_python(content)
+    if isinstance(content, str):
+        return content
+    if isinstance(content, dict):
+        if content.get("type") == "text":
+            return str(content.get("text", ""))
+        if "content" in content:
+            return _content_to_text(content["content"])
+        if "text" in content:
+            return str(content["text"])
+        return str(content)
+    if isinstance(content, Sequence):
+        parts = [_content_to_text(item) for item in content]
+        return "\n".join(part for part in parts if part)
+    if _is_missing(content):
+        return ""
+    return str(content)
+
+
+def _append_string_content(conversation: list[Any], content: str) -> None:
+    cursor = 0
+    for match in _MEDIA_TOKEN_PATTERN.finditer(content):
+        text = content[cursor : match.start()]
+        if text:
+            conversation.append(("text", text))
+        conversation.append((match.group(1), None))
+        cursor = match.end()
+    remaining = content[cursor:]
+    if remaining:
+        conversation.append(("text", remaining))
+
+
 def _append_content(conversation: list[Any], content: Any, media: dict[str, list[Any]]) -> None:
     content = _as_python(content)
     if isinstance(content, str):
-        conversation.append(("text", content))
+        _append_string_content(conversation, content)
         return
 
     for item in content or []:
@@ -81,21 +160,41 @@ def _append_content(conversation: list[Any], content: Any, media: dict[str, list
         if item_type == "text":
             conversation.append(("text", item.get("text", "")))
         elif item_type == "image":
-            media["images"].append(item.get("image"))
+            _append_media_path(media, "images", item.get("image"))
             conversation.append(("image", None))
         elif item_type == "video":
-            media["videos"].append(item.get("video"))
+            _append_media_path(media, "videos", item.get("video"))
             conversation.append(("video", None))
         elif item_type == "audio":
-            media["audios"].append(item.get("audio"))
+            _append_media_path(media, "audios", item.get("audio"))
             conversation.append(("audio", None))
         else:
             conversation.append(("text", str(item)))
 
 
-def _build_preference_branch(sample: dict[str, Any], answer: str) -> dict[str, Any]:
+def _count_media_tokens(conversations: Sequence[Sequence[Any]], modality: str) -> int:
+    count = 0
+    for conversation in conversations:
+        for item in conversation[1:]:
+            if isinstance(item, (list | tuple)) and item and item[0] == modality:
+                count += 1
+    return count
+
+
+def _validate_media_alignment(conversations: Sequence[Sequence[Any]], media: dict[str, list[Any]]) -> None:
+    for modality, media_key in (("image", "images"), ("video", "videos"), ("audio", "audios")):
+        token_count = _count_media_tokens(conversations, modality)
+        media_count = len(media[media_key])
+        if token_count != media_count:
+            raise ValueError(
+                f"Prompt contains {token_count} <{modality}> token(s) but {media_key} has {media_count} item(s). "
+                "Ensure compact multimodal rows include matching top-level media paths."
+            )
+
+
+def _build_preference_branch(sample: dict[str, Any], answer: Any) -> dict[str, Any]:
     prompt = _as_python(sample.get("prompt", []))
-    media: dict[str, list[Any]] = {"images": [], "videos": [], "audios": []}
+    media = _initial_media(sample)
     conversations: list[list[Any]] = []
 
     for message in prompt:
@@ -110,7 +209,8 @@ def _build_preference_branch(sample: dict[str, Any], answer: str) -> dict[str, A
         if len(conversation) > 1:
             conversations.append(conversation)
 
-    conversations.append(["assistant", ("text", str(_as_python(answer)))])
+    _validate_media_alignment(conversations, media)
+    conversations.append(["assistant", ("text", _answer_text(answer))])
     branch = {
         "conversations": conversations,
         "source_name": sample.get("source_name") or sample.get("data_source"),
@@ -121,9 +221,33 @@ def _build_preference_branch(sample: dict[str, Any], answer: str) -> dict[str, A
     return branch
 
 
-def _cat_sequence_tensors(chosen: torch.Tensor, rejected: torch.Tensor) -> torch.Tensor:
-    dim = -1 if chosen.ndim > 1 else 0
-    return torch.cat([chosen, rejected], dim=dim)
+def _pad_tensor_to_shape(tensor: torch.Tensor, shape: Sequence[int], pad_value: float | int | bool = 0) -> torch.Tensor:
+    if tuple(tensor.shape) == tuple(shape):
+        return tensor
+    output = torch.full(tuple(shape), pad_value, dtype=tensor.dtype, device=tensor.device)
+    slices = tuple(slice(0, size) for size in tensor.shape)
+    output[slices] = tensor
+    return output
+
+
+def _pad_value_for_key(key: str) -> float | int | bool:
+    if key == "labels":
+        return -100
+    if key == "attention_mask":
+        return 0
+    return 0
+
+
+def _stack_branch_tensors(key: str, chosen: torch.Tensor, rejected: torch.Tensor) -> torch.Tensor:
+    max_shape = tuple(max(chosen.shape[dim], rejected.shape[dim]) for dim in range(chosen.ndim))
+    pad_value = _pad_value_for_key(key)
+    return torch.stack(
+        [
+            _pad_tensor_to_shape(chosen, max_shape, pad_value),
+            _pad_tensor_to_shape(rejected, max_shape, pad_value),
+        ],
+        dim=0,
+    )
 
 
 def _merge_chosen_rejected(chosen: dict[str, Any], rejected: dict[str, Any]) -> dict[str, Any]:
@@ -140,20 +264,8 @@ def _merge_chosen_rejected(chosen: dict[str, Any], rejected: dict[str, Any]) -> 
         if not isinstance(chosen_value, torch.Tensor) or not isinstance(rejected_value, torch.Tensor):
             merged[key] = chosen_value
             continue
-        if key in {"input_ids", "attention_mask", "labels", "position_ids", "image_mask", "video_mask", "audio_mask"}:
-            merged[key] = _cat_sequence_tensors(chosen_value, rejected_value)
-        else:
-            merged[key] = torch.cat([chosen_value, rejected_value], dim=0)
+        merged[key] = _stack_branch_tensors(key, chosen_value, rejected_value)
     return merged
-
-
-def _pad_tensor_to_shape(tensor: torch.Tensor, shape: Sequence[int], pad_value: float | int | bool = 0) -> torch.Tensor:
-    if tuple(tensor.shape) == tuple(shape):
-        return tensor
-    output = torch.full(tuple(shape), pad_value, dtype=tensor.dtype, device=tensor.device)
-    slices = tuple(slice(0, size) for size in tensor.shape)
-    output[slices] = tensor
-    return output
 
 
 def _collate_tensor_values(key: str, values: Sequence[torch.Tensor | None]) -> torch.Tensor:
@@ -162,11 +274,7 @@ def _collate_tensor_values(key: str, values: Sequence[torch.Tensor | None]) -> t
         raise ValueError(f"Cannot collate tensor key {key!r} without any tensor values.")
 
     max_shape = tuple(max(value.shape[dim] for value in present) for dim in range(present[0].ndim))
-    pad_value: float | int | bool = 0
-    if key == "labels":
-        pad_value = -100
-    elif key == "attention_mask":
-        pad_value = 0
+    pad_value = _pad_value_for_key(key)
 
     padded = []
     for value in values:
@@ -240,6 +348,9 @@ def _row_modality(row: dict[str, Any], source_name_key: str, default: str = "unk
     extra_info = _as_python(row.get("extra_info", {}))
     if isinstance(extra_info, dict) and extra_info.get("modality"):
         return _normalise_modality(extra_info["modality"], default)
+    for key, modality in (("images", "image"), ("videos", "video"), ("audios", "audio")):
+        if _normalise_media_list(row.get(key)):
+            return modality
     return _normalise_modality(row.get(source_name_key) or row.get("source_name"), default)
 
 
@@ -312,6 +423,9 @@ class OfflineMLLMDPODataset(Dataset):
             "chosen": row[self.chosen_key],
             "rejected": row[self.rejected_key],
             "source_name": source_name,
+            "images": row.get("images"),
+            "videos": row.get("videos"),
+            "audios": row.get("audios"),
         }
         transformed = _transform_sample(
             sample, self.base_transform, {"processor": self.processor, **self.transform_kwargs}
@@ -333,30 +447,14 @@ class OfflineMLLMDPODataset(Dataset):
 
 
 class ModalityGroupedBatchSampler(Sampler[int]):
-    """Sample dataset indices as contiguous same-modality chunks.
+    """Yield indices in same-modality chunks for regular DataLoader batching.
 
-    This sampler is used with ``StatefulDataLoader`` via ``sampler=`` and
-    ``batch_size=`` rather than ``batch_sampler=``. It yields individual
-    indices, but orders them so each DataLoader batch contains rows from one
-    modality. Each chunk samples a modality uniformly by default, or according
-    to ``modality_sample_weights`` when provided, then samples rows from that
+    ``StatefulDataLoader`` is configured with ``sampler=`` and ``batch_size=``,
+    not ``batch_sampler=``. This sampler therefore yields individual indices,
+    but orders them as contiguous same-modality chunks of ``batch_size``. When
+    Each chunk first samples a modality uniformly by default, or by
+    ``modality_sample_weights`` when provided, then samples rows from that
     modality with replacement.
-
-    Args:
-        data_source: Dataset that provides ``get_modality(index)``.
-        dataset: Alternative name for ``data_source``.
-        data_config: Optional config used to infer ``batch_size`` from
-            ``gen_batch_size`` or ``train_batch_size``.
-        batch_size: Number of samples per same-modality chunk.
-        shuffle: Accepted for DataLoader compatibility and ignored.
-        drop_last: Whether to drop an incomplete final chunk when deriving the
-            number of chunks.
-        seed: Base random seed used for deterministic sampling by epoch.
-        modality_sample_weights: Optional sampling weight per modality.
-        num_batches: Optional explicit number of chunks to generate.
-
-    Returns:
-        Iterator over dataset indices ordered as same-modality chunks.
     """
 
     def __init__(
@@ -372,13 +470,6 @@ class ModalityGroupedBatchSampler(Sampler[int]):
         modality_sample_weights: dict[str, float] | None = None,
         num_batches: int | None = None,
     ):
-        if not shuffle:
-            warnings.warn(
-                "ModalityGroupedBatchSampler ignores shuffle=False; sampling order is controlled by modality "
-                "grouping, modality_sample_weights, and seed.",
-                UserWarning,
-                stacklevel=2,
-            )
         del shuffle
         self.data_source = data_source if data_source is not None else dataset
         if self.data_source is None:
@@ -460,20 +551,6 @@ class ModalityGroupedBatchSampler(Sampler[int]):
 
 
 def offline_mllm_dpo_collate_fn(features):
-    """Collate Offline MLLM DPO samples into a single-modality batch.
-
-    The collator requires every sample in the batch to share the same modality,
-    stacks tensor fields with modality-aware padding, and stores non-tensor
-    fields in object arrays.
-
-    Args:
-        features: Sequence of dataset samples produced by
-            ``OfflineMLLMDPODataset``.
-
-    Returns:
-        Batch dictionary containing collated tensor fields and object arrays for
-        non-tensor fields.
-    """
     modalities = {feature.get("modality") for feature in features}
     if len(modalities) != 1:
         raise ValueError(f"Offline MLLM DPO batches must contain a single modality, got {sorted(modalities)}")
@@ -488,6 +565,8 @@ def offline_mllm_dpo_collate_fn(features):
         batch[key] = _collate_tensor_values(key, [feature.get(key) for feature in features])
         if key == "position_ids" and batch[key].ndim == 4 and batch[key].shape[2] == 1:
             batch[key] = batch[key].squeeze(2).contiguous()
+        if key == "position_ids" and batch[key].ndim == 5 and batch[key].shape[3] == 1:
+            batch[key] = batch[key].squeeze(3).contiguous()
     for key in sorted(non_tensor_keys):
         batch[key] = np.fromiter((feature.get(key) for feature in features), dtype=object, count=len(features))
     return batch

--- a/verl_omni/utils/dataset/offline_mllm_dpo_dataset.py
+++ b/verl_omni/utils/dataset/offline_mllm_dpo_dataset.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import json
 import os
 import uuid
+import warnings
 from collections import defaultdict
 from collections.abc import Sequence
 from pathlib import Path
@@ -34,7 +35,7 @@ from verl_omni.utils.dataset.qwen3_omni_transform import process_qwen3_omni_samp
 
 
 def _read_dataframe(data_files: str | Sequence[str]) -> pd.DataFrame:
-    paths = [data_files] if isinstance(data_files, (str, Path)) else list(data_files)
+    paths = [data_files] if isinstance(data_files, str | Path) else list(data_files)
     frames = []
     for data_file in paths:
         path = Path(os.path.expanduser(data_file))
@@ -332,14 +333,30 @@ class OfflineMLLMDPODataset(Dataset):
 
 
 class ModalityGroupedBatchSampler(Sampler[int]):
-    """Yield indices in same-modality chunks for regular DataLoader batching.
+    """Sample dataset indices as contiguous same-modality chunks.
 
-    ``StatefulDataLoader`` is configured with ``sampler=`` and ``batch_size=``,
-    not ``batch_sampler=``. This sampler therefore yields individual indices,
-    but orders them as contiguous same-modality chunks of ``batch_size``. When
-    Each chunk first samples a modality uniformly by default, or by
-    ``modality_sample_weights`` when provided, then samples rows from that
+    This sampler is used with ``StatefulDataLoader`` via ``sampler=`` and
+    ``batch_size=`` rather than ``batch_sampler=``. It yields individual
+    indices, but orders them so each DataLoader batch contains rows from one
+    modality. Each chunk samples a modality uniformly by default, or according
+    to ``modality_sample_weights`` when provided, then samples rows from that
     modality with replacement.
+
+    Args:
+        data_source: Dataset that provides ``get_modality(index)``.
+        dataset: Alternative name for ``data_source``.
+        data_config: Optional config used to infer ``batch_size`` from
+            ``gen_batch_size`` or ``train_batch_size``.
+        batch_size: Number of samples per same-modality chunk.
+        shuffle: Accepted for DataLoader compatibility and ignored.
+        drop_last: Whether to drop an incomplete final chunk when deriving the
+            number of chunks.
+        seed: Base random seed used for deterministic sampling by epoch.
+        modality_sample_weights: Optional sampling weight per modality.
+        num_batches: Optional explicit number of chunks to generate.
+
+    Returns:
+        Iterator over dataset indices ordered as same-modality chunks.
     """
 
     def __init__(
@@ -355,6 +372,13 @@ class ModalityGroupedBatchSampler(Sampler[int]):
         modality_sample_weights: dict[str, float] | None = None,
         num_batches: int | None = None,
     ):
+        if not shuffle:
+            warnings.warn(
+                "ModalityGroupedBatchSampler ignores shuffle=False; sampling order is controlled by modality "
+                "grouping, modality_sample_weights, and seed.",
+                UserWarning,
+                stacklevel=2,
+            )
         del shuffle
         self.data_source = data_source if data_source is not None else dataset
         if self.data_source is None:

--- a/verl_omni/utils/dataset/offline_mllm_dpo_dataset.py
+++ b/verl_omni/utils/dataset/offline_mllm_dpo_dataset.py
@@ -1,0 +1,455 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Offline MLLM DPO dataset for Omni-Preference style parquet rows."""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from collections import defaultdict
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import torch
+from omegaconf import DictConfig, OmegaConf
+from torch.utils.data import Dataset, Sampler
+
+from verl_omni.utils.dataset.qwen3_omni_transform import process_qwen3_omni_sample
+
+
+def _read_dataframe(data_files: str | Sequence[str]) -> pd.DataFrame:
+    paths = [data_files] if isinstance(data_files, str) else list(data_files)
+    frames = []
+    for data_file in paths:
+        path = Path(os.path.expanduser(data_file))
+        if path.suffix == ".jsonl":
+            frames.append(pd.read_json(path, lines=True))
+        elif path.suffix == ".json":
+            frames.append(pd.read_json(path))
+        else:
+            frames.append(pd.read_parquet(path))
+    if not frames:
+        raise ValueError("Offline MLLM DPO dataset requires at least one data file.")
+    return pd.concat(frames, ignore_index=True)
+
+
+def _as_python(value: Any) -> Any:
+    if hasattr(value, "tolist"):
+        return value.tolist()
+    if isinstance(value, bytes):
+        value = value.decode("utf-8")
+    if isinstance(value, str):
+        text = value.strip()
+        if text.startswith("[") or text.startswith("{"):
+            try:
+                return json.loads(text)
+            except json.JSONDecodeError:
+                return value
+    return value
+
+
+def _append_content(conversation: list[Any], content: Any, media: dict[str, list[Any]]) -> None:
+    content = _as_python(content)
+    if isinstance(content, str):
+        conversation.append(("text", content))
+        return
+
+    for item in content or []:
+        item = _as_python(item)
+        if not isinstance(item, dict):
+            conversation.append(("text", str(item)))
+            continue
+
+        item_type = item.get("type")
+        if item_type == "text":
+            conversation.append(("text", item.get("text", "")))
+        elif item_type == "image":
+            media["images"].append(item.get("image"))
+            conversation.append(("image", None))
+        elif item_type == "video":
+            media["videos"].append(item.get("video"))
+            conversation.append(("video", None))
+        elif item_type == "audio":
+            media["audios"].append(item.get("audio"))
+            conversation.append(("audio", None))
+        else:
+            conversation.append(("text", str(item)))
+
+
+def _build_preference_branch(sample: dict[str, Any], answer: str) -> dict[str, Any]:
+    prompt = _as_python(sample.get("prompt", []))
+    media: dict[str, list[Any]] = {"images": [], "videos": [], "audios": []}
+    conversations: list[list[Any]] = []
+
+    for message in prompt:
+        message = _as_python(message)
+        if not isinstance(message, dict):
+            continue
+        role = message.get("role")
+        if role == "system":
+            continue
+        conversation = [role or "user"]
+        _append_content(conversation, message.get("content", ""), media)
+        if len(conversation) > 1:
+            conversations.append(conversation)
+
+    conversations.append(["assistant", ("text", str(_as_python(answer)))])
+    branch = {
+        "conversations": conversations,
+        "source_name": sample.get("source_name") or sample.get("data_source"),
+    }
+    for key, values in media.items():
+        if values:
+            branch[key] = values
+    return branch
+
+
+def _cat_sequence_tensors(chosen: torch.Tensor, rejected: torch.Tensor) -> torch.Tensor:
+    dim = -1 if chosen.ndim > 1 else 0
+    return torch.cat([chosen, rejected], dim=dim)
+
+
+def _merge_chosen_rejected(chosen: dict[str, Any], rejected: dict[str, Any]) -> dict[str, Any]:
+    merged: dict[str, Any] = {}
+    for key in chosen.keys() | rejected.keys():
+        chosen_value = chosen.get(key)
+        rejected_value = rejected.get(key)
+        if chosen_value is None:
+            merged[key] = rejected_value
+            continue
+        if rejected_value is None:
+            merged[key] = chosen_value
+            continue
+        if not isinstance(chosen_value, torch.Tensor) or not isinstance(rejected_value, torch.Tensor):
+            merged[key] = chosen_value
+            continue
+        if key in {"input_ids", "attention_mask", "labels", "position_ids", "image_mask", "video_mask", "audio_mask"}:
+            merged[key] = _cat_sequence_tensors(chosen_value, rejected_value)
+        else:
+            merged[key] = torch.cat([chosen_value, rejected_value], dim=0)
+    return merged
+
+
+def _pad_tensor_to_shape(tensor: torch.Tensor, shape: Sequence[int], pad_value: float | int | bool = 0) -> torch.Tensor:
+    if tuple(tensor.shape) == tuple(shape):
+        return tensor
+    output = torch.full(tuple(shape), pad_value, dtype=tensor.dtype, device=tensor.device)
+    slices = tuple(slice(0, size) for size in tensor.shape)
+    output[slices] = tensor
+    return output
+
+
+def _collate_tensor_values(key: str, values: Sequence[torch.Tensor | None]) -> torch.Tensor:
+    present = [value for value in values if value is not None]
+    if not present:
+        raise ValueError(f"Cannot collate tensor key {key!r} without any tensor values.")
+
+    max_shape = tuple(max(value.shape[dim] for value in present) for dim in range(present[0].ndim))
+    pad_value: float | int | bool = 0
+    if key == "labels":
+        pad_value = -100
+    elif key == "attention_mask":
+        pad_value = 0
+
+    padded = []
+    for value in values:
+        if value is None:
+            value = torch.zeros(max_shape, dtype=present[0].dtype, device=present[0].device)
+        padded.append(_pad_tensor_to_shape(value, max_shape, pad_value))
+    return torch.stack(padded, dim=0)
+
+
+def _prepare_qwen3_omni_processor(processor):
+    class ProcessorProxy:
+        def __getattr__(self, name):
+            return getattr(processor, name)
+
+        def __call__(self, *args, **kwargs):
+            audios = kwargs.pop("audios", None)
+            if audios:
+                audios = [audio for audio in audios if audio is not None]
+                if audios:
+                    kwargs["audio"] = audios
+            else:
+                kwargs.pop("audio", None)
+            kwargs = {key: value for key, value in kwargs.items() if value != []}
+            return processor(*args, **kwargs)
+
+    def get_rope_index(*args, **kwargs):
+        result = processor.get_rope_index(*args, **kwargs)
+        if isinstance(result, dict):
+            return result
+        position_ids, mrope_position_deltas = result
+        return {"position_ids": position_ids, "mrope_position_deltas": mrope_position_deltas}
+
+    proxy = ProcessorProxy()
+    if hasattr(processor, "get_rope_index"):
+        proxy.get_rope_index = get_rope_index
+    return proxy
+
+
+def _transform_sample(sample: dict[str, Any], base_transform, transform_kwargs: dict[str, Any]) -> dict[str, Any]:
+    chosen_sample = _build_preference_branch(sample, sample["chosen"])
+    rejected_sample = _build_preference_branch(sample, sample["rejected"])
+    chosen = base_transform(chosen_sample, **transform_kwargs)[0]
+    rejected = base_transform(rejected_sample, **transform_kwargs)[0]
+    return _merge_chosen_rejected(chosen, rejected)
+
+
+def _normalise_source_name(value: Any, default: str) -> str:
+    text = str(value or default)
+    lowered = text.lower()
+    if "image" in lowered:
+        return "Omni-Preference-Image"
+    if "video" in lowered:
+        return "Omni-Preference-Video"
+    if "audio" in lowered:
+        return "Omni-Preference-Audio"
+    return text
+
+
+def _normalise_modality(value: Any, default: str = "unknown") -> str:
+    text = str(value or default).lower()
+    if "image" in text:
+        return "image"
+    if "video" in text:
+        return "video"
+    if "audio" in text:
+        return "audio"
+    return default
+
+
+def _row_modality(row: dict[str, Any], source_name_key: str, default: str = "unknown") -> str:
+    extra_info = _as_python(row.get("extra_info", {}))
+    if isinstance(extra_info, dict) and extra_info.get("modality"):
+        return _normalise_modality(extra_info["modality"], default)
+    return _normalise_modality(row.get(source_name_key) or row.get("source_name"), default)
+
+
+class OfflineMLLMDPODataset(Dataset):
+    """Dataset for Omni-Preference rows consumed by Qwen3-Omni offline DPO."""
+
+    def __init__(self, data_files, tokenizer, processor=None, config: DictConfig | None = None, max_samples: int = -1):
+        del tokenizer
+        if config is None:
+            raise ValueError("OfflineMLLMDPODataset requires a data config.")
+        if processor is None:
+            raise ValueError("OfflineMLLMDPODataset requires a multimodal processor.")
+
+        self.dataframe = _read_dataframe(data_files)
+        if max_samples is not None and max_samples > 0:
+            self.dataframe = self.dataframe.iloc[:max_samples]
+        self.config = config
+        self.processor = _prepare_qwen3_omni_processor(processor)
+        self.prompt_key = config.get("prompt_key", "prompt")
+        self.chosen_key = config.get("chosen_key", "chosen")
+        self.rejected_key = config.get("rejected_key", "rejected")
+        self.win_score_key = config.get("win_score_key", "win_score")
+        self.lose_score_key = config.get("lose_score_key", "lose_score")
+        self.source_name_key = config.get("source_name_key", "data_source")
+        self.data_source = config.get("data_source", "offline_mllm_dpo")
+
+        mm_configs = config.get("mm_configs", {})
+        if isinstance(mm_configs, DictConfig):
+            mm_configs = OmegaConf.to_container(mm_configs, resolve=True)
+        self.transform_kwargs = dict(mm_configs or {})
+        if "position_id_func" not in self.transform_kwargs and hasattr(self.processor, "get_rope_index"):
+            self.transform_kwargs["position_id_func"] = self.processor.get_rope_index
+        if "position_id_func" not in self.transform_kwargs:
+            raise ValueError(
+                "OfflineMLLMDPODataset requires `mm_configs.position_id_func` or a processor with "
+                "`get_rope_index`. For Qwen3-Omni, bind "
+                "`Qwen3OmniMoeThinkerForConditionalGeneration.get_rope_index` to the processor before "
+                "constructing the dataset."
+            )
+        base_transform = config.get("base_transform", "qwen3_omni_moe")
+        if base_transform not in {"qwen3_omni_moe", "qwen2_5_omni"}:
+            raise ValueError(
+                f"Unsupported base_transform {base_transform!r}. Expected one of: 'qwen3_omni_moe', 'qwen2_5_omni'."
+            )
+        self.base_transform = process_qwen3_omni_sample
+
+        required = {self.prompt_key, self.chosen_key, self.rejected_key}
+        missing = required - set(self.dataframe.columns)
+        if missing:
+            raise ValueError(f"Offline MLLM DPO data is missing required columns: {sorted(missing)}")
+        self.modalities = [
+            _row_modality(row, self.source_name_key, self.data_source)
+            for row in self.dataframe.to_dict(orient="records")
+        ]
+
+    def get_modality(self, item: int) -> str:
+        return self.modalities[item]
+
+    def __len__(self) -> int:
+        return len(self.dataframe)
+
+    def __getitem__(self, item: int) -> dict[str, Any]:
+        row = self.dataframe.iloc[item].to_dict()
+        source_name = _normalise_source_name(
+            row.get(self.source_name_key) or row.get("source_name"),
+            self.data_source,
+        )
+        sample = {
+            "prompt": row[self.prompt_key],
+            "chosen": row[self.chosen_key],
+            "rejected": row[self.rejected_key],
+            "source_name": source_name,
+        }
+        transformed = _transform_sample(
+            sample, self.base_transform, {"processor": self.processor, **self.transform_kwargs}
+        )
+        transformed["uid"] = str(row.get("uid") or uuid.uuid4())
+        transformed["sample_level_scores"] = torch.tensor(
+            [float(row.get(self.win_score_key, 1.0)), float(row.get(self.lose_score_key, 0.0))],
+            dtype=torch.float32,
+        )
+        transformed["data_source"] = row.get(self.source_name_key) or self.data_source
+        transformed["reward_model"] = row.get("reward_model", {"style": "model", "ground_truth": row[self.chosen_key]})
+        modality = self.get_modality(item)
+        transformed["modality"] = modality
+        extra_info = _as_python(row.get("extra_info", {"index": int(item)}))
+        if isinstance(extra_info, dict):
+            extra_info = {**extra_info, "modality": modality}
+        transformed["extra_info"] = extra_info
+        return transformed
+
+
+class ModalityGroupedBatchSampler(Sampler[int]):
+    """Yield indices in same-modality chunks for regular DataLoader batching.
+
+    ``StatefulDataLoader`` is configured with ``sampler=`` and ``batch_size=``,
+    not ``batch_sampler=``. This sampler therefore yields individual indices,
+    but orders them as contiguous same-modality chunks of ``batch_size``. When
+    Each chunk first samples a modality uniformly by default, or by
+    ``modality_sample_weights`` when provided, then samples rows from that
+    modality with replacement.
+    """
+
+    def __init__(
+        self,
+        data_source: Dataset | None = None,
+        *,
+        dataset: Dataset | None = None,
+        data_config: DictConfig | None = None,
+        batch_size: int | None = None,
+        shuffle: bool = True,
+        drop_last: bool = True,
+        seed: int = 0,
+        modality_sample_weights: dict[str, float] | None = None,
+        num_batches: int | None = None,
+    ):
+        del shuffle
+        self.data_source = data_source if data_source is not None else dataset
+        if self.data_source is None:
+            raise ValueError("ModalityGroupedBatchSampler requires a dataset.")
+        if not hasattr(self.data_source, "get_modality"):
+            raise TypeError("ModalityGroupedBatchSampler requires a dataset with get_modality(index).")
+
+        if batch_size is None and data_config is not None:
+            batch_size = data_config.get("gen_batch_size", data_config.get("train_batch_size", None))
+        if batch_size is None or batch_size <= 0:
+            raise ValueError("ModalityGroupedBatchSampler requires a positive batch_size.")
+
+        self.batch_size = int(batch_size)
+        self.drop_last = bool(drop_last)
+        self.seed = int(seed)
+        self.modality_sample_weights = modality_sample_weights
+        self.num_batches = num_batches
+        self.epoch = 0
+        self._batches = self._build_batches()
+        self._length = sum(len(batch) for batch in self._batches)
+
+    def set_epoch(self, epoch: int) -> None:
+        self.epoch = int(epoch)
+
+    def _indices_by_modality(self) -> dict[str, list[int]]:
+        indices_by_modality: dict[str, list[int]] = defaultdict(list)
+        for index in range(len(self.data_source)):
+            indices_by_modality[self.data_source.get_modality(index)].append(index)
+        return dict(indices_by_modality)
+
+    def _build_weighted_batches(
+        self,
+        indices_by_modality: dict[str, list[int]],
+        generator: torch.Generator,
+    ) -> list[list[int]]:
+        weights_by_modality = self.modality_sample_weights or {}
+        modalities = sorted(indices_by_modality)
+        weights = []
+        for modality in modalities:
+            weight = float(weights_by_modality.get(modality, 1.0))
+            if weight < 0:
+                raise ValueError(f"modality_sample_weights[{modality!r}] must be non-negative, got {weight}.")
+            weights.append(weight)
+        weights_tensor = torch.tensor(weights, dtype=torch.float)
+        if weights_tensor.sum().item() <= 0:
+            raise ValueError("modality_sample_weights must contain at least one positive weight.")
+
+        if self.num_batches is not None:
+            num_batches = int(self.num_batches)
+        elif self.drop_last:
+            num_batches = len(self.data_source) // self.batch_size
+        else:
+            num_batches = (len(self.data_source) + self.batch_size - 1) // self.batch_size
+        if num_batches <= 0:
+            return []
+
+        batches: list[list[int]] = []
+        for _ in range(num_batches):
+            modality_index = torch.multinomial(
+                weights_tensor, num_samples=1, replacement=True, generator=generator
+            ).item()
+            indices = indices_by_modality[modalities[modality_index]]
+            sampled = torch.randint(len(indices), (self.batch_size,), generator=generator).tolist()
+            batches.append([indices[index] for index in sampled])
+        return batches
+
+    def _build_batches(self) -> list[list[int]]:
+        generator = torch.Generator()
+        generator.manual_seed(self.seed + self.epoch)
+        indices_by_modality = self._indices_by_modality()
+        return self._build_weighted_batches(indices_by_modality, generator)
+
+    def __iter__(self):
+        for batch in self._build_batches():
+            yield from batch
+
+    def __len__(self) -> int:
+        return self._length
+
+
+def offline_mllm_dpo_collate_fn(features):
+    modalities = {feature.get("modality") for feature in features}
+    if len(modalities) != 1:
+        raise ValueError(f"Offline MLLM DPO batches must contain a single modality, got {sorted(modalities)}")
+
+    tensor_keys = {key for feature in features for key, value in feature.items() if isinstance(value, torch.Tensor)}
+    non_tensor_keys = {
+        key for feature in features for key, value in feature.items() if not isinstance(value, torch.Tensor)
+    }
+
+    batch: dict[str, Any] = {}
+    for key in sorted(tensor_keys):
+        batch[key] = _collate_tensor_values(key, [feature.get(key) for feature in features])
+        if key == "position_ids" and batch[key].ndim == 4 and batch[key].shape[2] == 1:
+            batch[key] = batch[key].squeeze(2).contiguous()
+    for key in sorted(non_tensor_keys):
+        batch[key] = np.fromiter((feature.get(key) for feature in features), dtype=object, count=len(features))
+    return batch

--- a/verl_omni/utils/dataset/offline_mllm_dpo_dataset.py
+++ b/verl_omni/utils/dataset/offline_mllm_dpo_dataset.py
@@ -480,14 +480,32 @@ class OfflineMLLMDPODataset(Dataset):
 
 
 class ModalityGroupedBatchSampler(Sampler[int]):
-    """Yield indices in same-modality chunks for regular DataLoader batching.
+    """Build same-modality batches for regular DataLoader sampling.
 
     ``StatefulDataLoader`` is configured with ``sampler=`` and ``batch_size=``,
     not ``batch_sampler=``. This sampler therefore yields individual indices,
-    but orders them as contiguous same-modality chunks of ``batch_size``. When
-    Each chunk first samples a modality uniformly by default, or by
+    ordered as contiguous same-modality chunks of ``batch_size``. Each chunk
+    samples a modality uniformly by default, or according to
     ``modality_sample_weights`` when provided, then samples rows from that
     modality with replacement.
+
+    Args:
+        data_source: Dataset that provides ``get_modality(index)``.
+        dataset: Alias for ``data_source`` kept for compatibility with dataset
+            factory arguments.
+        data_config: Optional config used to infer ``batch_size`` from
+            ``gen_batch_size`` or ``train_batch_size``.
+        batch_size: Number of samples in each same-modality chunk.
+        shuffle: Unused compatibility argument.
+        drop_last: Whether to drop the final incomplete batch when inferring
+            the number of generated chunks.
+        seed: Base random seed used for modality and row sampling.
+        modality_sample_weights: Optional per-modality sampling weights.
+        num_batches: Optional explicit number of chunks to generate per epoch.
+
+    Returns:
+        A sampler whose iterator yields dataset indices arranged so each regular
+        DataLoader batch contains samples from a single modality.
     """
 
     def __init__(

--- a/verl_omni/utils/dataset/offline_mllm_dpo_dataset.py
+++ b/verl_omni/utils/dataset/offline_mllm_dpo_dataset.py
@@ -602,6 +602,22 @@ class ModalityGroupedBatchSampler(Sampler[int]):
 
 
 def offline_mllm_dpo_collate_fn(features):
+    """Collate a list of offline MLLM DPO samples into a single batch.
+
+    All samples must belong to the same modality. Tensor fields are padded to
+    the maximum shape across the batch and stacked; ``position_ids`` receive
+    additional shape normalization. Non-tensor fields are gathered into a NumPy
+    object array.
+
+    Args:
+        features (list[dict[str, Any]]): List of sample dictionaries produced by
+            :class:`OfflineMLLMDPODataset`.
+
+    Returns:
+        dict[str, Any]: A batched dictionary where tensor keys map to
+            :class:`torch.Tensor` and non-tensor keys map to
+            :class:`numpy.ndarray` with ``dtype=object``.
+    """
     modalities = {feature.get("modality") for feature in features}
     if len(modalities) != 1:
         raise ValueError(f"Offline MLLM DPO batches must contain a single modality, got {sorted(modalities)}")

--- a/verl_omni/utils/dataset/offline_mllm_dpo_dataset.py
+++ b/verl_omni/utils/dataset/offline_mllm_dpo_dataset.py
@@ -33,6 +33,12 @@ from torch.utils.data import Dataset, Sampler
 
 from verl_omni.utils.dataset.qwen3_omni_transform import process_qwen3_omni_sample
 
+__all__ = [
+    "ModalityGroupedBatchSampler",
+    "OfflineMLLMDPODataset",
+    "offline_mllm_dpo_collate_fn",
+]
+
 _MEDIA_TOKEN_PATTERN = re.compile(r"<(image|video|audio)>")
 
 
@@ -355,7 +361,27 @@ def _row_modality(row: dict[str, Any], source_name_key: str, default: str = "unk
 
 
 class OfflineMLLMDPODataset(Dataset):
-    """Dataset for Omni-Preference rows consumed by Qwen3-Omni offline DPO."""
+    """Build Qwen3-Omni offline DPO samples from Omni-Preference style rows.
+
+    The dataset reads parquet/json/jsonl files containing a multimodal prompt,
+    a preferred response, and a rejected response. Each row is converted into
+    paired chosen/rejected model inputs with aligned image, video, or audio
+    features, plus sample metadata needed by the offline DPO trainer.
+
+    Args:
+        data_files: Path or sequence of paths to parquet, json, or jsonl files.
+        tokenizer: Unused tokenizer argument kept for compatibility with the
+            common dataset factory signature.
+        processor: Multimodal processor used by the Qwen3-Omni transform.
+        config: Dataset config containing column names, multimodal transform
+            kwargs, and source metadata.
+        max_samples: Optional positive limit on the number of rows to load.
+
+    Returns:
+        A dataset whose ``__getitem__`` returns a dictionary of stacked
+        chosen/rejected tensors and metadata, including ``sample_level_scores``,
+        ``data_source``, ``reward_model``, ``modality``, and ``extra_info``.
+    """
 
     def __init__(self, data_files, tokenizer, processor=None, config: DictConfig | None = None, max_samples: int = -1):
         del tokenizer
@@ -390,6 +416,13 @@ class OfflineMLLMDPODataset(Dataset):
                 "`Qwen3OmniMoeThinkerForConditionalGeneration.get_rope_index` to the processor before "
                 "constructing the dataset."
             )
+
+        if self.transform_kwargs.get("use_audio_in_video"):
+            raise ValueError(
+                "use_audio_in_video=True is not supported yet for Qwen3-Omni offline DPO preprocessing. "
+                "Leave use_audio_in_video unset or set it to false."
+            )
+
         base_transform = config.get("base_transform", "qwen3_omni_moe")
         if base_transform not in {"qwen3_omni_moe", "qwen2_5_omni"}:
             raise ValueError(

--- a/verl_omni/utils/dataset/qwen3_omni_transform.py
+++ b/verl_omni/utils/dataset/qwen3_omni_transform.py
@@ -230,6 +230,9 @@ def _decode_video_path(video_path: str) -> tuple[torch.Tensor, float]:
         raise ImportError("PyAV (`pip install av`) is required to decode video files for Qwen3-Omni DPO.") from exc
 
     container = av.open(video_path)
+    if not container.streams.video:
+        container.close()
+        raise ValueError(f"Video {video_path} contains no video streams.")
     stream = container.streams.video[0]
     video_fps = float(stream.average_rate) if stream.average_rate else 2.0
     frames = [frame.to_image().convert("RGB") for frame in container.decode(video=0)]

--- a/verl_omni/utils/dataset/qwen3_omni_transform.py
+++ b/verl_omni/utils/dataset/qwen3_omni_transform.py
@@ -1,0 +1,387 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Qwen3-Omni sample transform for offline MLLM DPO without a VeOmni dependency.
+
+The logic mirrors VeOmni's ``process_sample_qwen_omni`` data transform and the
+minimal multimodal media helpers it relies on.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Callable, Sequence
+from typing import Any
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from PIL import Image
+
+IGNORE_INDEX = -100
+IMAGE_INPUT_INDEX = -200
+VIDEO_INPUT_INDEX = -300
+AUDIO_INPUT_INDEX = -400
+
+QWEN_OMNI_SYSTEM_MESSAGE = (
+    "You are Qwen, a virtual human developed by the Qwen Team, Alibaba Group, "
+    "capable of perceiving auditory and visual inputs, as well as generating text and speech."
+)
+
+__all__ = ["process_qwen3_omni_sample"]
+
+
+def _align_to_factor_remainder_floor(n: float, factor: int, remainder: int) -> int:
+    adjusted = n - remainder
+    return int(adjusted // factor) * factor + remainder
+
+
+def _align_to_factor_remainder_ceil(n: float, factor: int, remainder: int) -> int:
+    adjusted = n - remainder
+    return math.ceil(adjusted / factor) * factor + remainder
+
+
+def _smart_resize_image(
+    image: Image.Image,
+    *,
+    scale_factor: int | None = None,
+    image_min_pixels: int | None = None,
+    image_max_pixels: int | None = None,
+    max_ratio: int | None = None,
+    **kwargs,
+) -> Image.Image:
+    del kwargs
+    width, height = image.size
+    if max_ratio is not None:
+        ratio = max(width, height) / min(width, height)
+        if ratio > max_ratio:
+            raise ValueError(f"absolute aspect ratio must be smaller than {max_ratio}, got {ratio}")
+
+    if scale_factor is not None:
+        h_bar = max(scale_factor, round(height / scale_factor) * scale_factor)
+        w_bar = max(scale_factor, round(width / scale_factor) * scale_factor)
+    else:
+        h_bar = height
+        w_bar = width
+
+    if image_max_pixels is not None and h_bar * w_bar > image_max_pixels:
+        beta = math.sqrt((height * width) / image_max_pixels)
+        if scale_factor is not None:
+            h_bar = math.floor(height / beta / scale_factor) * scale_factor
+            w_bar = math.floor(width / beta / scale_factor) * scale_factor
+        else:
+            h_bar = math.floor(height / beta)
+            w_bar = math.floor(width / beta)
+    if image_min_pixels is not None and h_bar * w_bar < image_min_pixels:
+        beta = math.sqrt(image_min_pixels / (height * width))
+        if scale_factor is not None:
+            h_bar = math.ceil(height * beta / scale_factor) * scale_factor
+            w_bar = math.ceil(width * beta / scale_factor) * scale_factor
+        else:
+            h_bar = math.ceil(height * beta)
+            w_bar = math.ceil(width * beta)
+    return image.resize((w_bar, h_bar))
+
+
+def _fetch_images(images: Sequence[str], **kwargs) -> list[Image.Image]:
+    max_image_nums = kwargs.get("max_image_nums", len(images))
+    loaded = [Image.open(path).convert("RGB") for path in images[:max_image_nums]]
+    return [_smart_resize_image(image, **kwargs) for image in loaded]
+
+
+def _calculate_frame_indices(
+    total_frames: int,
+    video_fps: float,
+    *,
+    fps: float = 2.0,
+    frame_factor: int | None = None,
+    frame_factor_remainder: int = 0,
+    min_frames: int | None = None,
+    max_frames: int | None = None,
+    **kwargs,
+) -> tuple[list[int], int]:
+    del kwargs
+    r = frame_factor_remainder
+    if frame_factor is not None:
+        if frame_factor <= 0:
+            raise ValueError(f"frame_factor must be a positive integer, got {frame_factor}")
+        if not 0 <= r < frame_factor:
+            raise ValueError(f"frame_factor_remainder must be in [0, {frame_factor}), got {r}")
+
+    nframes = total_frames / video_fps * fps
+    if min_frames is not None:
+        if frame_factor is not None:
+            min_frames = _align_to_factor_remainder_ceil(min_frames, frame_factor, r)
+        nframes = max(min_frames, nframes)
+    if max_frames is not None:
+        if frame_factor is not None:
+            max_frames = _align_to_factor_remainder_floor(max_frames, frame_factor, r)
+        nframes = min(max_frames, nframes)
+    if frame_factor is not None:
+        nframes = _align_to_factor_remainder_floor(nframes, frame_factor, r)
+        min_valid = r if r > 0 else frame_factor
+        nframes = max(nframes, min_valid)
+
+    nframes = int(max(1, nframes))
+    pad_count = max(0, nframes - total_frames)
+    sample_count = min(nframes, total_frames)
+    if sample_count > 0:
+        indices = np.linspace(0, total_frames - 1, sample_count).round().astype(int).tolist()
+    else:
+        indices = []
+    return indices, pad_count
+
+
+def _smart_resize_video(
+    video: torch.Tensor,
+    *,
+    scale_factor: int | None = None,
+    video_min_pixels: int | None = None,
+    video_max_pixels: int | None = None,
+    max_ratio: int | None = None,
+    **kwargs,
+) -> torch.Tensor:
+    del kwargs
+    if video.ndim != 4:
+        raise ValueError(f"video must be 4-dim, but got {video.ndim}")
+    _, _, height, width = video.shape
+    if max_ratio is not None:
+        ratio = max(width, height) / min(width, height)
+        if ratio > max_ratio:
+            raise ValueError(f"absolute aspect ratio must be smaller than {max_ratio}, got {ratio}")
+
+    if scale_factor is not None:
+        h_bar = max(scale_factor, round(height / scale_factor) * scale_factor)
+        w_bar = max(scale_factor, round(width / scale_factor) * scale_factor)
+    else:
+        h_bar = height
+        w_bar = width
+
+    if video_max_pixels is not None and h_bar * w_bar > video_max_pixels:
+        beta = math.sqrt((height * width) / video_max_pixels)
+        if scale_factor is not None:
+            h_bar = math.floor(height / beta / scale_factor) * scale_factor
+            w_bar = math.floor(width / beta / scale_factor) * scale_factor
+        else:
+            h_bar = math.floor(height / beta)
+            w_bar = math.floor(width / beta)
+    if video_min_pixels is not None and h_bar * w_bar < video_min_pixels:
+        beta = math.sqrt(video_min_pixels / (height * width))
+        if scale_factor is not None:
+            h_bar = math.ceil(height * beta / scale_factor) * scale_factor
+            w_bar = math.ceil(width * beta / scale_factor) * scale_factor
+        else:
+            h_bar = math.ceil(height * beta)
+            w_bar = math.ceil(width * beta)
+
+    return F.interpolate(video, size=(h_bar, w_bar), mode="bicubic", align_corners=False).float()
+
+
+def _smart_video_nframes(
+    video: torch.Tensor,
+    video_fps: float,
+    *,
+    fps: float = 2.0,
+    frame_factor: int | None = None,
+    min_frames: int | None = None,
+    max_frames: int | None = None,
+    **kwargs,
+) -> torch.Tensor:
+    indices, pad_count = _calculate_frame_indices(
+        total_frames=video.shape[0],
+        video_fps=video_fps,
+        fps=fps,
+        frame_factor=frame_factor,
+        min_frames=min_frames,
+        max_frames=max_frames,
+        **kwargs,
+    )
+    video = video[indices]
+    if pad_count > 0:
+        last_frame = video[-1:].expand(pad_count, -1, -1, -1)
+        video = torch.cat([video, last_frame], dim=0)
+    return video
+
+
+def _pil_images_to_tensor(images: Sequence[Image.Image]) -> torch.Tensor:
+    tensors = []
+    for img in images:
+        if img.mode != "RGB":
+            img = img.convert("RGB")
+        tensors.append(torch.from_numpy(np.array(img)).permute(2, 0, 1))
+    return torch.stack(tensors)
+
+
+def _decode_video_path(video_path: str) -> tuple[torch.Tensor, float]:
+    try:
+        import av
+    except ImportError as exc:
+        raise ImportError("PyAV (`pip install av`) is required to decode video files for Qwen3-Omni DPO.") from exc
+
+    container = av.open(video_path)
+    stream = container.streams.video[0]
+    video_fps = float(stream.average_rate) if stream.average_rate else 2.0
+    frames = [frame.to_image().convert("RGB") for frame in container.decode(video=0)]
+    container.close()
+    if not frames:
+        raise ValueError(f"Video {video_path} contains no decodable frames.")
+    return _pil_images_to_tensor(frames), video_fps
+
+
+def _fetch_videos(videos: Sequence[str], **kwargs) -> tuple[list[torch.Tensor], list[Any]]:
+    video_inputs: list[torch.Tensor] = []
+    audio_inputs: list[Any] = []
+    for video in videos:
+        if not isinstance(video, str):
+            raise NotImplementedError("Only local video file paths are supported.")
+        tensor, video_fps = _decode_video_path(video)
+        tensor = _smart_video_nframes(_smart_resize_video(tensor, **kwargs), video_fps, **kwargs)
+        video_inputs.append(tensor)
+        audio_inputs.append(None)
+    return video_inputs, audio_inputs
+
+
+def _load_audio_from_path(audio_path: str, sample_rate: int = 16000) -> np.ndarray:
+    try:
+        import librosa
+    except ImportError as exc:
+        raise ImportError(
+            "librosa is required to load audio files for Qwen3-Omni DPO. Install with `pip install librosa`."
+        ) from exc
+    return librosa.load(audio_path, sr=sample_rate)[0]
+
+
+def _fetch_audios(audios: Sequence[str], **kwargs) -> list[np.ndarray]:
+    sample_rate = kwargs.get("sample_rate", 16000)
+    return [_load_audio_from_path(audio, sample_rate=sample_rate) for audio in audios]
+
+
+def _get_omni_token_ids(processor) -> tuple[int, int, int]:
+    tokenizer = getattr(processor, "tokenizer", processor)
+    vocab = tokenizer.get_vocab()
+    image_token_id = vocab.get("<|image_pad|>", vocab.get("<|IMAGE|>"))
+    video_token_id = vocab.get("<|video_pad|>", vocab.get("<|VIDEO|>"))
+    audio_token_id = vocab.get("<|audio_pad|>", vocab.get("<|AUDIO|>"))
+    if image_token_id is None:
+        raise ValueError("Cannot find image token (<|image_pad|> or <|IMAGE|>) in tokenizer vocab.")
+    if video_token_id is None:
+        raise ValueError("Cannot find video token (<|video_pad|> or <|VIDEO|>) in tokenizer vocab.")
+    if audio_token_id is None:
+        raise ValueError("Cannot find audio token (<|audio_pad|> or <|AUDIO|>) in tokenizer vocab.")
+    return image_token_id, video_token_id, audio_token_id
+
+
+def process_qwen3_omni_sample(
+    sample: dict[str, Any],
+    processor,
+    position_id_func: Callable,
+    **kwargs,
+) -> list[dict[str, Any]]:
+    """Transform one offline preference sample into Qwen3-Omni model inputs."""
+    image_token_id, video_token_id, audio_token_id = _get_omni_token_ids(processor)
+    conversations = (
+        sample["conversations"] if ("conversations" in sample and len(sample["conversations"]) > 0) else sample
+    )
+
+    input_conversations = [
+        {
+            "role": "system",
+            "content": [{"type": "text", "text": QWEN_OMNI_SYSTEM_MESSAGE}],
+        },
+    ]
+    for conversation in conversations:
+        contents = []
+        for message in conversation[1:]:
+            contents.append({"type": message[0], message[0]: message[1]})
+        input_conversations.append({"role": conversation[0], "content": contents})
+    text = processor.apply_chat_template(input_conversations, tokenize=False)
+
+    images = _fetch_images(sample.get("images", []), **kwargs) if sample.get("images") else []
+    videos, video_audios = _fetch_videos(sample.get("videos", []), **kwargs) if sample.get("videos") else ([], [])
+    audio_audios = _fetch_audios(sample.get("audios", []), **kwargs) if sample.get("audios") else []
+
+    video_audios_iter = iter(video_audios)
+    audio_audios_iter = iter(audio_audios)
+    audios = []
+    for item in input_conversations:
+        for content in item["content"]:
+            if content["type"] == "video":
+                audios.append(next(video_audios_iter))
+            elif content["type"] == "audio":
+                audios.append(next(audio_audios_iter))
+
+    model_inputs = processor(
+        text=text,
+        audios=audios,
+        images=images,
+        videos=videos,
+        return_tensors="pt",
+        padding=True,
+    )
+    model_inputs = model_inputs.data
+    input_features = model_inputs.pop("input_features", None)
+    feature_attention_mask = model_inputs.pop("feature_attention_mask", None)
+
+    if feature_attention_mask is not None:
+        audio_feature_lengths = torch.sum(feature_attention_mask, dim=1)
+        valid_mask = audio_feature_lengths != 0
+        input_features = input_features[valid_mask].permute(0, 2, 1)[feature_attention_mask[valid_mask].bool()]
+        model_inputs["input_features"] = input_features
+        model_inputs["audio_feature_lengths"] = audio_feature_lengths
+    else:
+        audio_feature_lengths = None
+
+    input_ids = model_inputs["input_ids"].squeeze(0)
+    image_mask = input_ids == image_token_id
+    video_mask = input_ids == video_token_id
+    audio_mask = input_ids == audio_token_id
+    input_ids[image_mask] = IMAGE_INPUT_INDEX
+    input_ids[video_mask] = VIDEO_INPUT_INDEX
+    input_ids[audio_mask] = AUDIO_INPUT_INDEX
+
+    position_id_returns = position_id_func(
+        input_ids=input_ids.unsqueeze(0),
+        image_grid_thw=model_inputs.get("image_grid_thw", None),
+        video_grid_thw=model_inputs.get("video_grid_thw", None),
+        attention_mask=model_inputs["attention_mask"],
+        audio_seqlens=audio_feature_lengths,
+        second_per_grids=model_inputs.pop("video_second_per_grid", None),
+    )
+    position_id_returns["position_ids"] = position_id_returns["position_ids"].clone()
+    model_inputs["position_ids"] = position_id_returns["position_ids"]
+
+    model_inputs["image_mask"] = image_mask
+    model_inputs["video_mask"] = video_mask
+    model_inputs["audio_mask"] = audio_mask
+    input_ids[image_mask | video_mask | audio_mask] = 0
+    model_inputs["input_ids"] = input_ids
+    model_inputs["attention_mask"] = model_inputs["attention_mask"].squeeze(0)
+
+    labels = torch.full_like(input_ids, fill_value=IGNORE_INDEX)
+    tokenizer = getattr(processor, "tokenizer", processor)
+    vocab = tokenizer.get_vocab()
+    user_token_id = vocab.get("user")
+    assistant_token_id = vocab.get("assistant")
+    if user_token_id is None or assistant_token_id is None:
+        raise ValueError("Cannot find user/assistant tokens in tokenizer vocab.")
+    user_start_index = torch.where(input_ids == user_token_id)[0].tolist()
+    assistant_start_index = torch.where(input_ids == assistant_token_id)[0].tolist()
+    user_start_index.append(len(input_ids) + 1)
+    user_i = 0
+    for assis_i in assistant_start_index:
+        while user_start_index[user_i] < assis_i:
+            user_i += 1
+        labels[assis_i + 2 : user_start_index[user_i] - 1] = input_ids[assis_i + 2 : user_start_index[user_i] - 1]
+    model_inputs["labels"] = labels
+    return [model_inputs]

--- a/verl_omni/utils/dataset/qwen3_omni_transform.py
+++ b/verl_omni/utils/dataset/qwen3_omni_transform.py
@@ -14,8 +14,9 @@
 
 """Qwen3-Omni sample transform for offline MLLM DPO without a VeOmni dependency.
 
-The logic mirrors VeOmni's ``process_sample_qwen_omni`` data transform and the
-minimal multimodal media helpers it relies on.
+Adapted from VeOmni's ``process_sample_qwen_omni`` data transform and the
+minimal multimodal media helpers it relies on:
+https://github.com/ByteDance-Seed/VeOmni/blob/main/veomni/data/data_transform.py
 """
 
 from __future__ import annotations

--- a/verl_omni/utils/dataset/qwen3_omni_transform.py
+++ b/verl_omni/utils/dataset/qwen3_omni_transform.py
@@ -14,13 +14,13 @@
 
 """Qwen3-Omni sample transform for offline MLLM DPO without a VeOmni dependency.
 
-Adapted from VeOmni's ``process_sample_qwen_omni`` data transform and the
-minimal multimodal media helpers it relies on:
-https://github.com/ByteDance-Seed/VeOmni/blob/main/veomni/data/data_transform.py
+The logic mirrors VeOmni's ``process_sample_qwen_omni`` data transform and the
+minimal multimodal media helpers it relies on.
 """
 
 from __future__ import annotations
 
+import copy
 import math
 from collections.abc import Callable, Sequence
 from typing import Any
@@ -286,6 +286,125 @@ def _get_omni_token_ids(processor) -> tuple[int, int, int]:
     return image_token_id, video_token_id, audio_token_id
 
 
+def _mark_assistant_content(messages: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], list[tuple[str, str]]]:
+    marked_messages = copy.deepcopy(messages)
+    markers: list[tuple[str, str]] = []
+    for index, message in enumerate(marked_messages):
+        if message.get("role") != "assistant":
+            continue
+        start_marker = f"__verl_omni_assistant_start_{index}__"
+        end_marker = f"__verl_omni_assistant_end_{index}__"
+        markers.append((start_marker, end_marker))
+        content = message.get("content", "")
+        if isinstance(content, str):
+            message["content"] = f"{start_marker}{content}{end_marker}"
+        else:
+            message["content"] = [
+                {"type": "text", "text": start_marker},
+                *content,
+                {"type": "text", "text": end_marker},
+            ]
+    return marked_messages, markers
+
+
+def _assistant_char_spans_from_template(
+    input_conversations: list[dict[str, Any]],
+    processor,
+    rendered_text: str,
+) -> list[tuple[int, int]]:
+    """Locate assistant content spans from the structured chat template."""
+    marked_conversations, markers = _mark_assistant_content(input_conversations)
+    if not markers:
+        return []
+
+    marked_text = processor.apply_chat_template(marked_conversations, tokenize=False)
+    spans: list[tuple[int, int]] = []
+    stripped_text = marked_text
+    for start_marker, end_marker in markers:
+        start = stripped_text.find(start_marker)
+        if start < 0:
+            raise ValueError("Cannot locate assistant start marker in rendered Qwen3-Omni chat template.")
+        stripped_text = stripped_text[:start] + stripped_text[start + len(start_marker) :]
+        end = stripped_text.find(end_marker, start)
+        if end < 0:
+            raise ValueError("Cannot locate assistant end marker in rendered Qwen3-Omni chat template.")
+        spans.append((start, end))
+        stripped_text = stripped_text[:end] + stripped_text[end + len(end_marker) :]
+
+    if stripped_text != rendered_text:
+        raise ValueError("Marked Qwen3-Omni chat template rendering does not match the unmarked rendering.")
+    return spans
+
+
+def _assistant_token_mask_from_template(
+    input_conversations: list[dict[str, Any]],
+    processor,
+    rendered_text: str,
+    input_ids: torch.Tensor,
+    media_token_ids: tuple[int, int, int],
+) -> torch.Tensor:
+    tokenizer = getattr(processor, "tokenizer", processor)
+    char_spans = _assistant_char_spans_from_template(input_conversations, processor, rendered_text)
+    loss_mask = torch.zeros(input_ids.shape, dtype=torch.bool, device=input_ids.device)
+    if not char_spans:
+        return loss_mask
+
+    tokenized = tokenizer(
+        rendered_text,
+        add_special_tokens=False,
+        return_offsets_mapping=True,
+    )
+    offsets = tokenized["offset_mapping"]
+    token_ids = tokenized["input_ids"]
+    token_to_processor_pos = _align_template_tokens_to_processor_tokens(token_ids, input_ids, set(media_token_ids))
+
+    span_i = 0
+    for token_i, (start, end) in enumerate(offsets):
+        if start == end:
+            continue
+        while span_i < len(char_spans) and end > char_spans[span_i][1]:
+            span_i += 1
+        if span_i >= len(char_spans):
+            break
+        span_start, span_end = char_spans[span_i]
+        if start < span_end and end > span_start:
+            loss_mask[token_to_processor_pos[token_i]] = True
+    return loss_mask
+
+
+def _align_template_tokens_to_processor_tokens(
+    token_ids: Sequence[int],
+    processor_input_ids: torch.Tensor,
+    media_token_ids: set[int],
+) -> list[int]:
+    """Map chat-template token positions to processor-expanded input positions."""
+    token_to_processor_pos: list[int] = []
+    processor_ids = processor_input_ids.tolist()
+    processor_i = 0
+    for token_i, token_id in enumerate(token_ids):
+        if processor_i >= len(processor_ids):
+            raise ValueError(
+                "Tokenizer chat-template tokens are longer than processor input_ids while building assistant labels."
+            )
+        if processor_ids[processor_i] != token_id:
+            raise ValueError(
+                "Cannot align tokenizer chat-template tokens with processor input_ids at "
+                f"token index {token_i}: tokenizer id {token_id}, processor id {processor_ids[processor_i]}."
+            )
+        token_to_processor_pos.append(processor_i)
+        processor_i += 1
+        if token_id in media_token_ids:
+            while processor_i < len(processor_ids) and processor_ids[processor_i] == token_id:
+                processor_i += 1
+
+    if processor_i != len(processor_ids):
+        raise ValueError(
+            "Processor input_ids contain trailing tokens that are not present in the rendered chat template "
+            f"({len(processor_ids) - processor_i} extra token(s))."
+        )
+    return token_to_processor_pos
+
+
 def process_qwen3_omni_sample(
     sample: dict[str, Any],
     processor,
@@ -334,19 +453,16 @@ def process_qwen3_omni_sample(
         padding=True,
     )
     model_inputs = model_inputs.data
-    input_features = model_inputs.pop("input_features", None)
-    feature_attention_mask = model_inputs.pop("feature_attention_mask", None)
+    feature_attention_mask = model_inputs.get("feature_attention_mask", None)
 
     if feature_attention_mask is not None:
         audio_feature_lengths = torch.sum(feature_attention_mask, dim=1)
-        valid_mask = audio_feature_lengths != 0
-        input_features = input_features[valid_mask].permute(0, 2, 1)[feature_attention_mask[valid_mask].bool()]
-        model_inputs["input_features"] = input_features
         model_inputs["audio_feature_lengths"] = audio_feature_lengths
     else:
         audio_feature_lengths = None
 
     input_ids = model_inputs["input_ids"].squeeze(0)
+    raw_input_ids = input_ids.clone()
     image_mask = input_ids == image_token_id
     video_mask = input_ids == video_token_id
     audio_mask = input_ids == audio_token_id
@@ -373,19 +489,13 @@ def process_qwen3_omni_sample(
     model_inputs["attention_mask"] = model_inputs["attention_mask"].squeeze(0)
 
     labels = torch.full_like(input_ids, fill_value=IGNORE_INDEX)
-    tokenizer = getattr(processor, "tokenizer", processor)
-    vocab = tokenizer.get_vocab()
-    user_token_id = vocab.get("user")
-    assistant_token_id = vocab.get("assistant")
-    if user_token_id is None or assistant_token_id is None:
-        raise ValueError("Cannot find user/assistant tokens in tokenizer vocab.")
-    user_start_index = torch.where(input_ids == user_token_id)[0].tolist()
-    assistant_start_index = torch.where(input_ids == assistant_token_id)[0].tolist()
-    user_start_index.append(len(input_ids) + 1)
-    user_i = 0
-    for assis_i in assistant_start_index:
-        while user_start_index[user_i] < assis_i:
-            user_i += 1
-        labels[assis_i + 2 : user_start_index[user_i] - 1] = input_ids[assis_i + 2 : user_start_index[user_i] - 1]
+    assistant_loss_mask = _assistant_token_mask_from_template(
+        input_conversations,
+        processor,
+        text,
+        raw_input_ids,
+        (image_token_id, video_token_id, audio_token_id),
+    )
+    labels[assistant_loss_mask] = input_ids[assistant_loss_mask]
     model_inputs["labels"] = labels
     return [model_inputs]

--- a/verl_omni/utils/dataset/qwen3_omni_transform.py
+++ b/verl_omni/utils/dataset/qwen3_omni_transform.py
@@ -411,7 +411,24 @@ def process_qwen3_omni_sample(
     position_id_func: Callable,
     **kwargs,
 ) -> list[dict[str, Any]]:
-    """Transform one offline preference sample into Qwen3-Omni model inputs."""
+    """Transform one offline preference sample into Qwen3-Omni model inputs.
+
+    The transform renders the conversation with the Qwen3-Omni chat template,
+    loads referenced image, video, and audio inputs, and builds model-ready
+    tensors with modality masks, position ids, attention masks, and labels.
+
+    Args:
+        sample: Offline preference sample containing conversations and optional
+            multimodal resource fields.
+        processor: Qwen3-Omni processor used to render text and encode
+            multimodal inputs.
+        position_id_func: Callable that builds multimodal position ids from the
+            encoded model inputs.
+        **kwargs: Additional options forwarded to multimodal resource loaders.
+
+    Returns:
+        A single-item list containing the encoded model input dictionary.
+    """
     image_token_id, video_token_id, audio_token_id = _get_omni_token_ids(processor)
     conversations = (
         sample["conversations"] if ("conversations" in sample and len(sample["conversations"]) > 0) else sample

--- a/verl_omni/utils/dataset/rl_dataset.py
+++ b/verl_omni/utils/dataset/rl_dataset.py
@@ -17,7 +17,7 @@ import logging
 
 from omegaconf import DictConfig
 from verl.trainer.ppo.utils import create_rl_dataset as _upstream_create_rl_dataset
-from verl.trainer.ppo.utils import create_rl_sampler
+from verl.trainer.ppo.utils import create_rl_sampler as _upstream_create_rl_sampler
 from verl.utils.dataset.rl_dataset import RLHFDataset as _UpstreamRLHFDataset
 from verl.utils.dataset.rl_dataset import collate_fn as _upstream_collate_fn
 from verl.utils.dataset.rl_dataset import get_dataset_class as _upstream_get_dataset_class
@@ -120,3 +120,18 @@ def create_rl_dataset(data_paths, data_config, tokenizer, processor, is_train=Tr
         config=data_config,
         max_samples=max_samples,
     )
+
+
+def create_rl_sampler(data_config: DictConfig, dataset):
+    """Create a sampler, supporting verl-omni custom sampler classes."""
+    sampler_config = data_config.get("sampler", None)
+    if sampler_config is not None:
+        class_path = sampler_config.get("class_path", None)
+        class_name = sampler_config.get("class_name", None)
+        if class_path is not None and class_name is not None:
+            sampler_cls = load_extern_object(class_path, class_name)
+            sampler_kwargs = sampler_config.get("sampler_kwargs", {}) or {}
+            logger.info("Using custom sampler: %s from %s", class_name, class_path)
+            return sampler_cls(data_source=dataset, data_config=data_config, **sampler_kwargs)
+
+    return _upstream_create_rl_sampler(data_config, dataset)

--- a/verl_omni/utils/dataset/rl_dataset.py
+++ b/verl_omni/utils/dataset/rl_dataset.py
@@ -123,7 +123,20 @@ def create_rl_dataset(data_paths, data_config, tokenizer, processor, is_train=Tr
 
 
 def create_rl_sampler(data_config: DictConfig, dataset):
-    """Create a sampler, supporting verl-omni custom sampler classes."""
+    """Create an RL dataset sampler with optional verl-omni custom classes.
+
+    When ``data_config.sampler`` provides both ``class_path`` and
+    ``class_name``, the sampler class is loaded dynamically and initialized with
+    the dataset, data config, and optional ``sampler_kwargs``. Otherwise, sampler
+    creation falls back to the upstream verl implementation.
+
+    Args:
+        data_config: Data config that may contain a custom sampler definition.
+        dataset: Dataset instance to sample from.
+
+    Returns:
+        Sampler instance used by the RL DataLoader.
+    """
     sampler_config = data_config.get("sampler", None)
     if sampler_config is not None:
         class_path = sampler_config.get("class_path", None)


### PR DESCRIPTION
## Summary

Adressing RFC  #266. Part of #269.

Add end-to-end data infrastructure for **offline MLLM DPO** training on the [Omni-Preference](https://huggingface.co/datasets/Omni-RRM/Omni-Preference) dataset (image / video / audio preference pairs):

- **Preprocessing**: convert `final_rl_data.jsonl` into multimodal parquet (`prompt` = media + question, `chosen` / `rejected` = candidate answers), with media-file-granularity train/test split.
- **Dataset layer**: `OfflineMLLMDPODataset`, `offline_mllm_dpo_collate_fn`, and `ModalityGroupedBatchSampler` for same-modality batching across mixed parquet sources.
- **Transform**: standalone `qwen3_omni_transform` (VeOmni-free) mirroring VeOmni's Qwen3-Omni sample processing for chosen/rejected branches.
- **Smoke data**: dummy parquet generator for e2e smoke tests.
- **Sampler hook**: extend `create_rl_sampler` in `rl_dataset.py` to load custom sampler classes from data config.
- **Docs**: dataset download, preprocessing, and parquet schema guide under `examples/dpo_trainer/data_process/` (not tied to a specific model example directory).

## Changes

| Area | File | Description |
|------|------|-------------|
| Preprocess | `examples/dpo_trainer/data_process/omni_preference_dpo_multisource.py` | JSONL → parquet for image/video/audio; media-name split; path resolution |
| Dataset | `verl_omni/utils/dataset/offline_mllm_dpo_dataset.py` | `OfflineMLLMDPODataset`, `offline_mllm_dpo_collate_fn`, `ModalityGroupedBatchSampler` |
| Transform | `verl_omni/utils/dataset/qwen3_omni_transform.py` | Qwen3-Omni multimodal sample transform (VeOmni-free) |
| Sampler | `verl_omni/utils/dataset/rl_dataset.py` | `create_rl_sampler` supports `data.sampler.class_path` / `class_name` |
| E2E data | `tests/special_e2e/create_dummy_omni_preference_dpo_data.py` | Tiny image/video/audio parquet + media for smoke tests |
| CPU tests | `tests/utils/test_offline_mllm_dpo_dataset_on_cpu.py` | 17 CPU unit tests for dataset helpers, collate, sampler, and preprocessing |
| Docs | `examples/dpo_trainer/data_process/omni_preference_dpo_dataset.md` | Download, preprocess, parquet schema, troubleshooting |


## Test plan

- [x] Generate dummy parquet:
  ```bash
  python tests/special_e2e/create_dummy_omni_preference_dpo_data.py \
     --local_save_dir /tmp/omni_pref_dummy

- [x] CPU unit tests:
  ```bash
  pytest tests/utils/test_offline_mllm_dpo_dataset_on_cpu.py -v

- [x] (Optional, with full Omni-Preference clone) Run preprocessing:

python examples/dpo_trainer/data_process/omni_preference_dpo_multisource.py \
  --dataset_root $HOME/Omni-Preference \
  --output_dir $HOME/Omni-Preference/parquet_dpo \
  --modalities image video audio \
  --test_ratio 0.10 \
  --seed 42