### PR TITLE
[2/N][cfg, omni, tests] feat: add Omni DPO config and OmniDPOLoss

### DIFF
--- a/tests/trainer/omni/test_omni_algos_on_cpu.py
+++ b/tests/trainer/omni/test_omni_algos_on_cpu.py
@@ -1,0 +1,184 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU tests for omni direct-preference loss functions."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+import torch
+from tensordict import TensorDict
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load module from {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _bootstrap_omni_algos():
+    sys.modules.setdefault("verl_omni", types.ModuleType("verl_omni"))
+    sys.modules.setdefault("verl_omni.trainer", types.ModuleType("verl_omni.trainer"))
+    sys.modules.setdefault("verl_omni.trainer.omni", types.ModuleType("verl_omni.trainer.omni"))
+    sys.modules.setdefault("verl_omni.workers", types.ModuleType("verl_omni.workers"))
+    sys.modules.setdefault("verl_omni.workers.config", types.ModuleType("verl_omni.workers.config"))
+    sys.modules.setdefault("verl_omni.workers.config.omni", types.ModuleType("verl_omni.workers.config.omni"))
+
+    actor_mod = _load_module(
+        "verl_omni.workers.config.omni.actor",
+        REPO_ROOT / "verl_omni" / "workers" / "config" / "omni" / "actor.py",
+    )
+    omni_pkg = sys.modules["verl_omni.workers.config.omni"]
+    omni_pkg.OmniLossConfig = actor_mod.OmniLossConfig
+
+    return _load_module(
+        "verl_omni.trainer.omni.omni_algos",
+        REPO_ROOT / "verl_omni" / "trainer" / "omni" / "omni_algos.py",
+    )
+
+
+@pytest.fixture(scope="module")
+def omni_algos():
+    return _bootstrap_omni_algos()
+
+
+@pytest.fixture(scope="module")
+def OmniLossConfig(omni_algos):
+    return sys.modules["verl_omni.workers.config.omni.actor"].OmniLossConfig
+
+
+@dataclass
+class _FakeActorConfig:
+    omni_loss: object
+
+
+class TestOmniLossRegistry:
+    def test_builtin_dpo_registered(self, omni_algos):
+        assert "dpo" in omni_algos.OMNI_LOSS_REGISTRY
+
+    def test_get_existing_loss_fn(self, omni_algos):
+        fn = omni_algos.get_omni_loss_fn("dpo")
+        assert isinstance(fn, omni_algos.OmniDPOLoss)
+
+    def test_get_unknown_loss_fn_raises(self, omni_algos):
+        with pytest.raises(ValueError, match="Unsupported omni loss mode"):
+            omni_algos.get_omni_loss_fn("nonexistent_loss")
+
+
+class TestOmniDPOLossComputeLoss:
+    def test_sigmoid_zero_logits_matches_log_two(self, omni_algos):
+        logps = torch.tensor([-1.0, -2.0, -1.1, -2.1])
+        loss, _ = omni_algos.OmniDPOLoss.compute_loss(
+            policy_chosen_logps=logps[0:1],
+            policy_rejected_logps=logps[1:2],
+            reference_chosen_logps=logps[2:3],
+            reference_rejected_logps=logps[3:4],
+            beta=0.1,
+            loss_type="sigmoid",
+        )
+        assert loss.shape == ()
+        assert loss.item() == pytest.approx(torch.log(torch.tensor(2.0)).item(), rel=1e-5)
+
+    def test_reward_accuracy_reflects_implicit_rewards(self, omni_algos):
+        _, metrics = omni_algos.OmniDPOLoss.compute_loss(
+            policy_chosen_logps=torch.tensor([0.0]),
+            policy_rejected_logps=torch.tensor([-1.0]),
+            reference_chosen_logps=torch.tensor([-1.0]),
+            reference_rejected_logps=torch.tensor([-1.0]),
+            beta=0.5,
+            loss_type="sigmoid",
+        )
+        assert metrics["reward_accuracy"].item() == pytest.approx(1.0)
+
+    def test_policy_margin_improves_over_reference_lowers_loss(self, omni_algos):
+        worse_loss, _ = omni_algos.OmniDPOLoss.compute_loss(
+            policy_chosen_logps=torch.tensor([-1.0]),
+            policy_rejected_logps=torch.tensor([-1.0]),
+            reference_chosen_logps=torch.tensor([-1.0]),
+            reference_rejected_logps=torch.tensor([-1.0]),
+            beta=0.5,
+            loss_type="sigmoid",
+        )
+        better_loss, _ = omni_algos.OmniDPOLoss.compute_loss(
+            policy_chosen_logps=torch.tensor([0.0]),
+            policy_rejected_logps=torch.tensor([-2.0]),
+            reference_chosen_logps=torch.tensor([-1.0]),
+            reference_rejected_logps=torch.tensor([-1.0]),
+            beta=0.5,
+            loss_type="sigmoid",
+        )
+        assert better_loss.item() < worse_loss.item()
+
+    def test_ipo_loss_is_non_negative(self, omni_algos):
+        loss, _ = omni_algos.OmniDPOLoss.compute_loss(
+            policy_chosen_logps=torch.tensor([0.2]),
+            policy_rejected_logps=torch.tensor([-0.3]),
+            reference_chosen_logps=torch.tensor([0.1]),
+            reference_rejected_logps=torch.tensor([-0.2]),
+            beta=0.2,
+            loss_type="ipo",
+        )
+        assert loss.item() >= 0.0
+
+    def test_label_smoothing_changes_loss(self, omni_algos):
+        kwargs = dict(
+            policy_chosen_logps=torch.tensor([0.5]),
+            policy_rejected_logps=torch.tensor([-0.5]),
+            reference_chosen_logps=torch.tensor([0.0]),
+            reference_rejected_logps=torch.tensor([0.0]),
+            beta=0.1,
+            loss_type="sigmoid",
+        )
+        plain_loss, _ = omni_algos.OmniDPOLoss.compute_loss(label_smoothing=0.0, **kwargs)
+        smooth_loss, _ = omni_algos.OmniDPOLoss.compute_loss(label_smoothing=0.1, **kwargs)
+        assert plain_loss.item() != smooth_loss.item()
+
+
+class TestOmniDPOLossCallable:
+    def test_callable_returns_scalar_loss_and_metrics(self, omni_algos, OmniLossConfig):
+        loss_fn = omni_algos.get_omni_loss_fn("dpo")
+        actor_config = _FakeActorConfig(omni_loss=OmniLossConfig())
+        model_output = {
+            "policy_chosen_logps": torch.tensor([0.0, 0.2]),
+            "policy_rejected_logps": torch.tensor([-1.0, -0.8]),
+            "reference_chosen_logps": torch.tensor([-0.1, 0.0]),
+            "reference_rejected_logps": torch.tensor([-0.9, -0.7]),
+        }
+        result = loss_fn(
+            config=actor_config,
+            model_output=model_output,
+            data=TensorDict({}, batch_size=[2]),
+        )
+        assert result.loss.shape == ()
+        assert "dpo_loss" in result.metrics
+        assert "reward_margin" in result.metrics
+
+    def test_validate_inputs_reports_missing_keys(self, omni_algos):
+        loss_fn = omni_algos.get_omni_loss_fn("dpo")
+        with pytest.raises(KeyError, match="missing required model_output keys"):
+            loss_fn.validate_inputs(
+                model_output={"policy_chosen_logps": torch.tensor([0.0])},
+                data=TensorDict({}, batch_size=[1]),
+            )

--- a/tests/workers/config/test_omni_config_on_cpu.py
+++ b/tests/workers/config/test_omni_config_on_cpu.py
@@ -13,9 +13,13 @@
 # limitations under the License.
 """CPU tests for omni trainer config dataclasses."""
 
+import json
+import os
+
 import pytest
 
 from verl_omni.trainer.config.algorithm import OmniAlgoConfig
+from verl_omni.workers.config import OmniModelConfig
 from verl_omni.workers.config.omni import OmniActorConfig, OmniLossConfig
 
 
@@ -83,6 +87,39 @@ class TestOmniActorConfig:
                 ppo_micro_batch_size_per_gpu=1,
                 trainer_type="policy_gradient",
             )
+
+
+class TestOmniModelConfigLoraFields:
+    def test_lora_fields_via_hydra(self, tmp_path):
+        from hydra import compose, initialize_config_dir
+        from verl.utils.config import omega_conf_to_dataclass
+
+        import verl_omni
+
+        model_dir = tmp_path / "dummy-model"
+        model_dir.mkdir()
+        (model_dir / "config.json").write_text(json.dumps({"architectures": ["Qwen3OmniMoeForConditionalGeneration"]}))
+
+        config_dir = os.path.join(os.path.dirname(verl_omni.__file__), "trainer/config/omni/model")
+        with initialize_config_dir(config_dir=config_dir, version_base=None):
+            cfg = compose(
+                config_name="omni_model",
+                overrides=[
+                    f"path={model_dir}",
+                    "+load_tokenizer=false",
+                    "architecture=Qwen3OmniMoeForConditionalGeneration",
+                    'policy_state_adapters=["default","old"]',
+                    "lora_init_weights=gaussian",
+                    "lora_dtype=fp32",
+                ],
+            )
+        model_cfg: OmniModelConfig = omega_conf_to_dataclass(cfg)
+
+        assert model_cfg.lora_init_weights == "gaussian"
+        assert tuple(model_cfg.policy_state_adapters) == ("default", "old")
+        assert model_cfg.lora_dtype == "fp32"
+        assert model_cfg.target_parameters is None
+        assert model_cfg.fsdp_layer_prefixes == []
 
     def test_instantiate_via_hydra(self):
         import os

--- a/tests/workers/config/test_omni_config_on_cpu.py
+++ b/tests/workers/config/test_omni_config_on_cpu.py
@@ -16,7 +16,7 @@
 import pytest
 
 from verl_omni.trainer.config.algorithm import OmniAlgoConfig
-from verl_omni.workers.config.omni import OmniLossConfig
+from verl_omni.workers.config.omni import OmniActorConfig, OmniLossConfig
 
 
 class TestOmniAlgoConfig:
@@ -62,3 +62,47 @@ class TestOmniLossConfig:
     def test_invalid_values_raise(self, kwargs):
         with pytest.raises(ValueError):
             OmniLossConfig(**kwargs)
+
+
+class TestOmniActorConfig:
+    def test_includes_omni_loss(self):
+        cfg = OmniActorConfig(
+            strategy="fsdp",
+            rollout_n=1,
+            ppo_micro_batch_size_per_gpu=1,
+        )
+        assert isinstance(cfg.omni_loss, OmniLossConfig)
+        assert cfg.omni_loss.loss_mode == "dpo"
+        assert cfg.trainer_type == "direct_preference"
+
+    def test_rejects_policy_gradient_trainer_type(self):
+        with pytest.raises(ValueError, match="OmniActorConfig is only valid"):
+            OmniActorConfig(
+                strategy="fsdp",
+                rollout_n=1,
+                ppo_micro_batch_size_per_gpu=1,
+                trainer_type="policy_gradient",
+            )
+
+    def test_instantiate_via_hydra(self):
+        import os
+
+        from hydra import compose, initialize_config_dir
+        from verl.utils.config import omega_conf_to_dataclass
+
+        import verl_omni
+
+        config_dir = os.path.join(os.path.dirname(verl_omni.__file__), "trainer/config")
+        with initialize_config_dir(config_dir=config_dir, version_base=None):
+            cfg = compose(
+                config_name="omni_trainer",
+                overrides=[
+                    "actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=1",
+                    "actor_rollout_ref.actor.omni_loss.beta=0.2",
+                ],
+            )
+        actor_cfg: OmniActorConfig = omega_conf_to_dataclass(cfg.actor_rollout_ref.actor)
+
+        assert isinstance(actor_cfg, OmniActorConfig)
+        assert isinstance(actor_cfg.omni_loss, OmniLossConfig)
+        assert actor_cfg.omni_loss.beta == pytest.approx(0.2)

--- a/tests/workers/config/test_omni_config_on_cpu.py
+++ b/tests/workers/config/test_omni_config_on_cpu.py
@@ -1,0 +1,64 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU tests for omni trainer config dataclasses."""
+
+import pytest
+
+from verl_omni.trainer.config.algorithm import OmniAlgoConfig
+from verl_omni.workers.config.omni import OmniLossConfig
+
+
+class TestOmniAlgoConfig:
+    def test_defaults(self):
+        cfg = OmniAlgoConfig()
+        assert cfg.trainer_type == "direct_preference"
+        assert cfg.sample_source == "offline"
+        assert cfg.paired_preference is True
+        assert cfg.adv_estimator == "dpo"
+        assert cfg.norm_adv_by_std_in_grpo is True
+        assert cfg.global_std is True
+
+    @pytest.mark.parametrize(
+        "field_name, value",
+        [
+            ("trainer_type", "invalid"),
+            ("sample_source", "invalid"),
+        ],
+    )
+    def test_invalid_values_raise(self, field_name, value):
+        with pytest.raises(ValueError):
+            OmniAlgoConfig(**{field_name: value})
+
+
+class TestOmniLossConfig:
+    def test_defaults(self):
+        cfg = OmniLossConfig()
+        assert cfg.loss_mode == "dpo"
+        assert cfg.beta == pytest.approx(0.1)
+        assert cfg.label_smoothing == pytest.approx(0.0)
+        assert cfg.loss_type == "sigmoid"
+        assert cfg.average_log_prob is False
+        assert cfg.refer_model_precision == "bfloat16"
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"loss_mode": "flow_grpo"},
+            {"loss_type": "invalid"},
+            {"beta": 0.0},
+        ],
+    )
+    def test_invalid_values_raise(self, kwargs):
+        with pytest.raises(ValueError):
+            OmniLossConfig(**kwargs)

--- a/tests/workers/config/test_omni_config_on_cpu.py
+++ b/tests/workers/config/test_omni_config_on_cpu.py
@@ -79,14 +79,14 @@ class TestOmniActorConfig:
         assert cfg.omni_loss.loss_mode == "dpo"
         assert cfg.trainer_type == "direct_preference"
 
-    def test_rejects_policy_gradient_trainer_type(self):
-        with pytest.raises(ValueError, match="OmniActorConfig is only valid"):
-            OmniActorConfig(
-                strategy="fsdp",
-                rollout_n=1,
-                ppo_micro_batch_size_per_gpu=1,
-                trainer_type="policy_gradient",
-            )
+    def test_accepts_policy_gradient_trainer_type(self):
+        cfg = OmniActorConfig(
+            strategy="fsdp",
+            rollout_n=1,
+            ppo_micro_batch_size_per_gpu=1,
+            trainer_type="policy_gradient",
+        )
+        assert cfg.trainer_type == "policy_gradient"
 
 
 class TestOmniModelConfigLoraFields:
@@ -98,7 +98,9 @@ class TestOmniModelConfigLoraFields:
 
         model_dir = tmp_path / "dummy-model"
         model_dir.mkdir()
-        (model_dir / "config.json").write_text(json.dumps({"architectures": ["Qwen3OmniMoeForConditionalGeneration"]}))
+        (model_dir / "config.json").write_text(
+            json.dumps({"architectures": ["Qwen3OmniMoeForConditionalGeneration"], "model_type": "qwen3_omni_moe"})
+        )
 
         config_dir = os.path.join(os.path.dirname(verl_omni.__file__), "trainer/config/omni/model")
         with initialize_config_dir(config_dir=config_dir, version_base=None):

--- a/tests/workers/config/test_omni_config_on_cpu.py
+++ b/tests/workers/config/test_omni_config_on_cpu.py
@@ -143,5 +143,6 @@ class TestOmniModelConfigLoraFields:
         actor_cfg: OmniActorConfig = omega_conf_to_dataclass(cfg.actor_rollout_ref.actor)
 
         assert isinstance(actor_cfg, OmniActorConfig)
-        assert isinstance(actor_cfg.omni_loss, OmniLossConfig)
+        assert actor_cfg.omni_loss.__class__.__name__ == OmniLossConfig.__name__
+        assert actor_cfg.omni_loss.loss_mode == "dpo"
         assert actor_cfg.omni_loss.beta == pytest.approx(0.2)

--- a/verl_omni/trainer/config/algorithm.py
+++ b/verl_omni/trainer/config/algorithm.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Diffusion-specific algorithm config additions for verl_omni."""
+"""Algorithm config additions for verl_omni."""
 
 from dataclasses import dataclass, field
 from typing import Optional
@@ -22,7 +22,7 @@ from verl.trainer.config.algorithm import RolloutCorrectionConfig
 
 from verl_omni.trainer.diffusion.diffusion_trainer_utils import OLD_POLICY_DECAY_SCHEDULES
 
-__all__ = ["DiffusionAlgoConfig", "RolloutCorrectionConfig"]
+__all__ = ["DiffusionAlgoConfig", "OmniAlgoConfig", "RolloutCorrectionConfig"]
 
 
 @dataclass
@@ -57,3 +57,25 @@ class DiffusionAlgoConfig(BaseConfig):
             raise ValueError(f"old_policy_update_interval must be positive, got {self.old_policy_update_interval}.")
         if not 0 < self.timestep_fraction <= 1:
             raise ValueError(f"timestep_fraction must be in (0, 1], got {self.timestep_fraction}.")
+
+
+@dataclass
+class OmniAlgoConfig(BaseConfig):
+    """Omni-specific algorithm config."""
+
+    trainer_type: str = "direct_preference"
+    sample_source: str = "offline"
+    paired_preference: bool = True
+    adv_estimator: str = "dpo"
+    norm_adv_by_std_in_grpo: bool = True
+    global_std: bool = True
+
+    def __post_init__(self):
+        valid_trainer_types = {"policy_gradient", "direct_preference"}
+        if self.trainer_type not in valid_trainer_types:
+            raise ValueError(f"Invalid trainer_type: {self.trainer_type}. Must be one of {sorted(valid_trainer_types)}")
+        valid_sample_sources = {"online", "offline"}
+        if self.sample_source not in valid_sample_sources:
+            raise ValueError(
+                f"Invalid sample_source: {self.sample_source}. Must be one of {sorted(valid_sample_sources)}"
+            )

--- a/verl_omni/trainer/config/omni/model/omni_model.yaml
+++ b/verl_omni/trainer/config/omni/model/omni_model.yaml
@@ -7,6 +7,9 @@
 # Target class for this configuration
 _target_: verl_omni.workers.config.omni.OmniModelConfig
 
+# verl-omni dispatch key for engine and trainer routing
+model_type: omni_model
+
 # path to the huggingface model
 path: ???
 

--- a/verl_omni/trainer/config/omni/model/omni_model.yaml
+++ b/verl_omni/trainer/config/omni/model/omni_model.yaml
@@ -58,6 +58,9 @@ lora_rank: 0
 # LoRA scaling factor
 lora_alpha: 16
 
+# Optional dtype for LoRA parameters (e.g., "float32"); null = use model dtype
+lora_dtype: null
+
 # Lora initialization method.
 lora_init_weights: gaussian
 
@@ -75,10 +78,6 @@ lora_adapter_path: null
 
 # Named LoRA policy states required by the algorithm. "reference" disables adapters.
 policy_state_adapters: ["default"]
-
-# Convert LoRA parameters to a target dtype for numerical stability (e.g., "fp32", "bf16").
-# Default null means no conversion.
-lora_dtype: null
 
 # FSDP layer name prefixes for LoRA parameter layered summon.
 fsdp_layer_prefixes: []

--- a/verl_omni/trainer/config/omni/model/omni_model.yaml
+++ b/verl_omni/trainer/config/omni/model/omni_model.yaml
@@ -58,8 +58,8 @@ lora_rank: 0
 # LoRA scaling factor
 lora_alpha: 16
 
-# Optional dtype for LoRA parameters (e.g., "float32"); null = use model dtype
-lora_dtype: null
+# Lora initialization method.
+lora_init_weights: gaussian
 
 # Target modules for LoRA adaptation ("all-linear" or a list of module names)
 target_modules: all-linear
@@ -72,6 +72,16 @@ exclude_modules: null
 
 # Path to pre-trained LoRA adapter to load for continued training
 lora_adapter_path: null
+
+# Named LoRA policy states required by the algorithm. "reference" disables adapters.
+policy_state_adapters: ["default"]
+
+# Convert LoRA parameters to a target dtype for numerical stability (e.g., "fp32", "bf16").
+# Default null means no conversion.
+lora_dtype: null
+
+# FSDP layer name prefixes for LoRA parameter layered summon.
+fsdp_layer_prefixes: []
 
 # whether to use liger
 use_liger: False

--- a/verl_omni/trainer/config/omni_trainer.yaml
+++ b/verl_omni/trainer/config/omni_trainer.yaml
@@ -16,18 +16,6 @@ defaults:
 # Config for actor, rollout and reference model.
 actor_rollout_ref:
 
-  # Model config.
-  model:
-
-    # Select Omni trainer and OmniModelConfig.
-    model_type: omni_model
-
-    # HuggingFace config architectures[0].
-    architecture: Qwen3OmniMoeForConditionalGeneration
-
-    # Which stage to train.
-    model_stage: thinker
-
   # Rollout config.
   rollout:
 

--- a/verl_omni/trainer/config/omni_trainer.yaml
+++ b/verl_omni/trainer/config/omni_trainer.yaml
@@ -25,6 +25,12 @@ actor_rollout_ref:
   # Actor config.
   actor:
 
+    # Required when using verl.utils.omega_conf_to_dataclass to instantiate dataclass configs
+    _target_: verl_omni.workers.config.omni.OmniActorConfig
+
+    # Mirrors algorithm.trainer_type; used by OmniActorConfig.__post_init__ and worker loss dispatch.
+    trainer_type: ${algorithm.trainer_type}
+
     # Omni loss config.
     omni_loss:
 

--- a/verl_omni/trainer/config/omni_trainer.yaml
+++ b/verl_omni/trainer/config/omni_trainer.yaml
@@ -64,7 +64,7 @@ actor_rollout_ref:
     # Shuffle training data across PPO epochs.
     shuffle: false
 
-    
+# Trainer configuration.
 trainer:
 
   v1:

--- a/verl_omni/trainer/config/omni_trainer.yaml
+++ b/verl_omni/trainer/config/omni_trainer.yaml
@@ -67,6 +67,7 @@ actor_rollout_ref:
 # Trainer configuration.
 trainer:
 
+  # V1 trainer settings.
   v1:
 
     # Use the omni trainer mode for omni models.

--- a/verl_omni/trainer/config/omni_trainer.yaml
+++ b/verl_omni/trainer/config/omni_trainer.yaml
@@ -13,16 +13,86 @@ defaults:
   - omni/model@actor_rollout_ref.model: omni_model
   - _self_
 
+# Config for actor, rollout and reference model.
 actor_rollout_ref:
 
+  # Model config.
+  model:
+
+    # Select Omni trainer and OmniModelConfig.
+    model_type: omni_model
+
+    # HuggingFace config architectures[0].
+    architecture: Qwen3OmniMoeForConditionalGeneration
+
+    # Which stage to train.
+    model_stage: thinker
+
+  # Rollout config.
   rollout:
 
     # Use vLLM-Omni as the rollout backend for omni models.
     name: vllm_omni
 
+  # Actor config.
+  actor:
+
+    # Omni loss config.
+    omni_loss:
+
+      # Required when using verl.utils.omega_conf_to_dataclass to instantiate dataclass configs
+      _target_: verl_omni.workers.config.omni.OmniLossConfig
+
+      # Loss function mode.
+      loss_mode: dpo
+
+      # DPO inverse temperature.
+      beta: 0.1
+
+      # DPO label smoothing.
+      label_smoothing: 0.0
+
+      # DPO loss type.
+      loss_type: sigmoid
+
+      # Whether to average log probabilities before DPO.
+      average_log_prob: false
+
+      # Precision for the reference model.
+      refer_model_precision: bfloat16
+
+    # Shuffle training data across PPO epochs.
+    shuffle: false
+
+    
 trainer:
 
   v1:
 
     # Use the omni trainer mode for omni models.
     trainer_mode: omni_sync
+
+
+# Config for the algorithm.
+algorithm:
+
+  # Required when using verl.utils.omega_conf_to_dataclass to instantiate dataclass configs
+  _target_: verl_omni.trainer.config.OmniAlgoConfig
+
+  # Trainer loop.
+  trainer_type: direct_preference
+
+  # Sample provenance.
+  sample_source: offline
+
+  # True for pair-based algorithms such as offline DPO.
+  paired_preference: true
+
+  # Advantage estimator placeholder inherited by shared trainer utilities.
+  adv_estimator: dpo
+
+  # Whether to normalize advantages by std.
+  norm_adv_by_std_in_grpo: true
+
+  # Whether to normalize advantages using global standard deviation.
+  global_std: true

--- a/verl_omni/trainer/omni/omni_algos.py
+++ b/verl_omni/trainer/omni/omni_algos.py
@@ -1,0 +1,132 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Omni AR direct-preference loss functions."""
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+import torch
+import torch.nn.functional as F
+from tensordict import TensorDict
+
+from verl_omni.workers.config.omni import OmniLossConfig
+
+__all__ = [
+    "OmniLossResult",
+    "OMNI_LOSS_REGISTRY",
+    "register_omni_loss",
+    "get_omni_loss_fn",
+    "OmniDPOLoss",
+]
+
+
+@dataclass
+class OmniLossResult:
+    loss: torch.Tensor
+    metrics: dict[str, Any]
+
+
+OMNI_LOSS_REGISTRY: dict[str, Any] = {}
+
+
+def register_omni_loss(name: str) -> Callable[[type], type]:
+    """Register a worker-side omni loss function class."""
+
+    def decorator(cls: type) -> type:
+        OMNI_LOSS_REGISTRY[name] = cls()
+        return cls
+
+    return decorator
+
+
+def get_omni_loss_fn(name: str):
+    """Return the registered omni loss function for ``name``."""
+    if name not in OMNI_LOSS_REGISTRY:
+        raise ValueError(f"Unsupported omni loss mode: {name}. Supported modes are: {list(OMNI_LOSS_REGISTRY.keys())}")
+    return OMNI_LOSS_REGISTRY[name]
+
+
+@register_omni_loss("dpo")
+class OmniDPOLoss:
+    """Bradley-Terry DPO on sequence-level policy vs. reference log-probs."""
+
+    required_model_output_keys: tuple[str, ...] = (
+        "policy_chosen_logps",
+        "policy_rejected_logps",
+        "reference_chosen_logps",
+        "reference_rejected_logps",
+    )
+
+    def validate_inputs(self, *, model_output: dict[str, Any], data: TensorDict) -> None:
+        del data
+        missing_model_output = [key for key in self.required_model_output_keys if key not in model_output]
+        if missing_model_output:
+            available = sorted(str(key) for key in model_output.keys())
+            raise KeyError(
+                "Omni DPO loss is missing required model_output keys: "
+                f"{missing_model_output}. Available model_output keys: {available}."
+            )
+
+    @staticmethod
+    def compute_loss(
+        *,
+        policy_chosen_logps: torch.Tensor,
+        policy_rejected_logps: torch.Tensor,
+        reference_chosen_logps: torch.Tensor,
+        reference_rejected_logps: torch.Tensor,
+        beta: float,
+        label_smoothing: float = 0.0,
+        loss_type: str = "sigmoid",
+    ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
+        pi_logratios = policy_chosen_logps - policy_rejected_logps
+        ref_logratios = reference_chosen_logps - reference_rejected_logps
+        logits = pi_logratios - ref_logratios
+        if loss_type == "ipo":
+            losses = (logits - 1 / (2 * beta)) ** 2
+        else:
+            losses = (
+                -F.logsigmoid(beta * logits) * (1 - label_smoothing) - F.logsigmoid(-beta * logits) * label_smoothing
+            )
+        chosen_rewards = beta * (policy_chosen_logps - reference_chosen_logps).detach()
+        rejected_rewards = beta * (policy_rejected_logps - reference_rejected_logps).detach()
+        loss = losses.mean()
+        metrics = {
+            "dpo_loss": loss.detach(),
+            "chosen_rewards": chosen_rewards.mean().detach(),
+            "rejected_rewards": rejected_rewards.mean().detach(),
+            "reward_accuracy": (chosen_rewards > rejected_rewards).float().mean().detach(),
+            "reward_margin": (chosen_rewards - rejected_rewards).mean().detach(),
+        }
+        return loss, metrics
+
+    def __call__(
+        self,
+        *,
+        config: Any,
+        model_output: dict[str, Any],
+        data: TensorDict,
+    ) -> OmniLossResult:
+        self.validate_inputs(model_output=model_output, data=data)
+        dpo_config: OmniLossConfig = config.omni_loss
+        loss, metrics = self.compute_loss(
+            policy_chosen_logps=model_output["policy_chosen_logps"],
+            policy_rejected_logps=model_output["policy_rejected_logps"],
+            reference_chosen_logps=model_output["reference_chosen_logps"],
+            reference_rejected_logps=model_output["reference_rejected_logps"],
+            beta=dpo_config.beta,
+            label_smoothing=dpo_config.label_smoothing,
+            loss_type=dpo_config.loss_type,
+        )
+        return OmniLossResult(loss=loss, metrics=metrics)

--- a/verl_omni/workers/config/omni/__init__.py
+++ b/verl_omni/workers/config/omni/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from . import model
-from .actor import OmniLossConfig
+from .actor import OmniActorConfig, OmniLossConfig
 from .model import *  # noqa: F401
 
-__all__ = list(model.__all__) + ["OmniLossConfig"]
+__all__ = list(model.__all__) + ["OmniLossConfig", "OmniActorConfig"]

--- a/verl_omni/workers/config/omni/__init__.py
+++ b/verl_omni/workers/config/omni/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from . import model
+from .actor import OmniLossConfig
 from .model import *  # noqa: F401
 
-__all__ = model.__all__
+__all__ = list(model.__all__) + ["OmniLossConfig"]

--- a/verl_omni/workers/config/omni/actor.py
+++ b/verl_omni/workers/config/omni/actor.py
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from verl.base_config import BaseConfig
+from verl.workers.config import FSDPActorConfig
 
 __all__ = [
     "OmniLossConfig",
+    "OmniActorConfig",
 ]
 
 
@@ -78,3 +80,20 @@ class OmniLossConfig(BaseConfig):
             raise ValueError(f"Invalid omni DPO loss_type={self.loss_type!r}; expected 'sigmoid' or 'ipo'.")
         if self.beta <= 0:
             raise ValueError(f"Omni DPO beta must be positive, got {self.beta}.")
+
+
+@dataclass
+class OmniActorConfig(FSDPActorConfig):
+    """FSDP actor config for omni model training."""
+
+    trainer_type: str = "direct_preference"  # "direct_preference" or "policy_gradient"
+    omni_loss: OmniLossConfig = field(default_factory=OmniLossConfig)
+
+    def __post_init__(self):
+        super().__post_init__()
+        if self.trainer_type not in ["direct_preference", "policy_gradient"]:
+            raise ValueError(
+                f"Invalid omni trainer_type={self.trainer_type}; expected ['direct_preference', 'policy_gradient']."
+            )
+        if self.trainer_type == "direct_preference" and self.omni_loss is None:
+            raise ValueError("OmniActorConfig.omni_loss is required for direct_preference training.")

--- a/verl_omni/workers/config/omni/actor.py
+++ b/verl_omni/workers/config/omni/actor.py
@@ -1,0 +1,80 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+
+from verl.base_config import BaseConfig
+
+__all__ = [
+    "OmniLossConfig",
+]
+
+
+@dataclass
+class OmniLossConfig(BaseConfig):
+    """Loss hyperparameters for omni AR **direct-preference** training.
+
+    Which config block to use depends on ``algorithm.trainer_type`` (``OmniAlgoConfig``):
+
+    * ``policy_gradient`` (online RL: GSPO, GRPO, PPO, …): use verl's inherited
+      ``actor_rollout_ref.actor.policy_loss`` (``PolicyLossConfig``) and sibling
+      ``actor`` fields such as ``clip_ratio_low``, ``clip_ratio_high``,
+      ``loss_agg_mode``, ``use_kl_loss``, and ``kl_loss_coef``. Those are consumed
+      by ``verl.trainer.ppo.core_algos`` via ``get_policy_loss_fn()``. This
+      dataclass is **not** read on that path.
+    * ``direct_preference`` (offline/online DPO): use this block at YAML path
+      ``actor_rollout_ref.actor.omni_loss``. Consumed by
+      ``verl_omni.trainer.omni.omni_algos`` (``OmniDPOLoss``) and
+      ``OmniDirectPreferenceRayTrainer``.
+
+    Field reference (``direct_preference`` only)
+    --------------------------------------------
+
+    loss_mode:
+        Preference loss registry key. Currently only ``"dpo"`` is supported.
+    beta:
+        DPO inverse temperature β. Scales the log-probability margin between
+        policy and reference on chosen vs. rejected pairs before the sigmoid/IPO
+        loss. Typical values for token-level AR DPO are ~0.01–0.5 (default 0.1).
+    label_smoothing:
+        Label smoothing for the Bradley-Terry sigmoid DPO loss (cDPO). ``0.0``
+        disables smoothing; values in ``(0, 1)`` soften chosen/rejected targets.
+        Ignored when ``loss_type="ipo"``.
+    loss_type:
+        ``"sigmoid"`` — standard DPO ``-log σ(β·Δlogπ)``; ``"ipo"`` — identity
+        preference optimization (squared error on the implicit reward).
+    average_log_prob:
+        If ``True``, sequence log-probs are averaged over response tokens before
+        the pairwise DPO margin; if ``False``, token log-probs are summed (TRL
+        default). Passed through the engine micro-batch for log-prob aggregation.
+    refer_model_precision:
+        Parameter dtype for the reference (frozen) policy during ref log-prob
+        computation, e.g. ``"bfloat16"`` or ``"float32"``. Policy (trainable)
+        precision is controlled separately by ``actor.fsdp_config.model_dtype``.
+    """
+
+    loss_mode: str = "dpo"
+    beta: float = 0.1
+    label_smoothing: float = 0.0
+    loss_type: str = "sigmoid"
+    average_log_prob: bool = False
+    refer_model_precision: str = "bfloat16"
+
+    def __post_init__(self):
+        if self.loss_mode not in {"dpo"}:
+            raise ValueError(f"Unsupported omni loss_mode={self.loss_mode!r}; currently supported: ['dpo'].")
+        if self.loss_type not in {"sigmoid", "ipo"}:
+            raise ValueError(f"Invalid omni DPO loss_type={self.loss_type!r}; expected 'sigmoid' or 'ipo'.")
+        if self.beta <= 0:
+            raise ValueError(f"Omni DPO beta must be positive, got {self.beta}.")

--- a/verl_omni/workers/config/omni/actor.py
+++ b/verl_omni/workers/config/omni/actor.py
@@ -29,7 +29,7 @@ class OmniLossConfig(BaseConfig):
 
     Which config block to use depends on ``algorithm.trainer_type`` (``OmniAlgoConfig``):
 
-    * ``policy_gradient`` (online RL: GSPO, GRPO, PPO, …): use verl's inherited
+    * policy_gradient (online RL: GSPO, GRPO, PPO, …): use verl's inherited
       ``actor_rollout_ref.actor.policy_loss`` (``PolicyLossConfig``) and sibling
       ``actor`` fields such as ``clip_ratio_low``, ``clip_ratio_high``,
       ``loss_agg_mode``, ``use_kl_loss``, and ``kl_loss_coef``. Those are consumed

--- a/verl_omni/workers/config/omni/actor.py
+++ b/verl_omni/workers/config/omni/actor.py
@@ -25,45 +25,45 @@ __all__ = [
 
 @dataclass
 class OmniLossConfig(BaseConfig):
-    """Loss hyperparameters for omni AR **direct-preference** training.
+    """Loss hyperparameters for omni AR direct-preference training.
 
-    Which config block to use depends on ``algorithm.trainer_type`` (``OmniAlgoConfig``):
+    Which config block to use depends on algorithm.trainer_type (OmniAlgoConfig):
 
-    * policy_gradient (online RL: GSPO, GRPO, PPO, …): use verl's inherited
-      ``actor_rollout_ref.actor.policy_loss`` (``PolicyLossConfig``) and sibling
-      ``actor`` fields such as ``clip_ratio_low``, ``clip_ratio_high``,
-      ``loss_agg_mode``, ``use_kl_loss``, and ``kl_loss_coef``. Those are consumed
-      by ``verl.trainer.ppo.core_algos`` via ``get_policy_loss_fn()``. This
-      dataclass is **not** read on that path.
-    * ``direct_preference`` (offline/online DPO): use this block at YAML path
-      ``actor_rollout_ref.actor.omni_loss``. Consumed by
-      ``verl_omni.trainer.omni.omni_algos`` (``OmniDPOLoss``) and
-      ``OmniDirectPreferenceRayTrainer``.
+    * policy_gradient (online RL: GSPO, GRPO, PPO, ...): use verl's inherited
+      actor_rollout_ref.actor.policy_loss (PolicyLossConfig) and sibling
+      actor fields such as clip_ratio_low, clip_ratio_high,
+      loss_agg_mode, use_kl_loss, and kl_loss_coef. Those are consumed
+      by verl.trainer.ppo.core_algos via get_policy_loss_fn(). This
+      dataclass is not read on that path.
+    * direct_preference (offline/online DPO): use this block at YAML path
+      actor_rollout_ref.actor.omni_loss. Consumed by
+      verl_omni.trainer.omni.omni_algos (OmniDPOLoss) and
+      OmniDirectPreferenceRayTrainer.
 
-    Field reference (``direct_preference`` only)
-    --------------------------------------------
+    Field reference (direct_preference only)
+    ----------------------------------------
 
     loss_mode:
-        Preference loss registry key. Currently only ``"dpo"`` is supported.
+        Preference loss registry key. Currently only "dpo" is supported.
     beta:
         DPO inverse temperature β. Scales the log-probability margin between
         policy and reference on chosen vs. rejected pairs before the sigmoid/IPO
         loss. Typical values for token-level AR DPO are ~0.01–0.5 (default 0.1).
     label_smoothing:
-        Label smoothing for the Bradley-Terry sigmoid DPO loss (cDPO). ``0.0``
-        disables smoothing; values in ``(0, 1)`` soften chosen/rejected targets.
-        Ignored when ``loss_type="ipo"``.
+        Label smoothing for the Bradley-Terry sigmoid DPO loss (cDPO). 0.0
+        disables smoothing; values in (0, 1) soften chosen/rejected targets.
+        Ignored when loss_type="ipo".
     loss_type:
-        ``"sigmoid"`` — standard DPO ``-log σ(β·Δlogπ)``; ``"ipo"`` — identity
+        "sigmoid" — standard DPO -log σ(β·Δlogπ); "ipo" — identity
         preference optimization (squared error on the implicit reward).
     average_log_prob:
-        If ``True``, sequence log-probs are averaged over response tokens before
-        the pairwise DPO margin; if ``False``, token log-probs are summed (TRL
+        If True, sequence log-probs are averaged over response tokens before
+        the pairwise DPO margin; if False, token log-probs are summed (TRL
         default). Passed through the engine micro-batch for log-prob aggregation.
     refer_model_precision:
         Parameter dtype for the reference (frozen) policy during ref log-prob
-        computation, e.g. ``"bfloat16"`` or ``"float32"``. Policy (trainable)
-        precision is controlled separately by ``actor.fsdp_config.model_dtype``.
+        computation, e.g. "bfloat16" or "float32". Policy (trainable)
+        precision is controlled separately by actor.fsdp_config.model_dtype.
     """
 
     loss_mode: str = "dpo"

--- a/verl_omni/workers/config/omni/model.py
+++ b/verl_omni/workers/config/omni/model.py
@@ -44,7 +44,6 @@ class OmniModelConfig(BaseConfig):
         "hf_config_path",
         "tokenizer_path",
         "tokenizer",
-        "hf_config_path",
         "processor",
         "local_path",
         "local_tokenizer_path",

--- a/verl_omni/workers/config/omni/model.py
+++ b/verl_omni/workers/config/omni/model.py
@@ -41,6 +41,7 @@ class OmniModelConfig(BaseConfig):
         "model_type",
         "architecture",
         "model_stage",
+        "hf_config_path",
         "tokenizer_path",
         "tokenizer",
         "hf_config_path",
@@ -102,6 +103,7 @@ class OmniModelConfig(BaseConfig):
     # fsdp / megatron lora related
     lora_rank: int = 0
     lora_alpha: int = 16
+    lora_init_weights: str = "gaussian"
     target_modules: Optional[Any] = "all-linear"  # allow both "all-linear" and ["q_proj", "k_proj"]
     target_parameters: Optional[list[str]] = None  # for lora adapter on nn.Parameter
     exclude_modules: Optional[str] = None
@@ -114,6 +116,15 @@ class OmniModelConfig(BaseConfig):
 
     # path to pre-trained LoRA adapter to load for continued training
     lora_adapter_path: Optional[str] = None
+
+    # Named LoRA policy states required by the algorithm. "reference" uses disabled adapters.
+    policy_state_adapters: tuple[str, ...] = ("default",)
+
+    # dtype to convert LoRA parameters to (e.g., "fp32", "bf16"). Default None means no conversion.
+    lora_dtype: Optional[str] = None
+
+    # FSDP layer name prefixes for LoRA parameter layered summon.
+    fsdp_layer_prefixes: list[str] = field(default_factory=list)
 
     use_liger: bool = False
 

--- a/verl_omni/workers/config/omni/model.py
+++ b/verl_omni/workers/config/omni/model.py
@@ -120,9 +120,6 @@ class OmniModelConfig(BaseConfig):
     # Named LoRA policy states required by the algorithm. "reference" uses disabled adapters.
     policy_state_adapters: tuple[str, ...] = ("default",)
 
-    # dtype to convert LoRA parameters to (e.g., "fp32", "bf16"). Default None means no conversion.
-    lora_dtype: Optional[str] = None
-
     # FSDP layer name prefixes for LoRA parameter layered summon.
     fsdp_layer_prefixes: list[str] = field(default_factory=list)
 

--- a/verl_omni/workers/engine_workers.py
+++ b/verl_omni/workers/engine_workers.py
@@ -344,9 +344,18 @@ class TrainingWorker(Worker, DistProfilerExtension):
             total_num_iterations = data.shape[0] // mini_batch_size_per_gpu * epochs
 
             for batch_idx, mini_batch_td in enumerate(dataloader):
-                # add global token num
+                # Per-sequence token counts for MFU (``FlopsCounter`` in ``_postprocess_output``).
+                # Batch layout depends on the dataloader / engine path:
+                #   - Packed remove-padding (NestedTensor): ``input_ids.offsets().diff()``.
+                #   - Dense padded batches (with attention mask): ``attention_mask.sum(-1)``.
                 if "input_ids" in mini_batch_td:
-                    global_token_num = mini_batch_td["input_ids"].offsets().diff().tolist()  # (total_nnz,)
+                    input_ids = mini_batch_td["input_ids"]
+                    if hasattr(input_ids, "offsets"):
+                        global_token_num = input_ids.offsets().diff().tolist()  # (total_nnz,)
+                    elif "attention_mask" in mini_batch_td:
+                        global_token_num = mini_batch_td["attention_mask"].sum(dim=-1).reshape(-1).tolist()
+                    else:
+                        raise ValueError(f"input_ids has no offsets or attention_mask: {mini_batch_td}")
                     # allgather from dp rank
                     global_token_num_output = [None] * torch.distributed.get_world_size(
                         self.engine.get_data_parallel_group()
@@ -374,11 +383,14 @@ class TrainingWorker(Worker, DistProfilerExtension):
                     for key, val in output.items():
                         # flattn dp and micro batch
                         if isinstance(val, list):
+                            flattened_val = list(chain.from_iterable(val)) if val and isinstance(val[0], list) else val
                             output[key] = (
-                                Metric.aggregate_dp(val)
-                                if isinstance(val[0], Metric)
-                                else list(chain.from_iterable(val))
+                                Metric.aggregate_dp(flattened_val)
+                                if flattened_val and isinstance(flattened_val[0], Metric)
+                                else flattened_val
                             )
+                        elif isinstance(val, Metric):
+                            output[key] = val.aggregate()
                     append_to_dict(metrics, output)
 
                 output = tu.get_tensordict(tensor_dict={}, non_tensor_dict={"metrics": metrics}).cpu()
@@ -595,6 +607,8 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
 
             # The ref model does not need to enable MTP; force it to false.
             ref_config.model_config = deepcopy(model_config)
+            if ref_config.model_config.get("model_type", "language_model") == "omni_model":
+                ref_config.model_config.trainer_type = self.config.actor.get("trainer_type", "policy_gradient")
             ref_config.model_config.mtp = MtpConfig(enable=False)
 
             # construct TrainingWorkerConfig
@@ -632,6 +646,8 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
         if "actor" in self.role:
             actor_config: ActorConfig = omega_conf_to_dataclass(self.config.actor)
             actor_config.model_config = model_config
+            if actor_config.model_config.get("model_type", "language_model") == "omni_model":
+                actor_config.model_config.trainer_type = getattr(actor_config, "trainer_type", "policy_gradient")
             distillation_config: Optional[DistillationConfig] = (
                 omega_conf_to_dataclass(self.distillation_config) if self.distillation_enabled else None
             )

--- a/verl_omni/workers/engine_workers.py
+++ b/verl_omni/workers/engine_workers.py
@@ -65,7 +65,7 @@ from verl_omni.workers.config import (
     DiffusionModelConfig,
     OmniModelConfig,
 )
-from verl_omni.workers.utils.losses import diffusion_loss
+from verl_omni.workers.utils.losses import diffusion_loss, omni_loss
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
@@ -695,6 +695,11 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
                 "diffusion_nft_model",
             ):
                 self.loss_fn = partial(diffusion_loss, config=actor_config)
+            elif (
+                model_config.get("model_type", "language_model") == "omni_model"
+                and getattr(actor_config, "trainer_type", "policy_gradient") == "direct_preference"
+            ):
+                self.loss_fn = partial(omni_loss, config=actor_config)
             else:
                 self.loss_fn = partial(ppo_loss, config=actor_config)
             self.actor = TrainingWorker(config=actor_training_config)

--- a/verl_omni/workers/engine_workers.py
+++ b/verl_omni/workers/engine_workers.py
@@ -65,7 +65,7 @@ from verl_omni.workers.config import (
     DiffusionModelConfig,
     OmniModelConfig,
 )
-from verl_omni.workers.utils.losses import diffusion_loss, omni_loss
+from verl_omni.workers.utils.losses import diffusion_loss
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
@@ -344,18 +344,9 @@ class TrainingWorker(Worker, DistProfilerExtension):
             total_num_iterations = data.shape[0] // mini_batch_size_per_gpu * epochs
 
             for batch_idx, mini_batch_td in enumerate(dataloader):
-                # Per-sequence token counts for MFU (``FlopsCounter`` in ``_postprocess_output``).
-                # Batch layout depends on the dataloader / engine path:
-                #   - Packed remove-padding (NestedTensor): ``input_ids.offsets().diff()``.
-                #   - Dense padded batches (with attention mask): ``attention_mask.sum(-1)``.
+                # add global token num
                 if "input_ids" in mini_batch_td:
-                    input_ids = mini_batch_td["input_ids"]
-                    if hasattr(input_ids, "offsets"):
-                        global_token_num = input_ids.offsets().diff().tolist()  # (total_nnz,)
-                    elif "attention_mask" in mini_batch_td:
-                        global_token_num = mini_batch_td["attention_mask"].sum(dim=-1).reshape(-1).tolist()
-                    else:
-                        raise ValueError(f"input_ids has no offsets or attention_mask: {mini_batch_td}")
+                    global_token_num = mini_batch_td["input_ids"].offsets().diff().tolist()  # (total_nnz,)
                     # allgather from dp rank
                     global_token_num_output = [None] * torch.distributed.get_world_size(
                         self.engine.get_data_parallel_group()
@@ -383,14 +374,11 @@ class TrainingWorker(Worker, DistProfilerExtension):
                     for key, val in output.items():
                         # flattn dp and micro batch
                         if isinstance(val, list):
-                            flattened_val = list(chain.from_iterable(val)) if val and isinstance(val[0], list) else val
                             output[key] = (
-                                Metric.aggregate_dp(flattened_val)
-                                if flattened_val and isinstance(flattened_val[0], Metric)
-                                else flattened_val
+                                Metric.aggregate_dp(val)
+                                if isinstance(val[0], Metric)
+                                else list(chain.from_iterable(val))
                             )
-                        elif isinstance(val, Metric):
-                            output[key] = val.aggregate()
                     append_to_dict(metrics, output)
 
                 output = tu.get_tensordict(tensor_dict={}, non_tensor_dict={"metrics": metrics}).cpu()
@@ -607,8 +595,6 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
 
             # The ref model does not need to enable MTP; force it to false.
             ref_config.model_config = deepcopy(model_config)
-            if ref_config.model_config.get("model_type", "language_model") == "omni_model":
-                ref_config.model_config.trainer_type = self.config.actor.get("trainer_type", "policy_gradient")
             ref_config.model_config.mtp = MtpConfig(enable=False)
 
             # construct TrainingWorkerConfig
@@ -646,8 +632,6 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
         if "actor" in self.role:
             actor_config: ActorConfig = omega_conf_to_dataclass(self.config.actor)
             actor_config.model_config = model_config
-            if actor_config.model_config.get("model_type", "language_model") == "omni_model":
-                actor_config.model_config.trainer_type = getattr(actor_config, "trainer_type", "policy_gradient")
             distillation_config: Optional[DistillationConfig] = (
                 omega_conf_to_dataclass(self.distillation_config) if self.distillation_enabled else None
             )
@@ -711,11 +695,6 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
                 "diffusion_nft_model",
             ):
                 self.loss_fn = partial(diffusion_loss, config=actor_config)
-            elif (
-                model_config.get("model_type", "language_model") == "omni_model"
-                and getattr(actor_config, "trainer_type", "policy_gradient") == "direct_preference"
-            ):
-                self.loss_fn = partial(omni_loss, config=actor_config)
             else:
                 self.loss_fn = partial(ppo_loss, config=actor_config)
             self.actor = TrainingWorker(config=actor_training_config)

--- a/verl_omni/workers/utils/losses.py
+++ b/verl_omni/workers/utils/losses.py
@@ -19,7 +19,8 @@ from verl.utils import tensordict_utils as tu
 from verl.utils.metric import AggregationType, Metric
 
 from verl_omni.trainer.diffusion.diffusion_algos import get_diffusion_loss_fn
-from verl_omni.workers.config import DiffusionActorConfig
+from verl_omni.trainer.omni.omni_algos import get_omni_loss_fn
+from verl_omni.workers.config import DiffusionActorConfig, OmniActorConfig
 
 
 def _apply_bypass_rc(
@@ -115,6 +116,30 @@ def diffusion_loss(config: DiffusionActorConfig, model_output, data: TensorDict,
 
     sp_size = tu.get_non_tensor_data(data, "sp_size", default=None)
     if sp_size > 1:
+        loss_value = loss_value * sp_size
+
+    return loss_value, metrics
+
+
+def omni_loss(config: OmniActorConfig, model_output, data: TensorDict, dp_group=None):
+    """Compute loss for omni AR direct-preference training."""
+    del dp_group
+    metrics = {}
+
+    loss_mode = config.omni_loss.loss_mode
+    loss_func = get_omni_loss_fn(loss_mode)
+    loss_func.validate_inputs(model_output=model_output, data=data)
+    loss_result = loss_func(config=config, model_output=model_output, data=data)
+    loss_value = loss_result.loss
+    metrics.update(Metric.from_dict(loss_result.metrics, aggregation=AggregationType.MEAN))
+    metrics["actor/loss"] = Metric(value=loss_value, aggregation=AggregationType.MEAN)
+
+    gradient_accumulation_steps = tu.get_non_tensor_data(data, "gradient_accumulation_steps", default=None)
+    if gradient_accumulation_steps:
+        loss_value = loss_value / gradient_accumulation_steps
+
+    sp_size = tu.get_non_tensor_data(data, "sp_size", default=None)
+    if sp_size is not None and sp_size > 1:
         loss_value = loss_value * sp_size
 
     return loss_value, metrics

--- a/verl_omni/workers/utils/losses.py
+++ b/verl_omni/workers/utils/losses.py
@@ -123,7 +123,7 @@ def diffusion_loss(config: DiffusionActorConfig, model_output, data: TensorDict,
 
 def omni_loss(config: OmniActorConfig, model_output, data: TensorDict, dp_group=None):
     """Compute loss for omni AR direct-preference training."""
-    del dp_group
+
     metrics = {}
 
     loss_mode = config.omni_loss.loss_mode


### PR DESCRIPTION
## Summary

Implements the **config + loss** slice of [Issue #266](https://github.com/verl-project/verl-omni/issues/266) (Qwen3-Omni offline DPO framework). This PR lands the Hydra/dataclass contracts and a CPU-tested DPO loss registry that later phases can consume.

- Add `OmniAlgoConfig` (`trainer_type`, `sample_source`, `paired_preference`, …) for routing offline DPO vs online policy-gradient paths.
- Add `OmniLossConfig` + extend `omni_trainer.yaml` with offline DPO defaults (`direct_preference`, `omni_loss.loss_mode=dpo`).
- Add `verl_omni/trainer/omni/omni_algos.py`: `register_omni_loss`, `get_omni_loss_fn`, `OmniDPOLoss` (sigmoid + IPO, label smoothing).
- Add L1 CPU tests for config dataclasses and DPO loss numerics.

## Motivation

Issue #266 Phase 0/2 needs a stable config surface and loss implementation before FSDP engine + trainer loop land. This mirrors the diffusion stack (`DiffusionAlgoConfig` / `DiffusionLossConfig` / `diffusion_algos.py`) but for omni AR direct-preference training.

**Config routing (documented in `OmniLossConfig` docstring):**
- `algorithm.trainer_type=policy_gradient` → verl `actor.policy_loss` (GSPO/GRPO/PPO)
- `algorithm.trainer_type=direct_preference` → `actor.omni_loss` → `OmniDPOLoss`

## Changes

| File | What |
|------|------|
| `verl_omni/trainer/config/algorithm.py` | `OmniAlgoConfig` |
| `verl_omni/workers/config/omni/actor.py` | `OmniLossConfig` + field docstring |
| `verl_omni/trainer/config/omni_trainer.yaml` | offline DPO defaults on top of `ppo_trainer` |
| `verl_omni/trainer/omni/omni_algos.py` | `OmniDPOLoss` registry |
| `tests/workers/config/test_omni_config_on_cpu.py` | config validation tests |
| `tests/trainer/omni/test_omni_algos_on_cpu.py` | DPO loss CPU tests (importlib bootstrap) |

## Out of scope (follow-up PRs)

- `main_omni` dual-path entrypoint (P0.2)
- `prepare_training_inputs` / `OmniFSDPEngine` (P1)
- `OmniDirectPreferenceRayTrainer` + ref-in-actor loop (P2.2+)
- Dataset / collate / e2e smoke (P3)


## Test plan

- [x] `python -m pytest tests/trainer/omni/test_omni_algos_on_cpu.py -q` 
- [x] `python -m pytest tests/workers/config/test_omni_config_on_cpu.py -q` 
- [ ] Hydra compose `omni_trainer.yaml` on CI (if config generation check is enabled)
