### PR TITLE
[doc] feat: add Qwen-Image-Edit and I2I integration guides

### DIFF
--- a/docs/contributing/integrating_an_i2i_diffusion_model.md
+++ b/docs/contributing/integrating_an_i2i_diffusion_model.md
@@ -11,7 +11,7 @@ contracts. Read that guide first.
 The worked example is the Qwen-Image-Edit-Plus implementation in
 [`verl_omni/pipelines/qwen_image_edit_flow_grpo/`](../../verl_omni/pipelines/qwen_image_edit_flow_grpo/__init__.py).
 For instructions on running that model, see
-[Train Qwen-Image-Edit-2511 with FlowGRPO](../start/qwen_image_edit.md).
+[Train Qwen-Image-Edit-2511 with FlowGRPO](../../examples/flowgrpo_trainer/qwen_image_edit/README.md).
 
 ## TL;DR
 
@@ -442,7 +442,7 @@ The prompt template, image placeholders, and processor calls must agree. A
 placeholder/image-count mismatch usually fails in the VLM encoder; a prompt
 template mismatch can silently change policy behavior.
 
-Use the [Qwen-Image-Edit training guide](../start/qwen_image_edit.md) as a
+Use the [Qwen-Image-Edit training guide](../../examples/flowgrpo_trainer/qwen_image_edit/README.md) as a
 complete example of raw data conversion, parquet schema, launcher overrides,
 and model-specific constraints.
 

--- a/docs/contributing/integrating_an_i2i_diffusion_model.md
+++ b/docs/contributing/integrating_an_i2i_diffusion_model.md
@@ -1,0 +1,487 @@
+# How to Integrate an Image-to-Image Diffusion Model
+
+Last updated: 07/14/2026.
+
+This guide explains the image-to-image (I2I) contracts required to add a new
+image-edit diffusion model to VeRL-Omni. It builds on
+[`integrating_a_diffusion_model.md`](integrating_a_diffusion_model.md), which
+covers the shared FlowGRPO scheduler, registry, rollout, training, and testing
+contracts. Read that guide first.
+
+The worked example is the Qwen-Image-Edit-Plus implementation in
+[`verl_omni/pipelines/qwen_image_edit_flow_grpo/`](../../verl_omni/pipelines/qwen_image_edit_flow_grpo/__init__.py).
+For instructions on running that model, see
+[Train Qwen-Image-Edit-2511 with FlowGRPO](../start/qwen_image_edit.md).
+
+## TL;DR
+
+An I2I integration uses the same three-file package and dual registries as a
+T2I integration. The additional work is to:
+
+1. Transport condition images from the dataset to the rollout request.
+2. Encode condition images for the text/vision encoder when required.
+3. VAE-encode condition images and inject their latents into the transformer.
+4. Return condition tensors and metadata with the rollout trajectory.
+5. Reconstruct the same condition input during training-time log-probability
+   recomputation.
+
+For concat-conditioned models, inherit `DiffusionI2IModelBase`, implement
+`prepare_condition`, and extend `inject_condition` only for model-specific
+metadata such as spatial shapes or position IDs.
+
+## Mental Model
+
+An I2I adapter serves two execution contexts:
+
+| Context | Runtime | I2I responsibility |
+|---|---|---|
+| Rollout | vLLM-Omni | Parse condition images, encode text/image features, VAE-encode condition images, run stochastic denoising, and return condition fields with the trajectory. |
+| Training | diffusers + FSDP | Reconstruct one denoising step, inject condition tensors into transformer inputs, and recompute the policy log-probability. |
+
+The rollout and training sides must use the same:
+
+- Architecture and algorithm registry keys.
+- Condition-image preprocessing and latent layout.
+- Transformer input construction and output slicing.
+- Scheduler, timestep scaling, CFG rule, and output sign.
+- Condition metadata such as spatial shapes and position IDs.
+
+For concat-conditioned models such as Qwen-Image-Edit, the data flow is:
+
+```text
+parquet images
+    -> agent loop decodes condition image
+    -> vLLM-Omni request preprocessing
+    -> rollout adapter VAE-encodes condition image
+    -> transformer([target noise | condition latent])
+    -> rollout custom_output["condition_image_latents"]
+    -> training micro-batch
+    -> prepare_condition()
+    -> inject_condition()
+    -> transformer([target noise | condition latent])
+    -> crop prediction to target token length
+```
+
+## Prerequisites
+
+Before adding VeRL-Omni adapters, the model should already have:
+
+- A diffusers transformer and reference inference pipeline.
+- A vLLM-Omni pipeline that can preprocess condition images, VAE-encode them,
+  and decode generated latents.
+- A known-good inference recipe, including prompt template, scheduler,
+  timestep convention, CFG behavior, and VAE normalization.
+
+If either upstream runtime cannot load and run the model, add support there
+first.
+
+## Step 1: Compare the Upstream T2I and I2I Pipelines
+
+If the model family already has a T2I pipeline, identify only what the I2I
+pipeline adds. Record these details before writing code:
+
+1. How condition images enter the request.
+2. Whether the text encoder consumes image features or text only.
+3. How condition images are resized and VAE-encoded.
+4. Whether condition latents are concatenated, used by cross-attention, or
+   injected through another path.
+5. Which position metadata changes after adding condition tokens.
+6. Which part of the transformer output corresponds to target tokens.
+7. Whether positive and negative CFG passes use the same condition image.
+8. The exact timestep scaling and scheduler inputs.
+
+Reuse the T2I adapter when these behaviors are unchanged. Keep model-specific
+I2I logic in the new model package.
+
+## Step 2: Scaffold and Register the Package
+
+Create the same three-file package used by T2I integrations:
+
+```text
+verl_omni/pipelines/<model>_flow_grpo/
+|-- __init__.py
+|-- diffusers_training_adapter.py
+`-- vllm_omni_rollout_adapter.py
+```
+
+Export both adapters from `__init__.py`:
+
+```python
+from .diffusers_training_adapter import MyEditModel
+from .vllm_omni_rollout_adapter import MyEditPipelineWithLogProb
+
+__all__ = ["MyEditModel", "MyEditPipelineWithLogProb"]
+```
+
+Import the package from
+[`verl_omni/pipelines/__init__.py`](../../verl_omni/pipelines/__init__.py) so
+the decorators run during startup.
+
+Both adapters register under the pair
+`(model_index.json::_class_name, algorithm)`. The architecture strings must
+match exactly:
+
+```python
+@DiffusionModelBase.register("MyEditPipeline", algorithm="flow_grpo")
+class MyEditModel(...):
+    ...
+
+
+@VllmOmniPipelineBase.register("MyEditPipeline", algorithm="flow_grpo")
+class MyEditPipelineWithLogProb(...):
+    ...
+```
+
+## Step 3: Implement the Training Adapter
+
+### Reuse an existing T2I adapter
+
+When the model family already has a T2I FlowGRPO adapter, inherit
+[`DiffusionI2IModelBase`](../../verl_omni/pipelines/model_base.py) and that T2I
+adapter:
+
+```python
+from verl_omni.pipelines.model_base import DiffusionI2IModelBase, DiffusionModelBase
+from verl_omni.pipelines.my_model_flow_grpo.diffusers_training_adapter import MyT2IModel
+
+
+@DiffusionModelBase.register("MyEditPipeline", algorithm="flow_grpo")
+class MyEditModel(DiffusionI2IModelBase, MyT2IModel):
+    @classmethod
+    def prepare_condition(cls, micro_batch, latents, step):
+        ...
+
+    @classmethod
+    def inject_condition(cls, model_inputs, negative_model_inputs, condition):
+        ...
+```
+
+This multiple-inheritance pattern reuses the T2I scheduler,
+`prepare_model_inputs`, and `forward_and_sample_previous_step` methods while
+adding I2I condition hooks.
+
+### Integrate an I2I-only model family
+
+If there is no reusable T2I adapter, inherit `DiffusionI2IModelBase` directly.
+Implement the scheduler, input preparation, and sampling methods described in
+the [T2I integration guide](integrating_a_diffusion_model.md), then implement
+the two I2I hooks:
+
+```python
+@DiffusionModelBase.register("MyEditPipeline", algorithm="flow_grpo")
+class MyEditModel(DiffusionI2IModelBase):
+    @classmethod
+    def build_scheduler(cls, model_config): ...
+
+    @classmethod
+    def set_timesteps(cls, scheduler, model_config, device): ...
+
+    @classmethod
+    def prepare_model_inputs(cls, module, model_config, latents, timesteps,
+                             prompt_embeds, prompt_embeds_mask,
+                             negative_prompt_embeds, negative_prompt_embeds_mask,
+                             micro_batch, step): ...
+
+    @classmethod
+    def forward_and_sample_previous_step(cls, module, scheduler, model_config,
+                                         model_inputs, negative_model_inputs,
+                                         scheduler_inputs, step): ...
+
+    @classmethod
+    def prepare_condition(cls, micro_batch, latents, step):
+        ...
+
+    @classmethod
+    def inject_condition(cls, model_inputs, negative_model_inputs, condition):
+        ...
+```
+
+### Implement `prepare_condition`
+
+This hook extracts condition fields from the training micro-batch. Most fields
+originate in rollout `custom_output`, while actor-only metadata such as
+`sp_size` is injected by the training engine. Return a non-empty dictionary.
+The dispatcher treats `None` as a missing rollout/data condition and fails
+closed.
+
+```python
+from verl.utils import tensordict_utils as tu
+
+
+@classmethod
+def prepare_condition(cls, micro_batch, latents, step):
+    del latents, step
+    image_latents = micro_batch.get("condition_image_latents", None)
+    if image_latents is None:
+        return None
+    return {
+        "image_latents": image_latents,
+        "img_shapes": tu.get(micro_batch, "img_shapes"),
+        "sp_size": tu.get(micro_batch, "sp_size"),
+    }
+```
+
+Use `condition_image_latents` as the micro-batch and rollout key. Do not use
+`image_latents`: that name is reserved by the MFU FLOPs counter for the
+denoised target latent. The hook maps the transport key to the
+`image_latents` field expected by `DiffusionI2IModelBase.inject_condition`.
+
+Tensor outputs are stored in the training `TensorDict`. Python metadata such
+as nested image-shape lists is transported as non-tensor data. Use TensorDict
+utilities to unwrap it before passing it to the transformer.
+
+Do not return `sp_size` from the rollout adapter. The FSDP engine assigns it to
+the actor micro-batch before `prepare_condition` runs, because rollout workers
+do not own the actor sequence-parallel configuration.
+
+### Implement `inject_condition`
+
+The base implementation supports the common concat-and-crop pattern:
+
+1. Concatenate `condition["image_latents"]` to `hidden_states` on the token
+   dimension.
+2. Store the original target sequence length in `_target_seq_len`.
+3. Apply the same concatenation to negative CFG inputs.
+4. Crop the transformer prediction to the target prefix in
+   `DiffusionI2IModelBase.forward`.
+
+Call the base implementation, then add model-specific metadata:
+
+```python
+@classmethod
+def inject_condition(cls, model_inputs, negative_model_inputs, condition):
+    model_inputs, negative_model_inputs = super().inject_condition(
+        model_inputs,
+        negative_model_inputs,
+        condition,
+    )
+
+    img_shapes = condition.get("img_shapes")
+    if img_shapes is not None:
+        model_inputs["img_shapes"] = img_shapes
+        if negative_model_inputs is not None:
+            negative_model_inputs["img_shapes"] = img_shapes
+
+    return model_inputs, negative_model_inputs
+```
+
+Qwen-Image-Edit replaces T2I `img_shapes` with metadata containing both target
+and condition shapes. A model with additional RoPE IDs should update those IDs
+here as well. A model that uses cross-attention or another conditioning
+mechanism should override the full method instead of calling the concat
+implementation.
+
+Validate sequence-parallel divisibility after determining both target and
+condition token counts. Padding condition tokens is usually incorrect because
+the padding participates in attention and positional encoding.
+
+### Prepare processor files when required
+
+Override `prepare_processor_files` only when the checkpoint's processor files
+need a model-specific fix before the driver calls `hf_processor()`:
+
+```python
+@classmethod
+def prepare_processor_files(cls, model_path: str) -> str | None:
+    ...
+```
+
+Return an alternate processor directory when appropriate, or `None` to use the
+default `<model_path>/processor` lookup. Keep the hook idempotent because the
+driver may restart.
+
+## Step 4: Implement the Rollout Adapter
+
+Subclass the upstream vLLM-Omni I2I pipeline and register the same
+architecture/algorithm pair:
+
+```python
+@VllmOmniPipelineBase.register("MyEditPipeline", algorithm="flow_grpo")
+class MyEditPipelineWithLogProb(MyUpstreamEditPipeline):
+    ...
+```
+
+The rollout adapter has five I2I-specific responsibilities.
+
+### 4.1 Parse condition images
+
+Use the shared
+[`ImageGenerationRequest`](../../verl_omni/pipelines/utils.py) parser instead
+of depending on one internal request layout:
+
+```python
+custom_prompt = req.prompts[0] if req.prompts else {}
+generation_request = ImageGenerationRequest.from_request_payload(custom_prompt)
+condition_images = generation_request.images
+if not condition_images:
+    raise ValueError("MyEditPipeline requires a condition image")
+```
+
+The parser normalizes images from top-level `images`/`image` fields,
+multimodal request data, and vLLM-Omni's `additional_information` fallback.
+Validate the supported number of images and aspect ratios before encoding.
+
+### 4.2 Encode prompts with image features when required
+
+For a VLM-based model such as Qwen-Image-Edit, the prompt contains image
+placeholder tokens. Move processor outputs to the text encoder's device and
+dtype before the forward call:
+
+```python
+image_inputs = self.processor.image_processor(
+    images=condition_images,
+    return_tensors="pt",
+)
+if attention_mask is None:
+    attention_mask = torch.ones_like(prompt_ids, dtype=torch.long)
+pixel_values = image_inputs["pixel_values"].to(
+    device=self.device,
+    dtype=self.text_encoder.dtype,
+)
+image_grid_thw = image_inputs["image_grid_thw"].to(self.device)
+
+encoder_hidden_states = self.text_encoder(
+    input_ids=prompt_ids.to(self.device),
+    attention_mask=attention_mask.to(self.device),
+    pixel_values=pixel_values,
+    image_grid_thw=image_grid_thw,
+    output_hidden_states=True,
+)
+```
+
+Apply the same condition images to positive and negative prompt encoding when
+the upstream CFG implementation does so. If the model uses a text-only
+encoder, do not add image placeholders merely to copy Qwen's format. Preserve
+the upstream prompt contract and provide an explicit condition-image transport
+path.
+
+### 4.3 Prepare condition latents and metadata
+
+Use the upstream pipeline's preprocessing and VAE helpers when possible. The
+rollout adapter must retain enough information to reproduce transformer inputs
+during training. For Qwen-Image-Edit this includes:
+
+- Packed condition image latents.
+- Target and condition spatial shapes used by 2D RoPE.
+- Positive and negative prompt embeddings and masks.
+
+Do not infer non-square spatial dimensions from packed sequence length alone.
+Carry explicit width/height or shape metadata when the transformer needs it.
+
+### 4.4 Concatenate during denoising and crop predictions
+
+The rollout and training paths must construct the same transformer input:
+
+```python
+latent_model_input = torch.cat([latents, condition_image_latents], dim=1)
+target_seq_len = latents.shape[1]
+
+noise_pred = self.transformer(
+    hidden_states=latent_model_input,
+    timestep=timestep / 1000,
+    img_shapes=img_shapes,
+    ...,
+)[0]
+noise_pred = noise_pred[:, :target_seq_len]
+```
+
+Match the upstream pipeline's timestep scaling, dtype casts, CFG formula, and
+prediction sign exactly. The scheduler should receive fp32 predictions and
+latents when the matching T2I FlowGRPO adapter does so.
+
+### 4.5 Return condition fields in `custom_output`
+
+Return every rollout-owned condition tensor and metadata field needed by
+`prepare_condition`, in addition to the standard FlowGRPO trajectory fields.
+Actor-owned metadata such as `sp_size` does not belong in `custom_output`. Use
+a null-safe CPU conversion because log-probabilities and negative prompt
+embeddings can be absent during validation or when CFG is disabled:
+
+```python
+def _maybe_to_cpu(value):
+    if isinstance(value, torch.Tensor):
+        return value.detach().cpu()
+    return value
+
+
+return DiffusionOutput(
+    output=_maybe_to_cpu(image),
+    custom_output={
+        "all_latents": _maybe_to_cpu(all_latents),
+        "all_log_probs": _maybe_to_cpu(all_log_probs),
+        "all_timesteps": _maybe_to_cpu(all_timesteps),
+        "prompt_embeds": _maybe_to_cpu(prompt_embeds),
+        "prompt_embeds_mask": _maybe_to_cpu(prompt_embeds_mask),
+        "negative_prompt_embeds": _maybe_to_cpu(negative_prompt_embeds),
+        "negative_prompt_embeds_mask": _maybe_to_cpu(negative_prompt_embeds_mask),
+        "condition_image_latents": _maybe_to_cpu(condition_image_latents),
+        "img_shapes": img_shapes,
+    },
+)
+```
+
+The diffusion server and agent loop move tensor fields into the training
+`TensorDict` and preserve Python values as non-tensor batch data. Keep names
+identical between rollout `custom_output` and training `prepare_condition`.
+
+## Step 5: Add Data Preparation and a Launch Recipe
+
+Ship a converter and a complete training command under
+`examples/flowgrpo_trainer/`. The parquet should contain at least:
+
+| Column | Type | Purpose |
+|---|---|---|
+| `prompt` | list of chat messages | Positive editing instruction in the upstream prompt format. |
+| `negative_prompt` | list of chat messages | Negative CFG prompt when CFG is enabled. |
+| `images` | list of `{"bytes": ...}` dictionaries | Condition images decoded by the multimodal dataset path. |
+| `data_source` | string | Dataset/reward identifier passed to the configured scorer and used for metric grouping. |
+| `reward_model` | dictionary | Carries reward style and ground truth/instruction. |
+| `extra_info` | dictionary | Optional sample provenance and reward metadata. |
+
+The prompt template, image placeholders, and processor calls must agree. A
+placeholder/image-count mismatch usually fails in the VLM encoder; a prompt
+template mismatch can silently change policy behavior.
+
+Use the [Qwen-Image-Edit training guide](../start/qwen_image_edit.md) as a
+complete example of raw data conversion, parquet schema, launcher overrides,
+and model-specific constraints.
+
+## Step 6: Test the Integration
+
+Add CPU tests for the model-specific contracts:
+
+- Both registry lookups resolve the new architecture.
+- Missing condition images fail with a clear error.
+- `prepare_condition` reads the exact `custom_output` key names.
+- Condition injection changes the transformer sequence as expected.
+- Transformer predictions are cropped back to the target sequence length.
+- Positive and negative CFG paths receive identical condition tensors.
+- Spatial metadata covers both target and condition tokens.
+- Sequence-parallel alignment rejects incompatible token counts.
+- Supported square and non-square aspect ratios behave as documented.
+
+Add a direct special E2E script under `tests/special_e2e/` that runs at least
+one training step with a tiny checkpoint and synthetic condition images. It
+must exercise rollout and training, not only upstream inference.
+
+Follow the repository's current GPU-smoke selection policy. If the new E2E is
+added to `tests/gpu_smoke/run_gpu_smoke_tests.sh`, add both its
+`run_selected_test` call and selection-map entry. Do not add an unused test ID.
+
+## Final Checklist
+
+- [ ] The model runs in both diffusers and vLLM-Omni before adapter work starts.
+- [ ] The package contains `__init__.py`, a training adapter, and a rollout adapter.
+- [ ] Both adapters use the exact `model_index.json::_class_name` and algorithm key.
+- [ ] `verl_omni/pipelines/__init__.py` imports the package.
+- [ ] The training adapter inherits `DiffusionI2IModelBase` for I2I dispatch.
+- [ ] `prepare_condition` returns a non-empty condition dictionary.
+- [ ] Rollout uses `condition_image_latents`, not the reserved `image_latents` key.
+- [ ] Rollout and training use identical condition concatenation/injection.
+- [ ] Transformer output is reduced to the target latent shape before scheduler use.
+- [ ] Positive and negative CFG paths use the intended condition tensors.
+- [ ] Timestep scaling, dtype handling, scheduler, and CFG match upstream inference.
+- [ ] Spatial/position metadata includes all target and condition tokens.
+- [ ] The data converter keeps prompt placeholders and condition-image count aligned.
+- [ ] The example launcher documents model, data, GPU, reward, and resolution overrides.
+- [ ] CPU contract tests and a one-step E2E test pass.

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,6 @@ See {doc}`start/models` for the full model catalogue and which algorithms run on
 start/install.md
 start/models.md
 start/flowgrpo_quickstart.md
-start/qwen_image_edit.md
 start/multi_node_training.md
 start/metrics.md
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,6 +29,7 @@ See {doc}`start/models` for the full model catalogue and which algorithms run on
 start/install.md
 start/models.md
 start/flowgrpo_quickstart.md
+start/qwen_image_edit.md
 start/multi_node_training.md
 start/metrics.md
 ```
@@ -88,6 +89,7 @@ api/utils.rst
 
 contributing/editing-agent-instructions.md
 contributing/integrating_a_diffusion_model.md
+contributing/integrating_an_i2i_diffusion_model.md
 contributing/integrating_a_non_diffusers_model.md
 contributing/integrating_a_stepwise_continuous_batching_model.md
 contributing/integrating_a_new_policy_gradient_algorithm_for_diffusion_model.md

--- a/docs/start/qwen_image_edit.md
+++ b/docs/start/qwen_image_edit.md
@@ -15,18 +15,6 @@ For implementation details or support for another image-edit architecture, see
 
 ## Prerequisites
 
-Follow the [installation guide](install.md). For an NVIDIA GPU environment, the
-relevant commands are:
-
-```bash
-uv pip install -e ".[gpu]" --torch-backend=auto
-uv pip install "vllm-omni @ git+https://github.com/vllm-project/vllm-omni.git@$(cat .github/vllm_omni_pin.txt)"
-uv pip install -e ".[train]"
-```
-
-Use the repository's vLLM-Omni pin. The rollout adapter depends on the matching
-Qwen-Image-Edit pipeline and request preprocessing behavior in vLLM-Omni.
-
 The example reward is PickScore. Its model weights are downloaded from Hugging
 Face the first time the reward workers start.
 

--- a/docs/start/qwen_image_edit.md
+++ b/docs/start/qwen_image_edit.md
@@ -1,0 +1,243 @@
+# Train Qwen-Image-Edit-2511 with FlowGRPO
+
+Last updated: 07/14/2026.
+
+This guide shows how to prepare an image-edit dataset and train
+[Qwen-Image-Edit-2511](https://huggingface.co/Qwen/Qwen-Image-Edit-2511)
+with LoRA and FlowGRPO.
+
+The current adapter is registered for `QwenImageEditPlusPipeline`. A replacement
+checkpoint must use that value in `model_index.json::_class_name`. The older
+`QwenImageEditPipeline` architecture is not supported by this recipe.
+
+For implementation details or support for another image-edit architecture, see
+[How to Integrate an Image-to-Image Diffusion Model](../contributing/integrating_an_i2i_diffusion_model.md).
+
+## Prerequisites
+
+Follow the [installation guide](install.md). For an NVIDIA GPU environment, the
+relevant commands are:
+
+```bash
+uv pip install -e ".[gpu]" --torch-backend=auto
+uv pip install "vllm-omni @ git+https://github.com/vllm-project/vllm-omni.git@$(cat .github/vllm_omni_pin.txt)"
+uv pip install -e ".[train]"
+```
+
+Use the repository's vLLM-Omni pin. The rollout adapter depends on the matching
+Qwen-Image-Edit pipeline and request preprocessing behavior in vLLM-Omni.
+
+The example reward is PickScore. Its model weights are downloaded from Hugging
+Face the first time the reward workers start.
+
+## Prepare the Dataset
+
+The example converter expects the following input layout:
+
+```text
+my_image_edit_data/
+|-- images/
+|   |-- 000001.png
+|   `-- 000002.png
+|-- train.jsonl
+`-- test.jsonl
+```
+
+Each line of `train.jsonl` and `test.jsonl` contains an editing instruction and
+an image path relative to `images/`:
+
+```json
+{"prompt": "Change the background to blue", "image": "000001.png"}
+```
+
+Convert the data to training parquet files:
+
+```bash
+python examples/flowgrpo_trainer/qwen_image_edit/prepare_data.py \
+    --input_dir my_image_edit_data \
+    --output_dir data/qwen_image_edit \
+    --image_size 512
+```
+
+The command writes:
+
+```text
+data/qwen_image_edit/
+|-- train.parquet
+`-- test.parquet
+```
+
+The converter letterboxes each condition image onto a square canvas and stores
+it as PNG bytes. The fields relevant to training follow this structure:
+
+```python
+{
+    "prompt": [
+        {"role": "system", "content": SYSTEM_PROMPT},
+        {"role": "user", "content": "Picture 1: <image>Change the background to blue"},
+    ],
+    "negative_prompt": [
+        {"role": "system", "content": SYSTEM_PROMPT},
+        {"role": "user", "content": "Picture 1: <image> "},
+    ],
+    "images": [{"bytes": condition_image_png_bytes}],
+    "data_source": "image_edit",
+    "reward_model": {
+        "style": "model",
+        "ground_truth": "Change the background to blue",
+    },
+    "extra_info": {
+        "instruction": "Change the background to blue",
+        "image": "000001.png",
+    },
+}
+```
+
+The number of `<image>` placeholders must match the number of entries in
+`images`. Qwen-Image-Edit-2511 training currently requires exactly one
+condition image per sample.
+
+## Launch Training
+
+The example recipe trains a LoRA adapter with PickScore:
+
+```bash
+WORKSPACE=$PWD \
+NUM_GPUS_ACTOR_ROLLOUT_REWARD=8 \
+bash examples/flowgrpo_trainer/qwen_image_edit/run_qwen_image_edit_lora.sh \
+    trainer.logger=console
+```
+
+By default, the launcher reads:
+
+```text
+$WORKSPACE/data/qwen_image_edit/train.parquet
+$WORKSPACE/data/qwen_image_edit/test.parquet
+```
+
+Set `TRAIN_FILES` and `VAL_FILES` to use different parquet files.
+
+### Environment Overrides
+
+| Variable | Default | Purpose |
+|---|---:|---|
+| `MODEL_PATH` | `Qwen/Qwen-Image-Edit-2511` | Hugging Face model ID or local compatible pipeline path. |
+| `TRAIN_FILES` | `$WORKSPACE/data/qwen_image_edit/train.parquet` | Training parquet path. |
+| `VAL_FILES` | `$WORKSPACE/data/qwen_image_edit/test.parquet` | Validation parquet path. |
+| `NUM_GPUS_ACTOR_ROLLOUT_REWARD` | `8` | Total GPUs visible to actor, rollout, and reward workers. |
+| `ACTOR_SP` | `1` | Actor Ulysses sequence-parallel size. Values greater than one require the attention overrides below. |
+| `ROLLOUT_TP` | `1` | Rollout tensor-parallel size. |
+| `REWARD_WORKERS` | `4` | Asynchronous reward worker count. |
+| `IMAGE_RESOLUTION` | `512` | Square target output resolution. |
+| `MAX_PROMPT_LENGTH` | `8192` | Token and prompt-embedding length limit. |
+| `REWARD_FUNCTION_PATH` | `pkg://verl_omni.utils.reward_score.pickscore_reward` | Reward module import path. |
+
+The launcher selects `compute_score_pickscore` from the reward module.
+
+Additional Hydra overrides can be appended to the command:
+
+```bash
+bash examples/flowgrpo_trainer/qwen_image_edit/run_qwen_image_edit_lora.sh \
+    actor_rollout_ref.rollout.n=4 \
+    data.train_batch_size=8 \
+    trainer.total_training_steps=20 \
+    trainer.logger=console
+```
+
+Keep `actor_rollout_ref.rollout.n` greater than one for group-relative
+advantages. When reducing GPU count, also reduce the training batch size,
+rollout count, micro-batch sizes, and reward worker count to fit memory.
+
+The launcher enables console, TensorBoard, and W&B logging by default. The
+first command overrides this with `trainer.logger=console` so it can run
+without W&B credentials. To use the launcher's default loggers, export
+`WANDB_API_KEY` before starting training.
+
+For `ACTOR_SP > 1`, use the SP-capable attention backends on both actor and
+rollout:
+
+```bash
+ACTOR_SP=2 \
+bash examples/flowgrpo_trainer/qwen_image_edit/run_qwen_image_edit_lora.sh \
+    actor_rollout_ref.model.attn_backend=native \
+    actor_rollout_ref.rollout.rollout_attn_backend=TORCH_SDPA \
+    trainer.logger=console
+```
+
+## Important Configuration
+
+The example launcher sets the model-specific fields required by the adapter:
+
+```text
+actor_rollout_ref.model.algorithm=flow_grpo
+actor_rollout_ref.rollout.name=vllm_omni
+actor_rollout_ref.rollout.pipeline.true_cfg_scale=4.0
+actor_rollout_ref.rollout.pipeline.height=512
+actor_rollout_ref.rollout.pipeline.width=512
+actor_rollout_ref.rollout.pipeline.num_inference_steps=12
+actor_rollout_ref.rollout.algo.sde_type=sde
+```
+
+Do not remove the negative prompt while `true_cfg_scale > 1`. Positive and
+negative prompt encoding both consume the condition image.
+
+PickScore measures instruction/image alignment but does not directly enforce
+source-image preservation. Use an edit-aware reward, or combine rewards, when
+the task requires strict preservation of identity, layout, or background.
+
+## Image and Sequence Constraints
+
+The rollout and actor adapters validate the following constraints at their
+respective execution stages:
+
+- Each sample has exactly one condition image.
+- The condition-image aspect ratio matches the target output aspect ratio.
+- Samples in a rollout batch produce compatible packed latent lengths.
+- With actor sequence parallelism, the combined target and condition token
+  count is divisible by `ACTOR_SP`.
+- `true_cfg_scale > 1` has a negative prompt.
+
+The example converter and launcher both use square images. For non-square
+training, use a custom converter that preserves the intended aspect ratio, then
+set `actor_rollout_ref.rollout.pipeline.height` and
+`actor_rollout_ref.rollout.pipeline.width` to that same ratio. Do not mix
+condition-image aspect ratios in one batch.
+
+Qwen-Image-Edit checkpoints may contain `processor/` without
+`processor/config.json`. The adapter creates the missing config before the
+driver loads the processor. The model directory must be writable when that
+file is absent.
+
+## Run the End-to-End Smoke Test
+
+The special E2E test covers parquet loading, multimodal prompt processing,
+vLLM-Omni rollout, trajectory transport, reward computation, FSDP LoRA
+training, and weight synchronization:
+
+```bash
+CUDA_VISIBLE_DEVICES=0 NUM_GPUS=1 \
+bash tests/special_e2e/run_flowgrpo_qwen_image_edit.sh
+```
+
+By default it expects a tiny random checkpoint at
+`~/models/tiny-random/qwen-image-edit-plus`. Build it before the first run:
+
+```bash
+python tests/special_e2e/build_qwen_image_edit_plus_tiny_random.py \
+    --output-dir ~/models/tiny-random/qwen-image-edit-plus
+```
+
+The builder copies tokenizer, processor, and scheduler assets from the locally
+cached `Qwen/Qwen-Image-Edit-2511` snapshot without loading its weight shards.
+Use `--source-model <local-path>` if those assets are stored elsewhere. The
+builder does not download missing source assets.
+
+Set `MODEL_PATH` on the smoke-test command to use another compatible tiny
+checkpoint. A successful run ends with:
+
+```text
+FlowGRPO Qwen-Image-Edit e2e test passed (training completed successfully).
+```
+
+Training logs and generated validation images are written below
+`$WORKSPACE/outputs/qwen_image_edit_lora/` by the full example launcher.

--- a/examples/flowgrpo_trainer/qwen_image_edit/README.md
+++ b/examples/flowgrpo_trainer/qwen_image_edit/README.md
@@ -11,7 +11,7 @@ checkpoint must use that value in `model_index.json::_class_name`. The older
 `QwenImageEditPipeline` architecture is not supported by this recipe.
 
 For implementation details or support for another image-edit architecture, see
-[How to Integrate an Image-to-Image Diffusion Model](../contributing/integrating_an_i2i_diffusion_model.md).
+[How to Integrate an Image-to-Image Diffusion Model](../../../docs/contributing/integrating_an_i2i_diffusion_model.md).
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary

Adds two user-facing documentation guides for the Qwen-Image-Edit / image-to-image (I2I) FlowGRPO path and links them from the docs index:

- `docs/contributing/integrating_an_i2i_diffusion_model.md` — the I2I integration contract (condition-image transport, `prepare_condition`/`inject_condition` hooks, rollout `custom_output` keys, CFG/metadata rules, and a final checklist), building on the existing T2I integration guide.
- `docs/start/qwen_image_edit.md` — an end-to-end "Train Qwen-Image-Edit-2511 with FlowGRPO" guide: dataset prep, launch recipe, environment overrides, image/sequence constraints, and the special E2E smoke test.
- `docs/index.md` — index entries for the two new guides.

Docs-only change; no runtime code, config, or API is modified.

## Not a duplicate

A search of open PRs on `verl-project/verl-omni` (`qwen image edit i2i guide doc` and `integrating image-to-image guide in:body`) returned no existing PR that adds these guides. The referenced Qwen-Image-Edit implementation already landed upstream (#260); this PR only documents it.

## Testing

Docs-only change, no code paths affected.

- Verified the branch is rebased on the latest `upstream/main` (`811f5ad`, includes #267/#272) with a clean linear history.
- Manually reviewed rendered Markdown for both new pages and the index links; commands and file paths cross-checked against the current `examples/flowgrpo_trainer/qwen_image_edit/` recipe and `tests/special_e2e/` scripts.

## AI assistance

AI assistance (Kilo) was used to draft and organize these guides. The submitter has reviewed every changed line.
