### PR TITLE
[WIP][omni, trainer, fsdp] feat: add direct-preference training framework for omni models

### DIFF
--- a/tests/trainer/omni/test_main_omni_on_cpu.py
+++ b/tests/trainer/omni/test_main_omni_on_cpu.py
@@ -1,0 +1,88 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU tests for omni training entrypoint routing."""
+
+import pytest
+from omegaconf import OmegaConf
+
+from verl_omni.trainer.diffusion.ray_diffusion_trainer import DirectPreferenceRayTrainer, PolicyGradientRayTrainer
+from verl_omni.trainer.main_omni import get_ray_trainer_cls, uses_v1_trainer
+from verl_omni.trainer.omni.ray_omni_dpo_trainer import OmniDirectPreferenceRayTrainer
+
+
+def _make_config(**overrides):
+    config = OmegaConf.create(
+        {
+            "algorithm": {
+                "sample_source": "online",
+                "trainer_type": "policy_gradient",
+            },
+            "actor_rollout_ref": {
+                "model": {"model_type": "omni"},
+            },
+            "trainer": {"use_v1": None},
+        }
+    )
+    OmegaConf.set_struct(config, False)
+    for key, value in overrides.items():
+        if isinstance(value, dict) and key in config and OmegaConf.is_dict(config[key]):
+            config[key] = OmegaConf.merge(config[key], value)
+        else:
+            config[key] = value
+    return config
+
+
+class TestUsesV1Trainer:
+    @pytest.mark.parametrize(
+        ("sample_source", "trainer_type", "use_v1", "expected"),
+        [
+            ("online", "policy_gradient", None, True),
+            ("offline", "direct_preference", None, False),
+            ("offline", "direct_preference", False, False),
+            ("online", "direct_preference", None, True),
+        ],
+    )
+    def test_routes_online_rl_to_v1_and_offline_preference_to_legacy(
+        self, sample_source, trainer_type, use_v1, expected
+    ):
+        config = _make_config(
+            algorithm={"sample_source": sample_source, "trainer_type": trainer_type},
+            trainer={"use_v1": use_v1},
+        )
+        assert uses_v1_trainer(config) is expected
+
+
+class TestGetRayTrainerCls:
+    def test_policy_gradient_returns_policy_gradient_trainer(self):
+        config = _make_config(algorithm={"trainer_type": "policy_gradient"})
+        assert get_ray_trainer_cls(config) is PolicyGradientRayTrainer
+
+    def test_direct_preference_omni_returns_omni_trainer(self):
+        config = _make_config(
+            algorithm={"trainer_type": "direct_preference"},
+            actor_rollout_ref={"model": {"model_type": "omni"}},
+        )
+        assert get_ray_trainer_cls(config) is OmniDirectPreferenceRayTrainer
+
+    def test_direct_preference_non_omni_returns_diffusion_trainer(self):
+        config = _make_config(
+            algorithm={"trainer_type": "direct_preference"},
+            actor_rollout_ref={"model": {"model_type": "diffusion_model"}},
+        )
+        assert get_ray_trainer_cls(config) is DirectPreferenceRayTrainer
+
+    def test_unsupported_trainer_type_raises(self):
+        config = _make_config(algorithm={"trainer_type": "unknown"})
+        with pytest.raises(ValueError, match="Unsupported trainer_type"):
+            get_ray_trainer_cls(config)

--- a/tests/trainer/omni/test_omni_dpo_trainer_on_cpu.py
+++ b/tests/trainer/omni/test_omni_dpo_trainer_on_cpu.py
@@ -1,0 +1,133 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU tests for OmniDirectPreferenceRayTrainer guardrails and helpers."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+from omegaconf import OmegaConf
+from tensordict import TensorDict
+from verl.protocol import DataProto
+from verl.utils import tensordict_utils as tu
+
+from verl_omni.trainer.diffusion.ray_diffusion_trainer import BaseRayDiffusionTrainer
+from verl_omni.trainer.omni.ray_omni_dpo_trainer import OmniDirectPreferenceRayTrainer
+
+
+def _make_config(**overrides):
+    config = OmegaConf.create(
+        {
+            "algorithm": {
+                "sample_source": "offline",
+                "trainer_type": "direct_preference",
+                "paired_preference": False,
+            },
+            "actor_rollout_ref": {
+                "model": {"model_type": "omni", "policy_state_adapters": ("default",)},
+                "actor": {
+                    "omni_loss": {"loss_mode": "dpo", "average_log_prob": False},
+                    "ppo_mini_batch_size": 2,
+                    "ppo_epochs": 1,
+                    "data_loader_seed": 0,
+                    "shuffle": True,
+                },
+                "rollout": {"multi_turn": {"enable": False}},
+            },
+        }
+    )
+    OmegaConf.set_struct(config, False)
+    for key, value in overrides.items():
+        if isinstance(value, dict) and key in config and OmegaConf.is_dict(config[key]):
+            config[key] = OmegaConf.merge(config[key], value)
+        else:
+            config[key] = value
+    return config
+
+
+def _make_trainer(config):
+    with patch.object(BaseRayDiffusionTrainer, "__init__", return_value=None):
+        trainer = OmniDirectPreferenceRayTrainer(config)
+    trainer.config = config
+    return trainer
+
+
+class TestOmniDirectPreferenceRayTrainerInit:
+    def test_rejects_online_sample_source(self):
+        config = _make_config(algorithm={"sample_source": "online"})
+        with patch.object(BaseRayDiffusionTrainer, "__init__", return_value=None):
+            with pytest.raises(NotImplementedError, match="sample_source=offline"):
+                OmniDirectPreferenceRayTrainer(config)
+
+    def test_requires_omni_model_type(self):
+        config = _make_config(actor_rollout_ref={"model": {"model_type": "language_model"}})
+        with patch.object(BaseRayDiffusionTrainer, "__init__", return_value=None):
+            with pytest.raises(ValueError, match="model_type=omni"):
+                OmniDirectPreferenceRayTrainer(config)
+
+    def test_requires_dpo_loss_mode(self):
+        config = _make_config(
+            actor_rollout_ref={"actor": {"omni_loss": {"loss_mode": "other", "average_log_prob": False}}}
+        )
+        with patch.object(BaseRayDiffusionTrainer, "__init__", return_value=None):
+            with pytest.raises(NotImplementedError, match="loss_mode=dpo"):
+                OmniDirectPreferenceRayTrainer(config)
+
+    def test_rejects_old_policy_adapter(self):
+        config = _make_config(actor_rollout_ref={"model": {"policy_state_adapters": ("default", "old")}})
+        with patch.object(BaseRayDiffusionTrainer, "__init__", return_value=None):
+            with pytest.raises(NotImplementedError, match="old-policy adapters"):
+                OmniDirectPreferenceRayTrainer(config)
+
+
+class TestOmniDirectPreferenceRayTrainerHelpers:
+    def test_infer_reference_policy_maps_chosen_and_rejected_logps(self):
+        config = _make_config()
+        trainer = _make_trainer(config)
+        trainer.ref_in_actor = False
+        trainer.ref_policy_wg = MagicMock()
+        trainer.ref_policy_wg.infer_ref_batch.return_value = TensorDict(
+            {
+                "chosen_logps": torch.tensor([1.0, 2.0]),
+                "rejected_logps": torch.tensor([0.5, 1.5]),
+            },
+            batch_size=2,
+        )
+        batch = DataProto.from_tensordict(TensorDict({"input_ids": torch.zeros(2, 4, dtype=torch.long)}, batch_size=2))
+
+        result = trainer._infer_reference_policy(batch)
+
+        assert result is not None
+        assert result.batch["reference_chosen_logps"].tolist() == [1.0, 2.0]
+        assert result.batch["reference_rejected_logps"].tolist() == [0.5, 1.5]
+
+    def test_update_actor_disables_shuffle_for_paired_preference(self):
+        config = _make_config(
+            algorithm={"paired_preference": True},
+            actor_rollout_ref={"actor": {"shuffle": True}},
+        )
+        trainer = _make_trainer(config)
+        trainer.actor_rollout_wg = MagicMock()
+        trainer.actor_rollout_wg.update_actor.return_value = TensorDict({"metrics": {}}, batch_size=0)
+        batch = DataProto.from_single_dict(
+            data={"input_ids": torch.zeros(2, 4, dtype=torch.long)},
+            meta_info={},
+        )
+
+        with pytest.warns(UserWarning, match="Shuffle is not supported"):
+            trainer._update_actor(batch)
+
+        sent_batch = trainer.actor_rollout_wg.update_actor.call_args.args[0]
+        dataloader_kwargs = tu.get_non_tensor_data(sent_batch, "dataloader_kwargs", default={})
+        assert dataloader_kwargs["shuffle"] is False

--- a/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
+++ b/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
@@ -1253,7 +1253,7 @@ class DirectPreferenceRayTrainer(BaseRayDiffusionTrainer):
             actor_output["perf/mfu/actor"] = actor_mfu
         return DataProto.from_single_dict(data={}, meta_info={"metrics": actor_output})
 
-    def _compute_ref_noise_pred(self, batch: DataProto) -> Optional[DataProto]:
+    def _infer_reference_policy(self, batch: DataProto) -> Optional[DataProto]:
         """Reference transformer output and shared flow tensors."""
         batch_td = batch.to_tensordict()
         batch_td = embeds_padding_2_no_padding(batch_td)
@@ -1400,7 +1400,7 @@ class DirectPreferenceRayTrainer(BaseRayDiffusionTrainer):
                         batch.batch["sample_level_rewards"] = batch.batch["sample_level_scores"]
                         if self.use_reference_policy:
                             with marked_timer(str(Role.RefPolicy), timing_raw, color="olive"):
-                                ref_infer_res = self._compute_ref_noise_pred(batch)
+                                ref_infer_res = self._infer_reference_policy(batch)
                                 if ref_infer_res is not None:
                                     batch = batch.union(ref_infer_res)
 
@@ -1451,7 +1451,7 @@ class DirectPreferenceRayTrainer(BaseRayDiffusionTrainer):
                         batch.batch["sample_level_rewards"] = batch.batch["sample_level_scores"]
                         if self.use_reference_policy:
                             with marked_timer(str(Role.RefPolicy), timing_raw, color="olive"):
-                                ref_infer_res = self._compute_ref_noise_pred(batch)
+                                ref_infer_res = self._infer_reference_policy(batch)
                                 if ref_infer_res is not None:
                                     batch = batch.union(ref_infer_res)
 

--- a/verl_omni/trainer/main_omni.py
+++ b/verl_omni/trainer/main_omni.py
@@ -1,0 +1,338 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Entrypoint for omni model training.
+
+``run_omni`` routes to one of two backends:
+
+* **V1 PPO** (GSPO, GRPO, and other online RL algorithms): delegates to verl's
+  ``run_ppo`` with ``TaskRunnerV1`` and ``trainer.use_v1=True``.
+* **Direct preference** (``sample_source=offline``): uses ``RayTrainerTaskRunner``.
+"""
+
+from __future__ import annotations
+
+import inspect
+import os
+import socket
+from pprint import pprint
+from typing import Any
+
+import hydra
+import ray
+from omegaconf import OmegaConf
+from verl.trainer.constants_ppo import get_ppo_ray_runtime_env
+from verl.trainer.ppo.utils import need_reference_policy
+from verl.utils.device import auto_set_device, is_cuda_available
+
+import verl_omni.trainer.omni  # noqa: F401  — registers @register_trainer("omni_sync")
+from verl_omni.trainer.diffusion.ray_diffusion_trainer import (
+    DirectPreferenceRayTrainer,
+    PolicyGradientRayTrainer,
+)
+from verl_omni.utils.fs import resolve_model_local_dir
+
+__all__ = [
+    "RayTrainerTaskRunner",
+    "get_ray_trainer_cls",
+    "launch_ray_task_runner",
+    "main",
+    "maybe_set_determinism_env",
+    "run_omni",
+    "uses_v1_trainer",
+]
+
+
+def get_ray_trainer_cls(config):
+    """Return the trainer class selected by ``algorithm.trainer_type`` and model type."""
+    trainer_type = config.algorithm.trainer_type
+    if trainer_type == "policy_gradient":
+        return PolicyGradientRayTrainer
+    if trainer_type == "direct_preference":
+        if config.actor_rollout_ref.model.get("model_type", "language_model") in ("omni", "omni_model"):
+            from verl_omni.trainer.omni.ray_omni_dpo_trainer import OmniDirectPreferenceRayTrainer
+
+            return OmniDirectPreferenceRayTrainer
+        return DirectPreferenceRayTrainer
+    raise ValueError(
+        f"Unsupported trainer_type {trainer_type!r}. Expected one of: 'policy_gradient', 'direct_preference'."
+    )
+
+
+class RayTrainerTaskRunner:
+    """Ray remote class for executing distributed training with the unified model engine."""
+
+    def __init__(self):
+        self.role_worker_mapping = {}
+        self.mapping = {}
+
+    def add_actor_rollout_worker(self, config):
+        """Add actor (and optional rollout/ref) workers using the unified model engine."""
+        from verl.single_controller.ray import RayWorkerGroup
+        from verl.trainer.ppo.ray_trainer import Role
+
+        from verl_omni.workers.engine_workers import ActorRolloutRefWorker
+
+        actor_rollout_cls = ActorRolloutRefWorker
+        ray_worker_group_cls = RayWorkerGroup
+
+        lora_rank = config.actor_rollout_ref.model.get("lora", {}).get("rank", 0)
+        if lora_rank <= 0:
+            lora_rank = config.actor_rollout_ref.model.get("lora_rank", 0)
+        ref_in_actor = lora_rank > 0 or config.actor_rollout_ref.model.get("lora_adapter_path") is not None
+
+        if config.algorithm.sample_source == "offline":
+            if not hasattr(Role, "Actor"):
+                raise ValueError("Offline training without rollout requires verl Role.Actor support.")
+            role = Role.Actor
+        elif need_reference_policy(config) and not ref_in_actor:
+            role = Role.ActorRolloutRef
+        else:
+            role = Role.ActorRollout
+
+        self.role_worker_mapping[role] = ray.remote(actor_rollout_cls)
+        self.mapping[role] = "global_pool"
+        return actor_rollout_cls, ray_worker_group_cls
+
+    def init_resource_pool_mgr(self, config):
+        """Initialize resource pool manager."""
+        global_pool_id = "global_pool"
+        resource_pool_spec = {
+            global_pool_id: [config.trainer.n_gpus_per_node] * config.trainer.nnodes,
+        }
+
+        if config.reward.reward_model.enable_resource_pool:
+            if config.reward.reward_model.n_gpus_per_node <= 0:
+                raise ValueError("config.reward.reward_model.n_gpus_per_node must be greater than 0")
+            if config.reward.reward_model.nnodes <= 0:
+                raise ValueError("config.reward.reward_model.nnodes must be greater than 0")
+
+            reward_pool = [config.reward.reward_model.n_gpus_per_node] * config.reward.reward_model.nnodes
+            resource_pool_spec["reward_pool"] = reward_pool
+        else:
+            config.reward.reward_model.nnodes = config.trainer.nnodes
+            config.reward.reward_model.n_gpus_per_node = config.trainer.n_gpus_per_node
+
+        from verl.trainer.ppo.ray_trainer import ResourcePoolManager
+
+        return ResourcePoolManager(resource_pool_spec=resource_pool_spec, mapping=self.mapping)
+
+    def add_reward_model_resource_pool(self, config):
+        """Register reward-model GPU pool for online sampling."""
+        from verl.trainer.ppo.ray_trainer import Role
+
+        if config.algorithm.sample_source == "online":
+            if config.reward.reward_model.enable:
+                if config.reward.reward_model.enable_resource_pool:
+                    self.mapping[Role.RewardModel] = "reward_pool"
+                else:
+                    self.mapping[Role.RewardModel] = "global_pool"
+
+    def add_ref_policy_worker(self, config, ref_policy_cls):
+        """Add reference policy worker if KL loss or KL reward is used."""
+        del config, ref_policy_cls
+        return
+
+    def get_trainer_cls(self, config):
+        """Return the trainer class for this task runner."""
+        return get_ray_trainer_cls(config)
+
+    def before_load_tokenizer(self, config):
+        """Hook invoked before tokenizer/processor loading."""
+        external_lib = config.actor_rollout_ref.model.get("external_lib", None)
+        if external_lib:
+            from verl.utils.import_utils import import_external_libs
+
+            import_external_libs(external_lib)
+
+    def run(self, config):
+        """Execute the main training workflow."""
+        print(f"TaskRunner hostname: {socket.gethostname()}, PID: {os.getpid()}")
+        pprint(OmegaConf.to_container(config, resolve=True))
+        OmegaConf.resolve(config)
+
+        actor_rollout_cls, ray_worker_group_cls = self.add_actor_rollout_worker(config)
+        self.add_reward_model_resource_pool(config)
+        self.add_ref_policy_worker(config, actor_rollout_cls)
+
+        local_path = resolve_model_local_dir(
+            config.actor_rollout_ref.model.path, use_shm=config.actor_rollout_ref.model.get("use_shm", False)
+        )
+
+        if config.actor_rollout_ref.model.tokenizer_path is None:
+            tokenizer_path = os.path.join(local_path, "tokenizer")
+            config.actor_rollout_ref.model.tokenizer_path = (
+                tokenizer_path if os.path.exists(tokenizer_path) else local_path
+            )
+
+        self.before_load_tokenizer(config)
+
+        from verl.utils import hf_processor, hf_tokenizer
+
+        trust_remote_code = config.data.get("trust_remote_code", False)
+        tokenizer = hf_tokenizer(config.actor_rollout_ref.model.tokenizer_path, trust_remote_code=trust_remote_code)
+        processor_path = os.path.join(local_path, "processor")
+        if not os.path.exists(processor_path):
+            processor_path = local_path
+        processor = hf_processor(processor_path, trust_remote_code=trust_remote_code, use_fast=True)
+
+        resource_pool_manager = self.init_resource_pool_mgr(config)
+
+        from verl_omni.utils.dataset.rl_dataset import create_rl_dataset, create_rl_sampler, get_collate_fn
+
+        collate_fn = get_collate_fn(config.data)
+        train_dataset = create_rl_dataset(
+            config.data.train_files,
+            config.data,
+            tokenizer,
+            processor,
+            is_train=True,
+            max_samples=config.data.get("train_max_samples", -1),
+        )
+        val_dataset = create_rl_dataset(
+            config.data.val_files,
+            config.data,
+            tokenizer,
+            processor,
+            is_train=False,
+            max_samples=config.data.get("val_max_samples", -1),
+        )
+        train_sampler = create_rl_sampler(config.data, train_dataset)
+
+        trainer_cls = self.get_trainer_cls(config)
+        trainer = trainer_cls(
+            config=config,
+            tokenizer=tokenizer,
+            processor=processor,
+            role_worker_mapping=self.role_worker_mapping,
+            resource_pool_manager=resource_pool_manager,
+            ray_worker_group_cls=ray_worker_group_cls,
+            train_dataset=train_dataset,
+            val_dataset=val_dataset,
+            collate_fn=collate_fn,
+            train_sampler=train_sampler,
+        )
+        trainer.init_workers()
+        trainer.fit()
+
+
+def maybe_set_determinism_env(config) -> None:
+    """Propagate determinism env vars before ``ray.init()`` when configured."""
+    rollout_cfg = config.actor_rollout_ref.rollout
+    rm_rollout_cfg = config.reward.reward_model.rollout
+    if rollout_cfg.full_determinism or (config.reward.reward_model.enable and rm_rollout_cfg.full_determinism):
+        os.environ["VERL_FULL_DETERMINISM"] = "1"
+        os.environ["VLLM_BATCH_INVARIANT"] = "1"
+        os.environ["PYTHONHASHSEED"] = str(rollout_cfg.seed)
+
+
+def _resolve_ppo_runtime_env(config) -> dict[str, Any]:
+    signature = inspect.signature(get_ppo_ray_runtime_env)
+    if len(signature.parameters) == 0:
+        return get_ppo_ray_runtime_env()
+    return get_ppo_ray_runtime_env(config)
+
+
+def launch_ray_task_runner(
+    config,
+    task_runner_class,
+    *,
+    enable_transfer_queue_env: bool = False,
+    propagate_determinism: bool = False,
+) -> None:
+    """Initialize Ray (if needed) and run ``task_runner_class.run(config)`` remotely."""
+    if propagate_determinism:
+        maybe_set_determinism_env(config)
+
+    if not ray.is_initialized():
+        default_runtime_env = _resolve_ppo_runtime_env(config)
+        ray_init_kwargs = config.ray_kwargs.get("ray_init", {})
+        runtime_env_kwargs = ray_init_kwargs.get("runtime_env", {})
+
+        if enable_transfer_queue_env and OmegaConf.select(config, "transfer_queue.enable", default=False):
+            runtime_env_vars = runtime_env_kwargs.get("env_vars", {})
+            runtime_env_vars["TRANSFER_QUEUE_ENABLE"] = "1"
+            runtime_env_kwargs["env_vars"] = runtime_env_vars
+
+        runtime_env = OmegaConf.merge(default_runtime_env, runtime_env_kwargs)
+        ray_init_kwargs = OmegaConf.create({**ray_init_kwargs, "runtime_env": runtime_env})
+        print(f"ray init kwargs: {ray_init_kwargs}")
+        ray.init(**OmegaConf.to_container(ray_init_kwargs))
+
+    if (
+        is_cuda_available
+        and OmegaConf.select(config, "global_profiler.tool") == "nsys"
+        and OmegaConf.select(config, "global_profiler.steps") is not None
+        and len(OmegaConf.select(config, "global_profiler.steps")) > 0
+    ):
+        from verl.utils.import_utils import is_nvtx_available
+
+        assert is_nvtx_available(), "nvtx is not available in CUDA platform. Please 'pip3 install nvtx'"
+        nsight_options = OmegaConf.to_container(
+            config.global_profiler.global_tool_config.nsys.controller_nsight_options
+        )
+        runner = task_runner_class.options(runtime_env={"nsight": nsight_options}).remote()
+    else:
+        runner = task_runner_class.remote()
+    ray.get(runner.run.remote(config))
+
+    timeline_json_file = config.ray_kwargs.get("timeline_json_file", None)
+    if timeline_json_file:
+        ray.timeline(filename=timeline_json_file)
+
+
+def uses_v1_trainer(config) -> bool:
+    """Return True when omni training should use verl's V1 PPO stack."""
+    if OmegaConf.select(config, "trainer.use_v1", default=None) is False:
+        return False
+
+    sample_source = OmegaConf.select(config, "algorithm.sample_source", default="online")
+    trainer_type = OmegaConf.select(config, "algorithm.trainer_type", default="policy_gradient")
+    return not (sample_source == "offline" and trainer_type == "direct_preference")
+
+
+def run_omni(config, task_runner_class=None) -> None:
+    """Initialize Ray and run distributed Omni training."""
+    if uses_v1_trainer(config):
+        from verl.trainer.main_ppo import TaskRunnerV1, run_ppo
+
+        config.trainer.use_v1 = True
+        if task_runner_class is None:
+            task_runner_class = TaskRunnerV1
+        run_ppo(config, task_runner_class=task_runner_class)
+        return
+
+    if task_runner_class is None:
+        task_runner_class = ray.remote(num_cpus=1)(RayTrainerTaskRunner)
+    launch_ray_task_runner(config, task_runner_class)
+
+
+@hydra.main(config_path="./config", config_name="omni_trainer", version_base=None)
+def main(config):
+    """Omni model training entrypoint."""
+    auto_set_device(config)
+    if uses_v1_trainer(config):
+        from verl.trainer.ppo.utils import need_critic, need_reference_policy
+        from verl.utils.config import validate_config
+
+        validate_config(
+            config=config,
+            use_reference_policy=need_reference_policy(config),
+            use_critic=need_critic(config),
+        )
+    OmegaConf.resolve(config)
+    run_omni(config)
+
+
+if __name__ == "__main__":
+    main()

--- a/verl_omni/trainer/omni/__init__.py
+++ b/verl_omni/trainer/omni/__init__.py
@@ -11,3 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from verl_omni.trainer.omni.ray_omni_dpo_trainer import OmniDirectPreferenceRayTrainer
+
+__all__ = ["OmniDirectPreferenceRayTrainer"]

--- a/verl_omni/trainer/omni/ray_omni_dpo_trainer.py
+++ b/verl_omni/trainer/omni/ray_omni_dpo_trainer.py
@@ -1,0 +1,118 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Offline omni direct-preference Ray trainer (Qwen3-Omni DPO)."""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from verl.protocol import DataProto
+from verl.trainer.ppo.utils import need_reference_policy
+from verl.utils import tensordict_utils as tu
+from verl.utils.py_functional import rename_dict
+
+from verl_omni.trainer.diffusion.ray_diffusion_trainer import (
+    BaseRayDiffusionTrainer,
+    DirectPreferenceRayTrainer,
+)
+
+sys_logger = logging.getLogger(__name__)
+
+__all__ = ["OmniDirectPreferenceRayTrainer"]
+
+
+class OmniDirectPreferenceRayTrainer(DirectPreferenceRayTrainer):
+    """Omni AR direct-preference trainer on the shared Ray preference loop.
+
+    Supports ref-in-actor (LoRA base weights as reference) and an optional
+    external ref worker when ``lora_rank == 0``.
+    """
+
+    def __init__(self, config, *args, **kwargs):
+        BaseRayDiffusionTrainer.__init__(self, config, *args, **kwargs)
+        self.is_offline = config.algorithm.get("sample_source", "online") == "offline"
+        if not self.is_offline:
+            raise NotImplementedError("OmniDirectPreferenceRayTrainer currently supports offline DPO only.")
+        if config.actor_rollout_ref.model.get("model_type", "language_model") != "omni_model":
+            raise ValueError("OmniDirectPreferenceRayTrainer requires actor_rollout_ref.model.model_type=omni_model.")
+        loss_mode = config.actor_rollout_ref.actor.omni_loss.loss_mode
+        if loss_mode != "dpo":
+            raise NotImplementedError("OmniDirectPreferenceRayTrainer currently supports omni_loss.loss_mode=dpo only.")
+        self.use_reference_policy = need_reference_policy(self.config) or (loss_mode == "dpo")
+        self._has_old_adapter = "old" in tuple(
+            config.actor_rollout_ref.model.get("policy_state_adapters", ("default",))
+        )
+        if self._has_old_adapter:
+            raise NotImplementedError("Omni DPO does not support old-policy adapters yet.")
+        self._loss_fn = None
+
+    def _infer_reference_policy(self, batch: DataProto) -> Optional[DataProto]:
+        """Compute reference-policy log-probs for chosen/rejected pairs."""
+        batch_td = batch.to_tensordict()
+        metadata = {
+            "compute_loss": False,
+            "average_log_prob": self.config.actor_rollout_ref.actor.omni_loss.average_log_prob,
+            "use_dynamic_bsz": False,
+        }
+        if self.ref_in_actor:
+            metadata["no_lora_adapter"] = True
+        tu.assign_non_tensor(batch_td, **metadata)
+        if self.ref_in_actor:
+            output = self.actor_rollout_wg.infer_actor_batch(batch_td)
+        else:
+            output = self.ref_policy_wg.infer_ref_batch(batch_td)
+        if output is None:
+            return None
+
+        ref_logps = tu.get_tensordict(
+            {
+                "reference_chosen_logps": tu.get(output, "chosen_logps").float(),
+                "reference_rejected_logps": tu.get(output, "rejected_logps").float(),
+            }
+        )
+        return DataProto.from_tensordict(ref_logps)
+
+    def _update_actor(self, batch: DataProto) -> DataProto:
+        rollout_config = self.config.actor_rollout_ref.rollout
+        batch.meta_info["multi_turn"] = rollout_config.multi_turn.enable
+        batch_td = batch.to_tensordict()
+
+        ppo_mini_batch_size = self.config.actor_rollout_ref.actor.ppo_mini_batch_size
+        ppo_epochs = self.config.actor_rollout_ref.actor.ppo_epochs
+        seed = self.config.actor_rollout_ref.actor.data_loader_seed
+        shuffle = self.config.actor_rollout_ref.actor.shuffle
+        if self.config.algorithm.get("paired_preference", False) and shuffle:
+            sys_logger.warning(
+                "Shuffle is not supported for omni direct preference because chosen/rejected "
+                "branches are packed together. Setting shuffle to False."
+            )
+            shuffle = False
+
+        tu.assign_non_tensor(
+            batch_td,
+            global_batch_size=ppo_mini_batch_size,
+            mini_batch_size=ppo_mini_batch_size,
+            epochs=ppo_epochs,
+            seed=seed,
+            dataloader_kwargs={"shuffle": shuffle},
+        )
+
+        actor_output = self.actor_rollout_wg.update_actor(batch_td)
+        actor_output = tu.get(actor_output, "metrics")
+        actor_output = rename_dict(actor_output, "actor/")
+        if (actor_mfu := actor_output.pop("actor/mfu", None)) is not None:
+            actor_output["perf/mfu/actor"] = actor_mfu
+        return DataProto.from_single_dict(data={}, meta_info={"metrics": actor_output})

--- a/verl_omni/trainer/omni/ray_omni_dpo_trainer.py
+++ b/verl_omni/trainer/omni/ray_omni_dpo_trainer.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Offline omni direct-preference Ray trainer (Qwen3-Omni DPO)."""
+"""Omni direct-preference Ray trainer."""
 
 from __future__ import annotations
 
@@ -45,9 +45,11 @@ class OmniDirectPreferenceRayTrainer(DirectPreferenceRayTrainer):
         BaseRayDiffusionTrainer.__init__(self, config, *args, **kwargs)
         self.is_offline = config.algorithm.get("sample_source", "online") == "offline"
         if not self.is_offline:
-            raise NotImplementedError("OmniDirectPreferenceRayTrainer currently supports offline DPO only.")
-        if config.actor_rollout_ref.model.get("model_type", "language_model") != "omni_model":
-            raise ValueError("OmniDirectPreferenceRayTrainer requires actor_rollout_ref.model.model_type=omni_model.")
+            raise NotImplementedError(
+                "OmniDirectPreferenceRayTrainer currently supports algorithm.sample_source=offline only."
+            )
+        if config.actor_rollout_ref.model.get("model_type", "language_model") != "omni":
+            raise ValueError("OmniDirectPreferenceRayTrainer requires actor_rollout_ref.model.model_type=omni.")
         loss_mode = config.actor_rollout_ref.actor.omni_loss.loss_mode
         if loss_mode != "dpo":
             raise NotImplementedError("OmniDirectPreferenceRayTrainer currently supports omni_loss.loss_mode=dpo only.")
@@ -56,7 +58,7 @@ class OmniDirectPreferenceRayTrainer(DirectPreferenceRayTrainer):
             config.actor_rollout_ref.model.get("policy_state_adapters", ("default",))
         )
         if self._has_old_adapter:
-            raise NotImplementedError("Omni DPO does not support old-policy adapters yet.")
+            raise NotImplementedError("OmniDirectPreferenceRayTrainer does not support old-policy adapters yet.")
         self._loss_fn = None
 
     def _infer_reference_policy(self, batch: DataProto) -> Optional[DataProto]:

--- a/verl_omni/workers/config/omni/model.py
+++ b/verl_omni/workers/config/omni/model.py
@@ -62,7 +62,7 @@ class OmniModelConfig(BaseConfig):
     local_tokenizer_path: Optional[str] = None
 
     # model type
-    model_type: str = "language_model"
+    model_type: str = "omni"
 
     # HF config architectures[0] (auto-detected from config.json if unset)
     architecture: str = MISSING

--- a/verl_omni/workers/engine/__init__.py
+++ b/verl_omni/workers/engine/__init__.py
@@ -15,6 +15,7 @@ from .fsdp import (  # noqa: F401
     DiffusersFSDPEngine,
     DPODiffusersFSDPEngine,
     NFTDiffusersFSDPEngine,
+    OmniFSDPEngine,
     PPODiffusersFSDPEngine,
 )
 
@@ -28,5 +29,6 @@ __all__ = [
     "DPODiffusersFSDPEngine",
     "NFTDiffusersFSDPEngine",
     "DiffusersFSDPEngine",
+    "OmniFSDPEngine",
     "VeOmniDiffusionEngine",
 ]

--- a/verl_omni/workers/engine/fsdp/__init__.py
+++ b/verl_omni/workers/engine/fsdp/__init__.py
@@ -17,6 +17,7 @@ from .diffusers_impl import (  # noqa: F401
     NFTDiffusersFSDPEngine,
     PPODiffusersFSDPEngine,
 )
+from .omni_impl import OmniFSDPEngine  # noqa: F401
 
 # TODO(andy): unify DPO and NFT engines later.
 __all__ = [
@@ -24,4 +25,5 @@ __all__ = [
     "DPODiffusersFSDPEngine",
     "NFTDiffusersFSDPEngine",
     "DiffusersFSDPEngine",
+    "OmniFSDPEngine",
 ]

--- a/verl_omni/workers/engine/fsdp/omni_impl.py
+++ b/verl_omni/workers/engine/fsdp/omni_impl.py
@@ -1,0 +1,423 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""FSDP/FSDP2 engine for omni models (online RL and direct preference).
+
+Model loading follows PR #258: ``AutoModelForMultimodalLM`` plus
+``OmniModelBase.configure_model``.  Direct preference adds token log-prob
+``infer_batch`` / ``train_batch`` on top of the shared FSDP stack.
+"""
+
+import logging
+import os
+import warnings
+from contextlib import contextmanager, nullcontext
+from typing import Any, Callable, Optional
+
+import torch
+import torch.nn.functional as F
+from tensordict import TensorDict
+from torch.distributed.tensor import DTensor
+from verl.trainer.config import CheckpointConfig
+from verl.utils import tensordict_utils as tu
+from verl.utils.device import get_device_id
+from verl.utils.fsdp_utils import (
+    get_init_weight_context_manager,
+    load_fsdp_model_to_gpu,
+    offload_fsdp_model_to_cpu,
+)
+from verl.utils.model import convert_weight_keys
+from verl.utils.torch_dtypes import PrecisionType
+from verl.workers.config import FSDPEngineConfig, FSDPOptimizerConfig
+from verl.workers.engine.base import EngineRegistry
+from verl.workers.engine.fsdp.transformer_impl import FSDPEngine
+from verl.workers.engine.utils import prepare_micro_batches
+
+from verl_omni.pipelines.utils import prepare_omni_model_inputs
+from verl_omni.utils.fsdp_utils import collect_lora_params
+from verl_omni.workers.config import OmniModelConfig
+from verl_omni.workers.engine.lora_adapter_mixin import LoRAAdapterMixin
+
+logger = logging.getLogger(__file__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
+
+_NON_MODEL_KEYS = {
+    "average_log_prob",
+    "compute_loss",
+    "disable_auto_offload",
+    "global_token_num",
+    "gradient_accumulation_steps",
+    "max_token_len_per_gpu",
+    "micro_batch_size_per_gpu",
+    "mini_batch_size",
+    "num_mini_batch",
+    "reference_chosen_logps",
+    "reference_rejected_logps",
+    "sample_level_rewards",
+    "sample_level_scores",
+    "sp_size",
+    "update_lr_scheduler",
+    "use_dynamic_bsz",
+    "use_fused_kernels",
+    "use_remove_padding",
+}
+
+# Text tensors rebuilt by the packed->dense unpack step, and the multimodal
+# placeholder masks consumed there. These are excluded from the dict handed to
+# the HF forward and replaced with the per-branch (2N-row) tensors.
+_UNPACK_KEYS = {
+    "input_ids",
+    "attention_mask",
+    "position_ids",
+    "labels",
+    "image_mask",
+    "video_mask",
+    "audio_mask",
+}
+
+
+@EngineRegistry.register(model_type="omni", backend=["fsdp", "fsdp2"], device=["cuda", "npu"])
+class OmniFSDPEngine(LoRAAdapterMixin, FSDPEngine):
+    """FSDP/FSDP2 omni model engine for direct preference and LoRA training."""
+
+    def __init__(
+        self,
+        model_config: OmniModelConfig,
+        engine_config: FSDPEngineConfig,
+        optimizer_config: FSDPOptimizerConfig,
+        checkpoint_config: CheckpointConfig,
+    ):
+        super().__init__(model_config, engine_config, optimizer_config, checkpoint_config)
+        self._is_lora = self.model_config.lora_rank > 0 or self.model_config.lora_adapter_path is not None
+        self._placeholder_token_ids: Optional[dict[str, Optional[int]]] = None
+
+    def _build_module(self):
+        from transformers import AutoModelForMultimodalLM
+
+        from verl_omni.pipelines.model_base import OmniModelBase
+
+        self.model_config: OmniModelConfig
+        architecture = self.model_config.architecture
+
+        torch_dtype = self.engine_config.model_dtype
+
+        if torch_dtype is None:
+            torch_dtype = torch.float32 if not self.engine_config.forward_only else torch.bfloat16
+
+        torch_dtype = PrecisionType.to_dtype(torch_dtype)
+
+        # Umbrella config delegates tie_word_embeddings to sub-configs.
+        if not hasattr(self.model_config.hf_config, "tie_word_embeddings"):
+            self.model_config.hf_config.tie_word_embeddings = False
+
+        init_context = get_init_weight_context_manager(
+            use_meta_tensor=not self.model_config.hf_config.tie_word_embeddings, mesh=self.device_mesh
+        )
+
+        with init_context(), warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+
+            module = AutoModelForMultimodalLM.from_pretrained(
+                pretrained_model_name_or_path=self.model_config.local_path,
+                torch_dtype=torch_dtype,
+                config=self.model_config.hf_config,
+                trust_remote_code=self.model_config.trust_remote_code,
+            )
+
+            adapter_cls = OmniModelBase.get_class_by_name(
+                architecture,
+                self.model_config.model_stage,
+                self.model_config.get("external_lib"),
+            )
+            module = adapter_cls.configure_model(module, self.model_config)
+
+            module.to(torch_dtype)
+
+            if self.model_config.enable_gradient_checkpointing:
+                module.gradient_checkpointing_enable(gradient_checkpointing_kwargs={"use_reentrant": False})
+        return module
+
+    def _build_fsdp_module(self, module):
+        saved_lora_rank = self.model_config.lora_rank
+        if self._is_lora and saved_lora_rank <= 0:
+            self.model_config.lora_rank = 1
+        try:
+            return super()._build_fsdp_module(module)
+        finally:
+            self.model_config.lora_rank = saved_lora_rank
+
+    def _model_module(self):
+        return getattr(self.module, "_fsdp_wrapped_module", self.module)
+
+    @contextmanager
+    def disable_adapter(self):
+        module = self._model_module()
+        if not hasattr(module, "disable_adapters"):
+            yield
+            return
+        module.disable_adapters()
+        try:
+            yield
+        finally:
+            module.enable_adapters()
+
+    def optimizer_zero_grad(self):
+        if self.optimizer is not None:
+            self.optimizer.zero_grad()
+
+    def lr_scheduler_step(self):
+        if self.lr_scheduler is None:
+            return None
+        return super().lr_scheduler_step()
+
+    def _get_placeholder_token_ids(self) -> dict[str, Optional[int]]:
+        """Multimodal placeholder token ids, matching the dataset transform.
+
+        The dataset zeroes the multimodal placeholder ids in
+        ``input_ids`` and tracks their positions in ``image_mask``/``video_mask``/
+        ``audio_mask``. The HF forward instead locates placeholders via
+        ``input_ids == config.<x>_token_id``, so we restore the real ids here.
+        """
+        if self._placeholder_token_ids is None:
+            processor = self.model_config.get_processor()
+            tokenizer = getattr(processor, "tokenizer", processor)
+            vocab = tokenizer.get_vocab()
+            self._placeholder_token_ids = {
+                "image": vocab.get("<|image_pad|>", vocab.get("<|IMAGE|>")),
+                "video": vocab.get("<|video_pad|>", vocab.get("<|VIDEO|>")),
+                "audio": vocab.get("<|audio_pad|>", vocab.get("<|AUDIO|>")),
+            }
+        return self._placeholder_token_ids
+
+    def _unpack_paired_rows(
+        self, micro_batch: TensorDict | dict[str, Any]
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Split packed ``[chosen; rejected]`` rows into a dense ``2N``-row batch.
+
+        The dataset packs each preference pair into a single row (chosen then
+        rejected along the sequence dim) for the VeOmni varlen forward. The HF
+        forward used here has no varlen isolation, so we split each row into two
+        independent branches (detected via per-branch ``position_ids`` resets),
+        restore the multimodal placeholder ids, and re-pad into ``[chosen0,
+        rejected0, chosen1, rejected1, ...]`` order. That order matches the
+        multimodal feature order produced by the adapter, so ``masked_scatter``
+        in the HF forward consumes features correctly without manual routing.
+        """
+        input_ids = micro_batch["input_ids"].clone()
+        attention_mask = micro_batch["attention_mask"]
+        labels = micro_batch["labels"]
+        position_ids = micro_batch["position_ids"]
+
+        token_ids = self._get_placeholder_token_ids()
+        for name, mask_key in (("image", "image_mask"), ("video", "video_mask"), ("audio", "audio_mask")):
+            mask = micro_batch.get(mask_key, None)
+            token_id = token_ids.get(name)
+            if mask is not None and token_id is not None:
+                input_ids[mask.bool()] = token_id
+
+        has_mrope = position_ids.dim() == 3  # (B, 3, L)
+        pos_reset_signal = position_ids.sum(dim=1) if has_mrope else position_ids  # (B, L)
+
+        seg_input_ids: list[torch.Tensor] = []
+        seg_labels: list[torch.Tensor] = []
+        seg_attn: list[torch.Tensor] = []
+        seg_pos: list[torch.Tensor] = []
+        for b in range(input_ids.shape[0]):
+            valid = attention_mask[b].bool()
+            valid_len = int(valid.sum().item())
+            starts = torch.nonzero((pos_reset_signal[b] == 0) & valid, as_tuple=False).flatten().tolist()
+            if len(starts) != 2:
+                raise ValueError(
+                    "OmniFSDPEngine expects exactly 2 packed sub-sequences (chosen, rejected) per row, "
+                    f"but found {len(starts)} position-id resets. Check the paired-preference dataset."
+                )
+            for start, end in ((starts[0], starts[1]), (starts[1], valid_len)):
+                seg_input_ids.append(input_ids[b, start:end])
+                seg_labels.append(labels[b, start:end])
+                seg_attn.append(attention_mask[b, start:end])
+                seg_pos.append(position_ids[b, :, start:end] if has_mrope else position_ids[b, start:end])
+
+        max_len = max(int(seg.shape[-1]) for seg in seg_input_ids)
+
+        def _pad_1d(tensor: torch.Tensor, pad_value: int) -> torch.Tensor:
+            if tensor.shape[-1] == max_len:
+                return tensor
+            out = tensor.new_full((max_len,), pad_value)
+            out[: tensor.shape[-1]] = tensor
+            return out
+
+        def _pad_pos(tensor: torch.Tensor) -> torch.Tensor:
+            if tensor.shape[-1] == max_len:
+                return tensor
+            shape = (*tensor.shape[:-1], max_len)
+            out = tensor.new_zeros(shape)
+            out[..., : tensor.shape[-1]] = tensor
+            return out
+
+        new_input_ids = torch.stack([_pad_1d(seg, 0) for seg in seg_input_ids], dim=0)
+        new_labels = torch.stack([_pad_1d(seg, -100) for seg in seg_labels], dim=0)
+        new_attn = torch.stack([_pad_1d(seg, 0) for seg in seg_attn], dim=0)
+        # HF mrope rotary expects position_ids as (3, batch, seq); the dataset
+        # collates them as (batch, 3, seq), so stack the per-branch (3, seq) segments
+        # along the new batch axis (dim=1) to yield (3, 2N, seq).
+        padded_pos = [_pad_pos(seg) for seg in seg_pos]
+        new_pos = torch.stack(padded_pos, dim=1) if has_mrope else torch.stack(padded_pos, dim=0)
+        return new_input_ids, new_attn, new_pos, new_labels
+
+    def _prepare_model_inputs(self, micro_batch: TensorDict | dict[str, Any]) -> tuple[dict[str, Any], torch.Tensor]:
+        new_input_ids, new_attention_mask, new_position_ids, labels = self._unpack_paired_rows(micro_batch)
+        branch_items = {
+            key: value for key, value in micro_batch.items() if key not in _NON_MODEL_KEYS and key not in _UNPACK_KEYS
+        }
+        branch_items["input_ids"] = new_input_ids
+        branch_items["attention_mask"] = new_attention_mask
+        branch_items["position_ids"] = new_position_ids
+        branch_items["labels"] = labels
+        branch_batch = TensorDict.from_dict(branch_items, batch_size=new_input_ids.shape[0])
+        model_inputs = prepare_omni_model_inputs(
+            self.model_config,
+            branch_batch,
+            dtype=next(self.module.parameters()).dtype,
+        )
+        return model_inputs, labels
+
+    @staticmethod
+    def _sequence_logps(logits: torch.Tensor, labels: torch.Tensor, average_log_prob: bool) -> torch.Tensor:
+        shift_logits = logits[:, :-1, :].float()
+        shift_labels = labels[:, 1:].contiguous()
+        loss_mask = shift_labels != -100
+        safe_labels = shift_labels.masked_fill(~loss_mask, 0)
+        token_logps = F.log_softmax(shift_logits, dim=-1).gather(dim=-1, index=safe_labels.unsqueeze(-1)).squeeze(-1)
+        seq_logps = (token_logps * loss_mask).sum(dim=-1)
+        if average_log_prob:
+            seq_logps = seq_logps / loss_mask.sum(dim=-1).clamp(min=1)
+        return seq_logps
+
+    def _concatenated_forward(self, model, micro_batch: TensorDict | dict[str, Any]):
+        model_inputs, labels = self._prepare_model_inputs(micro_batch)
+        outputs = model(**model_inputs, use_cache=False)
+        logits = outputs.logits if hasattr(outputs, "logits") else outputs[0]
+        all_logps = self._sequence_logps(
+            logits,
+            labels,
+            average_log_prob=tu.get_non_tensor_data(micro_batch, "average_log_prob", default=False),
+        )
+        return all_logps[0::2], all_logps[1::2]
+
+    def _forward_backward_micro_batch(self, micro_batch: TensorDict, loss_function: Callable):
+        micro_batch = micro_batch.to(get_device_id())
+        tu.assign_non_tensor(
+            micro_batch,
+            average_log_prob=tu.get_non_tensor_data(micro_batch, "average_log_prob", default=False),
+        )
+        policy_chosen_logps, policy_rejected_logps = self._concatenated_forward(self.module, micro_batch)
+        model_output = {
+            "policy_chosen_logps": policy_chosen_logps,
+            "policy_rejected_logps": policy_rejected_logps,
+            "reference_chosen_logps": micro_batch["reference_chosen_logps"],
+            "reference_rejected_logps": micro_batch["reference_rejected_logps"],
+        }
+        loss, metrics = loss_function(model_output=model_output, data=micro_batch)
+        loss.backward()
+        return loss.detach(), metrics
+
+    def train_batch(self, data: TensorDict, loss_function: Optional[Callable] = None):
+        if loss_function is None:
+            raise ValueError("OmniFSDPEngine.train_batch requires a loss_function.")
+        config = getattr(loss_function, "keywords", {}).get("config")
+        loss_config = getattr(config, "omni_loss", None)
+        tu.assign_non_tensor(data, average_log_prob=getattr(loss_config, "average_log_prob", False))
+        micro_batches, _ = prepare_micro_batches(
+            data=data,
+            dp_group=self.get_data_parallel_group(),
+            same_micro_num_in_dp=True,
+        )
+        gradient_accumulation_steps = len(micro_batches)
+        losses = []
+        metrics: dict[str, list[torch.Tensor]] = {}
+        for micro_batch in micro_batches:
+            tu.assign_non_tensor(micro_batch, gradient_accumulation_steps=gradient_accumulation_steps)
+            loss, micro_metrics = self._forward_backward_micro_batch(micro_batch, loss_function)
+            losses.append(loss.item())
+            for key, value in micro_metrics.items():
+                metrics.setdefault(key, []).append(value)
+        grad_norm = self.optimizer_step()
+        self.optimizer_zero_grad()
+        metrics = {key: torch.stack(value).mean().item() for key, value in metrics.items()}
+        metrics["grad_norm"] = grad_norm
+        return {"model_output": {}, "loss": losses, "metrics": metrics}
+
+    def infer_batch(self, data: TensorDict, loss_function: Optional[Callable] = None):
+        del loss_function
+        micro_batches, _ = prepare_micro_batches(
+            data=data,
+            dp_group=self.get_data_parallel_group(),
+            same_micro_num_in_dp=True,
+        )
+        chosen_logps = []
+        rejected_logps = []
+        with torch.no_grad():
+            for micro_batch in micro_batches:
+                micro_batch = micro_batch.to(get_device_id())
+                chosen, rejected = self._concatenated_forward(self.module, micro_batch)
+                chosen_logps.append(chosen)
+                rejected_logps.append(rejected)
+        return {
+            "model_output": {
+                "chosen_logps": torch.cat(chosen_logps, dim=0),
+                "rejected_logps": torch.cat(rejected_logps, dim=0),
+            },
+            "loss": [0.0],
+            "metrics": {},
+        }
+
+    def get_per_tensor_param(
+        self,
+        layered_summon=False,
+        base_sync_done=False,
+        adapter_name: str | None = None,
+        **kwargs,
+    ):
+        load_fsdp_model_to_gpu(self.module)
+        peft_config = None
+        peft_model = self._model_module()
+        if hasattr(peft_model, "peft_config"):
+            peft_config = peft_model.peft_config.get("default", None)
+            adapter_ctx = self.use_adapter(adapter_name) if adapter_name is not None else nullcontext()
+            with adapter_ctx:
+                params = collect_lora_params(
+                    module=self.module,
+                    layered_summon=layered_summon,
+                    base_sync_done=base_sync_done,
+                    is_diffusers=False,
+                    adapter_name=adapter_name or "default",
+                    layer_prefixes=self.model_config.fsdp_layer_prefixes,
+                )
+        else:
+            params = self.module.state_dict()
+        params = convert_weight_keys(params, peft_model)
+        if self._is_offload_param:
+            offload_fsdp_model_to_cpu(self.module)
+        device = get_device_id()
+        export_dtype = PrecisionType.to_dtype(self.engine_config.model_dtype)
+
+        def param_generator():
+            for name, param in params.items():
+                tensor = param.full_tensor() if isinstance(param, DTensor) else param
+                tensor = tensor.to(device, non_blocking=True)
+                if tensor.is_floating_point() and export_dtype is not None and tensor.dtype != export_dtype:
+                    tensor = tensor.to(export_dtype, non_blocking=True)
+                yield name, tensor
+
+        peft_config_dict = peft_config.to_dict() if peft_config is not None else None
+        return param_generator(), peft_config_dict


### PR DESCRIPTION
## Summary

**Overlapped with #258. Please review it after #258 is merged.**

This PR adds the core training framework for omni autoregressive models under
`algorithm.trainer_type=direct_preference` and `algorithm.sample_source=offline`.
It wires together a unified omni entrypoint, a Ray direct-preference trainer,
and an FSDP engine for paired-preference log-prob training.

- Add `verl_omni/trainer/main_omni.py` as the omni Hydra entrypoint. Online RL
  (GSPO/GRPO/etc.) routes to verl V1 PPO; offline direct preference uses an
  in-file `RayTrainerTaskRunner` that selects the trainer by
  `algorithm.trainer_type` and `model_type`.
- Add `OmniDirectPreferenceRayTrainer`, reusing the shared
  `DirectPreferenceRayTrainer` Ray loop for actor-only offline training, with
  reference log-prob inference via actor/ref workers and ref-in-actor LoRA
  support.
- Add `OmniFSDPEngine` (`model_type=omni`, FSDP/FSDP2) on top of
  `AutoModelForMultimodalLM` + `OmniModelBase.configure_model`. It unpacks
  packed `[chosen; rejected]` rows into dense `2N`-row batches for HF forward,
  and implements `train_batch` / `infer_batch` for DPO-style sequence log-probs.
- Rename `DirectPreferenceRayTrainer._compute_ref_noise_pred` to
  `_infer_reference_policy` so diffusion and omni trainers share the same
  override point.
- Set `OmniModelConfig.model_type` default to `"omni"`.

## Scope / limitations

- `OmniDirectPreferenceRayTrainer` currently supports:
  - `algorithm.sample_source=offline`
  - `actor_rollout_ref.model.model_type=omni`
  - `actor_rollout_ref.actor.omni_loss.loss_mode=dpo`
- Old-policy adapters are not supported yet.
- Dataset plumbing, example launch scripts, and end-to-end smoke tests are
  expected in other  PRs on related branches, like #268 

## Test plan

- [ ] CPU unit tests:
  ```bash
  echo '[pytest]' > pytest.ini
  echo 'python_files = *_on_cpu.py' >> pytest.ini
  pytest -s -x --asyncio-mode=auto \
    tests/trainer/omni/test_main_omni_on_cpu.py \
    tests/trainer/omni/test_omni_dpo_trainer_on_cpu.py