### PR TITLE
[omni] fix: drop stale vllm-omni 0.22 step-count mapping in BAGEL adapter

### DIFF
--- a/verl_omni/pipelines/bagel_flow_grpo/common.py
+++ b/verl_omni/pipelines/bagel_flow_grpo/common.py
@@ -46,11 +46,6 @@ def bagel_time_shift(shift: float, t):
     return (shift * t) / (1 + (shift - 1) * t)
 
 
-def vllm_omni_num_timesteps(bagel_num_timesteps: int) -> int:
-    """Map official BAGEL step count to vllm-omni 0.22 generate_image input."""
-    return bagel_num_timesteps - 1 if bagel_num_timesteps > 1 else bagel_num_timesteps
-
-
 def setup_bagel_sigmas(
     scheduler: FlowMatchSDEDiscreteScheduler,
     num_steps: int,

--- a/verl_omni/pipelines/bagel_flow_grpo/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/bagel_flow_grpo/vllm_omni_rollout_adapter.py
@@ -36,7 +36,6 @@ from verl_omni.pipelines.bagel_flow_grpo.common import (
     BAGEL_FLOWGRPO_CFG_DEFAULTS,
     maybe_to_cpu,
     setup_bagel_sigmas,
-    vllm_omni_num_timesteps,
 )
 from verl_omni.pipelines.model_base import VllmOmniPipelineBase
 from verl_omni.pipelines.schedulers import FlowMatchSDEDiscreteScheduler
@@ -337,12 +336,8 @@ class BagelPipelineWithLogProb(BagelPipeline):
             return_logprobs=logprobs,
         )
 
-        # vllm-omni 0.22 runs one extra denoise step; compensate for BAGEL parity.
-        req.sampling_params.num_inference_steps = vllm_omni_num_timesteps(bagel_num_timesteps)
-        try:
-            output = super().forward(req)
-        finally:
-            req.sampling_params.num_inference_steps = bagel_num_timesteps
+        # vllm-omni >= 0.24 (#4509) matches official BAGEL: n schedule points, n-1 denoise steps.
+        output = super().forward(req)
 
         # Slice trajectory to the SDE window so training only sees noisy steps.
         traj_latents = output.trajectory_latents


### PR DESCRIPTION
### What

The BAGEL rollout adapter maps `num_inference_steps` n -> n−1 before calling the engine, compensating for vllm-omni 0.22, where `generate_image(M)` sampled M+1 schedule points for M denoise steps. Since vllm-omni#4509 (in the current pin) `generate_image(M)` follows official BAGEL semantics with M points, M−1 steps, so the mapping now desyncs everything built from the unmapped count. With the recipe's n=15 the engine samples, conditions the model, and records trajectory timesteps on a 14-point schedule, while both scheduler tables (rollout inner + trainer replay) hold 15-point sigmas resolved by step index. BAGEL also silently runs one fewer denoise step than configured.

At HEAD this crashes the trainer replay (`IndexError` in `index_for_timestep` during `old_log_probs`). With only the replay table patched, a systematic +5.0e-3 log-prob bias remains — analytically predicted by the two schedules' std_eff mismatch (+5.0e-3/+5.6e-3 vs measured +4.8e-3/+5.3e-3). Against the recipe's `clip_ratio=1e-5`, that puts every sample ~500x outside the clip band.

Fix: drop the stale mapping. The engine builds the official n-point schedule and sampling, model conditioning, recorded timesteps, and replay all share it.

### Duplicate check

No open PR/issue touches the BAGEL schedule. Found while measuring rollout-train log-prob consistency, full data in RFC #280.

### Test

- 4×RTX PRO 6000, BAGEL OCR FlowGRPO recipe, `calculate_log_probs=True`, 3 training steps × 64 samples: mean `|old_log_probs − rollout_log_probs|` drops **5.03e-3 → 3.20e-5** (157x), matching the SD3.5/Qwen-Image bf16 noise floor; replay no longer crashes.
- `ruff check` / `ruff format` clean. No BAGEL CPU tests exist to extend.
