### PR TITLE
[doc, cfg] chore: document reward-server profiling in reward docs

### DIFF
--- a/docs/algo/async_reward.md
+++ b/docs/algo/async_reward.md
@@ -1,7 +1,7 @@
 (async_reward)=
 # Async Reward for Diffusion Training
 
-Last updated: 06/09/2026
+Last updated: 07/17/2026
 
 Async reward lets VeRL-Omni score completed rollout samples through reward-loop
 workers while other samples are still being generated. It is useful when reward
@@ -146,6 +146,16 @@ if self.use_rm and "rm_scores" not in batch.batch.keys():
 
 This is why async reward can reduce the measured `reward` section in the trainer
 timer: the reward work has already been streamed during generation.
+
+## Profiling the reward servers
+
+The reward-model servers support the same per-server torch profiler as the actor
+rollout servers, enabled via `reward.reward_model.rollout.profiler.*` (see the
+[profiler guide](../perf/profiler.md) for the recipe). The trainer profiles the
+phase where the servers actually score: with async reward that is the generation
+window — so expect a near-zero `reward` timer while the reward-server trace still
+captures the scoring compute. Without `enable_resource_pool`, the window is the
+colocated `reward` phase instead.
 
 ## External HTTP scorers
 

--- a/docs/api/reward.rst
+++ b/docs/api/reward.rst
@@ -8,15 +8,24 @@ compressibility) and model-based generative reward models (e.g. OCR via a
 vision-language model served behind an OpenAI-compatible router). Reward
 computation is dispatched per sample by the
 :class:`~verl_omni.reward_loop.reward_manager.VisualRewardManager`, which
-plugs into the standard :class:`verl.experimental.reward_loop.RewardLoopManager`.
+plugs into :class:`~verl_omni.reward_loop.reward_loop.OmniRewardLoopManager` —
+verl's :class:`~verl.experimental.reward_loop.RewardLoopManager` extended with
+profiler control over the reward-model rollout servers.
 
 .. autosummary::
    :nosignatures:
 
+   verl_omni.reward_loop.reward_loop.OmniRewardLoopManager
    verl_omni.reward_loop.reward_manager.VisualRewardManager
    verl_omni.utils.reward_score.default_compute_score_image
    verl_omni.utils.reward_score.http_scorer_client.compute_score
    verl_omni.utils.reward_score.unified_reward.compute_score_unified_reward
+
+Reward Loop Manager
+~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: verl_omni.reward_loop.reward_loop.OmniRewardLoopManager
+   :members: start_profile, stop_profile
 
 Reward Manager
 ~~~~~~~~~~~~~~~~~

--- a/docs/start/http_scorer.md
+++ b/docs/start/http_scorer.md
@@ -1,7 +1,7 @@
 (http_scorer)=
 # Using an External HTTP Scorer Service
 
-Last updated: 05/28/2026
+Last updated: 07/17/2026
 
 VeRL-Omni ships a generic HTTP reward client (`verl_omni.utils.reward_score.http_scorer_client`) that sends generated images to an external scorer service over HTTP and returns the score. This is useful when your reward model is too large to co-locate with training, needs a different runtime (e.g., a separate GPU pool), or is shared across multiple experiments.
 
@@ -114,3 +114,4 @@ OCR_REWARD_SERVER_URL=http://<server-ip>:19082 \
 - The HTTP client reuses a single `aiohttp.ClientSession` across calls to avoid per-request connection overhead.
 - Image serialization (tensor to PIL to JPEG) is offloaded to a thread pool via `asyncio.loop.run_in_executor` so it does not block the reward manager's async event loop.
 - The default request timeout is 120 seconds. If your scorer model is slow, consider scaling the service with Gunicorn workers or increasing the timeout in the client code.
+- Reward-server profiling (`reward.reward_model.rollout.profiler.*`, see the [profiler guide](../perf/profiler.md)) only covers model-backed rewards served by VeRL-Omni. With an HTTP scorer, reward inference runs inside your external service — profile it there.

--- a/verl_omni/trainer/config/_generated_omni_trainer.yaml
+++ b/verl_omni/trainer/config/_generated_omni_trainer.yaml
@@ -694,26 +694,30 @@ sandbox_fusion:
   max_concurrent: null
   memory_limit_mb: null
 reward:
-  num_workers: 8
-  custom_reward_function:
-    path: null
-    name: compute_score
-  reward_functions: {}
-  aggregation: weighted_sum
-  reward_manager:
-    _target_: verl.workers.config.reward_model.RewardManagerConfig
-    source: importlib
-    name: VisualRewardManager
-    module:
-      _target_: verl.trainer.config.config.ModuleConfig
-      path: pkg://verl_omni.reward_loop.reward_manager
   reward_model:
-    enable: false
-    enable_resource_pool: false
-    n_gpus_per_node: 8
-    nnodes: 0
-    model_path: null
     rollout:
+      profiler:
+        _target_: verl.utils.profiler.ProfilerConfig
+        tool: torch
+        enable: false
+        all_ranks: false
+        ranks: []
+        save_path: ${oc.select:global_profiler.save_path,outputs/profile}/reward_model
+        tool_config:
+          nsys:
+            _target_: verl.utils.profiler.config.NsightToolConfig
+            discrete: ${oc.select:global_profiler.global_tool_config.nsys.discrete,false}
+            name: nsight
+          torch:
+            _target_: verl.utils.profiler.config.TorchProfilerToolConfig
+            contents: []
+            discrete: false
+            name: torch
+          torch_memory:
+            _target_: verl.utils.profiler.config.TorchMemoryToolConfig
+            trace_alloc_max_entries: ${oc.select:global_profiler.global_tool_config.torch_memory.trace_alloc_max_entries,100000}
+            stack_depth: ${oc.select:global_profiler.global_tool_config.torch_memory.stack_depth,32}
+            name: torch_memory
       _target_: verl.workers.config.RolloutConfig
       name: ???
       dtype: bfloat16
@@ -757,6 +761,24 @@ reward:
         transfer_backend: nixl
         bootstrap_port: null
         ib_device: null
+    enable: false
+    enable_resource_pool: false
+    n_gpus_per_node: 8
+    nnodes: 0
+    model_path: null
+  num_workers: 8
+  custom_reward_function:
+    path: null
+    name: compute_score
+  reward_functions: {}
+  aggregation: weighted_sum
+  reward_manager:
+    _target_: verl.workers.config.reward_model.RewardManagerConfig
+    source: importlib
+    name: VisualRewardManager
+    module:
+      _target_: verl.trainer.config.config.ModuleConfig
+      path: pkg://verl_omni.reward_loop.reward_manager
   sandbox_fusion:
     url: null
     max_concurrent: 64


### PR DESCRIPTION
Doc follow-up to #256.

## What

- `docs/api/reward.rst`: add `OmniRewardLoopManager` to the API reference; the intro previously pointed at verl's `RewardLoopManager`, which #256 replaced.
- `docs/algo/async_reward.md`: new "Profiling the reward servers" section — under async reward the profiling window is the generation phase (near-zero `reward` timer, populated reward trace); recipe details stay in the profiler guide.
- `docs/start/http_scorer.md`: note that HTTP scorers run outside VeRL-Omni, so the reward-server profiler does not cover them.

Also regenerates `_generated_omni_trainer.yaml`: it was added in #253 in parallel with #256's `reward.yaml` change, so on main it is missing the `reward_model.rollout.profiler` block and fails the autogen pre-commit check for any PR.

## Testing

`pre-commit run` on the changed files passes (docs checks, autogen-config verification, license, compile).
