### PR TITLE
[model, rollout, reward, algo, worker, trainer] feat: Qwen3-TTS talker GSPO + online DPO

### DIFF
--- a/examples/qwen3_tts_dpo/README.md
+++ b/examples/qwen3_tts_dpo/README.md
@@ -11,15 +11,16 @@ recipe's talker actor, vLLM-Omni AR rollout, stage config and dependency patches
 - **Rollout**: `rollout.n=2` candidates per prompt (the vLLM-Omni AR talker, same stage config as GSPO).
 - **Reward**: `AudioJudgeRewardManager` decodes both candidates reward-side, buffers them by `uid`, and
   sends the pair to a judge `/rank` endpoint in one call. Each candidate's rating becomes `sj_score`.
-- **Loss**: `verl_omni.trainer.main_ppo` binds `tts_dpo_loss` on the actor (via the same `set_loss_fn`
+- **Loss**: `verl_omni.trainer.main_tts` binds `tts_dpo_loss` on the actor (via the same `set_loss_fn`
   seam base verl uses for the critic). Per sequence it sums the current and reference log-probs over
   the response, forms the implicit reward `r = sum(log pi_theta - log pi_ref)`, and minimizes
   `-logsigmoid(dpo_beta * (r_chosen - r_rejected))` plus an optional `dpo_nll_lambda * NLL(chosen)`.
   Pairing is internal to the loss (group by `uid`, best vs worst by `sj_score`); a judge tie yields a
   zero-gradient pair. No base-verl patch is involved.
 
-Launch with `python3 -m verl_omni.trainer.main_ppo` (not `verl.trainer.main_ppo`): the omni entry is
-the only difference, adding the DPO loss binding; every other recipe still runs on the base entry.
+Launch with `python3 -m verl_omni.trainer.main_tts`, the shared Qwen3-TTS entry (the GSPO recipe uses
+it too). It is base verl's PPO flow verbatim; the only addition is the DPO loss binding, a no-op
+unless `loss_mode` is dpo.
 
 ## Load-bearing invariants (baked into the config)
 
@@ -88,7 +89,7 @@ examples/qwen3_tts_dpo/
 ├── run_qwen3_tts_dpo.sh        launch (reuses ../qwen3_tts_gspo_trainer stage yaml + patches)
 └── judge_server.py             generic /rank judge (Gemini or OpenAI-compatible)
 
-verl_omni/trainer/main_ppo.py                        omni PPO/DPO entry (binds tts_dpo_loss)
+verl_omni/trainer/main_tts.py                        omni PPO/DPO entry (binds tts_dpo_loss)
 verl_omni/workers/utils/losses.py                    tts_dpo_loss (pairwise codec-0 DPO)
 verl_omni/workers/config/tts/actor.py                DPOPolicyLossConfig (dpo_beta / dpo_nll_lambda)
 verl_omni/reward_loop/reward_manager/audio_judge.py  AudioJudgeRewardManager

--- a/examples/qwen3_tts_dpo/README.md
+++ b/examples/qwen3_tts_dpo/README.md
@@ -1,0 +1,95 @@
+# Qwen3-TTS Talker Online DPO (LLM-audio judge)
+
+Online DPO post-training of a Qwen3-TTS talker: for each prompt the actor generates two candidates,
+a remote audio-capable LLM judges which reads the text more naturally, and the talker trains with a
+pairwise DPO loss on its codec-0 sequence log-prob against a frozen reference. It reuses the GSPO
+recipe's talker actor, vLLM-Omni AR rollout, stage config and dependency patches
+(`../qwen3_tts_gspo_trainer/`); only the loss, the reward, and the batch invariants differ.
+
+## How it works
+
+- **Rollout**: `rollout.n=2` candidates per prompt (the vLLM-Omni AR talker, same stage config as GSPO).
+- **Reward**: `AudioJudgeRewardManager` decodes both candidates reward-side, buffers them by `uid`, and
+  sends the pair to a judge `/rank` endpoint in one call. Each candidate's rating becomes `sj_score`.
+- **Loss**: `verl_omni.trainer.main_ppo` binds `tts_dpo_loss` on the actor (via the same `set_loss_fn`
+  seam base verl uses for the critic). Per sequence it sums the current and reference log-probs over
+  the response, forms the implicit reward `r = sum(log pi_theta - log pi_ref)`, and minimizes
+  `-logsigmoid(dpo_beta * (r_chosen - r_rejected))` plus an optional `dpo_nll_lambda * NLL(chosen)`.
+  Pairing is internal to the loss (group by `uid`, best vs worst by `sj_score`); a judge tie yields a
+  zero-gradient pair. No base-verl patch is involved.
+
+Launch with `python3 -m verl_omni.trainer.main_ppo` (not `verl.trainer.main_ppo`): the omni entry is
+the only difference, adding the DPO loss binding; every other recipe still runs on the base entry.
+
+## Load-bearing invariants (baked into the config)
+
+Online DPO needs each prompt's two candidates to reach the loss together in one in-order micro-batch
+on one data-parallel rank. The config enforces this and the loss asserts it:
+
+- `reward.num_workers: 1` - both candidates of a prompt must rendezvous in one reward worker's event
+  loop for the pairwise judge call. More workers split the group; the manager raises if it is not 1.
+- `actor.use_dynamic_bsz: false` and `ppo_micro_batch_size_per_gpu` == per-rank candidate count - so
+  the mini-batch is exactly one in-order micro-batch and a `uid` group is never split across micro-batches.
+- `trainer.balance_batch: false` - seqlen balancing would scatter a prompt's two candidates across
+  ranks; contiguous chunking keeps them together (needs `train_batch_size % dp == 0`).
+- `actor.use_kl_loss: true` - only to build the reference worker so `ref_log_prob` exists. The DPO loss
+  uses `ref_log_prob` directly; the PPO KL term is unused (`kl_loss_coef: 0.0`).
+
+If the loss logs `formed no preference pairs`, a `uid` group was split: check the sizing above.
+
+## Tuning
+
+- `dpo_beta` (default 0.1): implicit-KL strength. Higher sharpens the chosen/rejected separation but can
+  destabilize; lower is gentler.
+- `dpo_nll_lambda` (default 0.0): an SFT anchor on the chosen sequence. Raise to 0.1-0.5 if the chosen
+  log-prob collapses while `dpo_margin` keeps widening (the model gaming displacement).
+- Judge by held-out eval, not the training curve: fresh pairs each step keep `dpo_acc`/`dpo_margin` noisy.
+
+## The judge
+
+`judge_server.py` is a standalone server speaking the `/rank` contract
+(`{text, wavs_b64, debias} -> {scores, chosen, rejected}`). The provider is pluggable:
+
+```bash
+# Gemini (default)
+GOOGLE_API_KEY=... python3 judge_server.py --provider gemini --model gemini-3.5-flash --port 8901
+
+# Any OpenAI-audio-compatible endpoint (hosted, or a locally vLLM-served audio LLM)
+python3 judge_server.py --provider openai --base-url http://localhost:8000/v1 \
+    --model <audio-llm> --api-key-env OPENAI_API_KEY --port 8901
+```
+
+Point the run at it with `JUDGE_URL` (or `reward.judge_urls=[...]` for several replicas). Any server
+that answers `/rank` works; the reward manager is provider-agnostic.
+
+**Caveat**: an LLM judge discriminates weakly on same-text / same-voice pairs, so online DPO from it
+can regress vs the SFT checkpoint even while training metrics look healthy. Treat this as clean
+plumbing for an LLM-judge preference loop, and evaluate checkpoints on held-out data before shipping.
+
+## Run
+
+```bash
+MODEL_PATH=<qwen3-tts SFT ckpt> \
+TRAIN_FILE=~/data/tts_voice_synth/train.parquet \
+VAL_FILE=~/data/tts_voice_synth/test.parquet \
+SPK_EMBED=~/data/tts_voice_synth/spk_embed.json \
+JUDGE_URL=http://localhost:8901 \
+bash run_qwen3_tts_dpo.sh
+```
+
+Install and data prep are identical to `../qwen3_tts_gspo_trainer/` (same `[tts]` extra, qwen-tts, and
+`patches/`); the judge additionally needs `google-genai` (Gemini) or `openai` (OpenAI-compatible).
+
+## Files
+
+```
+examples/qwen3_tts_dpo/
+├── config/qwen3_tts_dpo.yaml   recipe (inherits verl ppo_trainer; DPO loss + audio judge)
+├── run_qwen3_tts_dpo.sh        launch (reuses ../qwen3_tts_gspo_trainer stage yaml + patches)
+└── judge_server.py             generic /rank judge (Gemini or OpenAI-compatible)
+
+verl_omni/trainer/main_ppo.py                        omni PPO/DPO entry (binds tts_dpo_loss)
+verl_omni/workers/utils/losses.py                    tts_dpo_loss (pairwise codec-0 DPO)
+verl_omni/workers/config/tts/actor.py                DPOPolicyLossConfig (dpo_beta / dpo_nll_lambda)
+verl_omni/reward_loop/reward_manager/audio_judge.py  AudioJudgeRewardManager
+```

--- a/examples/qwen3_tts_dpo/config/qwen3_tts_dpo.yaml
+++ b/examples/qwen3_tts_dpo/config/qwen3_tts_dpo.yaml
@@ -1,0 +1,137 @@
+# Qwen3-TTS talker online-DPO config (FSDP actor + vLLM-Omni AR rollout, LLM-audio-judge reward).
+#
+# Inherits verl's default ppo_trainer config. Volatile values (data/model paths, the stage config
+# path, the speaker x-vector path, the judge url) are set via CLI in the run script.
+#
+# Recipe: for each prompt, generate rollout.n=2 candidates; a remote LLM audio judge picks the
+# winner; the actor trains with the pairwise tts_dpo_loss on the talker codec-0 sequence log-prob
+# vs a frozen reference. Shares the GSPO recipe's model, rollout server, stage yaml and patches;
+# only the loss, reward, and batch invariants differ.
+#
+# Launch (verl_omni entry binds tts_dpo_loss on the actor via set_loss_fn):
+#   python3 -m verl_omni.trainer.main_ppo --config-path=<this dir> --config-name=qwen3_tts_dpo <overrides>
+
+hydra:
+  searchpath:
+    - pkg://verl.trainer.config
+
+defaults:
+  - ppo_trainer
+  - _self_
+
+data:
+  train_batch_size: 16            # prompts; x rollout.n=2 = 32 candidates
+  max_prompt_length: 512
+  max_response_length: 2048       # codec tokens at 12Hz
+  filter_overlong_prompts: false  # the filter's per-sample try/except hides real errors
+  truncation: left
+
+actor_rollout_ref:
+
+  model:
+    # Qwen3-TTS-Base has no chat_template; passthrough emits each message's content verbatim.
+    custom_chat_template: "{% for message in messages %}{{ message['content'] }}{% endfor %}"
+    override_config:
+      attn_implementation: sdpa
+      tts_spk_embed_path: null    # clone-voice x-vector JSON; set the real path via CLI
+    use_remove_padding: false
+    enable_gradient_checkpointing: true
+
+  actor:
+    optim:
+      lr: 3e-6                    # DPO is sensitive; keep it low
+      lr_warmup_steps: 10
+      weight_decay: 0.0
+      clip_grad: 1.0
+    ppo_mini_batch_size: 16       # prompts; == train_batch_size so one mini-batch per step
+    ppo_micro_batch_size_per_gpu: 4  # = candidates per DP rank so DPO sees one in-order micro-batch
+    ppo_epochs: 1
+    use_dynamic_bsz: false        # a uid group must stay in one micro-batch (adjacent pairs)
+    use_kl_loss: true             # builds the ref worker so ref_log_prob exists; the KL term is unused
+    kl_loss_coef: 0.0
+    strategy: fsdp
+    fsdp_config:
+      fsdp_size: 1                # DDP; the 1.7B talker fits one GPU
+      param_offload: false
+      optimizer_offload: false
+      model_dtype: bf16
+      use_orig_params: true
+      wrap_policy:
+        min_num_params: 100000000
+    policy_loss:
+      _target_: verl_omni.workers.config.DPOPolicyLossConfig
+      loss_mode: dpo
+      dpo_beta: 0.1               # implicit-KL strength of the pairwise loss
+      dpo_nll_lambda: 0.0         # RPO/DPOP anchor on the chosen sequence; raise to 0.1-0.5 if logp collapses
+
+  rollout:
+    name: vllm_omni
+    mode: async
+    n: 2                          # two candidates per prompt to pair chosen/rejected
+    temperature: 1.0
+    top_p: 1.0
+    top_k: -1
+    tensor_model_parallel_size: 1
+    calculate_log_probs: true
+    log_prob_use_dynamic_bsz: false
+    load_format: safetensors
+    layered_summon: true
+    log_prob_micro_batch_size_per_gpu: 4
+    engine_kwargs:
+      vllm_omni:
+        output_mode: ar
+        # stage_configs_path is set on the CLI (reuses ../qwen3_tts_gspo_trainer/qwen3_tts_stages.yaml).
+
+  ref:
+    log_prob_micro_batch_size_per_gpu: 4
+    log_prob_use_dynamic_bsz: false
+    strategy: fsdp
+    fsdp_config:
+      fsdp_size: 1
+      param_offload: false
+      model_dtype: bf16
+      use_orig_params: true
+      wrap_policy:
+        min_num_params: 100000000
+
+algorithm:
+  # grpo groups candidates by uid (which tts_dpo_loss also pairs on); advantages are computed but the
+  # DPO loss ignores them.
+  adv_estimator: grpo
+  use_kl_in_reward: false
+
+reward:
+  # Single reward worker: a prompt's two candidates rendezvous in one worker's event loop for the
+  # pairwise judge call. More than one worker splits the group and breaks the rendezvous.
+  num_workers: 1
+  reward_manager:
+    name: AudioJudgeRewardManager
+    source: importlib
+    module:
+      path: pkg://verl_omni.reward_loop.reward_manager
+  audio:
+    codec: qwen_tts               # reward-side decoder for the surfaced codec tokens
+    codec_eos_token_id: 2150
+    decoder_model_path: null      # null uses the actor model path
+    # Bounds concurrent judge POSTs (and the shared codec decode); the network judge dominates, so
+    # more threads mostly buys judge concurrency. Lower it if concurrent CUDA decode misbehaves.
+    score_threads: 8
+  # Any server speaking the /rank contract; examples/qwen3_tts_dpo/judge_server.py is the default.
+  judge_urls: ["http://localhost:8901"]
+  judge_debias: true              # average A-vs-B with B-vs-A to cancel position bias
+  judge_timeout_s: 1800
+
+trainer:
+  val_before_train: false
+  critic_warmup: 0
+  logger: ["console", "mlflow"]
+  project_name: qwen3_tts_dpo
+  experiment_name: tts_dpo_audiojudge
+  nnodes: 1
+  n_gpus_per_node: 8
+  # Off so a prompt's two candidates stay contiguous on one DP rank (seqlen balancing would scatter
+  # them and the pairing would find no complete group).
+  balance_batch: false
+  save_freq: 20
+  test_freq: 0
+  total_epochs: 1

--- a/examples/qwen3_tts_dpo/config/qwen3_tts_dpo.yaml
+++ b/examples/qwen3_tts_dpo/config/qwen3_tts_dpo.yaml
@@ -9,7 +9,7 @@
 # only the loss, reward, and batch invariants differ.
 #
 # Launch (verl_omni entry binds tts_dpo_loss on the actor via set_loss_fn):
-#   python3 -m verl_omni.trainer.main_ppo --config-path=<this dir> --config-name=qwen3_tts_dpo <overrides>
+#   python3 -m verl_omni.trainer.main_tts --config-path=<this dir> --config-name=qwen3_tts_dpo <overrides>
 
 hydra:
   searchpath:

--- a/examples/qwen3_tts_dpo/judge_server.py
+++ b/examples/qwen3_tts_dpo/judge_server.py
@@ -1,0 +1,194 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Generic LLM-audio judge for online TTS DPO.
+
+Serves the /rank contract AudioJudgeRewardManager speaks: POST {text, wavs_b64, debias} ->
+{scores, chosen, rejected}. An audio-capable LLM compares two clips of the same text and picks the
+more natural read. The provider is pluggable: Gemini (default) or any OpenAI-audio-compatible
+endpoint (a hosted API or a locally vLLM-served audio model) via --base-url.
+
+    python judge_server.py --provider gemini --model gemini-3.5-flash --port 8901
+    python judge_server.py --provider openai --base-url http://localhost:8000/v1 \
+        --model Qwen2.5-Omni-7B --api-key-env OPENAI_API_KEY --port 8901
+"""
+
+import argparse
+import base64
+import json
+import os
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+SYSTEM = (
+    "You are an expert judge of text-to-speech. You will hear two clips, A then B, both reading the "
+    "same target text. Decide which is the more natural, human-sounding read. Reply with exactly one "
+    "token: A, B, or tie."
+)
+
+
+def _user_prompt(text):
+    return f'Target text: "{text}"\nClip A is first, clip B is second. Which is better? Answer A, B, or tie.'
+
+
+def _parse_label(out):
+    t = (out or "").strip().lower()
+    if "tie" in t:
+        return 0.5
+    head = t[:6]
+    if "a" in head and "b" not in head:
+        return 1.0
+    if "b" in head and "a" not in head:
+        return 0.0
+    return 0.5
+
+
+class Judge:
+    """Return P(clip A is better) in {0.0, 0.5, 1.0} for one ordered A-vs-B call."""
+
+    def compare(self, text, wav_a, wav_b):
+        raise NotImplementedError
+
+
+class GeminiJudge(Judge):
+    def __init__(self, model):
+        from google import genai
+
+        self._model = model
+        self._client = genai.Client(api_key=os.environ["GOOGLE_API_KEY"])
+
+    def compare(self, text, wav_a, wav_b):
+        from google.genai import types
+
+        contents = [
+            SYSTEM,
+            _user_prompt(text),
+            types.Part.from_bytes(data=wav_a, mime_type="audio/wav"),
+            types.Part.from_bytes(data=wav_b, mime_type="audio/wav"),
+        ]
+        resp = self._client.models.generate_content(model=self._model, contents=contents)
+        return _parse_label(resp.text)
+
+
+class OpenAICompatJudge(Judge):
+    """Any OpenAI-audio-compatible chat endpoint (hosted or a locally vLLM-served audio LLM)."""
+
+    def __init__(self, model, base_url, api_key_env):
+        from openai import OpenAI
+
+        self._model = model
+        self._client = OpenAI(base_url=base_url, api_key=os.environ.get(api_key_env, "EMPTY"))
+
+    def compare(self, text, wav_a, wav_b):
+        def audio_part(wav):
+            return {"type": "input_audio", "input_audio": {"data": base64.b64encode(wav).decode(), "format": "wav"}}
+
+        user_content = [{"type": "text", "text": _user_prompt(text)}, audio_part(wav_a), audio_part(wav_b)]
+        messages = [
+            {"role": "system", "content": SYSTEM},
+            {"role": "user", "content": user_content},
+        ]
+        resp = self._client.chat.completions.create(model=self._model, messages=messages, temperature=0.0)
+        return _parse_label(resp.choices[0].message.content)
+
+
+def _pref(judge, text, wa, wb, debias):
+    """P(a better than b), optionally averaged with the swapped order to cancel position bias."""
+    p = judge.compare(text, wa, wb)
+    if debias:
+        p = 0.5 * (p + (1.0 - judge.compare(text, wb, wa)))
+    return p
+
+
+def _rank(judge, text, wavs, debias):
+    """Per-candidate score in [0, 1]. n==2 is one (debiased) call; n>2 is a round-robin average.
+
+    A debiased tie yields equal scores, so the DPO pairing drops that group.
+    """
+    n = len(wavs)
+    if n == 2:
+        s = _pref(judge, text, wavs[0], wavs[1], debias)
+        scores = [s, 1.0 - s]
+    else:
+        scores = []
+        for i in range(n):
+            others = [_pref(judge, text, wavs[i], wavs[j], debias) for j in range(n) if j != i]
+            scores.append(sum(others) / max(1, len(others)))
+    chosen = max(range(n), key=lambda i: scores[i])
+    rejected = min(range(n), key=lambda i: scores[i])
+    return {"scores": scores, "chosen": chosen, "rejected": rejected}
+
+
+def make_handler(judge, sem):
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, *args):
+            pass
+
+        def _send(self, code, obj):
+            body = json.dumps(obj).encode()
+            self.send_response(code)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_GET(self):
+            if self.path == "/health":
+                self._send(200, {"status": "ok", "model": judge._model})
+            else:
+                self._send(404, {"error": "not found"})
+
+        def do_POST(self):
+            if self.path != "/rank":
+                self._send(404, {"error": "not found"})
+                return
+            try:
+                payload = json.loads(self.rfile.read(int(self.headers.get("Content-Length", 0))))
+                wavs = [base64.b64decode(w) for w in payload["wavs_b64"]]
+                with sem:
+                    result = _rank(judge, payload.get("text", ""), wavs, bool(payload.get("debias", True)))
+                self._send(200, result)
+            except Exception as e:  # noqa: BLE001
+                self._send(500, {"error": str(e)})
+
+    return Handler
+
+
+def build_judge(args):
+    if args.provider == "gemini":
+        return GeminiJudge(args.model)
+    if args.provider == "openai":
+        return OpenAICompatJudge(args.model, args.base_url, args.api_key_env)
+    raise ValueError(f"unknown provider {args.provider!r}")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--provider", choices=["gemini", "openai"], default="gemini")
+    ap.add_argument("--model", default="gemini-3.5-flash")
+    ap.add_argument("--base-url", default=None, help="OpenAI-compatible endpoint base url")
+    ap.add_argument("--api-key-env", default="OPENAI_API_KEY", help="env var holding the openai api key")
+    ap.add_argument("--host", default="0.0.0.0")
+    ap.add_argument("--port", type=int, default=8901)
+    ap.add_argument("--max-concurrency", type=int, default=16, help="cap simultaneous LLM calls")
+    args = ap.parse_args()
+
+    judge = build_judge(args)
+    sem = threading.Semaphore(args.max_concurrency)
+    server = ThreadingHTTPServer((args.host, args.port), make_handler(judge, sem))
+    print(f"audio judge ({args.provider}:{args.model}) listening on {args.host}:{args.port}")
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/qwen3_tts_dpo/judge_server.py
+++ b/examples/qwen3_tts_dpo/judge_server.py
@@ -1,4 +1,4 @@
-# Copyright 2026 Bytedance Ltd. and/or its affiliates
+# Copyright 2026 Gulp AI Inc and/or its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/qwen3_tts_dpo/run_qwen3_tts_dpo.sh
+++ b/examples/qwen3_tts_dpo/run_qwen3_tts_dpo.sh
@@ -26,7 +26,7 @@ JUDGE_URL=${JUDGE_URL:-"http://localhost:8901"}
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 STAGE_CONFIG="${SCRIPT_DIR}/../qwen3_tts_gspo_trainer/qwen3_tts_stages.yaml"
 
-python3 -m verl_omni.trainer.main_ppo \
+python3 -m verl_omni.trainer.main_tts \
     --config-path="${SCRIPT_DIR}/config" \
     --config-name=qwen3_tts_dpo \
     data.train_files="${TRAIN_FILE}" \

--- a/examples/qwen3_tts_dpo/run_qwen3_tts_dpo.sh
+++ b/examples/qwen3_tts_dpo/run_qwen3_tts_dpo.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Qwen3-TTS talker online DPO (FSDP talker actor + vLLM-Omni AR rollout, LLM-audio-judge reward).
+# Reference hardware: 1 node x 8 H200. A judge server must be reachable at JUDGE_URL, e.g.
+#   python3 judge_server.py --provider gemini --port 8901
+#
+# Recipe config: config/qwen3_tts_dpo.yaml. Reuses the GSPO example's stage yaml. Volatile values:
+#   MODEL_PATH  - Qwen3-TTS SFT checkpoint (HF id or local dir)
+#   TRAIN_FILE / VAL_FILE - parquet from ../qwen3_tts_gspo_trainer/data_process/tts_content_synth.py
+#   SPK_EMBED   - clone-voice x-vector JSON from ../qwen3_tts_gspo_trainer/data_process/precompute_spk_embed.py
+#   JUDGE_URL   - the /rank judge endpoint (default http://localhost:8901)
+set -x
+
+export NCCL_IB_DISABLE=1
+export RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO=0
+
+# Load verl_omni on the driver (registers the vllm_omni rollout adapter + AudioJudgeRewardManager)
+# and the Qwen3-TTS model patch. Workers also load the model patch via external_lib in the args.
+export VERL_USE_EXTERNAL_MODULES=verl_omni,verl_omni.models.transformers.qwen3_tts
+
+MODEL_PATH=${MODEL_PATH:-"Qwen/Qwen3-TTS-12Hz-1.7B-Base"}
+TRAIN_FILE=${TRAIN_FILE:-"$HOME/data/tts_voice_synth/train.parquet"}
+VAL_FILE=${VAL_FILE:-"$HOME/data/tts_voice_synth/test.parquet"}
+SPK_EMBED=${SPK_EMBED:-"$HOME/data/tts_voice_synth/spk_embed.json"}
+JUDGE_URL=${JUDGE_URL:-"http://localhost:8901"}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STAGE_CONFIG="${SCRIPT_DIR}/../qwen3_tts_gspo_trainer/qwen3_tts_stages.yaml"
+
+python3 -m verl_omni.trainer.main_ppo \
+    --config-path="${SCRIPT_DIR}/config" \
+    --config-name=qwen3_tts_dpo \
+    data.train_files="${TRAIN_FILE}" \
+    data.val_files="${VAL_FILE}" \
+    actor_rollout_ref.model.path="${MODEL_PATH}" \
+    actor_rollout_ref.model.external_lib=verl_omni.models.transformers.qwen3_tts \
+    actor_rollout_ref.model.override_config.tts_spk_embed_path="${SPK_EMBED}" \
+    ++actor_rollout_ref.rollout.engine_kwargs.vllm_omni.stage_configs_path="${STAGE_CONFIG}" \
+    reward.judge_urls="[${JUDGE_URL}]" \
+    trainer.n_gpus_per_node=8 \
+    trainer.nnodes=1 \
+    "$@"

--- a/examples/qwen3_tts_gspo_trainer/README.md
+++ b/examples/qwen3_tts_gspo_trainer/README.md
@@ -1,0 +1,147 @@
+# Qwen3-TTS Talker GSPO Trainer
+
+RL post-training of `Qwen/Qwen3-TTS-12Hz-1.7B-Base`: the talker learns to speak text lines
+better, scored by audio reward functions on the decoded waveform. FSDP actor (talker codec-0
+path) + vLLM-Omni AR rollout, GSPO token-level policy loss + GDPO per-dimension advantage
+estimator (both from base verl).
+
+Validated end-to-end with a full training pass over a ~25k-line voice dataset on 1 node x 8 H200
+(reward rises on all dimensions; rollout and actor codec log-probs match to Pearson >= 0.999).
+
+## What is trained / frozen
+
+- Trainable: the talker (codec-0 main path: `talker.model` + `talker.codec_head`).
+- Frozen: sub-talker / `code_predictor` (codebooks 1-15), `speaker_encoder`, `code2wav`.
+- Reward is computed on the fully decoded 24 kHz waveform; gradient flows only to the talker.
+- Inverts the GSPO Thinker recipe (`examples/gspo_trainer/`), which trains the Thinker and
+  excludes the talker.
+
+The talker is not a plain causal LM (2-channel input, speaker slot, 16 codebooks), so
+`verl_omni/models/transformers/qwen3_tts.py` (loaded via `external_lib`) installs a custom
+teacher-forced codec-0 forward; the pure math lives in `qwen3_tts_forward.py` and is CPU-tested.
+
+## Reward
+
+`MultiAudioRewardManager` decodes the rollout's codec tokens reward-side once (decoder selected
+by `reward.audio.codec`, so other codec models can be added) and passes the waveform to every
+function declared under `reward.reward_functions`. Each entry loads one reward function that
+owns one scoring model, so backends can be reweighted, tweaked, or dropped independently in
+config; entry fields beyond path/name/weight are forwarded to the function as kwargs
+(e.g. `whisper_model`, `device`).
+
+| entry | reward form | model | module in verl_omni/utils/reward_score/tts/ |
+|-------|-------------|-------|---------------------------------------------|
+| `asr` | intelligibility exp(-2.5 * CER); extras: `stab` truncation / repetition / outlier penalty | whisper (GPU torch-native by default) | asr_reward.py |
+| `sim` | speaker similarity (1 + cos) / 2 vs the clone/target ref | 3D-Speaker ERes2Net | spk_sim_reward.py |
+| `emo` | P(tagged emotion), or 1 - P(neutral) untagged | emotion2vec_plus_large | emo_reward.py |
+
+The manager emits `reward/<key>` per entry plus `reward/<key>/<extra>` for dict extras, and
+trains on the weighted sum. With `adv_estimator: gdpo`, the dimensions named by
+`algorithm.gdpo_reward_keys` are instead z-scored within each prompt group before fusing, so one
+noisy dimension cannot dominate. Backends degrade gracefully (a failed backend scores 0.0,
+below any scored clip).
+
+Plain `AudioRewardManager` handles the single-function case: the standard
+`default_compute_score_audio` path dispatches `data_source` `tts` to
+`verl_omni/utils/reward_score/tts/__init__.py::compute_score`, a fixed-weight composition of
+the same three modules.
+
+## Data
+
+`data_process/tts_content_synth.py` extracts every assistant message from a conversations JSONL
+into verl parquet, cloning one fixed `--ref_audio` voice for each line:
+
+```bash
+python data_process/tts_content_synth.py \
+  --input conversations.jsonl \
+  --ref_audio clone_voice.wav \
+  --output_dir ~/data/tts_voice_synth
+```
+
+`data_process/tts_verbalize.py` has the matching written-to-spoken transforms (URLs, emails) to
+apply to text before synthesis; the reward side folds text with the consistent Whisper-standard
+normalizer.
+
+Precompute the clone voice's x-vector once (it feeds both rollout and actor, so generation and
+the teacher-forced recompute condition on the same speaker):
+
+```bash
+python data_process/precompute_spk_embed.py --ref clone_voice.wav --out ~/data/tts_voice_synth/spk_embed.json
+```
+
+## Install
+
+On top of the standard verl-omni GPU install, the recipe needs the TTS reward extras and the
+qwen-tts package (reward-side code2wav + the trainable model classes):
+
+```bash
+pip install -e ".[tts]"
+pip install --no-deps qwen-tts==0.1.1 sox
+```
+
+qwen-tts 0.1.1 pins transformers==4.57.3, which vllm 0.24 no longer supports; --no-deps plus a
+small compat patch runs it on this repo's transformers 5.x. `patches/` carries that patch and the
+gaps in the other pinned rollout dependencies, each an idempotent script to run once after
+install (and again after any package reinstall, which restores pristine files):
+
+```bash
+for p in patches/patch_*.py; do python "$p"; done
+```
+
+| script | fixes |
+|--------|-------|
+| patch_qwen_tts_tf5.py | qwen-tts 0.1.1 modeling code on transformers 5.x |
+| patch_vllm_omni_codec.py | vllm-omni 0.24.0 AR postprocess + output modality for "codec" stages |
+| patch_verl_unpad_fallback.py | base verl: hard flash_attn import in attention_utils; only needed on envs without flash-attn |
+
+Two further base-verl gaps this recipe hits are handled in process by the `external_lib` module
+(`verl_omni/models/transformers/qwen3_tts.py`), so they need no script: the forward_only ref is
+switched to manual param offload (FSDP-native CPUOffload leaves the leaf embedding tables on CPU
+for the custom talker forward), and the composite-config `save_pretrained` is made non-fatal (it
+trips transformers' to_diff_dict with KeyError 'dtype').
+
+## Run
+
+```bash
+TRAIN_FILE=~/data/tts_voice_synth/train.parquet \
+VAL_FILE=~/data/tts_voice_synth/test.parquet \
+SPK_EMBED=~/data/tts_voice_synth/spk_embed.json \
+bash run_qwen3_tts_gspo.sh
+```
+
+Any config field can be overridden on the CLI (standard hydra), e.g.
+`bash run_qwen3_tts_gspo.sh trainer.total_epochs=2 reward.num_workers=4`.
+
+## Files
+
+```
+examples/qwen3_tts_gspo_trainer/
+├── config/qwen3_tts_gspo.yaml       recipe (inherits verl ppo_trainer; gspo + gdpo)
+├── qwen3_tts_stages.yaml            vLLM-Omni single-stage AR talker config
+├── run_qwen3_tts_gspo.sh            launch (volatile overrides only)
+├── patches/                         one-time env fixes for the pinned deps (see Install)
+└── data_process/
+    ├── tts_content_synth.py         conversations jsonl to verl parquet
+    ├── tts_verbalize.py             written to spoken text transforms
+    └── precompute_spk_embed.py      clone-voice x-vector JSON
+
+verl_omni/models/transformers/qwen3_tts.py         talker actor patch (external_lib)
+verl_omni/models/transformers/qwen3_tts_forward.py pure codec-0 forward math (CPU-tested)
+verl_omni/reward_loop/reward_manager/audio.py      AudioRewardManager (codec decode)
+verl_omni/reward_loop/reward_manager/multi.py      MultiAudioRewardManager (weighted sub-rewards)
+verl_omni/utils/reward_score/tts/                  asr / spk sim / emo reward functions
+```
+
+## Notes / troubleshooting
+
+- On-policy correctness: the stage config neutralizes the model's deploy sampling defaults
+  (top_k=-1, repetition_penalty=1.0) so the rollout's processed logprobs match the actor's
+  full-softmax recompute. Keep `rollout.calculate_log_probs: true` and watch the logprob diff
+  metrics on the first steps of any new environment.
+- Rollout stops at codec eos: the untrained talker rambles to max_tokens; the rollout server
+  injects codec eos as a stop token (derived from the model config), and the stage config caps
+  `max_tokens: 384` (about 32s) to bound reward cost.
+- Reward throughput: keep `reward.audio.score_threads: 1` (the code2wav decode is not thread-safe
+  under CUDA; parallelism comes from `reward.num_workers` processes instead).
+- HF hub flakes across many ranks: if you see transient `config.json not found` errors at init
+  with a warm cache, export `HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1` for the training job.

--- a/examples/qwen3_tts_gspo_trainer/config/qwen3_tts_gspo.yaml
+++ b/examples/qwen3_tts_gspo_trainer/config/qwen3_tts_gspo.yaml
@@ -9,7 +9,7 @@
 # the decoded waveform (AudioRewardManager).
 #
 # Launch:
-#   python3 -m verl.trainer.main_ppo --config-path=<this dir> --config-name=qwen3_tts_gspo <overrides>
+#   python3 -m verl_omni.trainer.main_tts --config-path=<this dir> --config-name=qwen3_tts_gspo <overrides>
 
 hydra:
   searchpath:

--- a/examples/qwen3_tts_gspo_trainer/config/qwen3_tts_gspo.yaml
+++ b/examples/qwen3_tts_gspo_trainer/config/qwen3_tts_gspo.yaml
@@ -1,0 +1,152 @@
+# Qwen3-TTS talker GSPO training config (FSDP actor + vLLM-Omni AR rollout, reward on decoded audio).
+#
+# Inherits verl's default ppo_trainer config. Volatile values (data/model paths, the stage config
+# path, the speaker x-vector path) are set via CLI in the run script.
+#
+# Recipe: GSPO token-level clip-higher policy loss + GDPO per-dimension advantage estimator (both
+# from base verl). Mirrors examples/gspo_trainer/config/qwen3_omni_thinker_gspo.yaml, but inverts
+# what is trained: here we train the talker / codec head, freeze the rest, and the reward scores
+# the decoded waveform (AudioRewardManager).
+#
+# Launch:
+#   python3 -m verl.trainer.main_ppo --config-path=<this dir> --config-name=qwen3_tts_gspo <overrides>
+
+hydra:
+  searchpath:
+    - pkg://verl.trainer.config
+
+defaults:
+  - ppo_trainer
+  - _self_
+
+data:
+  train_batch_size: 32
+  max_prompt_length: 512
+  max_response_length: 2048       # codec tokens at 12Hz
+  filter_overlong_prompts: false  # the filter's per-sample try/except hides real errors
+  truncation: left
+
+actor_rollout_ref:
+
+  model:
+    # Qwen3-TTS-Base has no chat_template; passthrough emits each message's content verbatim
+    # so apply_chat_template returns the raw TTS text.
+    custom_chat_template: "{% for message in messages %}{{ message['content'] }}{% endfor %}"
+    override_config:
+      attn_implementation: sdpa
+      # Clone-voice x-vector JSON from data_process/precompute_spk_embed.py; read by both the
+      # actor forward and the rollout so generation and the teacher-forced recompute condition
+      # on the same speaker. Set the real path via CLI.
+      tts_spk_embed_path: null
+    use_remove_padding: false
+    enable_gradient_checkpointing: true
+
+  actor:
+    optim:
+      lr: 1e-6
+      lr_warmup_steps: 10
+      weight_decay: 0.0
+      clip_grad: 1.0
+    ppo_mini_batch_size: 32
+    ppo_micro_batch_size_per_gpu: 4
+    use_kl_loss: true
+    kl_loss_coef: 0.04
+    kl_loss_type: low_var_kl
+    entropy_coeff: 0
+    strategy: fsdp
+    fsdp_config:
+      # The 1.7B talker fits one GPU; sharding or offloading only costs step time.
+      fsdp_size: 1
+      param_offload: false
+      optimizer_offload: false
+      model_dtype: bf16
+      use_orig_params: true
+      wrap_policy:
+        min_num_params: 100000000
+    policy_loss:
+      loss_mode: gspo
+    clip_ratio_low: 0.2
+    clip_ratio_high: 0.3
+    loss_agg_mode: seq-mean-token-mean
+
+  rollout:
+    name: vllm_omni
+    mode: async
+    n: 8                        # rollouts per prompt (the group size)
+    temperature: 1.0
+    top_p: 1.0
+    top_k: -1
+    # tp=1: sharding the 1.7B talker makes all-reduce dominate generation time, and
+    # data_parallel = gpus_per_node // tp gives one rollout replica per GPU.
+    tensor_model_parallel_size: 1
+    calculate_log_probs: true
+    load_format: safetensors
+    layered_summon: true
+    log_prob_micro_batch_size_per_gpu: 4
+    engine_kwargs:
+      vllm_omni:
+        output_mode: ar
+        # stage_configs_path is set on the CLI (qwen3_tts_stages.yaml).
+
+  ref:
+    log_prob_micro_batch_size_per_gpu: 4
+    strategy: fsdp
+    fsdp_config:
+      fsdp_size: 1
+      param_offload: false
+      model_dtype: bf16
+      use_orig_params: true
+      wrap_policy:
+        min_num_params: 100000000
+
+algorithm:
+  # GDPO z-scores each reward dimension within the group before fusing, so one noisy dimension
+  # cannot dominate the fused score. The keys are emitted by MultiAudioRewardManager, one per
+  # reward.reward_functions entry (plus reward/asr/stab from the asr extras).
+  adv_estimator: gdpo
+  gdpo_reward_keys: [reward/asr, reward/sim, reward/emo, reward/asr/stab]
+  gdpo_reward_weights: [1.0, 1.0, 1.0, 1.0]
+  use_kl_in_reward: false
+
+reward:
+  num_workers: 2
+  reward_manager:
+    name: MultiAudioRewardManager
+    source: importlib
+    module:
+      path: pkg://verl_omni.reward_loop.reward_manager
+  audio:
+    codec: qwen_tts             # reward-side decoder for surfaced codec tokens
+    codec_eos_token_id: 2150
+    decoder_model_path: null    # null uses the actor model path
+    # One scoring thread per reward worker: the decode path is not thread-safe under CUDA;
+    # parallelism comes from reward.num_workers processes.
+    score_threads: 1
+  # Each entry loads a reward function and owns its model; extra fields beyond path/name/weight
+  # are passed to the function as kwargs (e.g. whisper_model, spk_model, emo_model, device).
+  # GPU backends are the defaults.
+  reward_functions:
+    asr:
+      path: pkg://verl_omni.utils.reward_score.tts.asr_reward
+      name: compute_score
+      weight: 1.0
+    sim:
+      path: pkg://verl_omni.utils.reward_score.tts.spk_sim_reward
+      name: compute_score
+      weight: 1.0
+    emo:
+      path: pkg://verl_omni.utils.reward_score.tts.emo_reward
+      name: compute_score
+      weight: 1.0
+
+trainer:
+  val_before_train: false
+  critic_warmup: 0
+  logger: ["console", "mlflow"]
+  project_name: qwen3_tts_gspo
+  experiment_name: tts_gspo_voice_synth
+  nnodes: 1
+  n_gpus_per_node: 8
+  save_freq: 20
+  test_freq: 0
+  total_epochs: 1

--- a/examples/qwen3_tts_gspo_trainer/data_process/precompute_spk_embed.py
+++ b/examples/qwen3_tts_gspo_trainer/data_process/precompute_spk_embed.py
@@ -1,4 +1,4 @@
-# Copyright 2026 Bytedance Ltd. and/or its affiliates
+# Copyright 2026 Gulp AI Inc and/or its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/qwen3_tts_gspo_trainer/data_process/precompute_spk_embed.py
+++ b/examples/qwen3_tts_gspo_trainer/data_process/precompute_spk_embed.py
@@ -1,0 +1,53 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Precompute the fixed clone voice's speaker x-vector ONCE, via the model's canonical
+``extract_speaker_embedding`` (ECAPA over a 24 kHz mel). The same vector feeds both the vLLM-Omni
+talker rollout (``voice_clone_prompt.ref_spk_embedding``, ``x_vector_only_mode=True``) and the verl
+actor (speaker @ pos 6), so generation and the teacher-forced recompute condition on an identical
+speaker. Saved as a JSON float list (consumed via
+``actor_rollout_ref.model.override_config.tts_spk_embed_path``).
+
+    python precompute_spk_embed.py --ref <clone_voice>.wav --out spk_embed.json
+"""
+
+import argparse
+import json
+
+import librosa
+import numpy as np
+import torch
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model", default="Qwen/Qwen3-TTS-12Hz-1.7B-Base")
+    ap.add_argument("--ref", required=True, help="fixed clone reference wav")
+    ap.add_argument("--out", required=True, help="output JSON path for the x-vector")
+    args = ap.parse_args()
+
+    from qwen_tts.inference.qwen3_tts_model import Qwen3TTSModel
+
+    m = Qwen3TTSModel.from_pretrained(args.model, device_map="cuda:0", dtype=torch.bfloat16)
+    inner = m.model
+    wav, sr = librosa.load(args.ref, sr=None, mono=True)
+    with torch.no_grad():
+        xvec = inner.extract_speaker_embedding(np.asarray(wav, dtype=np.float32), int(sr))
+    xvec = xvec.detach().reshape(-1).float().cpu().tolist()
+    with open(args.out, "w") as f:
+        json.dump(xvec, f)
+    print(f"saved {len(xvec)}-dim x-vector -> {args.out}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/qwen3_tts_gspo_trainer/data_process/tts_content_synth.py
+++ b/examples/qwen3_tts_gspo_trainer/data_process/tts_content_synth.py
@@ -1,4 +1,4 @@
-# Copyright 2026 Bytedance Ltd. and/or its affiliates
+# Copyright 2026 Gulp AI Inc and/or its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/qwen3_tts_gspo_trainer/data_process/tts_content_synth.py
+++ b/examples/qwen3_tts_gspo_trainer/data_process/tts_content_synth.py
@@ -1,0 +1,162 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Preprocess conversation transcripts to verl parquet for Qwen3-TTS RL training.
+
+Source: a JSONL file with one conversation per line, each carrying a ``messages`` list
+(``[{"role": ..., "content": ...}, ...]``). We take the text of **every ``assistant`` message**
+as a TTS prompt (the single-turn line to be spoken). The conversations have no reference audio,
+so every line is cloned from ONE fixed voice (``--ref_audio``) to keep speaker-similarity usable
+in the reward.
+
+Exact-duplicate lines (e.g. a greeting that repeats thousands of times) are collapsed by default
+(``--dedup``); pass ``--no-dedup`` to keep all lines.
+
+Each parquet row:
+    data_source         = "tts"
+    prompt              = [{"role": "user", "content": <text>}]   # the line to speak
+    reward_model        = {"style": "model", "ground_truth": <text>}  # CER target
+    extra_info          = {"id", "text", "ref_audio", "category", "split", "index"}
+"""
+
+import argparse
+import json
+import os
+
+import pandas as pd
+
+
+def _iter_assistant_lines(path):
+    """Yield (conversation_id, turn_index, text) for every non-empty assistant message."""
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            conv = json.loads(line)
+            cid = conv.get("conversation_id") or "conv"
+            n = 0
+            for msg in conv.get("messages", []):
+                if msg.get("role") != "assistant":
+                    continue
+                text = (msg.get("content") or "").strip()
+                if not text:
+                    continue
+                yield cid, n, text
+                n += 1
+
+
+def _make_lid(lang):
+    """Return a predicate(text) -> bool keeping only ``lang`` lines (None -> keep all).
+
+    langdetect with a pinned seed (it is stochastic by default). Detection failures
+    (raised on very short or symbol-only lines) KEEP the row; those are almost always
+    English interjections and ``--min_chars`` already governs the tiny ones.
+    """
+    if not lang:
+        return lambda text: True
+    from langdetect import DetectorFactory, LangDetectException, detect
+
+    DetectorFactory.seed = 0
+
+    def _keep(text):
+        try:
+            return detect(text) == lang
+        except LangDetectException:
+            return True
+
+    return _keep
+
+
+def build_rows(path, ref_audio, dedup, min_chars, lid=None):
+    rows = []
+    seen = set()
+    lid_keep = _make_lid(lid)
+    n_lid_dropped = 0
+    for cid, turn, text in _iter_assistant_lines(path):
+        if len(text) < min_chars:
+            continue
+        if dedup:
+            if text in seen:
+                continue
+            seen.add(text)
+        if not lid_keep(text):
+            n_lid_dropped += 1
+            continue
+        rows.append(
+            {
+                "data_source": "tts",
+                "prompt": [{"role": "user", "content": text}],
+                "ability": "tts",
+                "reward_model": {"style": "model", "ground_truth": text},
+                "extra_info": {
+                    "id": f"{cid}#{turn}",
+                    "text": text,
+                    "ref_audio": ref_audio,
+                    "category": None,
+                },
+            }
+        )
+    if lid:
+        print(f"LID filter ({lid}): dropped {n_lid_dropped} lines, kept {len(rows)}")
+    return rows
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--input", required=True, help="Conversations JSONL: one {'messages': [{'role', 'content'}, ...]} per line."
+    )
+    parser.add_argument(
+        "--output_dir", default="~/data/tts_voice_synth", help="Directory to save train.parquet / test.parquet"
+    )
+    parser.add_argument(
+        "--ref_audio", required=True, help="Fixed reference clip cloned for EVERY line (speaker-sim anchor)."
+    )
+    parser.add_argument(
+        "--dedup",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Collapse exact-duplicate lines (default: on).",
+    )
+    parser.add_argument("--min_chars", type=int, default=8, help="Drop lines shorter than this many characters.")
+    parser.add_argument(
+        "--lid",
+        default=None,
+        help="Keep only lines langdetect identifies as this language (e.g. 'en'). "
+        "Off by default; detection failures keep the row.",
+    )
+    parser.add_argument("--val_size", type=int, default=256, help="Number of held-out lines for the test split.")
+    parser.add_argument("--max_train", type=int, default=None, help="Optional cap on the number of training rows.")
+    args = parser.parse_args()
+
+    rows = build_rows(args.input, args.ref_audio, args.dedup, args.min_chars, lid=args.lid)
+    # Stable, deterministic ordering then a fixed head/tail split (no RNG, reproducible).
+    rows.sort(key=lambda r: r["extra_info"]["id"])
+    val_rows = rows[: args.val_size]
+    train_rows = rows[args.val_size :]
+    if args.max_train is not None:
+        train_rows = train_rows[: args.max_train]
+
+    for i, r in enumerate(train_rows):
+        r["extra_info"]["split"] = "train"
+        r["extra_info"]["index"] = i
+    for i, r in enumerate(val_rows):
+        r["extra_info"]["split"] = "test"
+        r["extra_info"]["index"] = i
+
+    out_dir = os.path.expanduser(args.output_dir)
+    os.makedirs(out_dir, exist_ok=True)
+    pd.DataFrame(train_rows).to_parquet(os.path.join(out_dir, "train.parquet"))
+    pd.DataFrame(val_rows).to_parquet(os.path.join(out_dir, "test.parquet"))
+    print(f"wrote {len(train_rows)} train + {len(val_rows)} test rows to {out_dir} (dedup={args.dedup})")

--- a/examples/qwen3_tts_gspo_trainer/data_process/tts_verbalize.py
+++ b/examples/qwen3_tts_gspo_trainer/data_process/tts_verbalize.py
@@ -1,4 +1,4 @@
-# Copyright 2026 Bytedance Ltd. and/or its affiliates
+# Copyright 2026 Gulp AI Inc and/or its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/qwen3_tts_gspo_trainer/data_process/tts_verbalize.py
+++ b/examples/qwen3_tts_gspo_trainer/data_process/tts_verbalize.py
@@ -1,0 +1,89 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Data-side written -> spoken text normalization for TTS prompts.
+
+``verbalize(text)`` rewrites written forms the talker cannot pronounce into their spoken form,
+applied to prompts BEFORE training/synthesis: URLs say "dot"/"slash" out loud and emails spell
+coined handles. Deterministic and idempotent.
+
+The matching REWARD/EVAL-side fold is ``verl_omni.utils.reward_score.tts_reward.normalize_for_cer``
+(Whisper EnglishTextNormalizer). The two halves are consistent, so a verbalized prompt and its
+ASR transcript meet in the same comparison form for CER.
+"""
+
+from __future__ import annotations
+
+import re
+
+_ONES = (
+    "zero one two three four five six seven eight nine ten eleven twelve thirteen fourteen "
+    "fifteen sixteen seventeen eighteen nineteen"
+).split()
+
+_EMAIL_RE = re.compile(r"\b[\w.+-]+@[\w-]+(?:\.[\w-]+)+\b")
+# path must not END on '.' (else a sentence-final period gets swallowed: ".../membership. Go")
+_URL_RE = re.compile(r"\b(?:https?://)?(?:[\w-]+\.)+[a-z]{2,6}(?:/[\w./~%+-]*[\w/~%+-])?", re.IGNORECASE)
+
+
+def _spell(token: str) -> str:
+    """Character-by-character spell-out for opaque codes/handles (case-insensitive speech)."""
+    out = []
+    for ch in token.lower():
+        if ch.isdigit():
+            out.append(_ONES[int(ch)])
+        elif ch.isalpha():
+            out.append(ch)
+        # separators inside codes are silent
+    return " ".join(out)
+
+
+def _is_coined(piece: str) -> bool:
+    """Heuristic: does an email/path token need spelling (coined handle) vs reading as a word?
+    Digits, long consonant runs, or very long blobs => spell. 'settings'/'kane' read fine."""
+    if any(c.isdigit() for c in piece):
+        return True
+    return re.search(r"[bcdfghjklmnpqrstvwxz]{4}", piece.lower()) is not None
+
+
+def _verbalize_email(m: re.Match) -> str:
+    local, domain = m.group(0).split("@", 1)
+    parts = []
+    for piece in re.split(r"[._+-]", local):
+        if not piece:
+            continue
+        parts.append(_spell(piece) if _is_coined(piece) else piece)
+    return " ".join(parts) + " at " + domain.replace(".", " dot ")
+
+
+def _verbalize_url(m: re.Match) -> str:
+    url = re.sub(r"^https?://", "", m.group(0))
+    segs = url.split("/")
+    host = segs[0].replace(".", " dot ")
+    spoken = [host]
+    for seg in segs[1:]:
+        if not seg:
+            continue
+        spoken.append("slash")
+        # URL path segments are real words (settings/account/membership) unless they carry a
+        # digit (short-link blobs like "2fmMGTq"); only those get spelled out.
+        spoken.append(_spell(seg) if any(c.isdigit() for c in seg) else seg)
+    return " ".join(spoken)
+
+
+def verbalize(text: str) -> str:
+    """Written -> spoken form: emails first, then URLs. Deterministic, idempotent (output has no
+    URL punctuation left for a second pass to rewrite)."""
+    t = _EMAIL_RE.sub(_verbalize_email, text)
+    t = _URL_RE.sub(_verbalize_url, t)
+    return re.sub(r"\s+", " ", t).strip()

--- a/examples/qwen3_tts_gspo_trainer/patches/patch_qwen_tts_tf5.py
+++ b/examples/qwen3_tts_gspo_trainer/patches/patch_qwen_tts_tf5.py
@@ -1,0 +1,102 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Patch qwen-tts 0.1.1 modeling code to run on transformers 5.x. Idempotent.
+
+qwen-tts pins transformers==4.57.3, but vllm 0.24 dropped transformers 4 support, so this repo
+installs qwen-tts with --no-deps and fixes the four transformers-5 breakages in place:
+check_model_inputs became a bare decorator, config attribute access became strict,
+ROPE_INIT_FUNCTIONS lost its "default" entry, and the mask helpers renamed input_embeds to
+inputs_embeds and dropped cache_position.
+
+Usage: python patch_qwen_tts_tf5.py [qwen_tts_pkg_dir]
+"""
+
+import importlib.util
+import pathlib
+import re
+import sys
+
+if len(sys.argv) > 1:
+    pkg_dir = pathlib.Path(sys.argv[1])
+else:
+    # find_spec locates the package without importing it (importing would execute the very
+    # modeling code this script exists to fix).
+    spec = importlib.util.find_spec("qwen_tts")
+    assert spec is not None and spec.origin, "qwen_tts is not installed"
+    pkg_dir = pathlib.Path(spec.origin).parent
+
+# All modeling files that use transformers internals (talker + speech-tokenizer decoder).
+FILES = [
+    pkg_dir / "core/models/modeling_qwen3_tts.py",
+    pkg_dir / "core/tokenizer_12hz/modeling_qwen3_tts_tokenizer_v2.py",
+]
+
+_ROPE_HELPER = (
+    "def _qtts_default_rope_init(config, device=None, **kw):\n"
+    "    import torch\n"
+    "    base = getattr(config, 'rope_theta', 10000.0) or 10000.0\n"
+    "    dim = getattr(config, 'head_dim', None) or (config.hidden_size // config.num_attention_heads)\n"
+    "    inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.int64)"
+    ".to(device=device, dtype=torch.float) / dim))\n"
+    "    return inv_freq, 1.0\n\n\n"
+)
+
+
+def patch_file(path):
+    if not path.exists():
+        print("skip (missing)", path.name)
+        return
+    s = orig = path.read_text()
+    # 1) tf5 made check_model_inputs a bare decorator.
+    s = s.replace("@check_model_inputs()", "@check_model_inputs")
+    # 2) tf5 strict config attribute access (no default pad_token_id).
+    s = s.replace("config.pad_token_id", 'getattr(config, "pad_token_id", None)')
+    # 3) tf5 dropped "default" from ROPE_INIT_FUNCTIONS; route default/None to a canonical init.
+    if "ROPE_INIT_FUNCTIONS[self.rope_type]" in s:
+        if "_qtts_default_rope_init" not in s:
+            # Insert after the module logger line; inserting before the first class can split
+            # decorators from their class.
+            anchor = s.find("\nlogger = logging.get_logger(__name__)\n")
+            if anchor != -1:
+                i = anchor + len("\nlogger = logging.get_logger(__name__)\n") + 1
+            else:
+                m = re.search(r"^(?:@.*\n)*class ", s, re.M)
+                i = m.start() if m else 0
+            s = s[:i] + "\n" + _ROPE_HELPER + s[i:]
+        s = s.replace(
+            "ROPE_INIT_FUNCTIONS[self.rope_type]",
+            "(ROPE_INIT_FUNCTIONS.get(self.rope_type) or _qtts_default_rope_init)",
+        )
+    # 4) tf5 mask helpers take inputs_embeds (renamed) and no longer accept cache_position.
+    s = s.replace('"input_embeds": inputs_embeds,', '"inputs_embeds": inputs_embeds,')
+    s = s.replace(
+        '"attention_mask": attention_mask,\n                "cache_position": cache_position,',
+        '"attention_mask": attention_mask,',
+    )
+    s = s.replace(
+        "            input_embeds=inputs_embeds,\n"
+        "            attention_mask=attention_mask,\n"
+        "            cache_position=cache_position,\n",
+        "            inputs_embeds=inputs_embeds,\n            attention_mask=attention_mask,\n",
+    )
+    if s != orig:
+        path.write_text(s)
+        print("patched", path.name)
+    else:
+        print("nochange", path.name)
+
+
+for f in FILES:
+    patch_file(f)
+print("PATCH_DONE")

--- a/examples/qwen3_tts_gspo_trainer/patches/patch_qwen_tts_tf5.py
+++ b/examples/qwen3_tts_gspo_trainer/patches/patch_qwen_tts_tf5.py
@@ -1,4 +1,4 @@
-# Copyright 2026 Bytedance Ltd. and/or its affiliates
+# Copyright 2026 Gulp AI Inc and/or its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/qwen3_tts_gspo_trainer/patches/patch_verl_unpad_fallback.py
+++ b/examples/qwen3_tts_gspo_trainer/patches/patch_verl_unpad_fallback.py
@@ -1,0 +1,54 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Patch verl's _get_attention_functions to fall back to transformers' reference unpad/pad
+helpers when flash_attn is not installed. Idempotent; only needed on envs without flash-attn.
+
+verl hard-imports from flash_attn.bert_padding on CUDA with no fallback
+(verl/utils/attention_utils.py). This recipe runs attn_implementation sdpa with
+use_remove_padding false, so the flash-attn kernels are never needed, only these padding
+helpers. Do NOT install a fake flash_attn package instead: vllm probes for it and would pick a
+broken attention backend. This routes the import to transformers.modeling_flash_attention_utils.
+
+Usage: python patch_verl_unpad_fallback.py
+"""
+
+import pathlib
+import sys
+
+import verl
+
+F = pathlib.Path(verl.__file__).parent / "utils" / "attention_utils.py"
+s = F.read_text()
+OLD = "        from flash_attn.bert_padding import index_first_axis, pad_input, rearrange, unpad_input"
+NEW = (
+    "        try:\n"
+    "            from flash_attn.bert_padding import index_first_axis, pad_input, rearrange, unpad_input\n"
+    "        except ImportError:\n"
+    "            from einops import rearrange\n"
+    "            from transformers.modeling_flash_attention_utils import (\n"
+    "                _index_first_axis as index_first_axis,\n"
+    "                _pad_input as pad_input,\n"
+    "                _unpad_input as unpad_input,\n"
+    "            )"
+)
+
+if "except ImportError:" in s and "_unpad_input as unpad_input" in s:
+    print("verl unpad fallback already patched")
+elif OLD in s:
+    F.write_text(s.replace(OLD, NEW))
+    print(f"patched verl unpad fallback (transformers) in {F}")
+else:
+    print("WARN: verl flash_attn import line not found; layout changed", file=sys.stderr)
+    sys.exit(1)
+print("PATCH_DONE")

--- a/examples/qwen3_tts_gspo_trainer/patches/patch_verl_unpad_fallback.py
+++ b/examples/qwen3_tts_gspo_trainer/patches/patch_verl_unpad_fallback.py
@@ -1,4 +1,4 @@
-# Copyright 2026 Bytedance Ltd. and/or its affiliates
+# Copyright 2026 Gulp AI Inc and/or its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/qwen3_tts_gspo_trainer/patches/patch_vllm_omni_codec.py
+++ b/examples/qwen3_tts_gspo_trainer/patches/patch_vllm_omni_codec.py
@@ -1,0 +1,52 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Patch vllm-omni 0.24.0 so a single-stage AR talker emitting "codec" output works. Idempotent.
+
+Two breakages:
+1. The per-step AR postprocess (which surfaces the generated code tensors) only fires for
+   engine_output_type "audio", so a "codec" stage wedges during decode.
+2. OutputModality does not know "codec". Alias it to "latent", whose CONCAT_DIM0 accumulation
+   stacks the per-step (frames, 16) code tensors on dim0; the "audio" alias would use
+   CONCAT_LAST and corrupt the code layout.
+
+Usage: python patch_vllm_omni_codec.py
+"""
+
+import pathlib
+
+import vllm_omni
+
+base = pathlib.Path(vllm_omni.__file__).parent
+
+f = base / "worker" / "gpu_ar_model_runner.py"
+s = f.read_text()
+old = 'if engine_output_type == "audio" and not downstream_req_ids:'
+new = 'if engine_output_type in ("audio", "codec", "latent") and not downstream_req_ids:'
+if new in s:
+    print("AR postprocess already patched")
+else:
+    assert old in s, "vllm-omni AR postprocess site changed"
+    f.write_text(s.replace(old, new))
+    print("patched AR postprocess (codec/latent)")
+
+f = base / "engine" / "output_modality.py"
+s = f.read_text()
+if '"codec": "latent",' in s:
+    print("codec modality alias already patched")
+else:
+    old = "_MODALITY_ALIASES: dict[str, str] = {"
+    assert old in s, "vllm-omni modality alias table changed"
+    f.write_text(s.replace(old, old + '\n    "codec": "latent",'))
+    print("patched codec modality alias (latent)")
+print("PATCH_DONE")

--- a/examples/qwen3_tts_gspo_trainer/patches/patch_vllm_omni_codec.py
+++ b/examples/qwen3_tts_gspo_trainer/patches/patch_vllm_omni_codec.py
@@ -1,4 +1,4 @@
-# Copyright 2026 Bytedance Ltd. and/or its affiliates
+# Copyright 2026 Gulp AI Inc and/or its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/qwen3_tts_gspo_trainer/qwen3_tts_stages.yaml
+++ b/examples/qwen3_tts_gspo_trainer/qwen3_tts_stages.yaml
@@ -1,0 +1,56 @@
+# vLLM-Omni stage config for the Qwen3-TTS RL rollout: a single AR talker stage.
+#
+# The talker emits codec tokens, the (T, 16) codes via multimodal_output, and processed logprobs.
+# Audio for the reward is decoded reward-side by AudioRewardManager, not as a rollout stage: the
+# orchestrator has no code2wav worker type and a 2-stage connector deadlocks colocated.
+#
+# NOTE: a single codec-emitting AR stage needs vLLM-Omni's per-step postprocess to also fire for
+# engine_output_type "codec" (it fires only for "audio" up to vllm-omni 0.24.0). See the README
+# install section for the one-line fix until it lands upstream.
+#
+# devices is relative to each rollout server and must list exactly tensor_parallel_size indices.
+stage_args:
+  - stage_id: 0
+    runtime:
+      devices: "0"
+    engine_args:
+      model_stage: talker
+      model_arch: Qwen3TTSTalkerForConditionalGeneration
+      worker_type: ar
+      scheduler_cls: vllm_omni.core.sched.omni_ar_scheduler.OmniARScheduler
+      engine_output_type: codec
+      hf_config_name: talker_config
+
+      # The 1.7B talker fits one GPU; tp=1 avoids all-reduce overhead and gives one rollout
+      # replica per GPU (data_parallel = gpus_per_node // tp).
+      tensor_parallel_size: 1
+      distributed_executor_backend: "mp"
+
+      gpu_memory_utilization: 0.35
+      max_num_seqs: 64
+      max_num_batched_tokens: 4096
+      max_model_len: 4096
+      enable_chunked_prefill: true
+
+      dtype: bfloat16
+      load_format: safetensors
+      trust_remote_code: true
+      enable_prefix_caching: false
+      enforce_eager: true
+
+      enable_sleep_mode: true
+      logprobs_mode: processed_logprobs   # talker codec logprobs for the importance ratio
+      disable_log_stats: true
+
+      # Neutralize the model's deploy sampling defaults (top_k=50, repetition_penalty=1.05) so
+      # the sampler agrees with the full-softmax logprob and generation stays on-policy.
+      default_sampling_params:
+        temperature: 1.0
+        top_k: -1
+        top_p: 1.0
+        repetition_penalty: 1.0
+        # The untrained talker does not stop at codec eos and rambles to the ceiling; 384 frames
+        # (about 32s) bounds reward cost while stab_reward teaches it to stop earlier.
+        max_tokens: 384
+    final_output: true
+    final_output_type: codec

--- a/examples/qwen3_tts_gspo_trainer/run_qwen3_tts_gspo.sh
+++ b/examples/qwen3_tts_gspo_trainer/run_qwen3_tts_gspo.sh
@@ -25,7 +25,7 @@ SPK_EMBED=${SPK_EMBED:-"$HOME/data/tts_voice_synth/spk_embed.json"}
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 STAGE_CONFIG="${SCRIPT_DIR}/qwen3_tts_stages.yaml"
 
-python3 -m verl.trainer.main_ppo \
+python3 -m verl_omni.trainer.main_tts \
     --config-path="${SCRIPT_DIR}/config" \
     --config-name=qwen3_tts_gspo \
     data.train_files="${TRAIN_FILE}" \

--- a/examples/qwen3_tts_gspo_trainer/run_qwen3_tts_gspo.sh
+++ b/examples/qwen3_tts_gspo_trainer/run_qwen3_tts_gspo.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Qwen3-TTS talker GSPO training (FSDP talker actor + vLLM-Omni AR talker rollout,
+# GDPO multi-dimension reward on decoded audio). Reference hardware: 1 node x 8 H200.
+#
+# Recipe config: config/qwen3_tts_gspo.yaml (inherits verl ppo_trainer). Only volatile values
+# (paths, GPU/node counts) are set here:
+#   MODEL_PATH  - Qwen3-TTS checkpoint (HF id or local dir)
+#   TRAIN_FILE / VAL_FILE - parquet from data_process/tts_content_synth.py
+#   SPK_EMBED   - clone-voice x-vector JSON from data_process/precompute_spk_embed.py
+set -x
+
+export NCCL_IB_DISABLE=1
+export RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO=0
+
+# Load verl_omni on the driver (registers the vllm_omni rollout adapter + AudioRewardManager) and
+# the Qwen3-TTS model patch (automodel registration + talker-only freeze hints). Workers also load
+# the model patch via external_lib in the launch args.
+export VERL_USE_EXTERNAL_MODULES=verl_omni,verl_omni.models.transformers.qwen3_tts
+
+MODEL_PATH=${MODEL_PATH:-"Qwen/Qwen3-TTS-12Hz-1.7B-Base"}
+TRAIN_FILE=${TRAIN_FILE:-"$HOME/data/tts_voice_synth/train.parquet"}
+VAL_FILE=${VAL_FILE:-"$HOME/data/tts_voice_synth/test.parquet"}
+SPK_EMBED=${SPK_EMBED:-"$HOME/data/tts_voice_synth/spk_embed.json"}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STAGE_CONFIG="${SCRIPT_DIR}/qwen3_tts_stages.yaml"
+
+python3 -m verl.trainer.main_ppo \
+    --config-path="${SCRIPT_DIR}/config" \
+    --config-name=qwen3_tts_gspo \
+    data.train_files="${TRAIN_FILE}" \
+    data.val_files="${VAL_FILE}" \
+    actor_rollout_ref.model.path="${MODEL_PATH}" \
+    actor_rollout_ref.model.external_lib=verl_omni.models.transformers.qwen3_tts \
+    actor_rollout_ref.model.override_config.tts_spk_embed_path="${SPK_EMBED}" \
+    ++actor_rollout_ref.rollout.engine_kwargs.vllm_omni.stage_configs_path="${STAGE_CONFIG}" \
+    trainer.n_gpus_per_node=8 \
+    trainer.nnodes=1 \
+    "$@"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ tts = [
     "modelscope",
     "addict",
     "funasr",
+    "langdetect",  # optional --lid language filter in the data-process script
     "simplejson",  # undeclared modelscope import; without it the ERes2Net load fails silently
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,19 @@ dev = [
 ocr = [
     "Levenshtein",
 ]
+# TTS reward backends (whisper ASR, ERes2Net speaker-sim, emotion2vec) for the tts reward modules.
+# NOTE: qwen-tts (reward-side code2wav + the trainable Qwen3-TTS classes) is not listed; it
+# hard-pins transformers==4.57.3, so install it separately with --no-deps; see
+# examples/qwen3_tts_gspo_trainer/README.md.
+tts = [
+    "librosa",
+    "soundfile",
+    "faster-whisper",
+    "modelscope",
+    "addict",
+    "funasr",
+    "simplejson",  # undeclared modelscope import; without it the ERes2Net load fails silently
+]
 
 # -------------------------------
 # tool.ruff - Linting configuration

--- a/tests/models/__init__.py
+++ b/tests/models/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/models/__init__.py
+++ b/tests/models/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2026 Bytedance Ltd. and/or its affiliates
+# Copyright 2026 Gulp AI Inc and/or its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/models/test_qwen3_tts_forward_on_cpu.py
+++ b/tests/models/test_qwen3_tts_forward_on_cpu.py
@@ -1,0 +1,139 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Pure (no-model) tests for the Qwen3-TTS talker codec-0 forward layout and realignment.
+
+These validate the index math: build_talker_batch reproduces the talker's teacher-forcing
+layout, and verl's roll(input_ids, -1) gather over realign_to_verl's output recovers the same
+per-token codec-0 log-probs as the talker-side teacher-forced gather. Needs only torch (CPU).
+"""
+
+import torch
+
+from verl_omni.models.transformers.qwen3_tts_forward import (
+    SPEAKER_SLOT,
+    TalkerTokens,
+    build_talker_batch,
+    realign_to_verl,
+)
+
+# Arbitrary but distinct control-token ids (real values come from the model config at runtime).
+TOKENS = TalkerTokens(
+    tts_pad=900,
+    tts_bos=901,
+    tts_eos=902,
+    codec_pad=4196,
+    codec_bos=4197,
+    codec_eos=4198,
+    codec_nothink=4203,
+    codec_think_bos=4204,
+    codec_think_eos=4205,
+)
+# Codec-head output width used only for the synthetic logits in these pure tests. It must exceed
+# every id used as a label below (incl. the codec specials ~4198), so the gather is in-bounds. The
+# real codec-head width comes from the model at runtime; the forward never hardcodes it.
+VOCAB = 4300
+SUB_VOCAB = 2048
+
+
+def _sample(tl, cl, seed):
+    g = torch.Generator().manual_seed(seed)
+    text_ids = torch.randint(0, 800, (1, tl), generator=g)
+    codes = torch.randint(0, SUB_VOCAB, (cl, 16), generator=g)  # col 0 = codec-0
+    return text_ids, codes
+
+
+def test_layout_matches_talker_collate():
+    """build_talker_batch places codec-0, labels, masks, and the speaker slot exactly where
+    the talker's collate layout requires."""
+    samples = [_sample(7, 5, 0), _sample(11, 9, 1)]
+    text_ids = [s[0] for s in samples]
+    audio_codes = [s[1] for s in samples]
+    batch = build_talker_batch(text_ids, audio_codes, TOKENS, sub_codebook_vocab=SUB_VOCAB)
+
+    for i, (tid, codes) in enumerate(samples):
+        tl, cl = tid.shape[1], codes.shape[0]
+        codec0 = codes[:, 0]
+        s = 8 + tl - 1  # codec-0 span start
+        # codec-0 lives in channel 1 and in the labels over [s, s+cl)
+        assert torch.equal(batch.input_ids[i, s : s + cl, 1], codec0)
+        assert torch.equal(batch.codec_0_labels[i, s : s + cl], codec0)
+        assert batch.codec_0_labels[i, s + cl].item() == TOKENS.codec_eos
+        # outside the codec span (and the eos) labels are masked
+        assert (batch.codec_0_labels[i, :s] == -100).all()
+        # full 16 codebooks retained at the codec span
+        assert torch.equal(batch.codec_ids[i, s : s + cl, :], codes)
+        # control block + speaker slot
+        assert batch.input_ids[i, 7, 0].item() == TOKENS.tts_bos
+        assert batch.input_ids[i, 8 + tl - 2, 1].item() == TOKENS.codec_bos
+        assert (
+            batch.codec_embedding_mask[i, SPEAKER_SLOT, 0].item() is False
+            or batch.codec_embedding_mask[i, SPEAKER_SLOT, 0].item() == 0
+        )
+        # the logit that predicts codec-0 token k is at index logit_start + k
+        assert batch.logit_start[i] == 8 + tl - 2
+        assert batch.codec_lens[i] == cl and batch.text_lens[i] == tl
+
+
+def test_realign_makes_verl_gather_equal_talker_gather():
+    """THE correctness claim: with random talker logits, verl's response-slice gather over the
+    realigned (B,T,V) tensor yields the identical codec-0 log-probs as the talker-side teacher-forced
+    gather (logits[j] vs codec_0_labels[j+1])."""
+    samples = [_sample(7, 5, 2), _sample(11, 9, 3)]
+    text_ids = [s[0] for s in samples]
+    audio_codes = [s[1] for s in samples]
+    batch = build_talker_batch(text_ids, audio_codes, TOKENS, sub_codebook_vocab=SUB_VOCAB)
+
+    b = len(samples)
+    t = batch.input_ids.shape[1]
+    torch.manual_seed(7)
+    talker_logits = torch.randn(b, t - 1, VOCAB)  # talker(emb[:, :-1]) output has length t-1
+
+    # talker-side gather: tok_logp[j] = log_softmax(talker_logits[j])[codec_0_labels[j+1]]
+    labels = batch.codec_0_labels[:, 1:]  # (b, t-1)
+    logp = torch.log_softmax(talker_logits.float(), dim=-1)
+    talker_tok_logp = logp.gather(-1, labels.clamp(min=0).unsqueeze(-1)).squeeze(-1)
+    talker_mask = labels != -100
+
+    # Build a verl-style flat batch: response region holds codec-0 (+eos) at a chosen start.
+    T = t + 4  # extra room to prove positions are not assumed
+    response_starts = []
+    flat_input_ids = torch.zeros(b, T, dtype=torch.long)
+    for i, (_, codes) in enumerate(samples):
+        cl = codes.shape[0]
+        rs = 3 + i  # arbitrary, per-sample-distinct response start
+        response_starts.append(rs)
+        flat_input_ids[i, rs : rs + cl] = codes[:, 0]
+        flat_input_ids[i, rs + cl] = TOKENS.codec_eos  # include eos as the last response token
+
+    # realign cl codec-0 rows; extend by 1 to also carry the eos-predicting row.
+    out = realign_to_verl(talker_logits, batch, response_starts, (b, T, VOCAB))
+    # also copy the eos-predicting row (talker index logit_start+cl) so verl can score eos too
+    for i, (_, codes) in enumerate(samples):
+        cl = codes.shape[0]
+        out[i, response_starts[i] - 1 + cl, :] = talker_logits[i, batch.logit_start[i] + cl, :]
+
+    # verl gather: logp_verl[p] = log_softmax(out[p])[flat_input_ids[p+1]] over the response slice
+    out_logp = torch.log_softmax(out.float(), dim=-1)
+    for i, (_, codes) in enumerate(samples):
+        cl = codes.shape[0]
+        rs = response_starts[i]
+        for k in range(cl + 1):  # cl codec-0 tokens + eos
+            label = flat_input_ids[i, rs + k]
+            verl_lp = out_logp[i, rs - 1 + k, label]
+            talker_j = batch.logit_start[i] + k  # 8+tl-2+k
+            talker_lp = talker_tok_logp[i, talker_j]
+            assert talker_mask[i, talker_j], f"sample {i} k {k}: talker position not a label"
+            assert torch.allclose(verl_lp, talker_lp, atol=1e-6), (
+                f"sample {i} token {k}: verl {verl_lp.item():.6f} != talker {talker_lp.item():.6f}"
+            )

--- a/tests/models/test_qwen3_tts_forward_on_cpu.py
+++ b/tests/models/test_qwen3_tts_forward_on_cpu.py
@@ -1,4 +1,4 @@
-# Copyright 2026 Bytedance Ltd. and/or its affiliates
+# Copyright 2026 Gulp AI Inc and/or its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/reward_loop/test_audio_judge_reward_manager_on_cpu.py
+++ b/tests/reward_loop/test_audio_judge_reward_manager_on_cpu.py
@@ -1,0 +1,91 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU tests for AudioJudgeRewardManager (mocked judge, no GPU, no network)."""
+
+import asyncio
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+import torch
+from omegaconf import OmegaConf
+from verl import DataProto
+
+from verl_omni.reward_loop.reward_manager.audio_judge import AudioJudgeRewardManager
+
+
+def _make_config(num_workers=1, n=2):
+    return OmegaConf.create(
+        {
+            "reward": {
+                "num_workers": num_workers,
+                "audio": {"codec": "qwen_tts"},
+                "judge_urls": ["http://localhost:8901"],
+                "judge_debias": True,
+                "judge_timeout_s": 5,
+            },
+            "actor_rollout_ref": {"model": {"path": "some/ckpt"}, "rollout": {"n": n}},
+        }
+    )
+
+
+def _make_item(uid="u0", audio=None, sr=24000) -> DataProto:
+    extra_info = {"id": uid, "text": "hello world"}
+    non_tensors = {
+        "data_source": ["tts"],
+        "reward_model": [{"ground_truth": "hello world"}],
+        "extra_info": [extra_info],
+        "uid": [uid],
+        "audio": [audio if audio is not None else np.zeros(24000, dtype=np.float32)],
+        "sr": [sr],
+    }
+    return DataProto.from_dict(
+        tensors={"responses": torch.zeros(1, 4, dtype=torch.long)},
+        non_tensors=non_tensors,
+    )
+
+
+def test_num_workers_must_be_one():
+    with pytest.raises(ValueError, match="num_workers=1"):
+        AudioJudgeRewardManager(_make_config(num_workers=2), MagicMock(), compute_score=None)
+
+
+def test_rendezvous_pairs_and_scores():
+    manager = AudioJudgeRewardManager(_make_config(n=2), MagicMock(), compute_score=None)
+    # Judge prefers candidate 0 over candidate 1.
+    manager._judge_group = lambda text, blobs: [1.0, 0.0]
+
+    d0 = _make_item(audio=np.ones(24000, dtype=np.float32))
+    d1 = _make_item(audio=np.zeros(24000, dtype=np.float32))
+    r0, r1 = manager.loop.run_until_complete(asyncio.gather(manager.run_single(d0), manager.run_single(d1)))
+    assert r0["reward_extra_info"]["sj_score"] == 1.0
+    assert r1["reward_extra_info"]["sj_score"] == 0.0
+    assert r0["reward_score"] == 1.0 and r1["reward_score"] == 0.0
+    assert r0["reward_extra_info"]["synth_ok"] == 1.0
+
+
+def test_judge_receives_both_blobs():
+    manager = AudioJudgeRewardManager(_make_config(n=2), MagicMock(), compute_score=None)
+    seen = {}
+
+    def fake_judge(text, blobs):
+        seen["n"] = len(blobs)
+        seen["text"] = text
+        return [1.0, 0.0]
+
+    manager._judge_group = fake_judge
+    d0, d1 = _make_item(), _make_item()
+    manager.loop.run_until_complete(asyncio.gather(manager.run_single(d0), manager.run_single(d1)))
+    assert seen["n"] == 2  # the group's two candidates judged in one call
+    assert seen["text"] == "hello world"

--- a/tests/reward_loop/test_audio_judge_reward_manager_on_cpu.py
+++ b/tests/reward_loop/test_audio_judge_reward_manager_on_cpu.py
@@ -89,3 +89,21 @@ def test_judge_receives_both_blobs():
     manager.loop.run_until_complete(asyncio.gather(manager.run_single(d0), manager.run_single(d1)))
     assert seen["n"] == 2  # the group's two candidates judged in one call
     assert seen["text"] == "hello world"
+
+
+def test_group_freed_after_rendezvous():
+    manager = AudioJudgeRewardManager(_make_config(n=2), MagicMock(), compute_score=None)
+    manager._judge_group = lambda text, blobs: [1.0, 0.0]
+    d0, d1 = _make_item(), _make_item()
+    manager.loop.run_until_complete(asyncio.gather(manager.run_single(d0), manager.run_single(d1)))
+    assert manager._groups == {}  # scored groups are dropped, not accumulated (no memory leak)
+
+
+def test_group_freed_after_timeout():
+    cfg = _make_config(n=2)
+    cfg.reward.judge_timeout_s = 0.05  # a sibling never arrives; the lone candidate self-judges fast
+    manager = AudioJudgeRewardManager(cfg, MagicMock(), compute_score=None)
+    manager._judge_group = lambda text, blobs: [1.0] * len(blobs)
+    r0 = manager.loop.run_until_complete(manager.run_single(_make_item()))
+    assert r0["reward_extra_info"]["sj_score"] == 1.0
+    assert manager._groups == {}

--- a/tests/reward_loop/test_audio_judge_reward_manager_on_cpu.py
+++ b/tests/reward_loop/test_audio_judge_reward_manager_on_cpu.py
@@ -1,4 +1,4 @@
-# Copyright 2026 Bytedance Ltd. and/or its affiliates
+# Copyright 2026 Gulp AI Inc and/or its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/reward_loop/test_audio_reward_manager_on_cpu.py
+++ b/tests/reward_loop/test_audio_reward_manager_on_cpu.py
@@ -1,0 +1,162 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU tests for AudioRewardManager and MultiAudioRewardManager (no models, no GPU)."""
+
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+import torch
+from omegaconf import OmegaConf
+from verl import DataProto
+
+from verl_omni.reward_loop.reward_manager.audio import AudioRewardManager
+from verl_omni.reward_loop.reward_manager.multi import MultiAudioRewardManager
+
+# Path to this file; sub-reward entries load the dummy functions below from here.
+DUMMY_REWARDS_PATH = "tests/reward_loop/test_audio_reward_manager_on_cpu.py"
+
+
+def reward_wav_seconds(solution_audio):
+    """Returns the clip length in seconds, 0.0 when synthesis failed."""
+    if solution_audio is None:
+        return 0.0
+    wav, sr = solution_audio
+    return len(wav) / sr
+
+
+def reward_with_extras(data_source, ground_truth):
+    return {"score": 1.0, "detail": 7.0}
+
+
+def _make_config(audio=None, reward_functions=None):
+    reward = {"audio": audio or {}}
+    if reward_functions is not None:
+        reward["reward_functions"] = reward_functions
+    return OmegaConf.create({"reward": reward, "actor_rollout_ref": {"model": {"path": "some/ckpt"}}})
+
+
+def _build_manager(compute_score, audio=None) -> AudioRewardManager:
+    return AudioRewardManager(_make_config(audio), MagicMock(), compute_score=compute_score)
+
+
+def _make_data(audio=None, sr=24000, codes=None) -> DataProto:
+    extra_info = {"id": "u0", "text": "hello world"}
+    non_tensors = {
+        "data_source": ["tts_reward"],
+        "reward_model": [{"ground_truth": "hello world"}],
+        "extra_info": [extra_info],
+    }
+    if codes is not None:
+        extra_info["tts_audio_codes"] = codes
+    if audio is not None:
+        non_tensors["audio"] = [audio]
+        non_tensors["sr"] = [sr]
+    return DataProto.from_dict(
+        tensors={"responses": torch.zeros(1, 4, dtype=torch.long)},
+        non_tensors=non_tensors,
+    )
+
+
+class TestInit:
+    def test_unknown_codec_raises(self):
+        with pytest.raises(ValueError, match="Unknown reward.audio.codec"):
+            _build_manager(compute_score=None, audio={"codec": "fish_s2"})
+
+    def test_decoder_path_defaults_to_actor_model(self):
+        manager = _build_manager(compute_score=None)
+        assert manager._decoder_model_path == "some/ckpt"
+
+    def test_assemble_rm_scores_shape(self):
+        out = AudioRewardManager.assemble_rm_scores(MagicMock(), [0.1, -1.0, 2.5])
+        assert out.shape == (3, 1)
+
+
+class TestRunSingle:
+    def test_dict_result_maps_to_extra_info(self):
+        def compute_score(data_source, solution_audio, ground_truth, extra_info):
+            assert data_source == "tts_reward"
+            assert solution_audio is not None and solution_audio[1] == 24000
+            assert ground_truth == "hello world"
+            return {"score": 2.5, "text": 1.0, "sim": 0.5}
+
+        manager = _build_manager(compute_score)
+        wav = np.zeros(24000, dtype=np.float32)
+        result = manager.loop.run_until_complete(manager.run_single(_make_data(audio=wav)))
+        assert result["reward_score"] == 2.5
+        assert result["reward_extra_info"] == {"text": 1.0, "sim": 0.5}
+
+    def test_float_result_maps_to_acc(self):
+        manager = _build_manager(lambda data_source, solution_audio, ground_truth, extra_info: 0.75)
+        wav = np.zeros(24000, dtype=np.float32)
+        result = manager.loop.run_until_complete(manager.run_single(_make_data(audio=wav)))
+        assert result["reward_score"] == 0.75
+        assert result["reward_extra_info"] == {"acc": 0.75}
+
+    def test_no_audio_passes_none(self):
+        seen = {}
+
+        def compute_score(data_source, solution_audio, ground_truth, extra_info):
+            seen["solution_audio"] = solution_audio
+            return 0.0
+
+        manager = _build_manager(compute_score)
+        manager.loop.run_until_complete(manager.run_single(_make_data()))
+        assert seen["solution_audio"] is None
+
+    def test_codes_are_decoded(self):
+        def compute_score(data_source, solution_audio, ground_truth, extra_info):
+            wav, sr = solution_audio
+            return {"score": float(len(wav)), "sr": sr}
+
+        manager = _build_manager(compute_score)
+        manager._decode = lambda codes: (np.ones(len(codes) * 100, dtype=np.float32), 24000)
+        manager._codebook_max = 2047
+        # 5 real frames, then eos at codec-0 of frame 5
+        codes = torch.zeros(8, 16, dtype=torch.long)
+        codes[5, 0] = manager._codec_eos
+        result = manager.loop.run_until_complete(manager.run_single(_make_data(codes=codes.numpy())))
+        assert result["reward_score"] == 500.0  # eos-trimmed to 5 frames
+        assert result["reward_extra_info"]["sr"] == 24000
+
+
+class TestMultiAudioRewardManager:
+    def _build(self, reward_functions):
+        config = _make_config(reward_functions=reward_functions)
+        return MultiAudioRewardManager(config, MagicMock(), compute_score=None)
+
+    def test_weighted_sum_over_decoded_audio(self):
+        manager = self._build(
+            {
+                "seconds": {"path": DUMMY_REWARDS_PATH, "name": "reward_wav_seconds", "weight": 2.0},
+                "extras": {"path": DUMMY_REWARDS_PATH, "name": "reward_with_extras", "weight": 1.0},
+            }
+        )
+        wav = np.zeros(24000, dtype=np.float32)  # 1 second
+        result = manager.loop.run_until_complete(manager.run_single(_make_data(audio=wav)))
+        info = result["reward_extra_info"]
+        assert info["reward/seconds"] == 1.0
+        assert info["reward/extras"] == 1.0
+        assert info["reward/extras/detail"] == 7.0
+        assert result["reward_score"] == 2.0 * 1.0 + 1.0 * 1.0
+        assert info["reward/combined"] == result["reward_score"]
+
+    def test_failed_synthesis_passes_none(self):
+        manager = self._build({"seconds": {"path": DUMMY_REWARDS_PATH, "name": "reward_wav_seconds"}})
+        result = manager.loop.run_until_complete(manager.run_single(_make_data()))
+        assert result["reward_extra_info"]["reward/seconds"] == 0.0
+
+    def test_empty_reward_functions_raises(self):
+        with pytest.raises(ValueError, match="non-empty reward.reward_functions"):
+            self._build({})

--- a/tests/reward_loop/test_audio_reward_manager_on_cpu.py
+++ b/tests/reward_loop/test_audio_reward_manager_on_cpu.py
@@ -1,4 +1,4 @@
-# Copyright 2026 Bytedance Ltd. and/or its affiliates
+# Copyright 2026 Gulp AI Inc and/or its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/special_sanity/check_license.py
+++ b/tests/special_sanity/check_license.py
@@ -21,11 +21,13 @@ license_head_bytedance_25 = "Copyright 2025 Bytedance Ltd. and/or its affiliates
 license_head_bytedance_26 = "Copyright 2026 Bytedance Ltd. and/or its affiliates"
 # Add custom license headers below
 license_head_amazon_26 = "Copyright 2026 Amazon.com Inc and/or its affiliates"
+license_head_gulp_26 = "Copyright 2026 Gulp AI Inc and/or its affiliates"
 license_headers = [
     license_head_bytedance,
     license_head_bytedance_25,
     license_head_bytedance_26,
     license_head_amazon_26,
+    license_head_gulp_26,
 ]
 
 

--- a/tests/utils/reward_score/__init__.py
+++ b/tests/utils/reward_score/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2026 Bytedance Ltd. and/or its affiliates
+# Copyright 2026 Gulp AI Inc and/or its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/utils/reward_score/__init__.py
+++ b/tests/utils/reward_score/__init__.py
@@ -11,9 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from .audio import AudioRewardManager
-from .multi import MultiAudioRewardManager, MultiVisualRewardManager
-from .visual import VisualRewardManager
-
-__all__ = ["VisualRewardManager", "MultiVisualRewardManager", "AudioRewardManager", "MultiAudioRewardManager"]

--- a/tests/utils/reward_score/test_tts_rewards_on_cpu.py
+++ b/tests/utils/reward_score/test_tts_rewards_on_cpu.py
@@ -1,4 +1,4 @@
-# Copyright 2026 Bytedance Ltd. and/or its affiliates
+# Copyright 2026 Gulp AI Inc and/or its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/utils/reward_score/test_tts_rewards_on_cpu.py
+++ b/tests/utils/reward_score/test_tts_rewards_on_cpu.py
@@ -1,0 +1,126 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU unit tests for the tts reward modules (stubbed backends, no models, no GPU)."""
+
+import math
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from verl_omni.utils.reward_score import tts
+from verl_omni.utils.reward_score.tts import asr_reward, emo_reward, spk_sim_reward
+
+
+def _audio(seconds=10.0, sr=24000):
+    return np.ones(int(seconds * sr), dtype=np.float32), sr
+
+
+@pytest.fixture
+def stub_backends(monkeypatch):
+    monkeypatch.setattr(asr_reward, "transcribe", lambda wav, sr, *a, **kw: "hello world")
+    monkeypatch.setattr(spk_sim_reward, "_spk_embed", lambda wav, sr, *a: np.asarray([1.0, 0.0], dtype=np.float32))
+    monkeypatch.setattr(spk_sim_reward, "_ref_cache", {})
+    monkeypatch.setattr(emo_reward, "_resample", lambda wav, sr, target_sr: wav)
+    monkeypatch.setattr(
+        emo_reward,
+        "_get_emo",
+        lambda *a: SimpleNamespace(generate=lambda *aa, **kk: [{"scores": [0.0, 0.0, 0.0, 0.7, 0.2, 0, 0, 0, 0]}]),
+    )
+
+
+class TestAsrReward:
+    def test_glm_form(self, stub_backends):
+        r = asr_reward.compute_score(_audio(), "hello world")
+        assert r["score"] == 1.0 and r["cer"] == 0.0 and r["stab"] == 0.0 and r["synth_ok"] == 1.0
+
+    def test_score_tracks_cer(self, stub_backends, monkeypatch):
+        monkeypatch.setattr(asr_reward, "transcribe", lambda wav, sr, *a, **kw: "hxllo world")
+        r = asr_reward.compute_score(_audio(), "hello world")
+        assert r["cer"] > 0.0
+        assert abs(r["score"] - math.exp(-2.5 * r["cer"])) < 1e-9
+
+    def test_stability_penalties(self, stub_backends, monkeypatch):
+        # truncated: 20 words expect 8s at 2.5 wps, a 1s clip is below the 0.5 ratio
+        text = " ".join(["word"] * 20)
+        monkeypatch.setattr(asr_reward, "transcribe", lambda wav, sr, *a, **kw: text)
+        r = asr_reward.compute_score(_audio(seconds=1.0), text)
+        assert r["truncated"] == 1.0 and r["stab"] <= -1.0
+
+        monkeypatch.setattr(
+            asr_reward, "transcribe", lambda wav, sr, *a, **kw: "please hold on please hold on please hold on"
+        )
+        r = asr_reward.compute_score(_audio(), "please hold on")
+        assert r["repeated"] == 1.0
+
+    def test_synth_failure_keeps_key_set(self, stub_backends):
+        ok = asr_reward.compute_score(_audio(), "hello world")
+        fail = asr_reward.compute_score(None, "hello world")
+        assert set(fail.keys()) == set(ok.keys())
+        assert fail["score"] == 0.0 and fail["stab"] == -1.0 and fail["synth_ok"] == 0.0
+
+    def test_cer_and_normalization(self):
+        assert asr_reward.normalize_text("Hello, World!") == "hello world"
+        assert asr_reward.cer("abc", "abc") == 0.0
+        assert asr_reward.cer("abcd", "abxd") == 0.25
+        assert asr_reward.cer("", "anything") is None
+
+    def test_has_repetition(self):
+        assert asr_reward.has_repetition("the the the cat cat cat", n=3) is False
+        assert asr_reward.has_repetition("please hold on please hold on", n=2) is True
+        assert asr_reward.has_repetition("a normal sentence with no loops", n=3) is False
+
+
+class TestSpkSimReward:
+    def test_cosine_form(self, stub_backends, tmp_path):
+        import soundfile as sf
+
+        ref = tmp_path / "ref.wav"
+        sf.write(ref, np.ones(16000, dtype=np.float32), 16000)
+        r = spk_sim_reward.compute_score(_audio(), extra_info={"ref_audio": str(ref)})
+        assert abs(r["score"] - 1.0) < 1e-6 and abs(r["cos"] - 1.0) < 1e-6
+
+    def test_missing_inputs_score_zero(self, stub_backends):
+        assert spk_sim_reward.compute_score(None, extra_info={})["score"] == 0.0
+        assert spk_sim_reward.compute_score(_audio(), extra_info={})["score"] == 0.0
+
+
+class TestEmoReward:
+    def test_tagged_and_untagged(self, stub_backends):
+        r = emo_reward.compute_score(_audio(), extra_info={"emotion": 3})
+        assert r == {"score": 0.7, "p_neutral": 0.2}
+        r = emo_reward.compute_score(_audio(), extra_info={})
+        assert abs(r["score"] - 0.8) < 1e-9  # 1 - P(neutral)
+
+    def test_unavailable_backend_scores_zero(self, monkeypatch):
+        monkeypatch.setattr(emo_reward, "_get_emo", lambda *a: None)
+        assert emo_reward.compute_score(_audio(), extra_info={})["score"] == 0.0
+
+
+class TestComposition:
+    def test_weighted_sum_and_dimensions(self, stub_backends, tmp_path):
+        import soundfile as sf
+
+        ref = tmp_path / "ref.wav"
+        sf.write(ref, np.ones(16000, dtype=np.float32), 16000)
+        r = tts.compute_score(_audio(), "hello world", extra_info={"ref_audio": str(ref)}, weights={"sim": 2.0})
+        assert r["asr"] == 1.0 and abs(r["sim"] - 1.0) < 1e-6 and abs(r["emo"] - 0.8) < 1e-9
+        assert r["stab"] == 0.0
+        assert abs(r["score"] - (1.0 + 2.0 * 1.0 + 0.8 + 0.0)) < 1e-6
+
+    def test_synth_failure_keeps_key_set(self, stub_backends):
+        ok = tts.compute_score(_audio(), "hello world", extra_info={})
+        fail = tts.compute_score(None, "hello world", extra_info={})
+        assert set(fail.keys()) == set(ok.keys())
+        assert fail["asr"] == fail["sim"] == fail["emo"] == 0.0 and fail["stab"] == -1.0

--- a/tests/workers/config/test_dpo_policy_loss_config_on_cpu.py
+++ b/tests/workers/config/test_dpo_policy_loss_config_on_cpu.py
@@ -1,0 +1,54 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU tests for DPOPolicyLossConfig selection via _target_ (no GPU)."""
+
+import pytest
+from omegaconf import OmegaConf
+from verl.utils.config import omega_conf_to_dataclass
+
+from verl_omni.workers.config import DPOPolicyLossConfig
+
+
+def test_target_resolves_to_subclass():
+    cfg = OmegaConf.create(
+        {
+            "_target_": "verl_omni.workers.config.DPOPolicyLossConfig",
+            "loss_mode": "dpo",
+            "dpo_beta": 0.2,
+            "dpo_nll_lambda": 0.5,
+        }
+    )
+    obj = omega_conf_to_dataclass(cfg)
+    assert isinstance(obj, DPOPolicyLossConfig)
+    assert obj.loss_mode == "dpo"
+    assert obj.dpo_beta == 0.2
+    assert obj.dpo_nll_lambda == 0.5
+    # inherited base field
+    assert hasattr(obj, "ppo_kl_coef")
+    # BaseConfig Mapping .get used by the loss
+    assert obj.get("dpo_beta", None) == 0.2
+
+
+def test_defaults():
+    obj = DPOPolicyLossConfig()
+    assert obj.loss_mode == "dpo" and obj.dpo_beta == 0.1 and obj.dpo_nll_lambda == 0.0
+
+
+def test_validation():
+    with pytest.raises(ValueError, match="loss_mode"):
+        DPOPolicyLossConfig(loss_mode="gspo")
+    with pytest.raises(ValueError, match="dpo_beta"):
+        DPOPolicyLossConfig(dpo_beta=0.0)
+    with pytest.raises(ValueError, match="dpo_nll_lambda"):
+        DPOPolicyLossConfig(dpo_nll_lambda=-1.0)

--- a/tests/workers/config/test_dpo_policy_loss_config_on_cpu.py
+++ b/tests/workers/config/test_dpo_policy_loss_config_on_cpu.py
@@ -1,4 +1,4 @@
-# Copyright 2026 Bytedance Ltd. and/or its affiliates
+# Copyright 2026 Gulp AI Inc and/or its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/workers/rollout/rollout_vllm/test_tts_mode_detection_on_cpu.py
+++ b/tests/workers/rollout/rollout_vllm/test_tts_mode_detection_on_cpu.py
@@ -1,0 +1,62 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU tests for the stage-output-type reader that detects a codec (TTS) rollout."""
+
+import yaml
+
+from verl_omni.workers.rollout.vllm_rollout.vllm_omni_async_server import _read_stage_output_type
+
+
+def _write(tmp_path, stages):
+    p = tmp_path / "stages.yaml"
+    p.write_text(yaml.safe_dump({"stage_args": stages}))
+    return {"vllm_omni": {"stage_configs_path": str(p)}}
+
+
+def test_codec_stage(tmp_path):
+    ek = _write(tmp_path, [{"engine_args": {"engine_output_type": "codec"}, "final_output": True}])
+    assert _read_stage_output_type(ek) == "codec"
+
+
+def test_final_output_type_wins(tmp_path):
+    ek = _write(tmp_path, [{"engine_args": {"engine_output_type": "codec"}, "final_output_type": "codec"}])
+    assert _read_stage_output_type(ek) == "codec"
+
+
+def test_text_stage_is_not_codec(tmp_path):
+    ek = _write(tmp_path, [{"engine_args": {"engine_output_type": "text"}}])
+    assert _read_stage_output_type(ek) == "text"
+
+
+def test_terminal_stage_selected(tmp_path):
+    ek = _write(
+        tmp_path,
+        [
+            {"engine_args": {"engine_output_type": "codec"}},
+            {"engine_args": {"engine_output_type": "audio"}, "final_output": True},
+        ],
+    )
+    assert _read_stage_output_type(ek) == "audio"
+
+
+def test_hyphenated_key(tmp_path):
+    p = tmp_path / "stages.yaml"
+    p.write_text(yaml.safe_dump({"stage_args": [{"engine_args": {"engine_output_type": "codec"}}]}))
+    assert _read_stage_output_type({"vllm_omni": {"stage-configs-path": str(p)}}) == "codec"
+
+
+def test_missing_config_is_none():
+    assert _read_stage_output_type({}) is None
+    assert _read_stage_output_type({"vllm_omni": {}}) is None
+    assert _read_stage_output_type(None) is None

--- a/tests/workers/rollout/rollout_vllm/test_tts_mode_detection_on_cpu.py
+++ b/tests/workers/rollout/rollout_vllm/test_tts_mode_detection_on_cpu.py
@@ -1,4 +1,4 @@
-# Copyright 2026 Bytedance Ltd. and/or its affiliates
+# Copyright 2026 Gulp AI Inc and/or its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/workers/test_tts_dpo_loss_on_cpu.py
+++ b/tests/workers/test_tts_dpo_loss_on_cpu.py
@@ -1,0 +1,112 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU unit tests for the online-DPO loss + pairing (no models, no GPU)."""
+
+import math
+from types import SimpleNamespace
+
+import pytest
+import torch
+from verl import DataProto
+
+from verl_omni.workers.utils import losses
+from verl_omni.workers.utils.losses import build_online_dpo_pair_indices, tts_dpo_loss
+
+
+def _config(beta=0.1, nll_lambda=0.0, use_dynamic_bsz=False):
+    return SimpleNamespace(
+        use_dynamic_bsz=use_dynamic_bsz,
+        policy_loss={"dpo_beta": beta, "dpo_nll_lambda": nll_lambda},
+    )
+
+
+def _data(logp, ref, uids, scores):
+    """A single-response-token batch; seq_logp == logp, seq_ref == ref (mask all ones)."""
+    n = len(logp)
+    dp = DataProto.from_dict(
+        tensors={
+            "response_mask": torch.ones(n, 1),
+            "ref_log_prob": torch.tensor(ref, dtype=torch.float32).reshape(n, 1),
+        },
+        non_tensors={"uid": list(uids), "sj_score": list(scores)},
+    )
+    data = dp.to_tensordict()
+    model_output = {"log_probs": torch.tensor(logp, dtype=torch.float32).reshape(n, 1)}
+    return model_output, data
+
+
+@pytest.fixture(autouse=True)
+def _identity_padding(monkeypatch):
+    # no_padding_2_padding turns flat log-probs into (B, resp_len); our fixtures are already (B, 1).
+    monkeypatch.setattr(losses, "no_padding_2_padding", lambda log_probs, data: log_probs)
+
+
+class TestPairIndices:
+    def test_groups_top_and_bottom(self):
+        # uid a: idx0 (0.9) > idx1 (0.1); uid b: idx3 (0.7) > idx2 (0.3)
+        assert build_online_dpo_pair_indices(["a", "a", "b", "b"], [0.9, 0.1, 0.3, 0.7]) == [0, 1, 3, 2]
+
+    def test_skips_singleton_groups(self):
+        assert build_online_dpo_pair_indices(["a", "a", "b"], [0.9, 0.1, 0.5]) == [0, 1]
+
+    def test_keeps_ties(self):
+        assert build_online_dpo_pair_indices(["a", "a"], [0.5, 0.5]) == [0, 1]
+
+
+class TestLoss:
+    def test_matches_hand_computed(self):
+        # r = logp - ref = [2, 1, 1, 3]; pairs (a: 2 vs 1), (b: 3 vs 1); inside = beta*[1, 2]
+        model_output, data = _data(
+            [2.0, 1.0, 1.0, 3.0], [0.0, 0.0, 0.0, 0.0], ["a", "a", "b", "b"], [0.9, 0.1, 0.3, 0.7]
+        )
+        loss, metrics = tts_dpo_loss(_config(beta=0.1), model_output, data)
+        expected = -(math.log(1 / (1 + math.exp(-0.1))) + math.log(1 / (1 + math.exp(-0.2)))) / 2
+        assert abs(loss.item() - expected) < 1e-6
+        assert metrics["actor/dpo_acc"].values[0] == 1.0  # both margins positive
+        assert abs(metrics["actor/dpo_margin"].values[0] - 1.5) < 1e-6  # mean of [1, 2]
+
+    def test_order_independent(self):
+        rows = ([2.0, 1.0, 1.0, 3.0], [0.0, 0.0, 0.0, 0.0], ["a", "a", "b", "b"], [0.9, 0.1, 0.3, 0.7])
+        loss_a, _ = tts_dpo_loss(_config(), *_data(*rows))
+        # shuffle rows: (b_hi, a_lo, a_hi, b_lo)
+        perm = ([3.0, 1.0, 2.0, 1.0], [0.0, 0.0, 0.0, 0.0], ["b", "a", "a", "b"], [0.7, 0.1, 0.9, 0.3])
+        loss_b, _ = tts_dpo_loss(_config(), *_data(*perm))
+        assert abs(loss_a.item() - loss_b.item()) < 1e-6
+
+    def test_tie_masks_the_pair(self):
+        # uid a is a tie (equal scores) -> zero weight; only uid b contributes.
+        model_output, data = _data(
+            [2.0, 1.0, 1.0, 3.0], [0.0, 0.0, 0.0, 0.0], ["a", "a", "b", "b"], [0.5, 0.5, 0.3, 0.7]
+        )
+        loss, metrics = tts_dpo_loss(_config(beta=0.1), model_output, data)
+        expected = -math.log(1 / (1 + math.exp(-0.2)))  # only pair b, inside = 0.1*2
+        assert abs(loss.item() - expected) < 1e-6
+        assert abs(metrics["actor/dpo_tie_frac"].values[0] - 0.5) < 1e-6
+
+    def test_nll_anchor_adds_chosen_nll(self):
+        rows = ([2.0, 1.0, 1.0, 3.0], [0.0, 0.0, 0.0, 0.0], ["a", "a", "b", "b"], [0.9, 0.1, 0.3, 0.7])
+        base, _ = tts_dpo_loss(_config(beta=0.1, nll_lambda=0.0), *_data(*rows))
+        anchored, _ = tts_dpo_loss(_config(beta=0.1, nll_lambda=0.5), *_data(*rows))
+        # chosen seq_logp are [2, 3] over 1 token -> nll = [-2, -3]; term = mean = -2.5; +0.5*(-2.5)
+        assert abs((anchored.item() - base.item()) - 0.5 * (-2.5)) < 1e-6
+
+    def test_dynamic_bsz_raises(self):
+        model_output, data = _data([2.0, 1.0], [0.0, 0.0], ["a", "a"], [0.9, 0.1])
+        with pytest.raises(ValueError, match="use_dynamic_bsz"):
+            tts_dpo_loss(_config(use_dynamic_bsz=True), model_output, data)
+
+    def test_no_pairs_raises(self):
+        model_output, data = _data([2.0, 1.0], [0.0, 0.0], ["a", "b"], [0.9, 0.1])  # no group has 2
+        with pytest.raises(RuntimeError, match="no preference pairs"):
+            tts_dpo_loss(_config(), model_output, data)

--- a/tests/workers/test_tts_dpo_loss_on_cpu.py
+++ b/tests/workers/test_tts_dpo_loss_on_cpu.py
@@ -1,4 +1,4 @@
-# Copyright 2026 Bytedance Ltd. and/or its affiliates
+# Copyright 2026 Gulp AI Inc and/or its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/verl_omni/models/transformers/qwen3_tts.py
+++ b/verl_omni/models/transformers/qwen3_tts.py
@@ -1,4 +1,4 @@
-# Copyright 2026 Bytedance Ltd. and/or its affiliates
+# Copyright 2026 Gulp AI Inc and/or its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/verl_omni/models/transformers/qwen3_tts.py
+++ b/verl_omni/models/transformers/qwen3_tts.py
@@ -1,0 +1,366 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Qwen3-TTS talker patches: register the qwen-tts model classes for verl's FSDP actor, install
+a teacher-forced codec-0 forward, freeze everything but the talker, and inject the per-sample
+talker inputs through the agent loop.
+
+Loaded via actor_rollout_ref.model.external_lib=verl_omni.models.transformers.qwen3_tts. The
+clone voice comes from actor_rollout_ref.model.override_config.tts_spk_embed_path.
+
+The custom forward reads four extra kwargs injected per sample via multi_modal_inputs:
+tts_text_ids (B, T_text), tts_audio_codes (B, R, 16), response_len (B,) and text_len (B,).
+"""
+
+import logging
+
+import torch
+
+from verl_omni.models.transformers.qwen3_tts_forward import (
+    TEXT_PROMPT_TRAILER_TOKENS,
+    build_assistant_text,
+    load_speaker_xvector,
+    tts_actor_logits,
+)
+
+logger = logging.getLogger(__name__)
+
+# Only these submodule prefixes stay trainable; the rest of the model is frozen.
+_TRAINABLE_PREFIXES = ("talker.model.", "talker.codec_head.")
+
+
+def _speaker_embedding(model, batch_size: int, device, dtype) -> torch.Tensor:
+    """Cached (B, D) speaker x-vector for the talker's speaker slot."""
+    cache = getattr(model, "_verl_tts_spk_cache", None)
+    if cache is None:
+        path = getattr(model.config, "tts_spk_embed_path", None)
+        if not path:
+            raise RuntimeError(
+                "Qwen3-TTS actor needs a precomputed clone x-vector: set "
+                "actor_rollout_ref.model.override_config.tts_spk_embed_path to the JSON produced "
+                "by the example's precompute_spk_embed.py."
+            )
+        cache = load_speaker_xvector(path)
+        model._verl_tts_spk_cache = cache
+        logger.info("verl_omni.qwen3_tts: loaded %d-dim speaker x-vector.", cache.shape[-1])
+    return cache.to(device=device, dtype=dtype).expand(batch_size, -1)
+
+
+def _reinit_rope_buffers(model) -> None:
+    """Recompute rotary inv_freq buffers. verl materializes the model from the meta device via
+    to_empty, which leaves non-persistent buffers as uninitialized memory; the weights load does
+    not cover them, so every rotary embedding must be re-initialized after materialization."""
+    for module in model.modules():
+        rope_init = getattr(module, "rope_init_fn", None)
+        inv_freq = getattr(module, "inv_freq", None)
+        if rope_init is None or not torch.is_tensor(inv_freq):
+            continue
+        new_inv_freq, attention_scaling = rope_init(module.config, device=inv_freq.device)
+        module.inv_freq.data.copy_(new_inv_freq.to(device=inv_freq.device, dtype=inv_freq.dtype))
+        module.attention_scaling = attention_scaling
+
+
+def _qwen3_tts_forward(
+    self,
+    input_ids=None,
+    attention_mask=None,
+    position_ids=None,
+    past_key_values=None,
+    inputs_embeds=None,
+    labels=None,
+    use_cache=None,
+    tts_text_ids=None,
+    tts_audio_codes=None,
+    response_len=None,
+    text_len=None,
+    **kwargs,
+):
+    """Return codec-0 logits aligned to verl's flat input_ids (see qwen3_tts_forward)."""
+    from transformers.modeling_outputs import CausalLMOutputWithPast
+
+    if tts_audio_codes is None or response_len is None or text_len is None or tts_text_ids is None:
+        raise RuntimeError(
+            "qwen3_tts forward requires tts_text_ids/tts_audio_codes/response_len/text_len via "
+            "multi_modal_inputs; missing keys mean the agent-loop patch did not run."
+        )
+
+    if not getattr(self, "_verl_rope_reinit_done", False):
+        _reinit_rope_buffers(self)
+        self._verl_rope_reinit_done = True
+
+    B = input_ids.shape[0]
+    spk = _speaker_embedding(self, B, input_ids.device, next(self.talker.parameters()).dtype)
+    out_logits = tts_actor_logits(
+        self, input_ids, attention_mask, tts_text_ids, tts_audio_codes, response_len, text_len, spk
+    )
+    return CausalLMOutputWithPast(logits=out_logits)
+
+
+def _qwen3_tts_get_input_embeddings(self):
+    return self.talker.model.codec_embedding
+
+
+def _qwen3_tts_set_input_embeddings(self, value):
+    self.talker.model.codec_embedding = value
+
+
+def _mirror_talker_config(config) -> None:
+    """Mirror standard transformer fields from talker_config to the top-level config, where
+    verl's generic init path expects them."""
+    tc = getattr(config, "talker_config", None)
+    if tc is None:
+        return
+    for attr in ("num_attention_heads", "num_key_value_heads", "hidden_size", "num_hidden_layers"):
+        if getattr(config, attr, None) is None and getattr(tc, attr, None) is not None:
+            setattr(config, attr, getattr(tc, attr))
+
+
+def _apply_freeze(model) -> None:
+    """Train only the talker backbone and codec head; everything else is used but frozen."""
+    n_train = 0
+    for name, p in model.named_parameters():
+        train = name.startswith(_TRAINABLE_PREFIXES)
+        p.requires_grad_(train)
+        n_train += int(train)
+    logger.info("verl_omni.qwen3_tts: %d trainable param tensors (talker.model + codec_head).", n_train)
+
+
+def _register_qwen3_tts_automodel() -> None:
+    try:
+        from transformers import AutoModelForCausalLM
+    except ImportError:
+        return
+
+    # The trainable class lives in the qwen-tts package, not transformers.
+    model_cls = config_cls = None
+    for mod_path, attr in (
+        ("transformers", "Qwen3TTSForConditionalGeneration"),
+        ("qwen_tts.core.models.modeling_qwen3_tts", "Qwen3TTSForConditionalGeneration"),
+    ):
+        try:
+            mod = __import__(mod_path, fromlist=[attr])
+        except Exception:  # noqa: BLE001
+            continue
+        model_cls = getattr(mod, attr, None)
+        if model_cls is not None:
+            break
+    for mod_path in ("transformers", "qwen_tts.core.models.configuration_qwen3_tts"):
+        try:
+            mod = __import__(mod_path, fromlist=["Qwen3TTSConfig"])
+        except Exception:  # noqa: BLE001
+            continue
+        config_cls = getattr(mod, "Qwen3TTSConfig", None)
+        if config_cls is not None:
+            break
+    if model_cls is None:
+        logger.warning("verl_omni.qwen3_tts: Qwen3TTSForConditionalGeneration not found; patch is a no-op.")
+        return
+
+    try:
+        from verl.utils.model import _architecture_to_auto_class
+
+        _architecture_to_auto_class.setdefault(model_cls.__name__, AutoModelForCausalLM)
+    except ImportError as e:
+        logger.warning("verl_omni.qwen3_tts: could not register architecture lookup (%s).", e)
+
+    model_cls.forward = _qwen3_tts_forward
+    model_cls.get_input_embeddings = _qwen3_tts_get_input_embeddings
+    model_cls.set_input_embeddings = _qwen3_tts_set_input_embeddings
+    model_cls._no_split_modules = ["Qwen3TTSTalkerDecoderLayer", "Qwen3TTSDecoderLayer"]
+
+    _orig_post_init = getattr(model_cls, "post_init", None)
+
+    def _post_init_with_freeze(self):
+        if _orig_post_init is not None:
+            _orig_post_init(self)
+        _mirror_talker_config(self.config)
+        _apply_freeze(self)
+
+    model_cls.post_init = _post_init_with_freeze
+
+    if config_cls is not None:
+        # tie_word_embeddings=True disables FSDP meta-tensor init.
+        class _FalseTie:
+            def __get__(self, obj, objtype=None):
+                return False
+
+            def __set__(self, obj, value):
+                pass
+
+        config_cls.tie_word_embeddings = _FalseTie()
+        # The HF repo ships no modeling code and importing qwen_tts does not self-register.
+        try:
+            from transformers import AutoConfig
+
+            AutoConfig.register(getattr(config_cls, "model_type", "qwen3_tts"), config_cls)
+        except ValueError:
+            pass
+        try:
+            AutoModelForCausalLM.register(config_cls, model_cls)
+        except ValueError:
+            pass
+        _make_config_save_non_fatal(config_cls)
+    logger.info("verl_omni.qwen3_tts: installed talker codec-0 forward + freeze on %s.", model_cls.__name__)
+
+
+def _make_config_save_non_fatal(config_cls) -> None:
+    """Guard save_pretrained on the composite Qwen3-TTS config. verl's checkpoint manager writes
+    the HF config unconditionally, and the nested talker/code2wav/speech_tokenizer config trips
+    transformers' to_diff_dict with KeyError('dtype'), which would kill the run at the first save
+    after the model and optim shards already wrote. Those shards plus model.path are all verl needs
+    to resume, so the config.json write is non-essential."""
+    if getattr(config_cls, "_verl_save_guarded", False):
+        return
+    _orig_save = config_cls.save_pretrained
+
+    def _save_pretrained(self, *args, **kwargs):
+        try:
+            return _orig_save(self, *args, **kwargs)
+        except Exception as e:  # noqa: BLE001
+            logger.warning(
+                "verl_omni.qwen3_tts: skipped composite config save_pretrained (non-fatal: %s); "
+                "model and optim shards are unaffected.",
+                e,
+            )
+
+    config_cls.save_pretrained = _save_pretrained
+    config_cls._verl_save_guarded = True
+
+
+def _unwrap_non_tensor(v):
+    """raw_prompt rides as a 0-d object array; unwrap to the underlying messages list."""
+    if hasattr(v, "item") and not isinstance(v, list | tuple):
+        try:
+            return v.item()
+        except ValueError:
+            return v
+    return v
+
+
+def patch_agent_loop_multi_modal_inputs() -> None:
+    """Inject the per-sample talker inputs into multi_modal_inputs so they reach the actor
+    forward as kwargs. Response data is left-aligned; the FSDP engine re-packs input_ids."""
+    try:
+        from verl.experimental.agent_loop import agent_loop as _al
+    except Exception as e:  # noqa: BLE001
+        logger.warning("verl_omni.qwen3_tts: agent_loop patch skipped (%s).", e)
+        return
+
+    _orig = _al.AgentLoopWorker._compute_multi_modal_inputs
+
+    def _patched(self, output, input_ids):
+        mmi = _orig(self, output, input_ids)
+        ef = getattr(output, "extra_fields", None) or {}
+        codes = ef.get("tts_audio_codes")
+        if codes is None:
+            return mmi  # not a TTS rollout
+
+        raw_prompt = _unwrap_non_tensor(ef.get("raw_prompt"))
+        text = raw_prompt[0]["content"] if raw_prompt else ""
+        tok = self.processor or self.tokenizer
+        text_ids = tok(text=build_assistant_text(text), return_tensors="pt", padding=True)["input_ids"]
+        text_ids = text_ids[:, :-TEXT_PROMPT_TRAILER_TOKENS].reshape(-1)
+
+        R = int(self.rollout_config.response_length)
+        Ttext = int(self.rollout_config.prompt_length)
+        codes = torch.as_tensor(codes, dtype=torch.long)
+        rl = min(codes.shape[0], R)
+        tl = min(text_ids.numel(), Ttext)
+
+        audio_buf = torch.zeros(1, R, codes.shape[-1], dtype=torch.long)
+        audio_buf[0, :rl] = codes[:rl]
+        text_buf = torch.zeros(1, Ttext, dtype=torch.long)
+        text_buf[0, :tl] = text_ids[:tl]
+
+        mmi["tts_audio_codes"] = audio_buf
+        mmi["tts_text_ids"] = text_buf
+        mmi["response_len"] = torch.tensor([rl], dtype=torch.long)
+        mmi["text_len"] = torch.tensor([tl], dtype=torch.long)
+        return mmi
+
+    _al.AgentLoopWorker._compute_multi_modal_inputs = _patched
+    logger.info("verl_omni.qwen3_tts: patched AgentLoopWorker._compute_multi_modal_inputs.")
+
+
+_TTS_PASSTHROUGH_CHAT_TEMPLATE = "{% for message in messages %}{{ message['content'] }}{% endfor %}"
+
+
+def patch_hf_tokenizer_for_qwen3_tts() -> None:
+    """Install a passthrough chat template: Qwen3-TTS-Base has none but verl's dataset calls
+    apply_chat_template on every prompt."""
+    try:
+        import verl.utils.tokenizer as _vt
+    except ImportError:
+        return
+
+    _original_hf_tokenizer = _vt.hf_tokenizer
+
+    def _patched_hf_tokenizer(name_or_path, **kwargs):
+        tok = _original_hf_tokenizer(name_or_path, **kwargs)
+        if tok is not None and not getattr(tok, "chat_template", None):
+            tok.chat_template = _TTS_PASSTHROUGH_CHAT_TEMPLATE
+            logger.info("verl_omni.qwen3_tts: installed passthrough chat_template on %s.", type(tok).__name__)
+        return tok
+
+    _vt.hf_tokenizer = _patched_hf_tokenizer
+
+
+def patch_verl_ref_manual_offload() -> None:
+    """Make verl's forward_only engine (the ref policy) use manual param offload instead of
+    FSDP-native CPUOffload. The talker forward assembles its input by indexing leaf embedding
+    tables and running text_projection outside the FSDP-wrapped module, so FSDP-native CPUOffload
+    leaves those params on CPU and compute_ref_log_prob dies with a cuda/cpu device mismatch. verl
+    forces CPUOffload for every forward_only engine regardless of param_offload; this neutralizes
+    that only for the ref config this recipe runs (forward_only with param_offload false), where
+    manual offload loads all params to GPU before the forward, the path the actor already takes."""
+    try:
+        from verl.workers.engine.fsdp.transformer_impl import FSDPEngine
+    except Exception as e:  # noqa: BLE001
+        logger.warning("verl_omni.qwen3_tts: ref-offload patch skipped (%s).", e)
+        return
+    if getattr(FSDPEngine, "_verl_tts_ref_offload_patched", False):
+        return
+
+    def _run_as_manual_offload(engine, call):
+        ec = engine.engine_config
+        if not (getattr(ec, "forward_only", False) and not getattr(ec, "param_offload", True)):
+            return call()
+        ec.forward_only = False  # skip the forced-CPUOffload / early-return branches
+        try:
+            return call()
+        finally:
+            ec.forward_only = True
+
+    _orig_build = FSDPEngine._build_fsdp_module
+    _orig_to = FSDPEngine.to
+
+    def _build_fsdp_module(self, module):
+        return _run_as_manual_offload(self, lambda: _orig_build(self, module))
+
+    def _to(self, device, model=True, optimizer=True, grad=True):
+        return _run_as_manual_offload(self, lambda: _orig_to(self, device, model=model, optimizer=optimizer, grad=grad))
+
+    FSDPEngine._build_fsdp_module = _build_fsdp_module
+    FSDPEngine.to = _to
+    FSDPEngine._verl_tts_ref_offload_patched = True
+    logger.info("verl_omni.qwen3_tts: patched FSDPEngine for ref manual offload.")
+
+
+def apply_qwen3_tts_patches() -> None:
+    _register_qwen3_tts_automodel()
+    patch_agent_loop_multi_modal_inputs()
+    patch_hf_tokenizer_for_qwen3_tts()
+    patch_verl_ref_manual_offload()
+
+
+apply_qwen3_tts_patches()

--- a/verl_omni/models/transformers/qwen3_tts_forward.py
+++ b/verl_omni/models/transformers/qwen3_tts_forward.py
@@ -1,0 +1,292 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Teacher-forced codec-0 forward math for the Qwen3-TTS talker.
+
+The talker is not a plain causal LM: its input is a 2-channel, position-co-located sequence with
+an 8-slot control prefix (think tokens, a speaker embedding slot at codec position 6), and each
+frame's codec-0 logits depend on the previous frame's full 16-codebook set. verl instead hands
+the actor a flat input_ids and gathers logits with roll(input_ids, -1). This module bridges the
+two: build_talker_batch rebuilds the talker's 2-channel batch, codec0_logits runs the talker, and
+realign_to_verl scatters the codec-0 logit rows onto verl's flat response positions.
+
+Layout per sample, with text length tl, codec length cl, total t = max(tl + cl) + 8:
+  ch0 (text):  [0:3]=text[:3]  [3:7]=tts_pad  [7]=tts_bos  [8:8+tl-3]=text[3:]
+               [8+tl-3]=tts_eos  [8+tl-2:8+tl+cl]=tts_pad
+  ch1 (codec): [3]=nothink [4]=think_bos [5]=think_eos [6]=0(speaker slot) [7]=codec_pad
+               [8:8+tl-2]=codec_pad  [8+tl-2]=codec_bos  [8+tl-1:8+tl-1+cl]=codec0  [.+cl]=codec_eos
+  codec_0_labels: [8+tl-1 : 8+tl-1+cl]=codec0 ; [8+tl-1+cl]=codec_eos ; else -100
+
+This module imports neither verl nor transformers, so the index math is unit-testable on CPU
+(tests/models/test_qwen3_tts_forward_on_cpu.py).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+
+NUM_SUB_CODEBOOKS = 15
+NUM_CODEBOOKS = NUM_SUB_CODEBOOKS + 1
+SPEAKER_SLOT = 6
+
+# The prompt template ends with a second assistant header whose trailing tokens are not part of
+# the teacher-forcing text channel; callers drop this many tokens from the tokenized prompt.
+TEXT_PROMPT_TRAILER_TOKENS = 5
+
+
+def build_assistant_text(text: str) -> str:
+    """The talker's text prompt template. The rollout server and the actor forward must tokenize
+    the same string so generation and the teacher-forced recompute see identical text channels."""
+    return f"<|im_start|>assistant\n{text}<|im_end|>\n<|im_start|>assistant\n"
+
+
+def load_speaker_xvector(path: str) -> torch.Tensor:
+    """Load a precomputed speaker x-vector (JSON float list) as a (1, D) float32 tensor.
+
+    The same vector must feed the rollout (voice_clone_prompt) and the actor (speaker slot) so
+    both condition on an identical speaker. See the example's precompute_spk_embed.py.
+    """
+    import json
+
+    with open(path) as f:
+        vec = json.load(f)
+    return torch.tensor(vec, dtype=torch.float32).reshape(1, -1)
+
+
+@dataclass
+class TalkerTokens:
+    """Control token ids for the talker layout, read from the model config."""
+
+    tts_pad: int
+    tts_bos: int
+    tts_eos: int
+    codec_pad: int
+    codec_bos: int
+    codec_eos: int
+    codec_nothink: int
+    codec_think_bos: int
+    codec_think_eos: int
+
+    @classmethod
+    def from_config(cls, config) -> TalkerTokens:
+        tcfg = config.talker_config
+        return cls(
+            tts_pad=int(config.tts_pad_token_id),
+            tts_bos=int(config.tts_bos_token_id),
+            tts_eos=int(config.tts_eos_token_id),
+            codec_pad=int(tcfg.codec_pad_id),
+            codec_bos=int(tcfg.codec_bos_id),
+            codec_eos=int(tcfg.codec_eos_token_id),
+            codec_nothink=int(tcfg.codec_nothink_id),
+            codec_think_bos=int(tcfg.codec_think_bos_id),
+            codec_think_eos=int(tcfg.codec_think_eos_id),
+        )
+
+
+@dataclass
+class TalkerBatch:
+    """Teacher-forcing batch plus per-sample offsets for realigning logits back to verl."""
+
+    input_ids: torch.Tensor  # (B, t, 2), channel 0 text, channel 1 codec
+    codec_ids: torch.Tensor  # (B, t, 16), column 0 is codec-0
+    text_embedding_mask: torch.Tensor  # (B, t, 1)
+    codec_embedding_mask: torch.Tensor  # (B, t, 1), False at the speaker slot
+    codec_mask: torch.Tensor  # (B, t), the acoustic-frame span
+    attention_mask: torch.Tensor  # (B, t)
+    codec_0_labels: torch.Tensor  # (B, t), -100 outside the codec span
+    text_lens: list[int]
+    codec_lens: list[int]
+    logit_start: list[int]  # 8 + tl - 2 per sample; logit at logit_start + k predicts codec-0 token k
+
+
+def build_talker_batch(
+    text_ids: list[torch.Tensor],
+    audio_codes: list[torch.Tensor],
+    tokens: TalkerTokens,
+    *,
+    device=None,
+    sub_codebook_vocab: int | None = None,
+) -> TalkerBatch:
+    """Build the talker's 2-channel teacher-forcing batch (see the module docstring layout).
+
+    text_ids are the tokenized build_assistant_text prompts with the trailing header dropped;
+    audio_codes are per-sample (cl, 16) codebooks. sub_codebook_vocab, if given, clamps
+    columns 1..15 to guard against device-side asserts on out-of-range sampled codes.
+    """
+    b = len(text_ids)
+    tls = [int(t.reshape(-1).shape[0]) for t in text_ids]
+    cls = [int(c.shape[0]) for c in audio_codes]
+    t = max(tl + cl for tl, cl in zip(tls, cls, strict=True)) + 8
+
+    input_ids = torch.zeros((b, t, 2), dtype=torch.long, device=device)
+    codec_ids = torch.zeros((b, t, NUM_CODEBOOKS), dtype=torch.long, device=device)
+    text_embedding_mask = torch.zeros((b, t), dtype=torch.bool, device=device)
+    codec_embedding_mask = torch.zeros((b, t), dtype=torch.bool, device=device)
+    codec_mask = torch.zeros((b, t), dtype=torch.bool, device=device)
+    attention_mask = torch.zeros((b, t), dtype=torch.long, device=device)
+    codec_0_labels = torch.full((b, t), -100, dtype=torch.long, device=device)
+
+    for i in range(b):
+        tid = text_ids[i].reshape(-1).to(device=device, dtype=torch.long)
+        codes = audio_codes[i].to(device=device, dtype=torch.long)
+        if sub_codebook_vocab is not None:
+            codes = codes.clone()
+            codes[:, 1:NUM_CODEBOOKS] = codes[:, 1:NUM_CODEBOOKS].clamp_(0, sub_codebook_vocab - 1)
+        codec0 = codes[:, 0]
+        tl, cl = tls[i], cls[i]
+
+        input_ids[i, :3, 0] = tid[:3]
+        input_ids[i, 3:7, 0] = tokens.tts_pad
+        input_ids[i, 7, 0] = tokens.tts_bos
+        input_ids[i, 8 : 8 + tl - 3, 0] = tid[3:]
+        input_ids[i, 8 + tl - 3, 0] = tokens.tts_eos
+        input_ids[i, 8 + tl - 2 : 8 + tl + cl, 0] = tokens.tts_pad
+        text_embedding_mask[i, : 8 + tl + cl] = True
+
+        input_ids[i, 3:8, 1] = torch.tensor(
+            [tokens.codec_nothink, tokens.codec_think_bos, tokens.codec_think_eos, 0, tokens.codec_pad],
+            dtype=torch.long,
+            device=device,
+        )
+        input_ids[i, 8 : 8 + tl - 3, 1] = tokens.codec_pad
+        input_ids[i, 8 + tl - 3, 1] = tokens.codec_pad
+        input_ids[i, 8 + tl - 2, 1] = tokens.codec_bos
+        input_ids[i, 8 + tl - 1 : 8 + tl - 1 + cl, 1] = codec0
+        input_ids[i, 8 + tl - 1 + cl, 1] = tokens.codec_eos
+
+        codec_0_labels[i, 8 + tl - 1 : 8 + tl - 1 + cl] = codec0
+        codec_0_labels[i, 8 + tl - 1 + cl] = tokens.codec_eos
+
+        codec_ids[i, 8 + tl - 1 : 8 + tl - 1 + cl, :] = codes
+
+        codec_embedding_mask[i, 3 : 8 + tl + cl] = True
+        codec_embedding_mask[i, SPEAKER_SLOT] = False
+        codec_mask[i, 8 + tl - 1 : 8 + tl - 1 + cl] = True
+        attention_mask[i, : 8 + tl + cl] = True
+
+    return TalkerBatch(
+        input_ids=input_ids,
+        codec_ids=codec_ids,
+        text_embedding_mask=text_embedding_mask.unsqueeze(-1),
+        codec_embedding_mask=codec_embedding_mask.unsqueeze(-1),
+        codec_mask=codec_mask,
+        attention_mask=attention_mask,
+        codec_0_labels=codec_0_labels,
+        text_lens=tls,
+        codec_lens=cls,
+        logit_start=[8 + tl - 2 for tl in tls],
+    )
+
+
+def assemble_talker_embeddings(talker, batch: TalkerBatch, speaker_emb: torch.Tensor) -> torch.Tensor:
+    """Build the talker input embedding (B, t, H); speaker_emb (B, H) is injected at position 6."""
+    ids = batch.input_ids
+    # Generation runs text-side embeddings through talker.text_projection (a learned resize MLP,
+    # not identity); apply it here too so the recompute matches the rollout.
+    te_raw = talker.model.text_embedding(ids[:, :, 0])
+    text_proj = getattr(talker, "text_projection", None)
+    if text_proj is not None:
+        te_raw = text_proj(te_raw)
+    te = te_raw * batch.text_embedding_mask
+    ce = talker.model.codec_embedding(ids[:, :, 1]) * batch.codec_embedding_mask
+    ce = ce.clone()
+    ce[:, SPEAKER_SLOT, :] = speaker_emb.to(ce.dtype)
+    emb = te + ce
+    sub_tables = talker.code_predictor.get_input_embeddings()
+    cmask = batch.codec_mask.unsqueeze(-1)
+    for i in range(1, NUM_CODEBOOKS):
+        emb = emb + sub_tables[i - 1](batch.codec_ids[:, :, i]) * cmask
+    return emb
+
+
+def codec0_logits(talker, batch: TalkerBatch, speaker_emb: torch.Tensor) -> torch.Tensor:
+    """Run the talker over the teacher-forcing window; logits[j] predicts the token at j + 1."""
+    emb = assemble_talker_embeddings(talker, batch, speaker_emb)
+    out = talker(
+        inputs_embeds=emb[:, :-1, :],
+        attention_mask=batch.attention_mask[:, :-1],
+        use_cache=False,
+        output_hidden_states=False,
+    )
+    return out.logits
+
+
+def tts_actor_logits(
+    model,
+    input_ids: torch.Tensor,
+    attention_mask: torch.Tensor,
+    tts_text_ids: torch.Tensor,
+    tts_audio_codes: torch.Tensor,
+    response_len: torch.Tensor,
+    text_len: torch.Tensor,
+    speaker_emb: torch.Tensor,
+) -> torch.Tensor:
+    """verl flat batch to codec-0 logits (B, T, vocab) realigned onto verl's positions.
+
+    input_ids/attention_mask are verl's dense tensors (real region [0, L_i), response is the
+    suffix of length response_len_i); tts_text_ids and tts_audio_codes are left-aligned
+    per-sample inputs from the rollout.
+    """
+    talker = model.talker
+    device = input_ids.device
+    b = input_ids.shape[0]
+    t_out = input_ids.shape[1]
+    real_len = attention_mask.sum(dim=1).to(torch.long)
+
+    text_ids_list, audio_codes_list, response_starts = [], [], []
+    for i in range(b):
+        rl, tl, li = int(response_len[i]), int(text_len[i]), int(real_len[i])
+        text_ids_list.append(tts_text_ids[i, :tl].to(torch.long))
+        audio_codes_list.append(tts_audio_codes[i, :rl].to(torch.long))
+        response_starts.append(li - rl)
+
+    tokens = TalkerTokens.from_config(model.config)
+    sub_vocab = int(talker.code_predictor.get_input_embeddings()[0].num_embeddings)
+
+    batch = build_talker_batch(text_ids_list, audio_codes_list, tokens, device=device, sub_codebook_vocab=sub_vocab)
+    talker_logits = codec0_logits(talker, batch, speaker_emb)
+    vocab = talker_logits.shape[-1]
+    # verl gathers log-probs over the full flat sequence before slicing the response, so the
+    # output must be wide enough for the text-prompt labels too (those rows are discarded).
+    out_vocab = max(vocab, int(input_ids.max().item()) + 1)
+    return realign_to_verl(talker_logits, batch, response_starts, (b, t_out, out_vocab))
+
+
+def realign_to_verl(
+    talker_logits: torch.Tensor,
+    batch: TalkerBatch,
+    response_starts: list[int],
+    out_shape: tuple[int, int, int],
+) -> torch.Tensor:
+    """Scatter codec-0 logit rows onto verl's flat (B, T, vocab) tensor.
+
+    verl computes logp[p] from logits[p] and input_ids[p + 1]; response token k sits at flat
+    position response_start + k and the talker's logit for it is at batch.logit_start + k, so
+    each sample copies cl contiguous rows. Prompt and pad rows stay zero; verl drops them via
+    the response mask.
+    """
+    b, T, out_vocab = out_shape
+    codec_vocab = talker_logits.shape[-1]
+    out = talker_logits.new_zeros((b, T, out_vocab))
+    for i in range(b):
+        cl = batch.codec_lens[i]
+        ls = batch.logit_start[i]
+        rs = response_starts[i]
+        sl = slice(rs - 1, rs - 1 + cl)
+        if out_vocab > codec_vocab:
+            # Mask non-codec columns so the response-row log_softmax is over the codec vocab only.
+            out[i, sl, codec_vocab:] = -1e4
+        out[i, sl, :codec_vocab] = talker_logits[i, ls : ls + cl, :]
+    return out

--- a/verl_omni/models/transformers/qwen3_tts_forward.py
+++ b/verl_omni/models/transformers/qwen3_tts_forward.py
@@ -1,4 +1,4 @@
-# Copyright 2026 Bytedance Ltd. and/or its affiliates
+# Copyright 2026 Gulp AI Inc and/or its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/verl_omni/reward_loop/__init__.py
+++ b/verl_omni/reward_loop/__init__.py
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from .reward_loop import OmniRewardLoopManager  # noqa: F401
-from .reward_manager import VisualRewardManager  # noqa: F401
+from .reward_manager import AudioRewardManager, VisualRewardManager  # noqa: F401
 
-__all__ = ["OmniRewardLoopManager", "VisualRewardManager"]
+__all__ = ["OmniRewardLoopManager", "VisualRewardManager", "AudioRewardManager"]

--- a/verl_omni/reward_loop/reward_manager/__init__.py
+++ b/verl_omni/reward_loop/reward_manager/__init__.py
@@ -13,7 +13,14 @@
 # limitations under the License.
 
 from .audio import AudioRewardManager
+from .audio_judge import AudioJudgeRewardManager
 from .multi import MultiAudioRewardManager, MultiVisualRewardManager
 from .visual import VisualRewardManager
 
-__all__ = ["VisualRewardManager", "MultiVisualRewardManager", "AudioRewardManager", "MultiAudioRewardManager"]
+__all__ = [
+    "VisualRewardManager",
+    "MultiVisualRewardManager",
+    "AudioRewardManager",
+    "MultiAudioRewardManager",
+    "AudioJudgeRewardManager",
+]

--- a/verl_omni/reward_loop/reward_manager/audio.py
+++ b/verl_omni/reward_loop/reward_manager/audio.py
@@ -1,0 +1,201 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import inspect
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+import numpy as np
+import torch
+from verl import DataProto
+from verl.experimental.reward_loop.reward_manager.base import RewardManagerBase
+from verl.utils.reward_score import default_compute_score as _upstream_default_compute_score
+
+from verl_omni.utils.reward_score import default_compute_score_audio
+
+
+def _load_qwen_tts_decoder(model_path, device):
+    """Load the qwen-tts speech tokenizer (code2wav vocoder). Returns (decode_fn, codebook_max)."""
+    import os
+
+    from qwen_tts import Qwen3TTSTokenizer
+    from transformers.utils import cached_file
+
+    cfg = cached_file(model_path, "speech_tokenizer/config.json")
+    dec = Qwen3TTSTokenizer.from_pretrained(os.path.dirname(cfg), device_map=device, dtype=torch.bfloat16)
+    codebook_size = getattr(getattr(dec.model.config, "decoder_config", None), "codebook_size", 2048)
+
+    def decode(codes):
+        wavs, sr = dec.decode([{"audio_codes": codes}])
+        return np.asarray(wavs[0], dtype=np.float32).reshape(-1), int(sr)
+
+    return decode, int(codebook_size) - 1
+
+
+# Codec decoders dispatched on reward.audio.codec; add new codec models here.
+_CODEC_DECODERS = {"qwen_tts": _load_qwen_tts_decoder}
+
+
+class AudioRewardManager(RewardManagerBase):
+    """The reward manager for audio response.
+
+    The rollout surfaces either a decoded waveform or codec tokens; codec tokens are decoded
+    reward-side with the decoder selected by reward.audio.codec, and the (wav, sr) tuple is
+    passed to compute_score as solution_audio.
+    """
+
+    def __init__(self, config, tokenizer, compute_score, reward_router_address=None, reward_model_tokenizer=None):
+        super().__init__(config, tokenizer, compute_score)
+
+        if compute_score is None or compute_score is _upstream_default_compute_score:
+            self.compute_score = default_compute_score_audio
+        else:
+            self.compute_score = compute_score
+
+        self.is_async_reward_score = inspect.iscoroutinefunction(self.compute_score)
+        self.reward_router_address = reward_router_address
+        self.reward_model_tokenizer = reward_model_tokenizer
+
+        audio_cfg = getattr(getattr(config, "reward", None), "audio", None) or {}
+        codec = audio_cfg.get("codec", "qwen_tts")
+        if codec not in _CODEC_DECODERS:
+            raise ValueError(f"Unknown reward.audio.codec {codec!r}, available: {sorted(_CODEC_DECODERS)}")
+        self._codec = codec
+        self._codec_eos = int(audio_cfg.get("codec_eos_token_id", 2150))
+        self._decode = None
+        self._codebook_max = None
+        self._decoder_lock = threading.Lock()
+        self._device = f"cuda:{torch.cuda.current_device()}" if torch.cuda.is_available() else "cpu"
+        model_cfg = getattr(getattr(config, "actor_rollout_ref", None), "model", None)
+        self._decoder_model_path = audio_cfg.get("decoder_model_path") or getattr(model_cfg, "path", None)
+        # Scoring runs in a small bounded pool: the decode and feature-extraction paths are
+        # CPU-bound and not thread-safe under CUDA, so parallelism comes from reward.num_workers
+        # processes rather than threads.
+        self._score_executor = ThreadPoolExecutor(max_workers=int(audio_cfg.get("score_threads", 1)))
+
+    @classmethod
+    def assemble_rm_scores(cls, data: DataProto, scores: list[float]) -> torch.Tensor:
+        """Per-sample audio rewards: ``rm_scores`` has shape ``(batch_size, 1)``."""
+        return torch.tensor(scores, dtype=torch.float32).unsqueeze(-1)
+
+    def _get_decoder(self):
+        if self._decode is None:
+            with self._decoder_lock:
+                if self._decode is None:
+                    loader = _CODEC_DECODERS[self._codec]
+                    self._decode, self._codebook_max = loader(self._decoder_model_path, self._device)
+        return self._decode
+
+    def _decode_codes(self, extra_info):
+        """Decode rollout codec tokens (T, 16) from extra_info into (wav, sr), or None."""
+        codes = extra_info.get("tts_audio_codes")
+        if codes is None:
+            return None
+        codes = torch.as_tensor(codes, dtype=torch.long)
+        if codes.ndim != 2:
+            return None
+        # Trim frames after codec eos, then clamp: out-of-range indices device-assert in decode.
+        eos = (codes[:, 0] == self._codec_eos).nonzero().flatten()
+        if len(eos):
+            codes = codes[: int(eos[0])]
+        if codes.shape[0] == 0:
+            return None
+        decode = self._get_decoder()
+        return decode(codes.clamp_(0, self._codebook_max))
+
+    def _extract_audio(self, data_item, extra_info):
+        """The generated audio as a (wav, sr) tuple, or None when nothing decodes."""
+        nb = data_item.non_tensor_batch
+        audio = nb.get("audio")
+        sr = nb.get("sr")
+        if audio is None and isinstance(nb.get("multimodal_output"), dict):
+            mm = nb["multimodal_output"]
+            audio, sr = mm.get("audio"), mm.get("sr")
+        if audio is None:
+            return self._decode_codes(extra_info)
+        if isinstance(audio, list | tuple):
+            audio = torch.cat([a if torch.is_tensor(a) else torch.as_tensor(a) for a in audio], dim=-1)
+        if torch.is_tensor(audio):
+            audio = audio.float().cpu().numpy()
+        audio = np.asarray(audio, dtype=np.float32).reshape(-1)
+        if audio.size == 0:
+            return None
+        if isinstance(sr, list | tuple):
+            sr = sr[-1]
+        sr = int(sr.item()) if hasattr(sr, "item") else int(sr or 24000)
+        return audio, sr
+
+    async def run_single(self, data: DataProto) -> dict:
+        assert len(data) == 1, "Only support single data item"
+        data_item = data[0]
+        data_source = data_item.non_tensor_batch["data_source"]
+        ground_truth = data_item.non_tensor_batch["reward_model"]["ground_truth"]
+        extra_info = data_item.non_tensor_batch.get("extra_info", {})
+        tool_extra_fields = data_item.non_tensor_batch.get("tool_extra_fields", None)
+        if tool_extra_fields is not None:
+            extra_info.update(tool_extra_fields.items())
+
+        num_turns = data_item.non_tensor_batch.get("__num_turns__", None)
+        rollout_reward_scores = data_item.non_tensor_batch.get("reward_scores", {})
+        extra_info["num_turns"] = num_turns
+        extra_info["rollout_reward_scores"] = rollout_reward_scores
+
+        extra_reward_kwargs = (
+            {
+                "reward_router_address": self.reward_router_address,
+                "reward_model_tokenizer": self.reward_model_tokenizer,
+                "model_name": self.config.reward.reward_model.model_path,
+            }
+            if self.reward_router_address is not None
+            else {}
+        )
+        if self.is_async_reward_score:
+            solution_audio = await self.loop.run_in_executor(
+                self._score_executor, lambda: self._extract_audio(data_item, extra_info)
+            )
+            result = await self.compute_score(
+                data_source=data_source,
+                solution_audio=solution_audio,
+                ground_truth=ground_truth,
+                extra_info=extra_info,
+                **extra_reward_kwargs,
+            )
+        else:
+            result = await self.loop.run_in_executor(
+                self._score_executor,
+                lambda: self.compute_score(
+                    data_source=data_source,
+                    solution_audio=self._extract_audio(data_item, extra_info),
+                    ground_truth=ground_truth,
+                    extra_info=extra_info,
+                    **extra_reward_kwargs,
+                ),
+            )
+
+        reward_extra_info = {}
+
+        score: float
+        if isinstance(result, dict):
+            score = result["score"]
+            for key, value in result.items():
+                if key == "score":
+                    continue
+                reward_extra_info[key] = value
+        else:
+            score = result
+            reward_extra_info["acc"] = score
+
+        reward = score
+
+        return {"reward_score": reward, "reward_extra_info": reward_extra_info}

--- a/verl_omni/reward_loop/reward_manager/audio.py
+++ b/verl_omni/reward_loop/reward_manager/audio.py
@@ -112,7 +112,7 @@ class AudioRewardManager(RewardManagerBase):
         if codes.shape[0] == 0:
             return None
         decode = self._get_decoder()
-        return decode(codes.clamp_(0, self._codebook_max))
+        return decode(codes.clamp(0, self._codebook_max))
 
     def _extract_audio(self, data_item, extra_info):
         """The generated audio as a (wav, sr) tuple, or None when nothing decodes."""

--- a/verl_omni/reward_loop/reward_manager/audio.py
+++ b/verl_omni/reward_loop/reward_manager/audio.py
@@ -1,4 +1,4 @@
-# Copyright 2026 Bytedance Ltd. and/or its affiliates
+# Copyright 2026 Gulp AI Inc and/or its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/verl_omni/reward_loop/reward_manager/audio_judge.py
+++ b/verl_omni/reward_loop/reward_manager/audio_judge.py
@@ -87,7 +87,9 @@ class AudioJudgeRewardManager(AudioRewardManager):
         req = urllib.request.Request(url + "/rank", data=body, headers={"Content-Type": "application/json"})
         try:
             r = json.loads(urllib.request.urlopen(req, timeout=self._judge_timeout_s).read())
-            for j, sc in zip(idxs, r["scores"], strict=False):
+            # strict: a score-count mismatch raises here and falls through to the neutral 0.0 below,
+            # rather than silently mis-assigning candidates.
+            for j, sc in zip(idxs, r["scores"], strict=True):
                 scores[j] = float(sc)
         except Exception as e:  # noqa: BLE001
             logger.warning("audio judge call failed (%s); group gives no signal this step", e)
@@ -124,6 +126,8 @@ class AudioJudgeRewardManager(AudioRewardManager):
             g["scores"] = await self.loop.run_in_executor(
                 self._score_executor, self._judge_group, g["text"], g["blobs"]
             )
+            # Drop the group so its wav bytes are freed; every sibling already holds its own g ref.
+            self._groups.pop(uid, None)
             g["event"].set()
         else:
             try:
@@ -135,6 +139,7 @@ class AudioJudgeRewardManager(AudioRewardManager):
                             self._score_executor, self._judge_group, g["text"], g["blobs"]
                         )
                         g["event"].set()
+                    self._groups.pop(uid, None)
 
         scores = g["scores"] or []
         my_score = float(scores[my_idx]) if my_idx < len(scores) else 0.0

--- a/verl_omni/reward_loop/reward_manager/audio_judge.py
+++ b/verl_omni/reward_loop/reward_manager/audio_judge.py
@@ -1,4 +1,4 @@
-# Copyright 2026 Bytedance Ltd. and/or its affiliates
+# Copyright 2026 Gulp AI Inc and/or its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/verl_omni/reward_loop/reward_manager/audio_judge.py
+++ b/verl_omni/reward_loop/reward_manager/audio_judge.py
@@ -1,0 +1,142 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import logging
+
+from verl import DataProto
+
+from .audio import AudioRewardManager
+
+logger = logging.getLogger(__name__)
+
+
+class AudioJudgeRewardManager(AudioRewardManager):
+    """Online-DPO reward: score a prompt's rollout candidates by direct LLM-judge A-vs-B comparison.
+
+    Reuses AudioRewardManager's codec decode path but skips the in-process reward functions. A prompt's
+    rollout.n candidates are buffered by uid and judged against each other in one /rank call; sj_score is
+    each candidate's rating. The actor pairs chosen/rejected within the uid group by sj_score for
+    tts_dpo_loss (adv_estimator grpo consumes reward_score but the DPO loss ignores advantages).
+
+    REQUIRES reward.num_workers=1: a prompt's siblings must rendezvous in one worker's event loop. Judge
+    endpoints come from reward.judge_urls (any /rank server, e.g. examples/qwen3_tts_dpo/judge_server.py).
+    """
+
+    def __init__(self, config, tokenizer, compute_score, reward_router_address=None, reward_model_tokenizer=None):
+        super().__init__(config, tokenizer, compute_score, reward_router_address, reward_model_tokenizer)
+        reward_cfg = config.reward
+        num_workers = int(reward_cfg.get("num_workers", 1) or 1)
+        if num_workers != 1:
+            raise ValueError(
+                "AudioJudgeRewardManager requires reward.num_workers=1: a prompt's rollout.n candidates "
+                f"rendezvous in one worker's event loop for the pairwise judge, got {num_workers}."
+            )
+        urls = reward_cfg.get("judge_urls", None) or ["http://localhost:8901"]
+        self._judge_urls = [str(u).rstrip("/") for u in urls]
+        self._judge_debias = bool(reward_cfg.get("judge_debias", True))
+        self._judge_timeout_s = float(reward_cfg.get("judge_timeout_s", 1800))
+        self._group_size = int(config.actor_rollout_ref.rollout.n)
+        self._groups: dict = {}
+        self._group_lock = asyncio.Lock()
+
+    def _decode_wav_bytes(self, data_item, extra_info):
+        """Decode this candidate to in-memory PCM16 WAV bytes for the judge, or None on synth failure."""
+        import io
+
+        res = self._extract_audio(data_item, extra_info)
+        if res is None or res[0] is None or res[0].size == 0:
+            return None
+        import soundfile as sf
+
+        wav, sr = res
+        buf = io.BytesIO()
+        sf.write(buf, wav, sr, format="WAV", subtype="PCM_16")
+        return buf.getvalue()
+
+    def _judge_group(self, text, blobs):
+        """Direct A-vs-B judging of a prompt's candidates. POSTs base64 WAV bytes to /rank and returns one
+        score per blob. Synth-failed blobs (None) get a worst score so they become the rejected side; a
+        judge failure returns a neutral score so the group contributes no signal this step."""
+        import base64
+        import json
+        import urllib.request
+
+        scores = [-10.0] * len(blobs)
+        valid = [(i, b) for i, b in enumerate(blobs) if b]
+        if not valid:
+            return scores
+        if len(valid) == 1:
+            scores[valid[0][0]] = 5.0  # lone survivor beats its failed sibling(s)
+            return scores
+        idxs = [i for i, _ in valid]
+        wavs_b64 = [base64.b64encode(b).decode("ascii") for _, b in valid]
+        url = self._judge_urls[hash(wavs_b64[0][:64]) % len(self._judge_urls)]
+        body = json.dumps({"text": text, "wavs_b64": wavs_b64, "debias": self._judge_debias}).encode()
+        req = urllib.request.Request(url + "/rank", data=body, headers={"Content-Type": "application/json"})
+        try:
+            r = json.loads(urllib.request.urlopen(req, timeout=self._judge_timeout_s).read())
+            for j, sc in zip(idxs, r["scores"], strict=False):
+                scores[j] = float(sc)
+        except Exception as e:  # noqa: BLE001
+            logger.warning("audio judge call failed (%s); group gives no signal this step", e)
+            for j in idxs:
+                scores[j] = 0.0
+        return scores
+
+    async def run_single(self, data: DataProto) -> dict:
+        assert len(data) == 1, "Only support single data item"
+        data_item = data[0]
+        extra_info = dict(data_item.non_tensor_batch.get("extra_info", {}) or {})
+        tool_extra_fields = data_item.non_tensor_batch.get("tool_extra_fields", None)
+        if tool_extra_fields is not None:
+            extra_info.update(tool_extra_fields.items())
+        text = extra_info.get("text") or data_item.non_tensor_batch.get("reward_model", {}).get("ground_truth", "")
+        uid = extra_info.get("id") or data_item.non_tensor_batch.get("uid")
+
+        my_blob = await self.loop.run_in_executor(
+            self._score_executor, lambda: self._decode_wav_bytes(data_item, extra_info)
+        )
+
+        # Rendezvous this candidate with its uid siblings; whichever coroutine completes the group runs
+        # the single direct-comparison judge call and releases scores to all members.
+        async with self._group_lock:
+            g = self._groups.get(uid)
+            if g is None:
+                g = {"text": text, "blobs": [], "scores": None, "event": asyncio.Event()}
+                self._groups[uid] = g
+            my_idx = len(g["blobs"])
+            g["blobs"].append(my_blob)
+            complete = len(g["blobs"]) >= self._group_size
+
+        if complete:
+            g["scores"] = await self.loop.run_in_executor(
+                self._score_executor, self._judge_group, g["text"], g["blobs"]
+            )
+            g["event"].set()
+        else:
+            try:
+                await asyncio.wait_for(g["event"].wait(), timeout=self._judge_timeout_s)
+            except asyncio.TimeoutError:  # a sibling never arrived (aborted rollout): judge what we have
+                async with self._group_lock:
+                    if g["scores"] is None:
+                        g["scores"] = await self.loop.run_in_executor(
+                            self._score_executor, self._judge_group, g["text"], g["blobs"]
+                        )
+                        g["event"].set()
+
+        scores = g["scores"] or []
+        my_score = float(scores[my_idx]) if my_idx < len(scores) else 0.0
+        synth_ok = 1.0 if my_blob else 0.0
+        return {"reward_score": my_score, "reward_extra_info": {"sj_score": my_score, "synth_ok": synth_ok}}

--- a/verl_omni/reward_loop/reward_manager/multi.py
+++ b/verl_omni/reward_loop/reward_manager/multi.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Multi-reward manager that aggregates multiple reward functions via weighted sum."""
+"""Multi-reward managers that aggregate multiple reward functions via weighted sum."""
 
 import inspect
 import logging
@@ -19,6 +19,7 @@ import logging
 from verl import DataProto
 from verl.utils.import_utils import load_extern_object
 
+from .audio import AudioRewardManager
 from .visual import VisualRewardManager
 
 logger = logging.getLogger(__name__)
@@ -27,7 +28,7 @@ logger = logging.getLogger(__name__)
 def _multi_reward_placeholder(**kwargs):
     """Sentinel function used as the upstream custom_reward_function placeholder.
 
-    This is never called directly; MultiVisualRewardManager overrides run_single.
+    This is never called directly; the multi reward managers override run_single.
     """
     raise RuntimeError("_multi_reward_placeholder should never be called directly")
 
@@ -46,6 +47,89 @@ def _filter_kwargs(all_kwargs: dict, sig: inspect.Signature) -> dict:
     return {k: v for k, v in all_kwargs.items() if k in params}
 
 
+def _load_sub_rewards(reward_functions_cfg):
+    """Load the sub-reward functions declared under reward.reward_functions."""
+    if not reward_functions_cfg:
+        raise ValueError("Multi reward managers require non-empty reward.reward_functions config")
+
+    sub_rewards = []
+    total_weight = 0.0
+    _reserved_keys = {"path", "name", "weight"}
+    for key, entry in reward_functions_cfg.items():
+        path = entry["path"]
+        name = entry["name"]
+        weight = float(entry.get("weight", 1.0))
+        total_weight += weight
+
+        # Collect extra config fields (beyond path/name/weight) to pass to compute_score
+        extra_args = {k: v for k, v in entry.items() if k not in _reserved_keys}
+
+        fn = load_extern_object(path, name)
+        sig = inspect.signature(fn)
+        is_async = inspect.iscoroutinefunction(fn)
+
+        sub_rewards.append(
+            {
+                "key": key,
+                "fn": fn,
+                "weight": weight,
+                "sig": sig,
+                "is_async": is_async,
+                "extra_args": extra_args,
+            }
+        )
+        logger.info(f"Loaded sub-reward '{key}': {path}:{name} (weight={weight}, async={is_async})")
+
+    if total_weight <= 0:
+        raise ValueError(
+            f"Total weight of reward functions must be > 0, got {total_weight}. Check reward.reward_functions config."
+        )
+    return sub_rewards
+
+
+async def _run_sub_rewards(loop, sub_rewards, all_kwargs, executor=None):
+    """Run every sub-reward with filtered kwargs and return (weighted sum, extra info)."""
+    combined_score = 0.0
+    reward_extra_info = {}
+
+    for sub in sub_rewards:
+        key = sub["key"]
+        fn = sub["fn"]
+        weight = sub["weight"]
+        sig = sub["sig"]
+        is_async = sub["is_async"]
+        extra_args = sub["extra_args"]
+
+        # Merge per-reward extra config fields into kwargs
+        sub_kwargs = {**all_kwargs, **extra_args}
+        filtered_kwargs = _filter_kwargs(sub_kwargs, sig)
+
+        try:
+            if is_async:
+                result = await fn(**filtered_kwargs)
+            else:
+                result = await loop.run_in_executor(executor, lambda f=fn, kw=filtered_kwargs: f(**kw))
+
+            if isinstance(result, dict):
+                score = float(result["score"])
+                for rk, rv in result.items():
+                    if rk == "score":
+                        continue
+                    reward_extra_info[f"reward/{key}/{rk}"] = rv
+            else:
+                score = float(result)
+
+        except Exception as e:
+            logger.error(f"Sub-reward '{key}' raised an exception: {e}. Contributing 0 to weighted sum.")
+            score = 0.0
+
+        reward_extra_info[f"reward/{key}"] = score
+        combined_score += weight * score
+
+    reward_extra_info["reward/combined"] = combined_score
+    return combined_score, reward_extra_info
+
+
 class MultiVisualRewardManager(VisualRewardManager):
     """Reward manager that loads and aggregates multiple reward functions.
 
@@ -62,43 +146,7 @@ class MultiVisualRewardManager(VisualRewardManager):
         # Initialize parent with the placeholder (never actually called)
         super().__init__(config, tokenizer, _multi_reward_placeholder, reward_router_address, reward_model_tokenizer)
 
-        reward_functions_cfg = config.reward.reward_functions
-        if not reward_functions_cfg:
-            raise ValueError("MultiVisualRewardManager requires non-empty reward.reward_functions config")
-
-        self._sub_rewards = []
-        total_weight = 0.0
-        _reserved_keys = {"path", "name", "weight"}
-        for key, entry in reward_functions_cfg.items():
-            path = entry["path"]
-            name = entry["name"]
-            weight = float(entry.get("weight", 1.0))
-            total_weight += weight
-
-            # Collect extra config fields (beyond path/name/weight) to pass to compute_score
-            extra_args = {k: v for k, v in entry.items() if k not in _reserved_keys}
-
-            fn = load_extern_object(path, name)
-            sig = inspect.signature(fn)
-            is_async = inspect.iscoroutinefunction(fn)
-
-            self._sub_rewards.append(
-                {
-                    "key": key,
-                    "fn": fn,
-                    "weight": weight,
-                    "sig": sig,
-                    "is_async": is_async,
-                    "extra_args": extra_args,
-                }
-            )
-            logger.info(f"Loaded sub-reward '{key}': {path}:{name} (weight={weight}, async={is_async})")
-
-        if total_weight <= 0:
-            raise ValueError(
-                f"Total weight of reward functions must be > 0, got {total_weight}. "
-                f"Check reward.reward_functions config."
-            )
+        self._sub_rewards = _load_sub_rewards(config.reward.reward_functions)
 
     async def run_single(self, data: DataProto) -> dict:
         assert len(data) == 1, "Only support single data item"
@@ -135,42 +183,62 @@ class MultiVisualRewardManager(VisualRewardManager):
             **extra_reward_kwargs,
         }
 
-        combined_score = 0.0
-        reward_extra_info = {}
+        combined_score, reward_extra_info = await _run_sub_rewards(self.loop, self._sub_rewards, all_kwargs)
+        return {"reward_score": combined_score, "reward_extra_info": reward_extra_info}
 
-        for sub in self._sub_rewards:
-            key = sub["key"]
-            fn = sub["fn"]
-            weight = sub["weight"]
-            sig = sub["sig"]
-            is_async = sub["is_async"]
-            extra_args = sub["extra_args"]
 
-            # Merge per-reward extra config fields into kwargs
-            sub_kwargs = {**all_kwargs, **extra_args}
-            filtered_kwargs = _filter_kwargs(sub_kwargs, sig)
+class MultiAudioRewardManager(AudioRewardManager):
+    """Audio counterpart of MultiVisualRewardManager.
 
-            try:
-                if is_async:
-                    result = await fn(**filtered_kwargs)
-                else:
-                    result = await self.loop.run_in_executor(None, lambda f=fn, kw=filtered_kwargs: f(**kw))
+    Same reward.reward_functions config and weighted-sum aggregation; sub-reward functions
+    receive solution_audio (the decoded (wav, sr) tuple, or None when synthesis failed) instead
+    of solution_image. Codec decoding comes from AudioRewardManager (reward.audio config).
+    """
 
-                if isinstance(result, dict):
-                    score = float(result["score"])
-                    for rk, rv in result.items():
-                        if rk == "score":
-                            continue
-                        reward_extra_info[f"reward/{key}/{rk}"] = rv
-                else:
-                    score = float(result)
+    def __init__(self, config, tokenizer, compute_score, reward_router_address=None, reward_model_tokenizer=None):
+        # Initialize parent with the placeholder (never actually called)
+        super().__init__(config, tokenizer, _multi_reward_placeholder, reward_router_address, reward_model_tokenizer)
 
-            except Exception as e:
-                logger.error(f"Sub-reward '{key}' raised an exception: {e}. Contributing 0 to weighted sum.")
-                score = 0.0
+        self._sub_rewards = _load_sub_rewards(config.reward.reward_functions)
 
-            reward_extra_info[f"reward/{key}"] = score
-            combined_score += weight * score
+    async def run_single(self, data: DataProto) -> dict:
+        assert len(data) == 1, "Only support single data item"
+        data_item = data[0]
+        data_source = data_item.non_tensor_batch["data_source"]
+        ground_truth = data_item.non_tensor_batch["reward_model"]["ground_truth"]
+        extra_info = data_item.non_tensor_batch.get("extra_info", {})
+        tool_extra_fields = data_item.non_tensor_batch.get("tool_extra_fields", None)
+        if tool_extra_fields is not None:
+            extra_info.update(tool_extra_fields.items())
 
-        reward_extra_info["reward/combined"] = combined_score
+        num_turns = data_item.non_tensor_batch.get("__num_turns__", None)
+        rollout_reward_scores = data_item.non_tensor_batch.get("reward_scores", {})
+        extra_info["num_turns"] = num_turns
+        extra_info["rollout_reward_scores"] = rollout_reward_scores
+
+        extra_reward_kwargs = (
+            {
+                "reward_router_address": self.reward_router_address,
+                "reward_model_tokenizer": self.reward_model_tokenizer,
+                "model_name": self.config.reward.reward_model.model_path,
+            }
+            if self.reward_router_address is not None
+            else {}
+        )
+
+        # Decode once; every sub-function scores the same waveform.
+        solution_audio = await self.loop.run_in_executor(
+            self._score_executor, lambda: self._extract_audio(data_item, extra_info)
+        )
+        all_kwargs = {
+            "data_source": data_source,
+            "solution_audio": solution_audio,
+            "ground_truth": ground_truth,
+            "extra_info": extra_info,
+            **extra_reward_kwargs,
+        }
+
+        combined_score, reward_extra_info = await _run_sub_rewards(
+            self.loop, self._sub_rewards, all_kwargs, executor=self._score_executor
+        )
         return {"reward_score": combined_score, "reward_extra_info": reward_extra_info}

--- a/verl_omni/trainer/main_ppo.py
+++ b/verl_omni/trainer/main_ppo.py
@@ -1,0 +1,194 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""PPO entrypoint for omni recipes that bind a worker-level loss the base entry cannot select.
+
+Mirrors verl/trainer/main_ppo_v0.py::TaskRunner (the legacy V0 flow the recipe runs) exactly, but
+runs a DPORayPPOTrainer that binds tts_dpo_loss on the actor after init_workers via the public
+set_loss_fn seam (the same seam base verl uses to bind the critic loss in
+ray_trainer.py::init_workers). Non-DPO configs are a pass-through, so this stays a drop-in for the
+plain PPO/GSPO path. Launch: python3 -m verl_omni.trainer.main_ppo.
+"""
+
+import os
+import socket
+from functools import partial
+
+import hydra
+import ray
+from omegaconf import OmegaConf
+from verl.trainer.main_ppo import run_ppo
+from verl.trainer.ppo.ray_trainer import RayPPOTrainer
+from verl.trainer.ppo.utils import create_rl_dataset, create_rl_sampler, need_critic, need_reference_policy
+from verl.utils.config import omega_conf_to_dataclass, validate_config
+from verl.utils.device import auto_set_device
+
+
+class DPORayPPOTrainer(RayPPOTrainer):
+    """RayPPOTrainer that binds the online-DPO loss on the actor after the workers come up.
+
+    The base trainer binds ppo_loss inside init_workers; here we re-bind tts_dpo_loss through the
+    same public set_loss_fn worker method the base trainer uses for the critic. No-op unless the
+    actor's policy_loss.loss_mode is "dpo", so the plain PPO/GSPO path is unchanged.
+    """
+
+    def init_workers(self):
+        super().init_workers()
+        actor_cfg = self.config.actor_rollout_ref.actor
+        if actor_cfg.policy_loss.get("loss_mode", None) == "dpo":
+            from verl_omni.workers.utils.losses import tts_dpo_loss
+
+            self.actor_rollout_wg.set_loss_fn(partial(tts_dpo_loss, config=omega_conf_to_dataclass(actor_cfg)))
+
+
+class OmniTaskRunner:
+    """Ray remote class for omni PPO/DPO training.
+
+    Mirrors verl/trainer/main_ppo_v0.py::TaskRunner; the only change is instantiating
+    DPORayPPOTrainer instead of RayPPOTrainer in run().
+    """
+
+    def __init__(self):
+        self.role_worker_mapping = {}
+        self.mapping = {}
+
+    def add_actor_rollout_worker(self, config):
+        from verl.single_controller.ray import RayWorkerGroup
+        from verl.trainer.ppo.ray_trainer import Role
+        from verl.workers.engine_workers import ActorRolloutRefWorker
+
+        actor_rollout_cls = ActorRolloutRefWorker
+        ray_worker_group_cls = RayWorkerGroup
+
+        lora_rank = config.actor_rollout_ref.model.get("lora", {}).get("rank", 0)
+        if lora_rank <= 0:
+            lora_rank = config.actor_rollout_ref.model.get("lora_rank", 0)
+        ref_in_actor = lora_rank > 0 or config.actor_rollout_ref.model.get("lora_adapter_path") is not None
+        if need_reference_policy(config) and not ref_in_actor:
+            role = Role.ActorRolloutRef
+        else:
+            role = Role.ActorRollout
+        self.role_worker_mapping[role] = ray.remote(actor_rollout_cls)
+        self.mapping[role] = "global_pool"
+        return actor_rollout_cls, ray_worker_group_cls
+
+    def add_critic_worker(self, config):
+        from verl.trainer.ppo.ray_trainer import Role
+        from verl.workers.engine_workers import TrainingWorker
+
+        self.role_worker_mapping[Role.Critic] = ray.remote(TrainingWorker)
+        self.mapping[Role.Critic] = "global_pool"
+
+    def init_resource_pool_mgr(self, config):
+        global_pool_id = "global_pool"
+        resource_pool_spec = {
+            global_pool_id: [config.trainer.n_gpus_per_node] * config.trainer.nnodes,
+        }
+        if config.reward.reward_model.enable_resource_pool:
+            if config.reward.reward_model.n_gpus_per_node <= 0:
+                raise ValueError("config.reward.reward_model.n_gpus_per_node must be greater than 0")
+            if config.reward.reward_model.nnodes <= 0:
+                raise ValueError("config.reward.reward_model.nnodes must be greater than 0")
+            reward_pool = [config.reward.reward_model.n_gpus_per_node] * config.reward.reward_model.nnodes
+            resource_pool_spec["reward_pool"] = reward_pool
+        else:
+            config.reward.reward_model.nnodes = config.trainer.nnodes
+            config.reward.reward_model.n_gpus_per_node = config.trainer.n_gpus_per_node
+
+        from verl.trainer.ppo.ray_trainer import ResourcePoolManager
+
+        return ResourcePoolManager(resource_pool_spec=resource_pool_spec, mapping=self.mapping)
+
+    def add_reward_model_resource_pool(self, config):
+        from verl.trainer.ppo.ray_trainer import Role
+
+        if config.reward.reward_model.enable:
+            if config.reward.reward_model.enable_resource_pool:
+                self.mapping[Role.RewardModel] = "reward_pool"
+            else:
+                self.mapping[Role.RewardModel] = "global_pool"
+
+    def run(self, config):
+        from pprint import pprint
+
+        from verl.utils import hf_processor, hf_tokenizer
+        from verl.utils.dataset.rl_dataset import collate_fn
+        from verl.utils.fs import copy_to_local
+
+        print(f"OmniTaskRunner hostname: {socket.gethostname()}, PID: {os.getpid()}")
+        pprint(OmegaConf.to_container(config, resolve=True))
+        OmegaConf.resolve(config)
+
+        actor_rollout_cls, ray_worker_group_cls = self.add_actor_rollout_worker(config)
+        self.add_critic_worker(config)
+        self.add_reward_model_resource_pool(config)
+
+        validate_config(
+            config=config,
+            use_reference_policy=need_reference_policy(config),
+            use_critic=need_critic(config),
+        )
+
+        local_path = copy_to_local(
+            config.actor_rollout_ref.model.path, use_shm=config.actor_rollout_ref.model.get("use_shm", False)
+        )
+        trust_remote_code = config.data.get("trust_remote_code", False)
+        tokenizer = hf_tokenizer(local_path, trust_remote_code=trust_remote_code)
+        processor = hf_processor(local_path, trust_remote_code=trust_remote_code, use_fast=True)
+
+        resource_pool_manager = self.init_resource_pool_mgr(config)
+
+        train_dataset = create_rl_dataset(
+            config.data.train_files,
+            config.data,
+            tokenizer,
+            processor,
+            is_train=True,
+            max_samples=config.data.get("train_max_samples", -1),
+        )
+        val_dataset = create_rl_dataset(
+            config.data.val_files,
+            config.data,
+            tokenizer,
+            processor,
+            is_train=False,
+            max_samples=config.data.get("val_max_samples", -1),
+        )
+        train_sampler = create_rl_sampler(config.data, train_dataset)
+
+        trainer = DPORayPPOTrainer(
+            config=config,
+            tokenizer=tokenizer,
+            processor=processor,
+            role_worker_mapping=self.role_worker_mapping,
+            resource_pool_manager=resource_pool_manager,
+            ray_worker_group_cls=ray_worker_group_cls,
+            train_dataset=train_dataset,
+            val_dataset=val_dataset,
+            collate_fn=collate_fn,
+            train_sampler=train_sampler,
+        )
+        trainer.init_workers()
+        trainer.fit()
+
+
+@hydra.main(config_path="config", config_name="ppo_trainer", version_base=None)
+def main(config):
+    auto_set_device(config)
+    if config.trainer.get("use_v1", False):
+        raise ValueError("verl_omni.trainer.main_ppo supports the legacy V0 trainer only; set trainer.use_v1=false.")
+    run_ppo(config, task_runner_class=ray.remote(num_cpus=1)(OmniTaskRunner))
+
+
+if __name__ == "__main__":
+    main()

--- a/verl_omni/trainer/main_ppo.py
+++ b/verl_omni/trainer/main_ppo.py
@@ -11,13 +11,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""PPO entrypoint for omni recipes that bind a worker-level loss the base entry cannot select.
+"""PPO entrypoint for online DPO, needed because base verl cannot select this loss from config.
 
-Mirrors verl/trainer/main_ppo_v0.py::TaskRunner (the legacy V0 flow the recipe runs) exactly, but
-runs a DPORayPPOTrainer that binds tts_dpo_loss on the actor after init_workers via the public
-set_loss_fn seam (the same seam base verl uses to bind the critic loss in
-ray_trainer.py::init_workers). Non-DPO configs are a pass-through, so this stays a drop-in for the
-plain PPO/GSPO path. Launch: python3 -m verl_omni.trainer.main_ppo.
+The DPO loss is sequence-level and pairwise (it needs ref_log_prob and the uid grouping), so it
+cannot be a registered policy-loss `loss_mode` like gspo (base verl's ppo_loss drops `data` before
+dispatching to the registry). It must be bound on the actor worker, which base verl only does for
+the critic, through the public set_loss_fn seam (ray_trainer.py::init_workers). To insert that one
+call we run our own trainer, but base verl's TaskRunner is a @ray.remote actor that hard-codes
+RayPPOTrainer and cannot be subclassed, so OmniTaskRunner below is a verbatim copy of
+verl/trainer/main_ppo_v0.py::TaskRunner (the legacy V0 flow the recipe runs; use_v1 defaults false),
+following the existing verl_omni/trainer/main_diffusion.py precedent. The ONLY departure from base
+is the marked set_loss_fn block in run(). Launch: python3 -m verl_omni.trainer.main_ppo.
 """
 
 import os
@@ -34,29 +38,8 @@ from verl.utils.config import omega_conf_to_dataclass, validate_config
 from verl.utils.device import auto_set_device
 
 
-class DPORayPPOTrainer(RayPPOTrainer):
-    """RayPPOTrainer that binds the online-DPO loss on the actor after the workers come up.
-
-    The base trainer binds ppo_loss inside init_workers; here we re-bind tts_dpo_loss through the
-    same public set_loss_fn worker method the base trainer uses for the critic. No-op unless the
-    actor's policy_loss.loss_mode is "dpo", so the plain PPO/GSPO path is unchanged.
-    """
-
-    def init_workers(self):
-        super().init_workers()
-        actor_cfg = self.config.actor_rollout_ref.actor
-        if actor_cfg.policy_loss.get("loss_mode", None) == "dpo":
-            from verl_omni.workers.utils.losses import tts_dpo_loss
-
-            self.actor_rollout_wg.set_loss_fn(partial(tts_dpo_loss, config=omega_conf_to_dataclass(actor_cfg)))
-
-
 class OmniTaskRunner:
-    """Ray remote class for omni PPO/DPO training.
-
-    Mirrors verl/trainer/main_ppo_v0.py::TaskRunner; the only change is instantiating
-    DPORayPPOTrainer instead of RayPPOTrainer in run().
-    """
+    """Copy of verl/trainer/main_ppo_v0.py::TaskRunner; see the module docstring for why."""
 
     def __init__(self):
         self.role_worker_mapping = {}
@@ -166,7 +149,7 @@ class OmniTaskRunner:
         )
         train_sampler = create_rl_sampler(config.data, train_dataset)
 
-        trainer = DPORayPPOTrainer(
+        trainer = RayPPOTrainer(
             config=config,
             tokenizer=tokenizer,
             processor=processor,
@@ -179,6 +162,17 @@ class OmniTaskRunner:
             train_sampler=train_sampler,
         )
         trainer.init_workers()
+
+        # --- the only departure from base verl's TaskRunner.run ---
+        # Bind the online-DPO loss on the actor through the same public set_loss_fn seam base verl
+        # uses for the critic (ray_trainer.py::init_workers). No-op for non-DPO configs.
+        actor_cfg = config.actor_rollout_ref.actor
+        if actor_cfg.policy_loss.get("loss_mode", None) == "dpo":
+            from verl_omni.workers.utils.losses import tts_dpo_loss
+
+            trainer.actor_rollout_wg.set_loss_fn(partial(tts_dpo_loss, config=omega_conf_to_dataclass(actor_cfg)))
+        # --- end departure ---
+
         trainer.fit()
 
 

--- a/verl_omni/trainer/main_tts.py
+++ b/verl_omni/trainer/main_tts.py
@@ -1,4 +1,4 @@
-# Copyright 2026 Bytedance Ltd. and/or its affiliates
+# Copyright 2026 Gulp AI Inc and/or its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/verl_omni/trainer/main_tts.py
+++ b/verl_omni/trainer/main_tts.py
@@ -11,17 +11,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""PPO entrypoint for online DPO, needed because base verl cannot select this loss from config.
+"""The Qwen3-TTS talker training entrypoint (GSPO and online DPO), analogous to main_diffusion.py.
 
-The DPO loss is sequence-level and pairwise (it needs ref_log_prob and the uid grouping), so it
-cannot be a registered policy-loss `loss_mode` like gspo (base verl's ppo_loss drops `data` before
-dispatching to the registry). It must be bound on the actor worker, which base verl only does for
-the critic, through the public set_loss_fn seam (ray_trainer.py::init_workers). To insert that one
-call we run our own trainer, but base verl's TaskRunner is a @ray.remote actor that hard-codes
-RayPPOTrainer and cannot be subclassed, so OmniTaskRunner below is a verbatim copy of
+Both TTS recipes launch through here. For GSPO it behaves exactly like base verl's PPO entry. For
+DPO it additionally binds the pairwise tts_dpo_loss on the actor, which base verl cannot select from
+config: the DPO loss is sequence-level and needs ref_log_prob and the uid grouping, so it cannot be
+a registered policy-loss `loss_mode` like gspo (base verl's ppo_loss drops `data` before dispatching
+to the registry). It must be bound on the actor worker, which base verl only does for the critic,
+through the public set_loss_fn seam (ray_trainer.py::init_workers). To insert that one call we run
+our own trainer, but base verl's TaskRunner is a @ray.remote actor that hard-codes RayPPOTrainer and
+cannot be subclassed, so OmniTaskRunner below is a verbatim copy of
 verl/trainer/main_ppo_v0.py::TaskRunner (the legacy V0 flow the recipe runs; use_v1 defaults false),
-following the existing verl_omni/trainer/main_diffusion.py precedent. The ONLY departure from base
-is the marked set_loss_fn block in run(). Launch: python3 -m verl_omni.trainer.main_ppo.
+following the existing verl_omni/trainer/main_diffusion.py precedent. The ONLY departure from base is
+the marked set_loss_fn block in run() (a no-op unless loss_mode is dpo). Launch:
+python3 -m verl_omni.trainer.main_tts.
 """
 
 import os
@@ -180,7 +183,7 @@ class OmniTaskRunner:
 def main(config):
     auto_set_device(config)
     if config.trainer.get("use_v1", False):
-        raise ValueError("verl_omni.trainer.main_ppo supports the legacy V0 trainer only; set trainer.use_v1=false.")
+        raise ValueError("verl_omni.trainer.main_tts supports the legacy V0 trainer only; set trainer.use_v1=false.")
     run_ppo(config, task_runner_class=ray.remote(num_cpus=1)(OmniTaskRunner))
 
 

--- a/verl_omni/utils/reward_score/__init__.py
+++ b/verl_omni/utils/reward_score/__init__.py
@@ -12,7 +12,45 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Visual (image) reward scoring functions for VeRL-Omni."""
+"""Visual (image) and audio reward scoring functions for VeRL-Omni."""
+
+
+def default_compute_score_audio(
+    data_source,
+    solution_audio,
+    ground_truth,
+    extra_info=None,
+    **kwargs,
+):
+    """Compute the reward score for an audio response.
+
+    Args:
+        data_source (str): Dataset identifier that determines the scoring method.
+        solution_audio: The generated audio as a ``(wav, sr)`` tuple with a float32
+            waveform, or ``None`` when synthesis failed.
+        ground_truth (str): Ground-truth answer (for TTS, the text the audio should speak).
+        extra_info (dict, optional): Additional metadata passed by the reward
+            manager.
+
+    Returns:
+        float or dict: The computed score (or a dict with a ``"score"`` key).
+
+    Raises:
+        NotImplementedError: If no scorer is registered for *data_source*.
+    """
+    if data_source == "tts":
+        from verl_omni.utils.reward_score import tts
+
+        res = tts.compute_score(solution_audio, ground_truth, extra_info, **kwargs)
+    else:
+        raise NotImplementedError(f"Reward function is not implemented for {data_source=}")
+
+    if isinstance(res, dict):
+        return res
+    elif isinstance(res, int | float | bool):
+        return float(res)
+    else:
+        return float(res[0])
 
 
 def default_compute_score_image(
@@ -54,4 +92,4 @@ def default_compute_score_image(
         return float(res[0])
 
 
-__all__ = ["default_compute_score_image"]
+__all__ = ["default_compute_score_audio", "default_compute_score_image"]

--- a/verl_omni/utils/reward_score/tts/__init__.py
+++ b/verl_omni/utils/reward_score/tts/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2026 Bytedance Ltd. and/or its affiliates
+# Copyright 2026 Gulp AI Inc and/or its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/verl_omni/utils/reward_score/tts/__init__.py
+++ b/verl_omni/utils/reward_score/tts/__init__.py
@@ -1,0 +1,68 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""TTS reward functions, one module per model backend.
+
+Each module owns its model as a lazy singleton and exposes compute_score, so rewards compose
+via MultiAudioRewardManager's reward.reward_functions entries and each model is configured
+independently. compute_score below is the all-in-one composition for the plain
+AudioRewardManager default path.
+"""
+
+
+def compute_score(
+    solution_audio,
+    ground_truth: str,
+    extra_info: dict = None,
+    weights: dict = None,
+    **kwargs,
+) -> dict:
+    """Weighted sum of the asr, sim, emo and stab dimensions (GLM-TTS reward forms).
+
+    Every dimension is also returned so per-dimension advantage estimators (gdpo) can normalize
+    them independently. Unscored dimensions get 0.0, below any scored clip. Per-model kwargs
+    (whisper_model, spk_model, emo_model, ...) pass through to the underlying modules.
+
+    Returns:
+        dict: {"score", "asr", "sim", "emo", "stab", plus raw metrics}.
+    """
+    from verl_omni.utils.reward_score.tts import asr_reward, emo_reward, spk_sim_reward
+
+    weights = {**{"asr": 1.0, "sim": 1.0, "emo": 1.0, "stab": 1.0}, **(weights or {})}
+    asr = asr_reward.compute_score(solution_audio, ground_truth, extra_info, **kwargs)
+    sim = spk_sim_reward.compute_score(solution_audio, extra_info, **kwargs)
+    emo = emo_reward.compute_score(solution_audio, extra_info, **kwargs)
+
+    score = (
+        weights["asr"] * asr["score"]
+        + weights["sim"] * sim["score"]
+        + weights["emo"] * emo["score"]
+        + weights["stab"] * asr["stab"]
+    )
+    return {
+        "score": score,
+        "asr": asr["score"],
+        "sim": sim["score"],
+        "emo": emo["score"],
+        "stab": asr["stab"],
+        "cer": asr["cer"],
+        "cos": sim["cos"],
+        "p_neutral": emo["p_neutral"],
+        "synth_ok": asr["synth_ok"],
+        "truncated": asr["truncated"],
+        "repeated": asr["repeated"],
+    }
+
+
+__all__ = ["compute_score"]

--- a/verl_omni/utils/reward_score/tts/asr_reward.py
+++ b/verl_omni/utils/reward_score/tts/asr_reward.py
@@ -1,0 +1,262 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+import re
+import threading
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "INFO"))
+
+_lock = threading.Lock()
+_asr = None
+
+# ASR checkpoint whose tokenizer ships the British->American spelling map (normalizer.json).
+_SPELLING_MAP_REPO = "distil-whisper/distil-large-v3"
+
+_WHISPER_NORM = None
+
+_WORD_RE = re.compile(r"[^\w\s]", flags=re.UNICODE)
+
+
+def normalize_text(s: str) -> str:
+    """Lowercase, strip punctuation, collapse whitespace."""
+    return " ".join(_WORD_RE.sub(" ", s.lower()).split())
+
+
+def _levenshtein(a: str, b: str) -> int:
+    if len(a) < len(b):
+        a, b = b, a
+    if not b:
+        return len(a)
+    prev = list(range(len(b) + 1))
+    for i, ca in enumerate(a, 1):
+        cur = [i]
+        for j, cb in enumerate(b, 1):
+            cur.append(min(prev[j] + 1, cur[j - 1] + 1, prev[j - 1] + (ca != cb)))
+        prev = cur
+    return prev[-1]
+
+
+def _whisper_normalizer(spelling_map_repo: str = _SPELLING_MAP_REPO):
+    global _WHISPER_NORM
+    if _WHISPER_NORM is None:
+        from transformers.models.whisper.english_normalizer import EnglishTextNormalizer
+
+        spelling = {}
+        try:  # British->American map (cancelled->canceled etc.) ships with the ASR tokenizer
+            import json
+
+            from transformers.utils import cached_file
+
+            spelling = json.load(open(cached_file(spelling_map_repo, "normalizer.json")))
+        except Exception:  # noqa: BLE001, fold everything else even without the spelling map
+            pass
+        _WHISPER_NORM = EnglishTextNormalizer(spelling)
+    return _WHISPER_NORM
+
+
+def normalize_for_cer(text: str) -> str:
+    """Whisper-standard fold: lowercase, punctuation, contractions, digit<->word, hesitation
+    fillers stripped, bracketed content fully removed. Apply to BOTH reference and hypothesis.
+
+    The matching data-side written-to-spoken transform lives with the example
+    (examples/qwen3_tts_gspo_trainer/data_process/tts_verbalize.py).
+    """
+    return re.sub(r"\s+", " ", _whisper_normalizer()(text)).strip()
+
+
+def _cer_normalize(s: str) -> str:
+    # Falls back to the simple normalizer where the Whisper normalizer cannot load
+    # (CPU-only unit tests).
+    try:
+        return normalize_for_cer(s)
+    except Exception:  # noqa: BLE001
+        return normalize_text(s)
+
+
+def cer(reference: str, hypothesis: str) -> float | None:
+    """Character error rate over normalized text. None if the reference is empty."""
+    ref = _cer_normalize(reference).replace(" ", "")
+    hyp = _cer_normalize(hypothesis).replace(" ", "")
+    if not ref:
+        return None
+    return _levenshtein(ref, hyp) / len(ref)
+
+
+def has_repetition(text: str | None, n: int = 3, max_span: int = 30) -> bool:
+    """True if any span of n..max_span words repeats immediately (a TTS looping artifact)."""
+    if not text:
+        return False
+    words = text.split()
+    upper = min(max_span, len(words) // 2)
+    for span in range(n, upper + 1):
+        for i in range(len(words) - 2 * span + 1):
+            if words[i : i + span] == words[i + span : i + 2 * span]:
+                return True
+    return False
+
+
+def _resample(wav: np.ndarray, sr: int, target_sr: int) -> np.ndarray:
+    if sr == target_sr:
+        return wav.astype(np.float32)
+    import librosa
+
+    return librosa.resample(wav.astype(np.float32), orig_sr=sr, target_sr=target_sr)
+
+
+def _get_asr(whisper_model, whisper_device, whisper_backend, whisper_compute_type):
+    # Two backends: "faster" (faster-whisper/ctranslate2, CPU) and "transformers" (torch-native
+    # whisper, default on cuda; ctranslate2 is a CUDA-12 binary and clashes with a CUDA-13 stack).
+    global _asr
+
+    with _lock:
+        if _asr is not None:
+            return _asr
+        import torch
+
+        if whisper_device is None:
+            whisper_device = f"cuda:{torch.cuda.current_device()}" if torch.cuda.is_available() else "cpu"
+        use_cuda = whisper_device.startswith("cuda")
+        if whisper_model is None:
+            whisper_model = "distil-whisper/distil-large-v3" if use_cuda else "large-v3"
+        backend = whisper_backend or ("transformers" if use_cuda else "faster")
+        if backend == "transformers":
+            from transformers import AutoModelForSpeechSeq2Seq, AutoProcessor, pipeline
+
+            dtype = torch.float16 if use_cuda else torch.float32
+            logger.info("loading transformers whisper %r on %s", whisper_model, whisper_device)
+            model = (
+                AutoModelForSpeechSeq2Seq.from_pretrained(whisper_model, dtype=dtype, low_cpu_mem_usage=False)
+                .to(whisper_device)
+                .eval()
+            )
+            proc = AutoProcessor.from_pretrained(whisper_model)
+            pipe = pipeline(
+                "automatic-speech-recognition",
+                model=model,
+                tokenizer=proc.tokenizer,
+                feature_extractor=proc.feature_extractor,
+                torch_dtype=dtype,
+                device=whisper_device,
+                chunk_length_s=30,
+            )
+            _asr = ("transformers", pipe)
+        else:
+            from faster_whisper import WhisperModel
+
+            if use_cuda:
+                idx = int(whisper_device.split(":", 1)[1]) if ":" in whisper_device else 0
+                dev, kw = "cuda", {"device_index": idx}
+            else:
+                dev, kw = "cpu", {}
+            ct = whisper_compute_type if dev == "cuda" else "int8"
+            logger.info("loading faster-whisper %r (%s) on %s", whisper_model, ct, dev)
+            _asr = ("faster", WhisperModel(whisper_model, device=dev, compute_type=ct, **kw))
+    return _asr
+
+
+def transcribe(
+    wav: np.ndarray,
+    sr: int,
+    whisper_model: str = None,
+    whisper_device: str = None,
+    whisper_backend: str = None,
+    whisper_compute_type: str = "int8",
+    language: str = "en",
+) -> str:
+    backend, model = _get_asr(whisper_model, whisper_device, whisper_backend, whisper_compute_type)
+    audio = np.asarray(_resample(wav, sr, 16000), dtype=np.float32)
+    if backend == "transformers":
+        import torch
+
+        # The worker's torch default device can be left as meta by prior model loads, which
+        # breaks the HF pipeline; pin it to cpu for the call.
+        prev_dev = torch.get_default_device()
+        torch.set_default_device("cpu")
+        try:
+            out = model({"array": audio, "sampling_rate": 16000})
+        finally:
+            torch.set_default_device(prev_dev)
+        return (out.get("text") or "").strip()
+    seg_iter, _ = model.transcribe(audio, language=language, beam_size=1, condition_on_previous_text=False)
+    return " ".join(s.text.strip() for s in seg_iter).strip()
+
+
+def compute_score(
+    solution_audio,
+    ground_truth: str,
+    extra_info: dict = None,
+    whisper_model: str = None,
+    whisper_device: str = None,
+    whisper_backend: str = None,
+    whisper_compute_type: str = "int8",
+    language: str = "en",
+    cer_outlier_threshold: float = 0.30,
+    truncation_ratio: float = 0.5,
+    speaking_rate_wps: float = 2.5,
+    repetition_ngram: int = 3,
+    p_trunc: float = 1.0,
+    p_rep: float = 1.0,
+    p_outlier: float = 1.0,
+    p_fail: float = 1.0,
+    **kwargs,
+) -> dict:
+    """Intelligibility reward exp(-2.5 * CER), GLM-TTS form, plus transcript-derived stability.
+
+    Both the score and the stability penalty consume one whisper transcription, so they live in
+    one function; the stab extra is a separate reward dimension for per-dimension estimators.
+
+    Args:
+        solution_audio: (wav, sr) tuple with a float32 waveform, or None when synthesis failed.
+        ground_truth (str): The text the audio should speak.
+        extra_info (dict, optional): May carry text (overrides ground_truth as the CER target).
+
+    Returns:
+        dict: {"score": exp(-2.5*CER), "cer", "stab", "synth_ok", "truncated", "repeated"}.
+    """
+    extra_info = extra_info or {}
+    text = extra_info.get("text") or ground_truth or ""
+
+    if solution_audio is None:
+        return {"score": 0.0, "cer": -1.0, "stab": -p_fail, "synth_ok": 0.0, "truncated": 0.0, "repeated": 0.0}
+
+    wav, sr = solution_audio
+    import math
+
+    transcript = transcribe(wav, sr, whisper_model, whisper_device, whisper_backend, whisper_compute_type, language)
+    c = cer(text, transcript)
+    score = math.exp(-2.5 * c) if c is not None else 0.0
+
+    duration_s = len(wav) / sr if sr else None
+    words = len(text.split())
+    expected_s = words / speaking_rate_wps if words and speaking_rate_wps > 0 else None
+    truncated = duration_s is not None and expected_s is not None and duration_s < truncation_ratio * expected_s
+    repeated = has_repetition(transcript, repetition_ngram)
+    outlier = c is not None and c > cer_outlier_threshold
+    stab = -(
+        p_trunc * float(truncated) + p_rep * float(repeated) + p_outlier * float(outlier) + p_fail * float(c is None)
+    )
+
+    return {
+        "score": score,
+        "cer": c if c is not None else -1.0,
+        "stab": stab,
+        "synth_ok": 1.0,
+        "truncated": float(truncated),
+        "repeated": float(repeated),
+    }

--- a/verl_omni/utils/reward_score/tts/asr_reward.py
+++ b/verl_omni/utils/reward_score/tts/asr_reward.py
@@ -1,4 +1,4 @@
-# Copyright 2026 Bytedance Ltd. and/or its affiliates
+# Copyright 2026 Gulp AI Inc and/or its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/verl_omni/utils/reward_score/tts/emo_reward.py
+++ b/verl_omni/utils/reward_score/tts/emo_reward.py
@@ -1,0 +1,101 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+import threading
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "INFO"))
+
+_lock = threading.Lock()
+_emo = None
+_emo_failed = False
+
+# emotion2vec_plus_large class head order: angry, disgusted, fearful, happy, neutral, other,
+# sad, surprised, unknown. GLM-TTS uses index 4 (neutral) for the untagged reward.
+_EMO_NEUTRAL_IDX = 4
+
+
+def _resample(wav: np.ndarray, sr: int, target_sr: int) -> np.ndarray:
+    if sr == target_sr:
+        return wav.astype(np.float32)
+    import librosa
+
+    return librosa.resample(wav.astype(np.float32), orig_sr=sr, target_sr=target_sr)
+
+
+def _get_emo(emo_model, device):
+    global _emo, _emo_failed
+
+    with _lock:
+        if _emo is None and not _emo_failed:
+            try:
+                import torch
+                from funasr import AutoModel
+
+                if device is None:
+                    device = f"cuda:{torch.cuda.current_device()}" if torch.cuda.is_available() else "cpu"
+                _emo = AutoModel(model=emo_model, device=device, disable_update=True)
+            except Exception as e:  # noqa: BLE001
+                logger.warning("emotion2vec unavailable (%s), emotion reward disabled for this run", e)
+                _emo_failed = True
+    return _emo
+
+
+def compute_score(
+    solution_audio,
+    extra_info: dict = None,
+    emo_model: str = "iic/emotion2vec_plus_large",
+    emo_max_sec: float = 60.0,
+    device: str = None,
+    **kwargs,
+) -> dict:
+    """Emotion reward, GLM-TTS form: P(tagged emotion), or 1 - P(neutral) for untagged prompts.
+
+    Args:
+        solution_audio: (wav, sr) tuple with a float32 waveform, or None when synthesis failed.
+        extra_info (dict, optional): May carry emotion, the emotion2vec class index of the
+            prompt's tag; untagged prompts (absent) use 1 - P(neutral) as expressiveness.
+
+    Returns:
+        dict: {"score": class probability, "p_neutral": P(neutral)}. Unavailable inputs score 0.0.
+    """
+    extra_info = extra_info or {}
+    emotion = extra_info.get("emotion")
+    emotion = int(emotion) if emotion is not None else -1
+
+    if solution_audio is None:
+        return {"score": 0.0, "p_neutral": -1.0}
+    m = _get_emo(emo_model, device)
+    if m is None:
+        return {"score": 0.0, "p_neutral": -1.0}
+    wav, sr = solution_audio
+    try:
+        # Cap the scored window: emotion2vec attention is quadratic in length and a runaway clip
+        # OOMs; degenerate rollouts are already penalized by the asr stability dimension.
+        max_n = int(emo_max_sec * sr)
+        if max_n > 0 and wav.shape[0] > max_n:
+            wav = wav[:max_n]
+        audio = _resample(wav, sr, 16000)
+        res = m.generate(audio, fs=16000, granularity="utterance", extract_embedding=False, disable_pbar=True)
+        scores = res[0]["scores"]
+        p_neutral = float(scores[_EMO_NEUTRAL_IDX])
+        p_emo = float(scores[emotion]) if emotion >= 0 else 1.0 - p_neutral
+        return {"score": p_emo, "p_neutral": p_neutral}
+    except Exception as e:  # noqa: BLE001
+        logger.warning("emotion2vec predict failed (%s)", e)
+        return {"score": 0.0, "p_neutral": -1.0}

--- a/verl_omni/utils/reward_score/tts/emo_reward.py
+++ b/verl_omni/utils/reward_score/tts/emo_reward.py
@@ -1,4 +1,4 @@
-# Copyright 2026 Bytedance Ltd. and/or its affiliates
+# Copyright 2026 Gulp AI Inc and/or its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/verl_omni/utils/reward_score/tts/spk_sim_reward.py
+++ b/verl_omni/utils/reward_score/tts/spk_sim_reward.py
@@ -1,0 +1,107 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+import threading
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "INFO"))
+
+_lock = threading.Lock()
+_spk = None
+_ref_cache: dict = {}
+
+
+def _resample(wav: np.ndarray, sr: int, target_sr: int) -> np.ndarray:
+    if sr == target_sr:
+        return wav.astype(np.float32)
+    import librosa
+
+    return librosa.resample(wav.astype(np.float32), orig_sr=sr, target_sr=target_sr)
+
+
+def _cosine(a: np.ndarray, b: np.ndarray) -> float:
+    na, nb = float(np.linalg.norm(a)), float(np.linalg.norm(b))
+    if na == 0.0 or nb == 0.0:
+        return 0.0
+    return float(np.dot(a, b) / (na * nb))
+
+
+def _get_spk(spk_model, device):
+    global _spk
+
+    with _lock:
+        if _spk is None:
+            import torch
+            from modelscope.pipelines import pipeline
+
+            if device is None:
+                device = f"cuda:{torch.cuda.current_device()}" if torch.cuda.is_available() else "cpu"
+            _spk = pipeline(task="speaker-verification", model=spk_model, device=device)
+    return _spk
+
+
+def _spk_embed(wav, sr, spk_model, device):
+    try:
+        out = _get_spk(spk_model, device)([_resample(wav, sr, 16000)], output_emb=True)
+        return np.asarray(out["embs"][0], dtype=np.float32)
+    except Exception as e:  # noqa: BLE001
+        logger.warning("speaker embedding unavailable (%s)", e)
+        return None
+
+
+def _load_ref_wav(path):
+    if not path:
+        return None
+    if path not in _ref_cache:
+        import soundfile as sf
+
+        wav, sr = sf.read(path, dtype="float32", always_2d=False)
+        if wav.ndim > 1:
+            wav = wav.mean(axis=1)
+        _ref_cache[path] = (np.asarray(wav, dtype=np.float32), int(sr))
+    return _ref_cache[path]
+
+
+def compute_score(
+    solution_audio,
+    extra_info: dict = None,
+    spk_model: str = "iic/speech_eres2net_sv_en_voxceleb_16k",
+    device: str = None,
+    **kwargs,
+) -> dict:
+    """Speaker similarity reward (1 + cos) / 2, GLM-TTS form, against a reference clip.
+
+    Args:
+        solution_audio: (wav, sr) tuple with a float32 waveform, or None when synthesis failed.
+        extra_info (dict, optional): Carries target_audio or ref_audio, the reference clip path
+            (the per-utterance target recording is preferred over the fixed clone reference).
+
+    Returns:
+        dict: {"score": (1 + cos) / 2, "cos": raw cosine}. Unavailable inputs score 0.0.
+    """
+    extra_info = extra_info or {}
+    ref = _load_ref_wav(extra_info.get("target_audio") or extra_info.get("ref_audio"))
+    if solution_audio is None or ref is None:
+        return {"score": 0.0, "cos": -1.0}
+    wav, sr = solution_audio
+    a = _spk_embed(wav, sr, spk_model, device)
+    b = _spk_embed(ref[0], ref[1], spk_model, device)
+    if a is None or b is None:
+        return {"score": 0.0, "cos": -1.0}
+    cos = _cosine(a, b)
+    return {"score": (1.0 + cos) / 2.0, "cos": cos}

--- a/verl_omni/utils/reward_score/tts/spk_sim_reward.py
+++ b/verl_omni/utils/reward_score/tts/spk_sim_reward.py
@@ -1,4 +1,4 @@
-# Copyright 2026 Bytedance Ltd. and/or its affiliates
+# Copyright 2026 Gulp AI Inc and/or its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/verl_omni/workers/config/tts/__init__.py
+++ b/verl_omni/workers/config/tts/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2026 Bytedance Ltd. and/or its affiliates
+# Copyright 2026 Gulp AI Inc and/or its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/verl_omni/workers/config/tts/__init__.py
+++ b/verl_omni/workers/config/tts/__init__.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from . import diffusion, omni, tts
-from .diffusion import *  # noqa: F401,F403
-from .omni import *  # noqa: F401,F403
-from .tts import *  # noqa: F401,F403
+from . import actor
+from .actor import *  # noqa: F401,F403
 
-__all__ = list(diffusion.__all__) + list(omni.__all__) + list(tts.__all__)
+__all__ = list(actor.__all__)

--- a/verl_omni/workers/config/tts/actor.py
+++ b/verl_omni/workers/config/tts/actor.py
@@ -1,0 +1,40 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+
+from verl.workers.config import PolicyLossConfig
+
+__all__ = ["DPOPolicyLossConfig"]
+
+
+@dataclass
+class DPOPolicyLossConfig(PolicyLossConfig):
+    """Policy-loss config for the online TTS DPO recipe (tts_dpo_loss).
+
+    Selected in yaml via actor.policy_loss._target_ = verl_omni.workers.config.DPOPolicyLossConfig,
+    carrying the DPO knobs the base PolicyLossConfig has no field for.
+    """
+
+    loss_mode: str = "dpo"
+    dpo_beta: float = 0.1
+    dpo_nll_lambda: float = 0.0
+
+    def __post_init__(self):
+        if self.loss_mode != "dpo":
+            raise ValueError(f"DPOPolicyLossConfig requires loss_mode='dpo', got {self.loss_mode!r}.")
+        if self.dpo_beta <= 0:
+            raise ValueError(f"dpo_beta must be positive, got {self.dpo_beta}.")
+        if self.dpo_nll_lambda < 0:
+            raise ValueError(f"dpo_nll_lambda must be non-negative, got {self.dpo_nll_lambda}.")

--- a/verl_omni/workers/config/tts/actor.py
+++ b/verl_omni/workers/config/tts/actor.py
@@ -1,4 +1,4 @@
-# Copyright 2026 Bytedance Ltd. and/or its affiliates
+# Copyright 2026 Gulp AI Inc and/or its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/verl_omni/workers/rollout/vllm_rollout/vllm_omni_async_server.py
+++ b/verl_omni/workers/rollout/vllm_rollout/vllm_omni_async_server.py
@@ -53,6 +53,26 @@ logger = logging.getLogger(__file__)
 logger.setLevel(logging.INFO)
 
 
+def _read_stage_output_type(engine_kwargs: dict) -> Optional[str]:
+    """The terminal stage's output type from the vLLM-Omni stage config, or None.
+
+    Read once at init to tell a codec (TTS) rollout apart from a plain text AR rollout, without
+    depending on whether a speaker x-vector is configured.
+    """
+    omni_kwargs = (engine_kwargs or {}).get("vllm_omni", {}) or {}
+    path = omni_kwargs.get("stage_configs_path") or omni_kwargs.get("stage-configs-path")
+    if not path:
+        return None
+    import yaml
+
+    with open(path) as f:
+        stages = (yaml.safe_load(f) or {}).get("stage_args") or []
+    if not stages:
+        return None
+    terminal = next((s for s in stages if s.get("final_output")), stages[-1])
+    return terminal.get("final_output_type") or (terminal.get("engine_args") or {}).get("engine_output_type")
+
+
 class vLLMOmniHttpServer(vLLMHttpServer):
     """vLLM-Omni http server in single node, this is equivalent to launch server with command line:
     ```
@@ -88,11 +108,14 @@ class vLLMOmniHttpServer(vLLMHttpServer):
         """Diffusion needs a PIL→tensor converter; AR does not."""
         if not self._ar_mode:
             self._to_tensor = T.PILToTensor()
+        # A codec-emitting AR stage is the TTS talker; detect it from the stage output type so the
+        # codec handling does not depend on a speaker x-vector being set.
+        self._is_tts = self._ar_mode and _read_stage_output_type(getattr(self.config, "engine_kwargs", None)) == "codec"
         super()._post_init(cuda_visible_devices)
 
     @functools.cached_property
     def _tts_spk_embedding(self):
-        """The clone voice x-vector (list of floats), or None when this is not a TTS rollout.
+        """The clone voice x-vector (list of floats), or None when unset.
 
         Set via actor_rollout_ref.model.override_config.tts_spk_embed_path; the same vector
         feeds the actor's speaker slot so generation and the teacher-forced recompute condition
@@ -396,8 +419,7 @@ class vLLMOmniHttpServer(vLLMHttpServer):
             else:
                 sampling_params["logprobs"] = None
             sampling_params.setdefault("repetition_penalty", getattr(self.config, "repetition_penalty", 1.0))
-            spk_embedding = self._tts_spk_embedding
-            if spk_embedding is not None:
+            if self._is_tts:
                 # Stop at codec eos: without it the talker emits eos and then generates garbage
                 # to max_tokens.
                 se = list(sampling_params.get("stop_token_ids") or [])
@@ -406,7 +428,14 @@ class vLLMOmniHttpServer(vLLMHttpServer):
             params = SamplingParams(max_tokens=max_tokens, **sampling_params)
 
             prompt = {"prompt_token_ids": prompt_ids}
-            if spk_embedding is not None:
+            if self._is_tts:
+                spk_embedding = self._tts_spk_embedding
+                if spk_embedding is None:
+                    raise RuntimeError(
+                        "codec TTS rollout requires a speaker x-vector; set "
+                        "actor_rollout_ref.model.override_config.tts_spk_embed_path "
+                        "(default-voice TTS is not supported)."
+                    )
                 tts_ai, ar_prompt_ids = self.generate_tts(prompt_ids, spk_embedding)
                 prompt = {"prompt_token_ids": ar_prompt_ids, "additional_information": tts_ai}
             if multi_modal_data:
@@ -464,7 +493,7 @@ class vLLMOmniHttpServer(vLLMHttpServer):
         # only the last output, so accumulate the per-step chunks to recover the full sequence
         # and attach them to the final output for _process_output.
         acc_codes = None
-        for_tts = self._ar_mode and self._tts_spk_embedding is not None
+        for_tts = self._is_tts
         async for output in generator:
             final_res = output
             if for_tts:

--- a/verl_omni/workers/rollout/vllm_rollout/vllm_omni_async_server.py
+++ b/verl_omni/workers/rollout/vllm_rollout/vllm_omni_async_server.py
@@ -108,8 +108,7 @@ class vLLMOmniHttpServer(vLLMHttpServer):
         """Diffusion needs a PIL→tensor converter; AR does not."""
         if not self._ar_mode:
             self._to_tensor = T.PILToTensor()
-        # A codec-emitting AR stage is the TTS talker; detect it from the stage output type so the
-        # codec handling does not depend on a speaker x-vector being set.
+        # A codec-emitting AR stage is the TTS talker; detect it from the stage output type
         self._is_tts = self._ar_mode and _read_stage_output_type(getattr(self.config, "engine_kwargs", None)) == "codec"
         super()._post_init(cuda_visible_devices)
 
@@ -420,8 +419,7 @@ class vLLMOmniHttpServer(vLLMHttpServer):
                 sampling_params["logprobs"] = None
             sampling_params.setdefault("repetition_penalty", getattr(self.config, "repetition_penalty", 1.0))
             if self._is_tts:
-                # Stop at codec eos: without it the talker emits eos and then generates garbage
-                # to max_tokens.
+                # Stop at codec eos: without it the talker emits eos and then generates garbage to max_tokens.
                 se = list(sampling_params.get("stop_token_ids") or [])
                 if self._tts_codec_eos not in se:
                     sampling_params["stop_token_ids"] = se + [self._tts_codec_eos]
@@ -493,10 +491,10 @@ class vLLMOmniHttpServer(vLLMHttpServer):
         # only the last output, so accumulate the per-step chunks to recover the full sequence
         # and attach them to the final output for _process_output.
         acc_codes = None
-        for_tts = self._is_tts
+
         async for output in generator:
             final_res = output
-            if for_tts:
+            if self._is_tts:
                 try:
                     mm = output.multimodal_output
                     chunk = mm.get("codes", {}).get("audio") if mm is not None else None
@@ -527,13 +525,9 @@ class vLLMOmniHttpServer(vLLMHttpServer):
 
             extra_fields = {"global_steps": self.global_steps}
             token_ids = req_output.outputs[0].token_ids
-            # Surface the talker's full (T, 16) sampled codes for the actor's teacher-forced
-            # recompute. The accumulated stream starts with zero placeholder frames written during
-            # prefill; the real decode frames are the suffix. Align with a short probe so that
-            # codes[k, 0] == token_ids[k]: a short probe matters because the stream is usually one
-            # frame short of len(token_ids) (the eos frame is not emitted), and a long probe with
-            # a full-window bound would then exclude the true start, leaving every sub-codebook
-            # shifted one frame against the actor. No-op for non-TTS AR.
+            # Surface the talker's (T, 16) codes for the actor's teacher-forced recompute, trimming the
+            # leading prefill placeholders so codes[k, 0] == token_ids[k]. The probe is short because the
+            # stream is often one frame short of len(token_ids), so a long probe would shift the codebooks.
             audio_codes = getattr(final_res, "verl_tts_codes", None)
             if audio_codes is not None:
                 L = len(token_ids)

--- a/verl_omni/workers/rollout/vllm_rollout/vllm_omni_async_server.py
+++ b/verl_omni/workers/rollout/vllm_rollout/vllm_omni_async_server.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import argparse
+import functools
 import logging
 import os
 from dataclasses import asdict
@@ -88,6 +89,27 @@ class vLLMOmniHttpServer(vLLMHttpServer):
         if not self._ar_mode:
             self._to_tensor = T.PILToTensor()
         super()._post_init(cuda_visible_devices)
+
+    @functools.cached_property
+    def _tts_spk_embedding(self):
+        """The clone voice x-vector (list of floats), or None when this is not a TTS rollout.
+
+        Set via actor_rollout_ref.model.override_config.tts_spk_embed_path; the same vector
+        feeds the actor's speaker slot so generation and the teacher-forced recompute condition
+        on an identical speaker.
+        """
+        path = getattr(getattr(self.model_config, "hf_config", None), "tts_spk_embed_path", None)
+        if not path:
+            return None
+        from verl_omni.models.transformers.qwen3_tts_forward import load_speaker_xvector
+
+        logger.info("Qwen3-TTS rollout mode: voice-clone x-vector from %s", path)
+        return load_speaker_xvector(path).reshape(-1).tolist()
+
+    @functools.cached_property
+    def _tts_codec_eos(self) -> int:
+        talker_cfg = getattr(getattr(self.model_config, "hf_config", None), "talker_config", None)
+        return int(getattr(talker_cfg, "codec_eos_token_id", 2150))
 
     # -----------------------------------------------------------------------
     # launch_server hooks
@@ -306,6 +328,32 @@ class vLLMOmniHttpServer(vLLMHttpServer):
     # Mode-specific pipeline steps
     # -----------------------------------------------------------------------
 
+    def generate_tts(self, prompt_ids: list[int], spk_embedding: list[float]):
+        """Build the Qwen3-TTS voice-clone generation request for a prompt.
+
+        Returns (additional_information, placeholder_prompt_ids). Generation must run in
+        non-streaming mode (full text in the prefill), the layout the actor reconstructs in
+        build_talker_batch; streaming log-probs cannot be on-policy with the actor's
+        full-context recompute. The talker overwrites all prompt embeddings, so only the
+        placeholder's length matters, and it must equal the talker's real prompt length or
+        every codec frame's RoPE shifts against the actor.
+        """
+        from verl_omni.models.transformers.qwen3_tts_forward import build_assistant_text
+
+        tok = self.model_config.tokenizer
+        text = tok.decode(prompt_ids, skip_special_tokens=True).strip()
+        additional_information = {
+            "task_type": ["Base"],
+            "text": [text],
+            "language": ["Auto"],
+            "x_vector_only_mode": [True],
+            "non_streaming_mode": [True],
+            "voice_clone_prompt": [{"ref_spk_embedding": spk_embedding}],
+        }
+        assistant_len = len(tok(build_assistant_text(text))["input_ids"])
+        placeholder = [0] * (assistant_len + 2)
+        return additional_information, placeholder
+
     def _preprocess_input(
         self,
         prompt_ids: list[int],
@@ -348,9 +396,19 @@ class vLLMOmniHttpServer(vLLMHttpServer):
             else:
                 sampling_params["logprobs"] = None
             sampling_params.setdefault("repetition_penalty", getattr(self.config, "repetition_penalty", 1.0))
+            spk_embedding = self._tts_spk_embedding
+            if spk_embedding is not None:
+                # Stop at codec eos: without it the talker emits eos and then generates garbage
+                # to max_tokens.
+                se = list(sampling_params.get("stop_token_ids") or [])
+                if self._tts_codec_eos not in se:
+                    sampling_params["stop_token_ids"] = se + [self._tts_codec_eos]
             params = SamplingParams(max_tokens=max_tokens, **sampling_params)
 
             prompt = {"prompt_token_ids": prompt_ids}
+            if spk_embedding is not None:
+                tts_ai, ar_prompt_ids = self.generate_tts(prompt_ids, spk_embedding)
+                prompt = {"prompt_token_ids": ar_prompt_ids, "additional_information": tts_ai}
             if multi_modal_data:
                 prompt["multi_modal_data"] = multi_modal_data
             return prompt, params
@@ -402,8 +460,30 @@ class vLLMOmniHttpServer(vLLMHttpServer):
                 sampling_params_list=params,
             )
         final_res: Optional[OmniRequestOutput] = None
+        # The TTS talker streams its (T, 16) codes one frame per decode step and the engine keeps
+        # only the last output, so accumulate the per-step chunks to recover the full sequence
+        # and attach them to the final output for _process_output.
+        acc_codes = None
+        for_tts = self._ar_mode and self._tts_spk_embedding is not None
         async for output in generator:
             final_res = output
+            if for_tts:
+                try:
+                    mm = output.multimodal_output
+                    chunk = mm.get("codes", {}).get("audio") if mm is not None else None
+                    if chunk is not None:
+                        chunk = torch.as_tensor(chunk)
+                        if chunk.ndim == 2 and chunk.shape[0] > 0:
+                            if acc_codes is None:
+                                acc_codes = chunk
+                            elif chunk.shape[0] > acc_codes.shape[0]:
+                                acc_codes = chunk  # cumulative snapshot
+                            else:
+                                acc_codes = torch.cat([acc_codes, chunk], dim=0)  # per-step delta
+                except (AttributeError, KeyError, TypeError, ValueError):
+                    pass  # not a codes chunk
+        if acc_codes is not None and final_res is not None:
+            final_res.verl_tts_codes = acc_codes
         return final_res
 
     def _process_output(self, final_res, params, sampling_params: dict[str, Any]):
@@ -418,6 +498,35 @@ class vLLMOmniHttpServer(vLLMHttpServer):
 
             extra_fields = {"global_steps": self.global_steps}
             token_ids = req_output.outputs[0].token_ids
+            # Surface the talker's full (T, 16) sampled codes for the actor's teacher-forced
+            # recompute. The accumulated stream starts with zero placeholder frames written during
+            # prefill; the real decode frames are the suffix. Align with a short probe so that
+            # codes[k, 0] == token_ids[k]: a short probe matters because the stream is usually one
+            # frame short of len(token_ids) (the eos frame is not emitted), and a long probe with
+            # a full-window bound would then exclude the true start, leaving every sub-codebook
+            # shifted one frame against the actor. No-op for non-TTS AR.
+            audio_codes = getattr(final_res, "verl_tts_codes", None)
+            if audio_codes is not None:
+                L = len(token_ids)
+                tid_t = torch.as_tensor(list(token_ids), dtype=audio_codes.dtype)
+                A = audio_codes.shape[0]
+                probe = min(L, 16)
+                best_o, best_m = max(0, A - L), -1.0
+                for o in range(0, max(1, A - probe + 1)):
+                    m = (audio_codes[o : o + probe, 0] == tid_t[:probe]).float().mean().item()
+                    if m > best_m:
+                        best_m, best_o = m, o
+                        if best_m >= 0.999:
+                            break
+                audio_codes = audio_codes[best_o : best_o + L]
+                if audio_codes.shape[0] < L:
+                    # Pad a short tail so the code count stays equal to the response length; the
+                    # padded frames are never used as context for an in-response token.
+                    pad_n = L - audio_codes.shape[0]
+                    pad = audio_codes.new_zeros((pad_n, audio_codes.shape[1]))
+                    pad[:, 0] = tid_t[L - pad_n : L]
+                    audio_codes = torch.cat([audio_codes, pad], dim=0)
+                extra_fields["tts_audio_codes"] = audio_codes
             log_probs = None
             if params.logprobs is not None:
                 log_probs = [

--- a/verl_omni/workers/utils/losses.py
+++ b/verl_omni/workers/utils/losses.py
@@ -12,11 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections import defaultdict
+
 import torch
+import torch.nn.functional as F
 from tensordict import TensorDict
 from verl.trainer.ppo.rollout_corr_helper import compute_rollout_correction_and_rejection_mask
 from verl.utils import tensordict_utils as tu
 from verl.utils.metric import AggregationType, Metric
+from verl.workers.utils.padding import no_padding_2_padding
 
 from verl_omni.trainer.diffusion.diffusion_algos import get_diffusion_loss_fn
 from verl_omni.workers.config import DiffusionActorConfig
@@ -118,3 +122,128 @@ def diffusion_loss(config: DiffusionActorConfig, model_output, data: TensorDict,
         loss_value = loss_value * sp_size
 
     return loss_value, metrics
+
+
+def _as_pylist(v):
+    """Coerce a per-row non-tensor field to a plain Python list.
+
+    On the actor batch, uid/sj_score arrive as NonTensorStack handles whose np.asarray/iteration
+    indexes a 0-dim tensordict and raises; .tolist() is the safe path.
+    """
+    if v is None:
+        return None
+    if torch.is_tensor(v):
+        return v.reshape(-1).detach().cpu().tolist()
+    if isinstance(v, list | tuple):
+        return list(v)
+    tolist = getattr(v, "tolist", None)
+    if callable(tolist):
+        return tolist()
+    return list(v)
+
+
+def build_online_dpo_pair_indices(uids, scores) -> list[int]:
+    """One adjacent (chosen, rejected) pair per prompt group.
+
+    Groups sample indices by prompt uid, sorts each group by preference score descending, and emits
+    [top, bottom] so the flat list alternates chosen/rejected. Groups with fewer than two members
+    (e.g. an aborted sibling) are skipped; ties are kept and masked in the loss.
+    """
+    uid_vals = _as_pylist(uids)
+    vals = _as_pylist(scores)
+    if uid_vals is None or vals is None or len(uid_vals) != len(vals):
+        raise ValueError("DPO pairing needs one uid per score.")
+    groups: dict = defaultdict(list)
+    for i, u in enumerate(uid_vals):
+        groups[u].append(i)
+    out: list[int] = []
+    for idxs in groups.values():
+        if len(idxs) < 2:
+            continue
+        s = sorted(idxs, key=lambda i: float(vals[i]), reverse=True)
+        out.extend([s[0], s[-1]])
+    return out
+
+
+def tts_dpo_loss(config, model_output, data: TensorDict, dp_group=None):
+    """Online DPO on the talker codec-0 sequence log-prob, judged pairwise within each uid group.
+
+    For every prompt (uid) the batch holds rollout.n candidates; the judge's sj_score picks the best
+    (chosen) and worst (rejected). Per sequence we sum the current-policy and frozen-reference
+    log-probs over the response, form the implicit reward r = sum(log pi_theta - log pi_ref), and
+    minimize -logsigmoid(beta*(r_chosen - r_rejected)) plus an optional lambda*NLL(chosen) anchor.
+    beta and lambda come from DPOPolicyLossConfig (dpo_beta / dpo_nll_lambda).
+
+    Pairing is internal: the config keeps a prompt's candidates in one in-order micro-batch per rank
+    (use_dynamic_bsz false + one micro-batch + balance_batch false), so grouping by uid here recovers
+    the pairs without a reorder pass. The per-rank weighted mean is the whole optimizer-step gradient;
+    FSDP averages it across data-parallel ranks.
+    """
+    if getattr(config, "use_dynamic_bsz", False):
+        raise ValueError("Online DPO requires actor.use_dynamic_bsz=false so a uid group stays in one micro-batch.")
+
+    log_prob = no_padding_2_padding(model_output["log_probs"], data)  # (B, resp_len), current policy
+    sel = data.select("response_mask", "ref_log_prob").to_padded_tensor()
+    mask = sel["response_mask"].to(torch.float32)
+    ref_log_prob = sel["ref_log_prob"].to(torch.float32)
+
+    seq_logp = (log_prob.float() * mask).sum(-1)  # (B,) sum log pi_theta over response
+    seq_ref = (ref_log_prob * mask).sum(-1)  # (B,) sum log pi_ref over response
+    implicit_reward = seq_logp - seq_ref  # (B,) DPO implicit reward (pre-beta)
+
+    uids = _as_pylist(tu.get_non_tensor_data(data, "uid", default=None))
+    scores = _as_pylist(tu.get_non_tensor_data(data, "sj_score", default=None))
+    if uids is None or scores is None:
+        raise RuntimeError(
+            "Online DPO needs `uid` and `sj_score` in the batch; the AudioJudgeRewardManager must emit sj_score."
+        )
+    sc = [float(x) for x in scores]
+    idx = build_online_dpo_pair_indices(uids, sc)
+    if not idx:
+        raise RuntimeError(
+            "Online DPO formed no preference pairs on this micro-batch; need rollout.n>=2 and each uid "
+            "group co-located on one DP rank (trainer.balance_batch=false)."
+        )
+    device = implicit_reward.device
+    order = torch.as_tensor(idx, dtype=torch.long, device=device)
+    r = implicit_reward.index_select(0, order)
+    sl = seq_logp.index_select(0, order)
+    m = mask.index_select(0, order)
+    # One flag per pair: 1 = real preference, 0 = judge tie (equal scores) -> zero gradient.
+    valid = torch.tensor(
+        [1.0 if sc[idx[k]] != sc[idx[k + 1]] else 0.0 for k in range(0, len(idx), 2)],
+        dtype=torch.float32,
+        device=device,
+    )
+
+    beta = float(config.policy_loss.get("dpo_beta", 0.1))
+    chosen, rejected = r[0::2], r[1::2]
+    inside = beta * (chosen - rejected)
+    per_pair = -F.logsigmoid(inside)
+    denom = valid.sum().clamp(min=1.0)
+    loss = (per_pair * valid).sum() / denom
+
+    # RPO/DPOP anchor: L = L_DPO + lambda*NLL(chosen). A per-token SFT loss on the chosen sequence so
+    # its log-prob cannot collapse while the model merely widens the chosen-rejected margin.
+    nll_lambda = float(config.policy_loss.get("dpo_nll_lambda", 0.0))
+    chosen_tok = m[0::2].sum(-1).clamp(min=1.0)
+    nll_chosen = -(sl[0::2] / chosen_tok)  # (n/2,) per-token NLL of chosen
+    nll_term = (nll_chosen * valid).sum() / denom
+    loss = loss + nll_lambda * nll_term
+
+    with torch.no_grad():
+        acc = ((inside > 0).float() * valid).sum() / denom
+        margin = ((chosen - rejected) * valid).sum() / denom
+        mean = AggregationType.MEAN
+        metrics = {
+            "actor/dpo_loss": Metric(value=loss, aggregation=mean),
+            "actor/dpo_acc": Metric(value=acc, aggregation=mean),
+            "actor/dpo_margin": Metric(value=margin, aggregation=mean),
+            "actor/dpo_tie_frac": Metric(value=1.0 - valid.mean(), aggregation=mean),
+            "actor/logp_chosen": Metric(value=sl[0::2].mean(), aggregation=mean),
+            "actor/logp_rejected": Metric(value=sl[1::2].mean(), aggregation=mean),
+            "actor/nll_chosen": Metric(value=(nll_chosen * valid).sum() / denom, aggregation=mean),
+            "actor/dpo_beta": beta,
+            "actor/dpo_nll_lambda": nll_lambda,
+        }
+    return loss, metrics


### PR DESCRIPTION
### What does this PR do?

Adds native Qwen3-TTS talker RL to verl-omni as two recipes that share one talker actor and one
vLLM-Omni AR rollout:

- **GSPO** (group RL): a multi-metric audio reward (intelligibility, speaker similarity, emotion, stability) through verl's stock GSPO policy loss and GDPO advantage estimator.
- **Online DPO**: two candidates per prompt, judged pairwise by a remote audio-capable LLM (Gemini by default, any endpoint), trained with a pairwise DPO loss on the talker's codec-0 sequence log-prob against a frozen reference.

Addresses RFC #90. The talker is not a plain causal LM (2-channel input, speaker slot, 16 codebooks), so the actor computes real teacher-forced codec-0 log-probs and the rollout stays on-policy while the codec2wav decoding is reward-side.

### Checklist Before Starting

- [x] Searched for similar open PRs: [`is:pr is:open tts`](https://github.com/verl-project/verl-omni/pulls?q=is%3Apr+is%3Aopen+tts), plus `qwen3-tts`, `speechjudge`, `audio judge dpo`. No open PR contains Qwen3-TTS or TTS RL (the single `tts` hit, #233, is a CI refactor). RFC #90 requests this recipe and has no implementation PR.
- [x] Title formatted as `[{modules}] {type}: {description}`: `[model, rollout, reward, algo, worker, trainer] feat: Qwen3-TTS talker GSPO + online DPO`.
- [x] No breaking API change: everything is additive (a new `[tts]` extra, new `reward.*` / `actor.policy_loss` config keys, a new trainer entry). Existing T2I/LLM/diffusion behavior is untouched.

### Test

#### CPU tests

```bash
pytest -q --asyncio-mode=auto tests/     # python_files = *_on_cpu.py
```

```text
299 passed   # 45 in the 7 TTS-specific files
```

| Area | File |
| --- | --- |
| talker forward (layout; verl-gather == talker-gather) | `tests/models/test_qwen3_tts_forward_on_cpu.py` |
| reward functions (asr/sim/emo, CER, stability, composition) | `tests/utils/reward_score/test_tts_rewards_on_cpu.py` |
| audio reward managers (decode, multi weighted-sum) | `tests/reward_loop/test_audio_reward_manager_on_cpu.py` |
| audio-judge rendezvous + `num_workers=1` guard | `tests/reward_loop/test_audio_judge_reward_manager_on_cpu.py` |
| DPO loss + pairing + ties + NLL anchor | `tests/workers/test_tts_dpo_loss_on_cpu.py` |
| `DPOPolicyLossConfig` via `_target_` | `tests/workers/config/test_dpo_policy_loss_config_on_cpu.py` |
| TTS-mode detection from stage config | `tests/workers/rollout/rollout_vllm/test_tts_mode_detection_on_cpu.py` |

#### GPU end-to-end (1 node x 8 H200)

| Recipe | Run | Result |
| --- | --- | --- |
| GSPO | 25-step regression vs a reference run | EXIT=0; rollout/actor Pearson 0.9993; reward dims match reference (asr 0.99, sim 0.884, emo 0.14, stab 0.0) |
| DPO | 2-step on pristine base verl + a mock `/rank` judge | EXIT=0; `actor/dpo_loss = 0.6931 = ln 2` at init (policy == reference, so the margin is 0), which confirms the loss bind, `ref_log_prob`, and pairing are all live; Pearson 0.9993 |
| GSPO via the shared `main_tts` entry | 2-step | EXIT=0; metric is `actor/pg_loss` (not `actor/dpo_loss`), so the DPO bind is a no-op for GSPO; numbers identical to the base-entry run |

GSPO was also validated originally with a full training pass over a ~25k-line voice dataset (all reward dimensions rise). Caveat: an LLM judge discriminates weakly on same-text / same-voice pairs, so online DPO from it can regress on quality even while training metrics look healthy; evaluate checkpoints on held-out data (documented in the DPO README).

#### Static checks

`ruff check` / `ruff format`, `tests/special_sanity/check_license.py`, and
`tests/special_sanity/validate_structure.py` pass.

### API and Usage Example

GSPO:

```bash
python data_process/tts_content_synth.py --input conversations.jsonl --ref_audio clone.wav --output_dir ~/data/tts
python data_process/precompute_spk_embed.py --ref clone.wav --out ~/data/tts/spk_embed.json

MODEL_PATH=<qwen3-tts ckpt> TRAIN_FILE=~/data/tts/train.parquet VAL_FILE=~/data/tts/test.parquet \
  SPK_EMBED=~/data/tts/spk_embed.json \
  bash examples/qwen3_tts_gspo_trainer/run_qwen3_tts_gspo.sh
```

Online DPO (start a judge, then train):

```bash
GOOGLE_API_KEY=... python examples/qwen3_tts_dpo/judge_server.py --provider gemini --port 8901

MODEL_PATH=<qwen3-tts SFT ckpt> TRAIN_FILE=... VAL_FILE=... SPK_EMBED=... JUDGE_URL=http://localhost:8901 \
  bash examples/qwen3_tts_dpo/run_qwen3_tts_dpo.sh
```

Both launch `python3 -m verl_omni.trainer.main_tts`. Install adds the `[tts]` extra plus `pip install --no-deps qwen-tts==0.1.1 sox`; three idempotent dependency-wall patches ship in `examples/qwen3_tts_gspo_trainer/patches/` (documented in the README).

### Design & Code Changes

- **Talker actor** — `verl_omni/models/transformers/qwen3_tts.py` (external_lib patch: registers the
  qwen-tts classes, installs the teacher-forced codec-0 forward, talker-only freeze) +
  `qwen3_tts_forward.py` (side-effect-free tensor math, CPU-tested).
- **Rollout** — `verl_omni/workers/rollout/vllm_rollout/vllm_omni_async_server.py`: voice-clone AR
  generation; TTS mode detected once from the stage's `codec` output type; codec frames surfaced as
  `tts_audio_codes` for the actor's recompute.
- **Reward** — `reward_loop/reward_manager/{audio,multi,audio_judge}.py` and
  `utils/reward_score/tts/`: `AudioRewardManager` mirrors `VisualRewardManager`;
  `MultiAudioRewardManager` composes per-model reward functions; `AudioJudgeRewardManager` adds the
  DPO judge rendezvous. `examples/qwen3_tts_dpo/judge_server.py` is a small generic Gemini /
  OpenAI-compatible `/rank` server.
- **DPO** — `workers/utils/losses.py` (`tts_dpo_loss`, pairs chosen/rejected internally),
  `workers/config/tts/actor.py` (`DPOPolicyLossConfig` carries β/λ via `_target_`), and
  `trainer/main_tts.py` (the shared Qwen3-TTS entry: base verl's V0 runner verbatim plus one
  `set_loss_fn` call, a no-op unless `loss_mode` is dpo).

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md).
- [x] Ran the pre-commit hooks (ruff check/format, license header, structure validation) and the CPU suite; all pass.
- [x] Added docs: `examples/qwen3_tts_gspo_trainer/README.md` and `examples/qwen3_tts_dpo/README.md`.
- [x] Added CPU tests (`*_on_cpu.py`, auto-collected by the [CPU CI workflow](https://github.com/verl-project/verl-omni/tree/main/.github/workflows)). GPU end-to-end needs an 8xH200 node and a qwen-tts checkpoint, so it runs manually and is not wired into CI.

### AI Assistance

AI assistance was used to restructure the implementation from an internal branch, add the tests, and draft this description. I reviewed the final diff and the test results and can explain and maintain the change end to end.