### PR TITLE
[trainer, doc, tests] feat: log rollout-train log-prob consistency metrics by default

### DIFF
--- a/docs/algo/rollout_correction.md
+++ b/docs/algo/rollout_correction.md
@@ -1,6 +1,6 @@
 # Rollout Correction for Diffusion Training (Experimental)
 
-Last updated: 05/19/2026
+Last updated: 07/22/2026
 
 > **Status:** Experimental. The API, default thresholds and recommended preset may change.
 
@@ -84,6 +84,29 @@ rollout backend is drifting too far — tighten the RS band or fall back to
 > At high sustained rejection rates the effective gradient magnitude decreases by
 > the factor `kept / total`.  Monitor `rollout_corr/rollout_rs_seq_masked_fraction`
 > and widen the RS band if it exceeds ~10 % over several steps.
+
+## Consistency monitoring
+
+Whenever the rollout returns log-probs (`actor_rollout_ref.rollout.calculate_log_probs=true`)
+and bypass mode is off, the trainer additionally logs rollout-train consistency diagnostics
+once per global batch — no `rollout_correction` config needed:
+
+- `rollout_corr/logprob_abs_diff_mean` / `_max` — |`old_log_probs` − `rollout_log_probs`|.
+- `rollout_corr/logprob_abs_diff/ts_{t}` — the same grouped by denoising timestep value
+  (the SDE window is per-sample random, so aggregates hide the strong timestep dependence).
+- The off-policy metrics above (`kl`, `k3_kl`, PPL family).
+
+With matched attention backends the gap is bf16 noise, mean |Δlogp| in the 1e-5 range;
+guidance scale and later denoising steps amplify it. Values orders of magnitude above that
+indicate a schedule or backend mismatch — enable `calculate_log_probs=true` and check these
+metrics first when debugging convergence.
+
+> **Threshold caveat:** some recipes ship `diffusion_loss.clip_ratio` or `kl_mask_threshold`
+> at 1e-5, below the measured noise floor. Bypass mode is the worst case — the PPO ratio
+> `exp(current − rollout)` then carries the full rollout-train gap, so most samples fall
+> outside the clip band / inside the mask from numerical noise alone. Decoupled mode compares
+> against the recompute instead, but a noticeable `actor/pg_clipfrac` can still be pure noise
+> there. Keep thresholds above the |Δlogp| level these metrics report (the default is `1e-4`).
 
 ## Hyperparameter notes
 

--- a/tests/trainer/diffusion/test_rollout_correction_on_cpu.py
+++ b/tests/trainer/diffusion/test_rollout_correction_on_cpu.py
@@ -358,6 +358,41 @@ class TestLossIntegration:
 # ---------------------------------------------------------------------------
 
 
+class TestConsistencyMetrics:
+    def test_abs_diff_aggregates(self):
+        """Mean/max |Δlogp| are exact on known tensors."""
+        old = torch.tensor([[1.0, 2.0], [3.0, 5.0]])
+        rollout = torch.tensor([[1.5, 2.0], [2.0, 5.5]])
+        metrics = rollout_correction.compute_rollout_corr_metrics_from_logprobs(old, rollout)
+        assert metrics["rollout_corr/logprob_abs_diff_mean"] == pytest.approx(0.5)
+        assert metrics["rollout_corr/logprob_abs_diff_max"] == pytest.approx(1.0)
+        assert "rollout_corr/kl" in metrics
+
+    def test_per_timestep_breakdown(self):
+        """|Δlogp| is grouped by timestep value, not column index."""
+        old = torch.tensor([[1.0, 2.0], [3.0, 5.0]])
+        rollout = torch.tensor([[1.5, 2.0], [2.0, 5.5]])
+        timesteps = torch.tensor([[800.0, 700.0], [800.0, 700.0]])
+        metrics = rollout_correction.compute_rollout_corr_metrics_from_logprobs(old, rollout, timesteps=timesteps)
+        assert metrics["rollout_corr/logprob_abs_diff/ts_800"] == pytest.approx(0.75)
+        assert metrics["rollout_corr/logprob_abs_diff/ts_700"] == pytest.approx(0.25)
+
+    def test_no_timesteps_no_breakdown(self):
+        """Without timesteps the output has no per-timestep keys (backward compat)."""
+        old = torch.randn(4, 2)
+        metrics = rollout_correction.compute_rollout_corr_metrics_from_logprobs(old, old + 0.1)
+        assert not any("logprob_abs_diff/ts_" in k for k in metrics)
+
+    def test_shape_mismatch_skips_breakdown(self):
+        """Misaligned timesteps yield aggregates only, never a wrong grouping."""
+        old = torch.randn(4, 2)
+        metrics = rollout_correction.compute_rollout_corr_metrics_from_logprobs(
+            old, old + 0.1, timesteps=torch.randn(4, 3)
+        )
+        assert "rollout_corr/logprob_abs_diff_mean" in metrics
+        assert not any("logprob_abs_diff/ts_" in k for k in metrics)
+
+
 class TestConfigHelpers:
     def test_rollout_correction_enabled(self):
         """rollout_correction_enabled returns True when IS or RS is set."""

--- a/tests/utils/test_diffusion_attention_on_cpu.py
+++ b/tests/utils/test_diffusion_attention_on_cpu.py
@@ -12,10 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+
 from omegaconf import OmegaConf
 
 from tests.utils.smoke_attention import resolve_smoke_attention_backends
 from verl_omni.utils.diffusion_attention import fallback_fa3_if_unavailable, validate_attention_consistency
+
+
+def test_veomni_strategy_skips_with_warning(caplog):
+    with caplog.at_level(logging.WARNING, logger="verl_omni.utils.diffusion_attention"):
+        validate_attention_consistency(
+            OmegaConf.create(
+                {
+                    "actor_rollout_ref": {
+                        "model": {"attn_backend": "native"},
+                        "actor": {"strategy": "veomni"},
+                        "rollout": {"rollout_attn_backend": "FLASH_ATTN"},
+                    }
+                }
+            )
+        )
+    assert "veomni" in caplog.text
 
 
 def test_fa3_actor_allows_flash_attn_3_hub():

--- a/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
+++ b/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
@@ -68,6 +68,7 @@ from verl_omni.trainer.diffusion.diffusion_trainer_utils import NoOpCheckpointMa
 from verl_omni.trainer.diffusion.rollout_correction import (
     apply_bypass_mode_to_diffusion_batch,
     apply_rollout_correction_to_diffusion_batch,
+    compute_rollout_corr_metrics_from_logprobs,
     rollout_correction_enabled,
 )
 from verl_omni.workers.utils.padding import embeds_padding_2_no_padding
@@ -1033,6 +1034,17 @@ class PolicyGradientRayTrainer(BaseRayDiffusionTrainer):
                             batch = batch.union(old_log_prob)
 
                     assert "old_log_probs" in batch.batch, f'"old_log_prob" not in {batch.batch.keys()=}'
+
+                    # Consistency monitoring (needs calculate_log_probs=true); in bypass
+                    # mode old == rollout so there is nothing to compare.
+                    if not bypass_recomputing_logprobs and "rollout_log_probs" in batch.batch:
+                        metrics.update(
+                            compute_rollout_corr_metrics_from_logprobs(
+                                batch.batch["old_log_probs"],
+                                batch.batch["rollout_log_probs"],
+                                timesteps=batch.batch.get("all_timesteps", None),
+                            )
+                        )
 
                     # Decoupled-mode rollout correction (old vs rollout).
                     # In bypass mode old == rollout, so correction runs per-step in ``diffusion_loss``.

--- a/verl_omni/trainer/diffusion/rollout_correction.py
+++ b/verl_omni/trainer/diffusion/rollout_correction.py
@@ -169,6 +169,7 @@ def apply_rollout_correction_to_diffusion_batch(
 def compute_rollout_corr_metrics_from_logprobs(
     log_prob: torch.Tensor,
     rollout_log_prob: torch.Tensor,
+    timesteps: Optional[torch.Tensor] = None,
 ) -> dict[str, float]:
     """Off-policy diagnostics from (current, rollout) log probs.
 
@@ -177,9 +178,12 @@ def compute_rollout_corr_metrics_from_logprobs(
     Args:
         log_prob: Current policy log-prob, shape ``(B,)`` or ``(B, T)``.
         rollout_log_prob: Rollout policy log-prob, same shape.
+        timesteps: Optional denoising timesteps aligned with ``log_prob`` columns;
+            adds a per-timestep ``|Δlogp|`` breakdown (grouped by timestep value —
+            the SDE window is per-sample random, so column index is not meaningful).
 
     Returns:
-        Dict of ``rollout_corr/`` metrics (KL, PPL, χ², etc.).
+        Dict of ``rollout_corr/`` metrics (KL, PPL, χ², |Δlogp|, etc.).
     """
     if log_prob.dim() == 1:
         log_prob = log_prob.unsqueeze(-1)
@@ -198,5 +202,15 @@ def compute_rollout_corr_metrics_from_logprobs(
             metrics_with_prefix[f"rollout_corr/{key}"] = value.item()
         else:
             metrics_with_prefix[f"rollout_corr/{key}"] = value
+
+    abs_diff = (log_prob - rollout_log_prob).abs()
+    metrics_with_prefix["rollout_corr/logprob_abs_diff_mean"] = abs_diff.mean().item()
+    metrics_with_prefix["rollout_corr/logprob_abs_diff_max"] = abs_diff.max().item()
+
+    if timesteps is not None and timesteps.shape == log_prob.shape:
+        for ts in torch.unique(timesteps):
+            metrics_with_prefix[f"rollout_corr/logprob_abs_diff/ts_{ts.item():.4g}"] = (
+                abs_diff[timesteps == ts].mean().item()
+            )
 
     return metrics_with_prefix

--- a/verl_omni/utils/diffusion_attention.py
+++ b/verl_omni/utils/diffusion_attention.py
@@ -108,6 +108,7 @@ def validate_attention_consistency(config: Any) -> None:
     actor_cfg = config.actor_rollout_ref.actor
     strategy = actor_cfg.get("strategy") if hasattr(actor_cfg, "get") else None
     if strategy == "veomni":
+        logger.warning("strategy=veomni: attention consistency is not validated; ensure backends match manually.")
         return  # VeOmni engine manages its own attention independently
 
     model_cfg = config.actor_rollout_ref.model


### PR DESCRIPTION
### What

Implements the observability part of RFC #280: rollout-train log-prob consistency is measurable today only with throwaway code — `compute_rollout_corr_metrics_from_logprobs` has no callers and nothing reports the gap that let the #279 regression ship silently.

- **Default monitoring**: when the rollout returns log-probs (`calculate_log_probs=true`) and bypass mode is off, the trainer logs `rollout_corr/*` diagnostics per global batch — mean/max `|old_log_probs − rollout_log_probs|` plus the existing KL/PPL family. No new config, no behavior change; inactive when log-probs are absent (the default).
- **Per-timestep breakdown**: `|Δlogp|` grouped by denoising **timestep value** as `rollout_corr/logprob_abs_diff/ts_{t}` — the SDE window is per-sample random, so column index would mix timesteps; values come from the fixed schedule table, so key cardinality is bounded by `num_inference_steps`. Emitted only when `all_timesteps` aligns with the log-prob columns.
- **Docs**: consistency-monitoring section in `docs/algo/rollout_correction.md` — what the metrics mean, what a healthy magnitude looks like, and the caveat that recipes shipping `clip_ratio`/`kl_mask_threshold` at 1e-5 sit below the noise floor.
- **VeOmni**: `validate_attention_consistency` warns instead of silently skipping `strategy=veomni`.

### Duplicate check

No open PR touches consistency monitoring; follows up my own RFC #280. Omni-model pearson correlation (review point 2) is deferred until the omni trainer refactor lands, as discussed in the RFC thread.

### Test

- `pytest tests/trainer/diffusion/test_rollout_correction_on_cpu.py tests/utils/test_diffusion_attention_on_cpu.py` — 25 passed, including 5 new ones: exact aggregate/group values, no-timesteps backward compat, shape-mismatch guard, veomni warning.
- E2e on 3×RTX 4090, SD3.5-Medium LoRA OCR recipe, `calculate_log_probs=True`, 2 steps: metrics appear once per global batch and reproduce the offline analysis behind #280 on the same recipe/seed — step 1 `logprob_abs_diff_mean` 2.0970e-5 / `_max` 1.3846e-4 vs 2.097e-5 / 1.385e-4 measured offline. The breakdown emits the 5 timestep values the recipe's window actually covers (`ts_1000` 6.1e-6 → `ts_790.4` 3.4e-5), matching the trainer's scheduler table exactly.
- `ruff check` / `ruff format` clean.

