### PR TITLE
[reward, diffusion, tests] fix: align reward_extra_info keys across the batch

### DIFF
--- a/tests/agent_loop/test_diffusion_agent_loop_postprocess_on_cpu.py
+++ b/tests/agent_loop/test_diffusion_agent_loop_postprocess_on_cpu.py
@@ -1,0 +1,93 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU tests for reward_extra_info aggregation in DiffusionAgentLoopWorker._postprocess.
+
+Sub-rewards do not publish a fixed key set per sample. ``MultiVisualRewardManager``
+emits ``reward/{key}/{subkey}`` for every field of a dict result, but on an exception
+it emits only ``reward/{key}``. ``_postprocess`` must therefore align a batch whose
+samples carry different reward-extra keys.
+"""
+
+import numpy as np
+import torch
+from verl.experimental.agent_loop.agent_loop import AgentLoopMetrics
+
+from verl_omni.agent_loop.diffusion_agent_loop import (
+    DiffusionAgentLoopWorker,
+    _InternalDiffusionAgentLoopOutput,
+)
+
+# Mirrors MultiVisualRewardManager: a dict-returning sub-reward publishes the extra
+# field, the exception path publishes the bare score only.
+_OK = {"reward/ocr": 1.0, "reward/ocr/genrm_response": "matched", "reward/combined": 1.0}
+_FAILED = {"reward/ocr": 0.0, "reward/combined": 0.0}
+
+
+def _make_output(reward_extra_info: dict) -> _InternalDiffusionAgentLoopOutput:
+    return _InternalDiffusionAgentLoopOutput(
+        prompt_ids=torch.zeros(1, 4, dtype=torch.long),
+        response_diffusion_output=torch.zeros(1, 3, 8, 8),
+        reward_score=float(reward_extra_info["reward/combined"]),
+        num_turns=1,
+        metrics=AgentLoopMetrics(),
+        extra_fields={"reward_extra_info": dict(reward_extra_info)},
+    )
+
+
+def _postprocess(reward_extra_infos: list[dict]):
+    """_postprocess never touches ``self``; call it unbound to avoid building a worker."""
+    outputs = [_make_output(info) for info in reward_extra_infos]
+    return DiffusionAgentLoopWorker._postprocess(None, outputs)
+
+
+class TestRewardExtraInfoAggregation:
+    def test_later_sample_missing_subkey_does_not_crash(self):
+        """A sub-reward failing on any sample but the first must not kill the batch."""
+        result = _postprocess([_OK, _FAILED])
+
+        assert result.non_tensor_batch["reward/ocr/genrm_response"].tolist() == ["matched", None]
+        np.testing.assert_allclose(result.non_tensor_batch["reward/ocr"].astype(float), [1.0, 0.0])
+
+    def test_first_sample_missing_subkey_keeps_other_samples(self):
+        """Keys are collected over the whole batch, not read off sample 0."""
+        result = _postprocess([_FAILED, _OK])
+
+        assert "reward/ocr/genrm_response" in result.non_tensor_batch
+        assert result.non_tensor_batch["reward/ocr/genrm_response"].tolist() == [None, "matched"]
+        assert "reward/ocr/genrm_response" in result.meta_info["reward_extra_keys"]
+
+    def test_homogeneous_keys_keep_numeric_dtype(self):
+        """When every sample agrees, arrays stay numeric so downstream metrics still work."""
+        result = _postprocess([_FAILED, _FAILED])
+
+        combined = result.non_tensor_batch["reward/combined"]
+        assert np.issubdtype(combined.dtype, np.floating)
+        np.testing.assert_allclose(combined, [0.0, 0.0])
+
+    def test_all_samples_failed(self):
+        """A sub-reward that fails everywhere yields no subkey column at all."""
+        result = _postprocess([_FAILED, _FAILED])
+
+        assert "reward/ocr/genrm_response" not in result.meta_info["reward_extra_keys"]
+
+    def test_disjoint_key_sets_are_unioned(self):
+        """Different sub-rewards failing on different samples still produce a full batch."""
+        left = {"reward/combined": 1.0, "reward/a": 1.0, "reward/a/detail": "x"}
+        right = {"reward/combined": 1.0, "reward/b": 1.0, "reward/b/detail": "y"}
+        result = _postprocess([left, right])
+
+        assert result.non_tensor_batch["reward/a/detail"].tolist() == ["x", None]
+        assert result.non_tensor_batch["reward/b/detail"].tolist() == [None, "y"]
+        for key in ("reward/a", "reward/b", "reward/a/detail", "reward/b/detail"):
+            assert len(result.non_tensor_batch[key]) == 2

--- a/verl_omni/agent_loop/diffusion_agent_loop.py
+++ b/verl_omni/agent_loop/diffusion_agent_loop.py
@@ -341,10 +341,21 @@ class DiffusionAgentLoopWorker:
             non_tensor_batch.update(input_non_tensor_batch)
 
         # add reward_extra_info to non_tensor_batch
+        # A sub-reward may emit different keys for different samples: MultiVisualRewardManager
+        # publishes `reward/{key}/{subkey}` for every field of a dict result, but falls back to
+        # only `reward/{key}` when the sub-reward raises. Take the union of keys over the batch
+        # rather than trusting sample 0, so a single failed sample neither crashes the step nor
+        # silently drops the other samples' extras.
         reward_extra_infos = [input.extra_fields.get("reward_extra_info", {}) for input in inputs]
-        reward_extra_keys = list(reward_extra_infos[0].keys())
+        reward_extra_keys = list(dict.fromkeys(key for info in reward_extra_infos for key in info))
         for key in reward_extra_keys:
-            non_tensor_batch[key] = np.array([info[key] for info in reward_extra_infos])
+            if all(key in info for info in reward_extra_infos):
+                non_tensor_batch[key] = np.array([info[key] for info in reward_extra_infos])
+            else:
+                # Fill gaps with None, mirroring how extra_fields is aggregated below.
+                values = np.empty(len(inputs), dtype=object)
+                values[:] = [info.get(key) for info in reward_extra_infos]
+                non_tensor_batch[key] = values
 
         metrics = [input.metrics.model_dump() for input in inputs]
         # Collect extra fields from all inputs and convert them to np.ndarray


### PR DESCRIPTION
# [reward, diffusion, tests] fix: align reward_extra_info keys across the batch

## Problem

`MultiVisualRewardManager` publishes a **sample-dependent** key set. For a sub-reward
that returns a dict it emits `reward/{key}` *plus* `reward/{key}/{subkey}` for every
extra field ([`multi.py#L159-L164`](https://github.com/verl-project/verl-omni/blob/main/verl_omni/reward_loop/reward_manager/multi.py#L159-L164)),
but when the sub-reward raises, the exception path emits **only** `reward/{key}`
([`multi.py#L168-L172`](https://github.com/verl-project/verl-omni/blob/main/verl_omni/reward_loop/reward_manager/multi.py#L168-L172)).

`DiffusionAgentLoopWorker._postprocess` took the key list from sample 0 alone and then
indexed every other sample with `info[key]`:

```python
reward_extra_keys = list(reward_extra_infos[0].keys())
for key in reward_extra_keys:
    non_tensor_batch[key] = np.array([info[key] for info in reward_extra_infos])
```

So a batch whose samples disagree on keys either crashes or silently loses data:

1. **Crash** — a sub-reward that fails on any sample *other than the first* raises
   `KeyError: 'reward/{key}/{subkey}'` and kills the whole training step.
2. **Silent data loss** — a sub-reward that fails on *sample 0* makes the subkey
   disappear from the batch for every other sample, with no warning.

This is reachable today: `genrm_ocr.compute_score` returns `{"score", "genrm_response"}`
and talks to a GenRM over HTTP, so a single timeout in a batch is enough. It is used by
`examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_multi_reward.sh` and
`tests/special_e2e/run_flowgrpo_qwen_image.sh`.

## Fix

Collect the union of keys over the batch and fill gaps with `None`, mirroring how
`extra_fields` is already aggregated a few lines below in the same function
(`np.empty(..., dtype=object)` + `.get(key)`).

When every sample carries the key — the common case — the original `np.array` path is
kept unchanged, so numeric columns keep their `float64` dtype and downstream metric
reduction is unaffected. The object-dtype path is only taken for keys that are genuinely
missing somewhere.

## Not a duplicate

Checked before opening, per `AGENTS.md`:

```
gh pr list --repo verl-project/verl-omni --state open --search "reward_extra_info"
gh pr list --repo verl-project/verl-omni --state open --search "reward extra keys"
gh pr list --repo verl-project/verl-omni --state open --search "diffusion_agent_loop"
gh issue list --repo verl-project/verl-omni --state open --search "reward_extra_info"
```

No open PR or issue touches this path. The keyword hits (#282, #278, #115, #290, #288,
#149) are feature PRs that do not modify `_postprocess`'s reward-extra aggregation.
Closest neighbour is **#289**, which adds a `required` flag so a sub-reward can fail-fast
instead of zero-filling — that changes *policy* on failure, while this PR fixes the
*batch aggregation* that breaks once any failure path is taken. They are complementary
and do not touch the same lines; happy to rebase if #289 lands first.

## Tests

New CPU test file `tests/agent_loop/test_diffusion_agent_loop_postprocess_on_cpu.py`
(5 cases): later-sample failure, first-sample failure, dtype-preservation regression
guard, all-samples-failed, and disjoint key sets across two sub-rewards.

Verified the tests actually catch the bug — with the source change reverted and only the
tests applied, 3 of the 5 fail at the exact line being fixed:

```
$ git checkout HEAD~1 -- verl_omni/agent_loop/diffusion_agent_loop.py
$ pytest -q --asyncio-mode=auto tests/agent_loop/test_diffusion_agent_loop_postprocess_on_cpu.py
E   KeyError: 'reward/ocr/genrm_response'
verl_omni/agent_loop/diffusion_agent_loop.py:347: KeyError
E   KeyError: 'reward/a'
verl_omni/agent_loop/diffusion_agent_loop.py:347: KeyError
3 failed, 2 passed, 16 warnings in 6.86s
```

With the fix applied:

```
$ pytest -q --asyncio-mode=auto tests/agent_loop/test_diffusion_agent_loop_postprocess_on_cpu.py
5 passed, 16 warnings in 6.78s
```

Full CPU suite, no regressions:

```
$ pytest -q --asyncio-mode=auto tests/          # pytest.ini: python_files = *_on_cpu.py
264 passed, 18 warnings in 10.42s
```

Lint:

```
$ ruff check verl_omni/agent_loop/diffusion_agent_loop.py tests/agent_loop/test_diffusion_agent_loop_postprocess_on_cpu.py
All checks passed!
$ ruff format --diff <same files>
2 files already formatted
```

Environment: Linux x86_64, Python 3.10, vllm 0.24.0+cpu, torch 2.11.0+cpu, verl @ pinned
commit — i.e. the `cpu_unit_tests.yml` recipe.

## AI assistance

AI assistance (Claude) was used to locate the defect, draft the patch and write the
tests. Every command and result shown above was actually executed on the environment
described, and is reproducible from this branch.

Opening as a **draft** while I complete my own line-by-line review of the change; I will
mark it ready for review once that is done. Please do not spend review time on it until
then.

## Follow-up

The same sample-0-key-set pattern exists upstream in
`verl/experimental/agent_loop/agent_loop.py`. Happy to send the matching fix to `verl`
once this lands, if maintainers agree the approach is right.
