### PR TITLE
[trainer, algo, cfg] feat: add teacher-anchored continuous distillation losses for diffusion OPD

### DIFF
--- a/tests/trainer/diffusion/test_diffusion_distillation_losses_on_cpu.py
+++ b/tests/trainer/diffusion/test_diffusion_distillation_losses_on_cpu.py
@@ -1,0 +1,301 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU tests for teacher-anchored continuous distillation losses (OPD, #293)."""
+
+import os
+
+import pytest
+import torch
+
+from verl_omni.trainer.diffusion.diffusion_algos import (
+    DIFFUSION_LOSS_REGISTRY,
+    DiffusionLossResult,
+    DistillFlowMatchingMSELoss,
+    DistillKLLoss,
+    get_diffusion_loss_fn,
+)
+from verl_omni.workers.config.diffusion import DiffusionLossConfig
+
+# ---------------------------------------------------------------------------
+# DistillKLLoss.compute_loss
+# ---------------------------------------------------------------------------
+
+
+class TestDistillKLLoss:
+    def setup_method(self):
+        self.loss_fn = DistillKLLoss()
+
+    def test_identical_means_gives_zero(self):
+        mean = torch.randn(4, 16, 3)
+        std_dev_t = torch.ones(4, 1, 1)
+
+        loss, _ = self.loss_fn.compute_loss(
+            prev_sample_mean=mean,
+            teacher_prev_sample_mean=mean.clone(),
+            std_dev_t=std_dev_t,
+        )
+
+        assert loss.item() == pytest.approx(0.0, abs=1e-6)
+
+    def test_matches_gaussian_kl_closed_form(self):
+        """Constant deviation d with unit variance gives KL = d^2 / 2."""
+        mean = torch.zeros(4, 16, 3)
+        teacher_mean = mean + 2.0
+        std_dev_t = torch.ones(4, 1, 1)
+
+        loss, _ = self.loss_fn.compute_loss(
+            prev_sample_mean=mean,
+            teacher_prev_sample_mean=teacher_mean,
+            std_dev_t=std_dev_t,
+        )
+
+        assert loss.item() == pytest.approx(2.0, rel=1e-5)
+
+    def test_larger_deviation_gives_larger_loss(self):
+        mean = torch.zeros(4, 16, 3)
+        std_dev_t = torch.ones(4, 1, 1)
+
+        loss_small, _ = self.loss_fn.compute_loss(
+            prev_sample_mean=mean,
+            teacher_prev_sample_mean=mean + 0.1,
+            std_dev_t=std_dev_t,
+        )
+        loss_large, _ = self.loss_fn.compute_loss(
+            prev_sample_mean=mean,
+            teacher_prev_sample_mean=mean + 10.0,
+            std_dev_t=std_dev_t,
+        )
+
+        assert loss_large.item() > loss_small.item()
+
+    def test_output_is_scalar_and_nonnegative(self):
+        loss, _ = self.loss_fn.compute_loss(
+            prev_sample_mean=torch.randn(2, 8, 4),
+            teacher_prev_sample_mean=torch.randn(2, 8, 4),
+            std_dev_t=torch.rand(2, 1, 1) + 0.1,
+        )
+
+        assert loss.shape == ()
+        assert loss.item() >= 0.0
+
+    def test_call_returns_result_with_metrics(self):
+        mean = torch.randn(4, 16, 3)
+        teacher_mean = torch.randn(4, 16, 3)
+        std_dev_t = torch.ones(4, 1, 1)
+
+        result = self.loss_fn(
+            config=None,
+            model_output={"prev_sample_mean": mean, "std_dev_t": std_dev_t},
+            data={"teacher_prev_sample_mean": teacher_mean},
+        )
+
+        assert isinstance(result, DiffusionLossResult)
+        assert "actor/distill_kl_loss" in result.metrics
+        assert result.metrics["actor/distill_kl_loss"] == pytest.approx(result.loss.item())
+
+    def test_validate_inputs_reports_missing_teacher_key(self):
+        with pytest.raises(KeyError) as exc_info:
+            self.loss_fn.validate_inputs(
+                loss_name="distill_kl",
+                model_output={"prev_sample_mean": torch.randn(4, 16, 3), "std_dev_t": torch.ones(4, 1, 1)},
+                data={"old_log_probs": torch.randn(4)},
+            )
+
+        message = str(exc_info.value)
+        assert "distill_kl" in message
+        assert "teacher_prev_sample_mean" in message
+
+
+# ---------------------------------------------------------------------------
+# DistillFlowMatchingMSELoss.compute_loss
+# ---------------------------------------------------------------------------
+
+
+class TestDistillFlowMatchingMSELoss:
+    def setup_method(self):
+        self.loss_fn = DistillFlowMatchingMSELoss()
+
+    def test_identical_predictions_give_zero(self):
+        pred = torch.randn(4, 16, 3)
+
+        loss, _ = self.loss_fn.compute_loss(
+            noise_pred=pred,
+            teacher_noise_pred=pred.clone(),
+        )
+
+        assert loss.item() == pytest.approx(0.0, abs=1e-6)
+
+    def test_matches_elementwise_mse(self):
+        """Constant deviation d gives MSE = d^2."""
+        pred = torch.zeros(4, 16, 3)
+        teacher_pred = pred + 3.0
+
+        loss, _ = self.loss_fn.compute_loss(
+            noise_pred=pred,
+            teacher_noise_pred=teacher_pred,
+        )
+
+        assert loss.item() == pytest.approx(9.0, rel=1e-5)
+
+    @pytest.mark.parametrize("shape", [(4, 16, 3), (2, 4, 8, 8), (1, 16, 3, 32, 32)])
+    def test_supports_image_and_video_shapes(self, shape):
+        pred = torch.randn(*shape)
+        teacher_pred = torch.randn(*shape)
+
+        loss, _ = self.loss_fn.compute_loss(
+            noise_pred=pred,
+            teacher_noise_pred=teacher_pred,
+        )
+
+        expected = torch.nn.functional.mse_loss(pred, teacher_pred)
+        assert loss.shape == ()
+        assert loss.item() == pytest.approx(expected.item(), rel=1e-5)
+
+    def test_call_returns_result_with_metrics(self):
+        pred = torch.randn(4, 16, 3)
+        teacher_pred = torch.randn(4, 16, 3)
+
+        result = self.loss_fn(
+            config=None,
+            model_output={"noise_pred": pred},
+            data={"teacher_noise_pred": teacher_pred},
+        )
+
+        assert isinstance(result, DiffusionLossResult)
+        assert "actor/distill_fm_mse_loss" in result.metrics
+        assert result.metrics["actor/distill_fm_mse_loss"] == pytest.approx(result.loss.item())
+
+    def test_validate_inputs_reports_missing_teacher_key(self):
+        with pytest.raises(KeyError) as exc_info:
+            self.loss_fn.validate_inputs(
+                loss_name="distill_fm_mse",
+                model_output={"noise_pred": torch.randn(4, 16, 3)},
+                data={},
+            )
+
+        message = str(exc_info.value)
+        assert "distill_fm_mse" in message
+        assert "teacher_noise_pred" in message
+
+
+# ---------------------------------------------------------------------------
+# Registry and config plumbing
+# ---------------------------------------------------------------------------
+
+
+class TestDistillationRegistryAndConfig:
+    def test_distill_kl_registered(self):
+        assert "distill_kl" in DIFFUSION_LOSS_REGISTRY
+        assert isinstance(get_diffusion_loss_fn("distill_kl"), DistillKLLoss)
+
+    def test_distill_fm_mse_registered(self):
+        assert "distill_fm_mse" in DIFFUSION_LOSS_REGISTRY
+        assert isinstance(get_diffusion_loss_fn("distill_fm_mse"), DistillFlowMatchingMSELoss)
+
+    @pytest.mark.parametrize("loss_mode", ["distill_kl", "distill_fm_mse"])
+    def test_diffusion_loss_config_accepts_distill_modes(self, loss_mode):
+        cfg = DiffusionLossConfig(loss_mode=loss_mode)
+        assert cfg.loss_mode == loss_mode
+
+    def test_diffusion_loss_config_still_rejects_unknown_mode(self):
+        with pytest.raises(ValueError):
+            DiffusionLossConfig(loss_mode="nonexistent_distill_loss")
+
+
+# ---------------------------------------------------------------------------
+# Auxiliary distillation term in the worker-side diffusion_loss entry point
+# ---------------------------------------------------------------------------
+
+
+def _compose_actor_config(overrides):
+    from hydra import compose, initialize_config_dir
+    from verl.utils.config import omega_conf_to_dataclass
+
+    import verl_omni
+
+    config_dir = os.path.join(os.path.dirname(verl_omni.__file__), "trainer/config/diffusion/actor")
+    with initialize_config_dir(config_dir=config_dir, version_base=None):
+        cfg = compose(
+            config_name="dp_diffusion_actor",
+            overrides=["strategy=fsdp", "ppo_micro_batch_size_per_gpu=4", *overrides],
+        )
+    return omega_conf_to_dataclass(cfg)
+
+
+class TestAuxiliaryDistillLoss:
+    def _build_batch(self):
+        from verl.utils import tensordict_utils as tu
+
+        torch.manual_seed(0)
+        model_output = {
+            "log_probs": torch.randn(4),
+            "prev_sample_mean": torch.randn(4, 16, 3),
+            "std_dev_t": torch.ones(4, 1, 1),
+        }
+        data = tu.get_tensordict(
+            {
+                "old_log_probs": torch.randn(4),
+                "advantages": torch.randn(4),
+                "teacher_prev_sample_mean": torch.randn(4, 16, 3),
+            }
+        )
+        tu.assign_non_tensor(data, gradient_accumulation_steps=1, sp_size=1)
+        return model_output, data
+
+    def test_use_distill_loss_adds_weighted_term(self):
+        from verl_omni.workers.utils.losses import diffusion_loss
+
+        coef = 0.5
+        actor_cfg = _compose_actor_config(
+            overrides=["use_distill_loss=true", f"distill_loss_coef={coef}", "distill_loss_mode=distill_kl"]
+        )
+        model_output, data = self._build_batch()
+
+        total_loss, metrics = diffusion_loss(actor_cfg, model_output, data)
+
+        pg_loss, _ = get_diffusion_loss_fn("flow_grpo").compute_loss(
+            old_log_prob=data["old_log_probs"],
+            log_prob=model_output["log_probs"],
+            advantages=data["advantages"],
+            config=actor_cfg,
+        )
+        distill_loss_value, _ = DistillKLLoss.compute_loss(
+            prev_sample_mean=model_output["prev_sample_mean"],
+            teacher_prev_sample_mean=data["teacher_prev_sample_mean"],
+            std_dev_t=model_output["std_dev_t"],
+        )
+
+        expected = (pg_loss + coef * distill_loss_value).item()
+        assert total_loss.item() == pytest.approx(expected, rel=1e-5)
+        assert "actor/distill_kl_loss" in metrics
+        assert "distill_coef" in metrics
+
+    def test_distill_disabled_by_default(self):
+        from verl_omni.workers.utils.losses import diffusion_loss
+
+        actor_cfg = _compose_actor_config(overrides=[])
+        assert actor_cfg.use_distill_loss is False
+
+        model_output, data = self._build_batch()
+        total_loss, metrics = diffusion_loss(actor_cfg, model_output, data)
+
+        pg_loss, _ = get_diffusion_loss_fn("flow_grpo").compute_loss(
+            old_log_prob=data["old_log_probs"],
+            log_prob=model_output["log_probs"],
+            advantages=data["advantages"],
+            config=actor_cfg,
+        )
+
+        assert total_loss.item() == pytest.approx(pg_loss.item(), rel=1e-5)
+        assert "actor/distill_kl_loss" not in metrics

--- a/verl_omni/trainer/config/_generated_diffusion_trainer.yaml
+++ b/verl_omni/trainer/config/_generated_diffusion_trainer.yaml
@@ -92,6 +92,9 @@ actor_rollout_ref:
     loss_scale_factor: null
     use_kl_loss: false
     kl_loss_coef: 0.001
+    use_distill_loss: false
+    distill_loss_mode: distill_kl
+    distill_loss_coef: 1.0
     ppo_epochs: 1
     shuffle: false
     data_loader_seed: 42

--- a/verl_omni/trainer/config/_generated_diffusion_veomni_trainer.yaml
+++ b/verl_omni/trainer/config/_generated_diffusion_veomni_trainer.yaml
@@ -104,6 +104,9 @@ actor_rollout_ref:
     loss_scale_factor: null
     use_kl_loss: false
     kl_loss_coef: 0.001
+    use_distill_loss: false
+    distill_loss_mode: distill_kl
+    distill_loss_coef: 1.0
     ppo_epochs: 1
     shuffle: false
     data_loader_seed: 42

--- a/verl_omni/trainer/config/diffusion/actor/diffusion_actor.yaml
+++ b/verl_omni/trainer/config/diffusion/actor/diffusion_actor.yaml
@@ -93,6 +93,15 @@ use_kl_loss: false
 # KL loss coefficient when use_kl_loss is enabled. For FlowGRPO
 kl_loss_coef: 0.001
 
+# Whether to add a teacher-anchored distillation loss (online policy distillation)
+use_distill_loss: false
+
+# Distillation loss mode: distill_kl or distill_fm_mse
+distill_loss_mode: distill_kl
+
+# Distillation loss coefficient
+distill_loss_coef: 1.0
+
 # Number of PPO epochs per batch
 ppo_epochs: 1
 

--- a/verl_omni/trainer/diffusion/diffusion_algos.py
+++ b/verl_omni/trainer/diffusion/diffusion_algos.py
@@ -1049,3 +1049,84 @@ class KLLoss(DiffusionLossFn):
             std_dev_t=model_output["std_dev_t"],
         )
         return DiffusionLossResult(loss=kl_loss, metrics=metrics)
+
+
+@register_diffusion_loss("distill_kl")
+class DistillKLLoss(DiffusionLossFn):
+    """KL divergence between student and teacher reverse-SDE means (online policy distillation)."""
+
+    required_model_output_keys = ("prev_sample_mean", "std_dev_t")
+    required_data_keys = ("teacher_prev_sample_mean",)
+
+    @classmethod
+    def compute_loss(
+        cls,
+        *,
+        prev_sample_mean: torch.Tensor,
+        teacher_prev_sample_mean: torch.Tensor,
+        std_dev_t: torch.Tensor,
+    ) -> tuple[torch.Tensor, dict[str, Any]]:
+        """Compute KL divergence given student and teacher previous sample means.
+
+        Args:
+            prev_sample_mean: (torch.Tensor) shape is (bs, s, c)
+            teacher_prev_sample_mean: (torch.Tensor) shape is (bs, s, c)
+            std_dev_t: (torch.Tensor) shape is (bs, 1, 1)
+        """
+        kl_loss = ((prev_sample_mean - teacher_prev_sample_mean) ** 2).mean(dim=(1, 2), keepdim=True) / (
+            2 * std_dev_t**2
+        )
+        metrics = {"actor/distill_kl_loss": kl_loss.mean().detach().item()}
+        return kl_loss.mean(), metrics
+
+    def __call__(
+        self,
+        *,
+        config: DiffusionActorConfig,
+        model_output: dict[str, Any],
+        data: TensorDict,
+    ) -> DiffusionLossResult:
+        distill_loss, metrics = self.compute_loss(
+            prev_sample_mean=model_output["prev_sample_mean"],
+            teacher_prev_sample_mean=data["teacher_prev_sample_mean"],
+            std_dev_t=model_output["std_dev_t"],
+        )
+        return DiffusionLossResult(loss=distill_loss, metrics=metrics)
+
+
+@register_diffusion_loss("distill_fm_mse")
+class DistillFlowMatchingMSELoss(DiffusionLossFn):
+    """MSE between student and teacher flow/noise predictions (online policy distillation)."""
+
+    required_model_output_keys = ("noise_pred",)
+    required_data_keys = ("teacher_noise_pred",)
+
+    @classmethod
+    def compute_loss(
+        cls,
+        *,
+        noise_pred: torch.Tensor,
+        teacher_noise_pred: torch.Tensor,
+    ) -> tuple[torch.Tensor, dict[str, Any]]:
+        """Compute the elementwise MSE between student and teacher predictions.
+
+        Args:
+            noise_pred: (torch.Tensor) shape is (bs, ...), e.g. (bs, s, c) or (bs, c, h, w)
+            teacher_noise_pred: (torch.Tensor) same shape as ``noise_pred``
+        """
+        mse_loss = ((noise_pred - teacher_noise_pred) ** 2).mean()
+        metrics = {"actor/distill_fm_mse_loss": mse_loss.detach().item()}
+        return mse_loss, metrics
+
+    def __call__(
+        self,
+        *,
+        config: DiffusionActorConfig,
+        model_output: dict[str, Any],
+        data: TensorDict,
+    ) -> DiffusionLossResult:
+        distill_loss, metrics = self.compute_loss(
+            noise_pred=model_output["noise_pred"],
+            teacher_noise_pred=data["teacher_noise_pred"],
+        )
+        return DiffusionLossResult(loss=distill_loss, metrics=metrics)

--- a/verl_omni/workers/config/diffusion/actor.py
+++ b/verl_omni/workers/config/diffusion/actor.py
@@ -49,7 +49,16 @@ class DiffusionLossConfig(BaseConfig):
 
     def __post_init__(self):
         """Validate diffusion loss configuration."""
-        valid_modes = ["flow_grpo", "flow_dppo", "grpo_guard", "diffusion_nft", "dpo", "dance_grpo"]
+        valid_modes = [
+            "flow_grpo",
+            "flow_dppo",
+            "grpo_guard",
+            "diffusion_nft",
+            "dpo",
+            "dance_grpo",
+            "distill_kl",
+            "distill_fm_mse",
+        ]
         if self.loss_mode not in valid_modes:
             raise ValueError(f"Invalid diffusion loss_mode: {self.loss_mode}. Must be one of {valid_modes}")
         if self.adv_clip_max <= 0:
@@ -137,6 +146,9 @@ class DiffusionActorConfig(BaseConfig):
     loss_scale_factor: Optional[float] = None
     use_kl_loss: bool = False
     kl_loss_coef: float = 0.001
+    use_distill_loss: bool = False
+    distill_loss_mode: str = "distill_kl"
+    distill_loss_coef: float = 1.0
     ppo_epochs: int = 1
     shuffle: bool = False
     data_loader_seed: int = 42
@@ -161,6 +173,11 @@ class DiffusionActorConfig(BaseConfig):
         """Validate diffusion actor configuration parameters."""
         assert self.strategy != MISSING
         assert self.rollout_n != MISSING
+        valid_distill_modes = ["distill_kl", "distill_fm_mse"]
+        if self.use_distill_loss and self.distill_loss_mode not in valid_distill_modes:
+            raise ValueError(
+                f"Invalid distill_loss_mode: {self.distill_loss_mode}. Must be one of {valid_distill_modes}"
+            )
 
 
 @dataclass

--- a/verl_omni/workers/engine/fsdp/diffusers_impl.py
+++ b/verl_omni/workers/engine/fsdp/diffusers_impl.py
@@ -911,6 +911,9 @@ class PPODiffusersFSDPEngine(DiffusersFSDPEngine):
             if micro_batch.get("ref_prev_sample_mean", None) is not None:
                 data["ref_prev_sample_mean"] = micro_batch["ref_prev_sample_mean"][:, step]
 
+            if micro_batch.get("teacher_prev_sample_mean", None) is not None:
+                data["teacher_prev_sample_mean"] = micro_batch["teacher_prev_sample_mean"][:, step]
+
             if micro_batch.get("old_prev_sample_mean", None) is not None:
                 data["old_prev_sample_mean"] = micro_batch["old_prev_sample_mean"][:, step]
 
@@ -1098,6 +1101,11 @@ class DPODiffusersFSDPEngine(DiffusersFSDPEngine):
                 if ref_noise_pred.ndim == model_output["noise_pred"].ndim + 1 and ref_noise_pred.shape[1] == 1:
                     ref_noise_pred = ref_noise_pred[:, 0]
                 data["ref_noise_pred"] = ref_noise_pred
+            if micro_batch.get("teacher_noise_pred", None) is not None:
+                teacher_noise_pred = micro_batch["teacher_noise_pred"]
+                if teacher_noise_pred.ndim == model_output["noise_pred"].ndim + 1 and teacher_noise_pred.shape[1] == 1:
+                    teacher_noise_pred = teacher_noise_pred[:, 0]
+                data["teacher_noise_pred"] = teacher_noise_pred
             loss, metrics = loss_function(model_output=model_output, data=data, dp_group=self.get_data_parallel_group())
         else:
             assert forward_only, "forward_only must be True when loss_function is None"

--- a/verl_omni/workers/engine/veomni/diffusion_impl.py
+++ b/verl_omni/workers/engine/veomni/diffusion_impl.py
@@ -419,6 +419,9 @@ class VeOmniDiffusionEngine(BaseEngine):
             if micro_batch.get("ref_prev_sample_mean", None) is not None:
                 data["ref_prev_sample_mean"] = micro_batch["ref_prev_sample_mean"][:, step]
 
+            if micro_batch.get("teacher_prev_sample_mean", None) is not None:
+                data["teacher_prev_sample_mean"] = micro_batch["teacher_prev_sample_mean"][:, step]
+
             if micro_batch.get("old_prev_sample_mean", None) is not None:
                 data["old_prev_sample_mean"] = micro_batch["old_prev_sample_mean"][:, step]
 

--- a/verl_omni/workers/utils/losses.py
+++ b/verl_omni/workers/utils/losses.py
@@ -110,6 +110,14 @@ def diffusion_loss(config: DiffusionActorConfig, model_output, data: TensorDict,
                 aggregation=AggregationType.MEAN,
             )
 
+    if config.use_distill_loss:
+        loss_func = get_diffusion_loss_fn(config.distill_loss_mode)
+        loss_func.validate_inputs(loss_name=config.distill_loss_mode, model_output=model_output, data=data)
+        distill_result = loss_func(config=config, model_output=model_output, data=data)
+        loss_value += distill_result.loss * config.distill_loss_coef
+        metrics.update(Metric.from_dict(distill_result.metrics, aggregation=AggregationType.MEAN))
+        metrics["distill_coef"] = config.distill_loss_coef
+
     gradient_accumulation_steps = tu.get_non_tensor_data(data, "gradient_accumulation_steps", default=None)
     loss_value = loss_value / gradient_accumulation_steps
 


### PR DESCRIPTION
### What does this PR do?

Implements the "Distillation Loss/Reward kernels" item of RFC #293: two continuous-latent distillation losses registered in `DIFFUSION_LOSS_REGISTRY`, usable standalone via `diffusion_loss.loss_mode` or as an auxiliary term alongside a policy-gradient loss via `use_distill_loss` / `distill_loss_coef` (mirrors `use_kl_loss`).

- `distill_kl`: Gaussian transition-kernel KL between student and teacher reverse-SDE means (same form as `KLLoss`, anchored to `teacher_prev_sample_mean`).
- `distill_fm_mse`: MSE between student and teacher flow/noise predictions (`teacher_noise_pred`), bypassing log-prob / Top-K machinery entirely.

Note on RFC #293 3: extending verl's `DISTILLATION_LOSS_REGISTRY` does not fit as written — `DistillationLossSettings` hard-requires top-k xor estimator (token) semantics, and the diffusion actor never passes through verl's token-based distillation pipeline. verl-omni's own `DIFFUSION_LOSS_REGISTRY` is the natural extension point. This PR is scoped to compose with (not replace) the TeacherWorker / trajectory-caching / pipeline-integration workstream: teacher targets enter through the documented `teacher_*` batch keys, per-step sliced in both engine impls (mirrors `ref_*`). Producing those tensors is out of scope here.

### Checklist Before Starting

- [x] Search for similar PRs: https://github.com/verl-project/verl-omni/pulls?q=is%3Apr+distillation (no PRs touch distillation; #293 has no linked PRs)
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

CPU unit tests (new file `tests/trainer/diffusion/test_diffusion_distillation_losses_on_cpu.py`, 20 cases):

```bash
pytest tests/trainer/diffusion/test_diffusion_distillation_losses_on_cpu.py  # 20 passed
pytest tests/trainer/                                                        # 116 passed
pre-commit run --all-files                                                    # clean
```

Coverage: closed-form KL/MSE value checks, zero-at-identity, monotonicity, image/video shapes, `validate_inputs` missing-key errors, registry/config plumbing, and signal-integrity of the auxiliary combination (`total == pg_loss + coef * distill_loss`; default-off leaves existing losses bit-identical).

The engine-side `teacher_*` per-step slicing follows the existing `ref_*` pattern and is a guarded no-op unless teacher tensors are present in the batch; it becomes exercisable end-to-end once a teacher producer lands (follow-up scope of #293).

### API and Usage Example

```yaml
# auxiliary distillation term alongside a policy-gradient loss
actor_rollout_ref.actor.use_distill_loss: true
actor_rollout_ref.actor.distill_loss_mode: distill_kl   # or distill_fm_mse
actor_rollout_ref.actor.distill_loss_coef: 1.0

# or pure supervised distillation
actor_rollout_ref.actor.diffusion_loss.loss_mode: distill_kl
```

Batch-key contract (produced by the future TeacherWorker, evaluated at the student's explored latents):

- `distill_kl`: `teacher_prev_sample_mean` (bs, num_steps, s, c), per-step sliced like `ref_prev_sample_mean`
- `distill_fm_mse`: `teacher_noise_pred`, handled like `ref_noise_pred`

### Design & Code Changes

- `verl_omni/trainer/diffusion/diffusion_algos.py`: `DistillKLLoss`, `DistillFlowMatchingMSELoss` (registered; follows Step 3 of the diffusion algorithm integration guide — adapter/estimator/launch-script checklist items do not apply since this adds loss kernels, not a new algorithm)
- `verl_omni/workers/config/diffusion/actor.py`: new modes in `valid_modes`; `use_distill_loss` / `distill_loss_mode` / `distill_loss_coef` fields + validation
- `verl_omni/workers/utils/losses.py`: auxiliary distillation term in `diffusion_loss()`, mirroring the `use_kl_loss` block
- `verl_omni/workers/engine/fsdp/diffusers_impl.py`, `verl_omni/workers/engine/veomni/diffusion_impl.py`: `teacher_*` batch-key slicing, mirroring `ref_*`
- `verl_omni/trainer/config/diffusion/actor/diffusion_actor.yaml` + regenerated `_generated_*.yaml`

