### PR TITLE
[trainer, worker, cfg] feat: OPD end-to-end draft — teacher-in-ref + distill verification (#293)

### DIFF
--- a/scripts/merge_lora_teacher.py
+++ b/scripts/merge_lora_teacher.py
@@ -1,0 +1,67 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Merge a LoRA checkpoint into a base diffusion model to build a distillation teacher.
+
+Produces a full model directory usable as ``actor_rollout_ref.ref.model_path``:
+the merged transformer is saved for real, every other pipeline component is
+symlinked from the base model directory.
+
+Usage:
+    python scripts/merge_lora_teacher.py \
+        --base_model /path/to/stable-diffusion-3.5-medium \
+        --lora_adapter checkpoints/<proj>/<exp>/global_step_100/actor/lora_adapter \
+        --output /path/to/teacher_dir
+"""
+
+import argparse
+import os
+
+import torch
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base_model", required=True, help="Base model directory (diffusers layout).")
+    parser.add_argument("--lora_adapter", required=True, help="PEFT LoRA adapter directory from a checkpoint.")
+    parser.add_argument("--output", required=True, help="Output teacher model directory.")
+    parser.add_argument("--subfolder", default="transformer", help="Pipeline subfolder the adapter applies to.")
+    args = parser.parse_args()
+
+    from diffusers import SD3Transformer2DModel
+    from peft import PeftModel
+
+    base_model = os.path.abspath(os.path.expanduser(args.base_model))
+    output = os.path.abspath(os.path.expanduser(args.output))
+
+    transformer = SD3Transformer2DModel.from_pretrained(
+        base_model, subfolder=args.subfolder, torch_dtype=torch.bfloat16
+    )
+    transformer = PeftModel.from_pretrained(transformer, os.path.expanduser(args.lora_adapter))
+    transformer = transformer.merge_and_unload()
+
+    os.makedirs(output, exist_ok=True)
+    transformer.save_pretrained(os.path.join(output, args.subfolder))
+
+    for entry in os.listdir(base_model):
+        if entry == args.subfolder or entry.startswith("."):
+            continue
+        dst = os.path.join(output, entry)
+        if not os.path.exists(dst):
+            os.symlink(os.path.join(base_model, entry), dst)
+
+    print(f"Teacher model written to {output} (merged {args.subfolder} + symlinked components)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/merge_lora_teacher.py
+++ b/scripts/merge_lora_teacher.py
@@ -11,55 +11,127 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Merge a LoRA checkpoint into a base diffusion model to build a distillation teacher.
+"""Merge a sharded FSDP LoRA checkpoint into a base diffusion model to build a distillation teacher.
 
-Produces a full model directory usable as ``actor_rollout_ref.ref.model_path``:
-the merged transformer is saved for real, every other pipeline component is
-symlinked from the base model directory.
+Reads ``model_world_size_{W}_rank_{r}.pt`` shards saved by the FSDP checkpoint
+manager (peft-wrapped keys, DTensor values), folds LoRA deltas into the base
+weights, and writes a full model directory usable as
+``actor_rollout_ref.ref.model_path``: the merged transformer is saved for real,
+every other pipeline component is symlinked from the base model directory.
 
 Usage:
     python scripts/merge_lora_teacher.py \
         --base_model /path/to/stable-diffusion-3.5-medium \
-        --lora_adapter checkpoints/<proj>/<exp>/global_step_100/actor/lora_adapter \
+        --checkpoint checkpoints/<proj>/<exp>/global_step_100/actor \
         --output /path/to/teacher_dir
 """
 
 import argparse
+import glob
+import json
 import os
+import re
 
 import torch
+from torch.distributed.tensor import DTensor
+
+
+def load_full_state_dict(ckpt_dir: str) -> dict[str, torch.Tensor]:
+    """Load all FSDP rank shards and concatenate DTensor locals along the shard dim."""
+    shard_paths = sorted(
+        glob.glob(os.path.join(ckpt_dir, "model_world_size_*_rank_*.pt")),
+        key=lambda p: int(re.search(r"rank_(\d+)\.pt$", p).group(1)),
+    )
+    assert shard_paths, f"No model_world_size_*_rank_*.pt found in {ckpt_dir}"
+    shards = [torch.load(p, map_location="cpu", weights_only=False) for p in shard_paths]
+
+    state_dict = {}
+    for key in shards[0]:
+        values = [shard[key] for shard in shards]
+        if isinstance(values[0], DTensor):
+            placement = values[0].placements[0]
+            locals_ = [v._local_tensor.bfloat16() for v in values]
+            state_dict[key] = locals_[0] if placement.is_replicate() else torch.cat(locals_, dim=placement.dim)
+        elif len(values) > 1 and not all(torch.equal(values[0], v) for v in values[1:]):
+            state_dict[key] = torch.cat([v.bfloat16() for v in values], dim=0)
+        else:
+            state_dict[key] = values[0].bfloat16()
+    return state_dict
+
+
+def normalize_key(key: str) -> str:
+    """Map peft/FSDP-wrapped names back to plain module names."""
+    for prefix in ("base_model.model.", "_orig_mod.", "module."):
+        key = key.replace(prefix, "")
+    return key.replace(".base_layer.", ".")
 
 
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--base_model", required=True, help="Base model directory (diffusers layout).")
-    parser.add_argument("--lora_adapter", required=True, help="PEFT LoRA adapter directory from a checkpoint.")
+    parser.add_argument("--checkpoint", required=True, help="Checkpoint actor dir with model_world_size_*.pt shards.")
     parser.add_argument("--output", required=True, help="Output teacher model directory.")
-    parser.add_argument("--subfolder", default="transformer", help="Pipeline subfolder the adapter applies to.")
+    parser.add_argument("--subfolder", default="transformer", help="Pipeline subfolder the LoRA applies to.")
+    parser.add_argument("--lora_rank", type=int, default=None, help="Override LoRA r (default: lora_train_meta.json).")
+    parser.add_argument("--lora_alpha", type=int, default=None, help="Override LoRA alpha (same default).")
     args = parser.parse_args()
 
     from diffusers import SD3Transformer2DModel
-    from peft import PeftModel
 
     base_model = os.path.abspath(os.path.expanduser(args.base_model))
+    ckpt = os.path.abspath(os.path.expanduser(args.checkpoint))
     output = os.path.abspath(os.path.expanduser(args.output))
 
+    r, alpha = args.lora_rank, args.lora_alpha
+    for meta_path in (
+        os.path.join(os.path.dirname(ckpt), "lora_train_meta.json"),
+        os.path.join(ckpt, "lora_train_meta.json"),
+    ):
+        if os.path.exists(meta_path) and (r is None or alpha is None):
+            with open(meta_path) as f:
+                meta = json.load(f)
+            r = r if r is not None else int(meta["r"])
+            alpha = alpha if alpha is not None else int(meta["lora_alpha"])
+            break
+    assert r and alpha, "LoRA r/alpha not found; pass --lora_rank/--lora_alpha"
+    scale = alpha / r
+
+    # Split checkpoint into base-weight overrides and LoRA A/B pairs.
+    base_overrides: dict[str, torch.Tensor] = {}
+    lora_a: dict[str, torch.Tensor] = {}
+    lora_b: dict[str, torch.Tensor] = {}
+    for key, value in load_full_state_dict(ckpt).items():
+        norm = normalize_key(key)
+        m = re.match(r"(.*)\.lora_(A|B)(?:\.default)?\.weight$", norm)
+        if m:
+            (lora_a if m.group(2) == "A" else lora_b)[m.group(1)] = value
+        else:
+            base_overrides[norm] = value
+    assert set(lora_a) == set(lora_b), "Mismatched lora_A/lora_B key sets"
+
+    # Overlay onto the base transformer, then fold in W += scale * B @ A.
     transformer = SD3Transformer2DModel.from_pretrained(
         base_model, subfolder=args.subfolder, torch_dtype=torch.bfloat16
     )
-    transformer = PeftModel.from_pretrained(transformer, os.path.expanduser(args.lora_adapter))
-    transformer = transformer.merge_and_unload()
+    full = transformer.state_dict()
+    unknown = [k for k in base_overrides if k not in full]
+    assert not unknown, f"Checkpoint keys not in base model (first 5): {unknown[:5]}"
+    full.update(base_overrides)
+    for module, a in lora_a.items():
+        target = f"{module}.weight"
+        assert target in full, f"LoRA target {target} missing from base model"
+        full[target] = full[target] + scale * (lora_b[module].float() @ a.float()).bfloat16()
+    transformer.load_state_dict(full, strict=True)
+    print(f"Merged {len(lora_a)} LoRA layers (scale={scale}), overrode {len(base_overrides)} base tensors")
 
     os.makedirs(output, exist_ok=True)
     transformer.save_pretrained(os.path.join(output, args.subfolder))
-
     for entry in os.listdir(base_model):
         if entry == args.subfolder or entry.startswith("."):
             continue
         dst = os.path.join(output, entry)
         if not os.path.exists(dst):
             os.symlink(os.path.join(base_model, entry), dst)
-
     print(f"Teacher model written to {output} (merged {args.subfolder} + symlinked components)")
 
 

--- a/tests/trainer/diffusion/test_diffusion_distillation_losses_on_cpu.py
+++ b/tests/trainer/diffusion/test_diffusion_distillation_losses_on_cpu.py
@@ -1,0 +1,301 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU tests for teacher-anchored continuous distillation losses (OPD, #293)."""
+
+import os
+
+import pytest
+import torch
+
+from verl_omni.trainer.diffusion.diffusion_algos import (
+    DIFFUSION_LOSS_REGISTRY,
+    DiffusionLossResult,
+    DistillFlowMatchingMSELoss,
+    DistillKLLoss,
+    get_diffusion_loss_fn,
+)
+from verl_omni.workers.config.diffusion import DiffusionLossConfig
+
+# ---------------------------------------------------------------------------
+# DistillKLLoss.compute_loss
+# ---------------------------------------------------------------------------
+
+
+class TestDistillKLLoss:
+    def setup_method(self):
+        self.loss_fn = DistillKLLoss()
+
+    def test_identical_means_gives_zero(self):
+        mean = torch.randn(4, 16, 3)
+        std_dev_t = torch.ones(4, 1, 1)
+
+        loss, _ = self.loss_fn.compute_loss(
+            prev_sample_mean=mean,
+            teacher_prev_sample_mean=mean.clone(),
+            std_dev_t=std_dev_t,
+        )
+
+        assert loss.item() == pytest.approx(0.0, abs=1e-6)
+
+    def test_matches_gaussian_kl_closed_form(self):
+        """Constant deviation d with unit variance gives KL = d^2 / 2."""
+        mean = torch.zeros(4, 16, 3)
+        teacher_mean = mean + 2.0
+        std_dev_t = torch.ones(4, 1, 1)
+
+        loss, _ = self.loss_fn.compute_loss(
+            prev_sample_mean=mean,
+            teacher_prev_sample_mean=teacher_mean,
+            std_dev_t=std_dev_t,
+        )
+
+        assert loss.item() == pytest.approx(2.0, rel=1e-5)
+
+    def test_larger_deviation_gives_larger_loss(self):
+        mean = torch.zeros(4, 16, 3)
+        std_dev_t = torch.ones(4, 1, 1)
+
+        loss_small, _ = self.loss_fn.compute_loss(
+            prev_sample_mean=mean,
+            teacher_prev_sample_mean=mean + 0.1,
+            std_dev_t=std_dev_t,
+        )
+        loss_large, _ = self.loss_fn.compute_loss(
+            prev_sample_mean=mean,
+            teacher_prev_sample_mean=mean + 10.0,
+            std_dev_t=std_dev_t,
+        )
+
+        assert loss_large.item() > loss_small.item()
+
+    def test_output_is_scalar_and_nonnegative(self):
+        loss, _ = self.loss_fn.compute_loss(
+            prev_sample_mean=torch.randn(2, 8, 4),
+            teacher_prev_sample_mean=torch.randn(2, 8, 4),
+            std_dev_t=torch.rand(2, 1, 1) + 0.1,
+        )
+
+        assert loss.shape == ()
+        assert loss.item() >= 0.0
+
+    def test_call_returns_result_with_metrics(self):
+        mean = torch.randn(4, 16, 3)
+        teacher_mean = torch.randn(4, 16, 3)
+        std_dev_t = torch.ones(4, 1, 1)
+
+        result = self.loss_fn(
+            config=None,
+            model_output={"prev_sample_mean": mean, "std_dev_t": std_dev_t},
+            data={"teacher_prev_sample_mean": teacher_mean},
+        )
+
+        assert isinstance(result, DiffusionLossResult)
+        assert "actor/distill_kl_loss" in result.metrics
+        assert result.metrics["actor/distill_kl_loss"] == pytest.approx(result.loss.item())
+
+    def test_validate_inputs_reports_missing_teacher_key(self):
+        with pytest.raises(KeyError) as exc_info:
+            self.loss_fn.validate_inputs(
+                loss_name="distill_kl",
+                model_output={"prev_sample_mean": torch.randn(4, 16, 3), "std_dev_t": torch.ones(4, 1, 1)},
+                data={"old_log_probs": torch.randn(4)},
+            )
+
+        message = str(exc_info.value)
+        assert "distill_kl" in message
+        assert "teacher_prev_sample_mean" in message
+
+
+# ---------------------------------------------------------------------------
+# DistillFlowMatchingMSELoss.compute_loss
+# ---------------------------------------------------------------------------
+
+
+class TestDistillFlowMatchingMSELoss:
+    def setup_method(self):
+        self.loss_fn = DistillFlowMatchingMSELoss()
+
+    def test_identical_predictions_give_zero(self):
+        pred = torch.randn(4, 16, 3)
+
+        loss, _ = self.loss_fn.compute_loss(
+            noise_pred=pred,
+            teacher_noise_pred=pred.clone(),
+        )
+
+        assert loss.item() == pytest.approx(0.0, abs=1e-6)
+
+    def test_matches_elementwise_mse(self):
+        """Constant deviation d gives MSE = d^2."""
+        pred = torch.zeros(4, 16, 3)
+        teacher_pred = pred + 3.0
+
+        loss, _ = self.loss_fn.compute_loss(
+            noise_pred=pred,
+            teacher_noise_pred=teacher_pred,
+        )
+
+        assert loss.item() == pytest.approx(9.0, rel=1e-5)
+
+    @pytest.mark.parametrize("shape", [(4, 16, 3), (2, 4, 8, 8), (1, 16, 3, 32, 32)])
+    def test_supports_image_and_video_shapes(self, shape):
+        pred = torch.randn(*shape)
+        teacher_pred = torch.randn(*shape)
+
+        loss, _ = self.loss_fn.compute_loss(
+            noise_pred=pred,
+            teacher_noise_pred=teacher_pred,
+        )
+
+        expected = torch.nn.functional.mse_loss(pred, teacher_pred)
+        assert loss.shape == ()
+        assert loss.item() == pytest.approx(expected.item(), rel=1e-5)
+
+    def test_call_returns_result_with_metrics(self):
+        pred = torch.randn(4, 16, 3)
+        teacher_pred = torch.randn(4, 16, 3)
+
+        result = self.loss_fn(
+            config=None,
+            model_output={"noise_pred": pred},
+            data={"teacher_noise_pred": teacher_pred},
+        )
+
+        assert isinstance(result, DiffusionLossResult)
+        assert "actor/distill_fm_mse_loss" in result.metrics
+        assert result.metrics["actor/distill_fm_mse_loss"] == pytest.approx(result.loss.item())
+
+    def test_validate_inputs_reports_missing_teacher_key(self):
+        with pytest.raises(KeyError) as exc_info:
+            self.loss_fn.validate_inputs(
+                loss_name="distill_fm_mse",
+                model_output={"noise_pred": torch.randn(4, 16, 3)},
+                data={},
+            )
+
+        message = str(exc_info.value)
+        assert "distill_fm_mse" in message
+        assert "teacher_noise_pred" in message
+
+
+# ---------------------------------------------------------------------------
+# Registry and config plumbing
+# ---------------------------------------------------------------------------
+
+
+class TestDistillationRegistryAndConfig:
+    def test_distill_kl_registered(self):
+        assert "distill_kl" in DIFFUSION_LOSS_REGISTRY
+        assert isinstance(get_diffusion_loss_fn("distill_kl"), DistillKLLoss)
+
+    def test_distill_fm_mse_registered(self):
+        assert "distill_fm_mse" in DIFFUSION_LOSS_REGISTRY
+        assert isinstance(get_diffusion_loss_fn("distill_fm_mse"), DistillFlowMatchingMSELoss)
+
+    @pytest.mark.parametrize("loss_mode", ["distill_kl", "distill_fm_mse"])
+    def test_diffusion_loss_config_accepts_distill_modes(self, loss_mode):
+        cfg = DiffusionLossConfig(loss_mode=loss_mode)
+        assert cfg.loss_mode == loss_mode
+
+    def test_diffusion_loss_config_still_rejects_unknown_mode(self):
+        with pytest.raises(ValueError):
+            DiffusionLossConfig(loss_mode="nonexistent_distill_loss")
+
+
+# ---------------------------------------------------------------------------
+# Auxiliary distillation term in the worker-side diffusion_loss entry point
+# ---------------------------------------------------------------------------
+
+
+def _compose_actor_config(overrides):
+    from hydra import compose, initialize_config_dir
+    from verl.utils.config import omega_conf_to_dataclass
+
+    import verl_omni
+
+    config_dir = os.path.join(os.path.dirname(verl_omni.__file__), "trainer/config/diffusion/actor")
+    with initialize_config_dir(config_dir=config_dir, version_base=None):
+        cfg = compose(
+            config_name="dp_diffusion_actor",
+            overrides=["strategy=fsdp", "ppo_micro_batch_size_per_gpu=4", *overrides],
+        )
+    return omega_conf_to_dataclass(cfg)
+
+
+class TestAuxiliaryDistillLoss:
+    def _build_batch(self):
+        from verl.utils import tensordict_utils as tu
+
+        torch.manual_seed(0)
+        model_output = {
+            "log_probs": torch.randn(4),
+            "prev_sample_mean": torch.randn(4, 16, 3),
+            "std_dev_t": torch.ones(4, 1, 1),
+        }
+        data = tu.get_tensordict(
+            {
+                "old_log_probs": torch.randn(4),
+                "advantages": torch.randn(4),
+                "teacher_prev_sample_mean": torch.randn(4, 16, 3),
+            }
+        )
+        tu.assign_non_tensor(data, gradient_accumulation_steps=1, sp_size=1)
+        return model_output, data
+
+    def test_use_distill_loss_adds_weighted_term(self):
+        from verl_omni.workers.utils.losses import diffusion_loss
+
+        coef = 0.5
+        actor_cfg = _compose_actor_config(
+            overrides=["use_distill_loss=true", f"distill_loss_coef={coef}", "distill_loss_mode=distill_kl"]
+        )
+        model_output, data = self._build_batch()
+
+        total_loss, metrics = diffusion_loss(actor_cfg, model_output, data)
+
+        pg_loss, _ = get_diffusion_loss_fn("flow_grpo").compute_loss(
+            old_log_prob=data["old_log_probs"],
+            log_prob=model_output["log_probs"],
+            advantages=data["advantages"],
+            config=actor_cfg,
+        )
+        distill_loss_value, _ = DistillKLLoss.compute_loss(
+            prev_sample_mean=model_output["prev_sample_mean"],
+            teacher_prev_sample_mean=data["teacher_prev_sample_mean"],
+            std_dev_t=model_output["std_dev_t"],
+        )
+
+        expected = (pg_loss + coef * distill_loss_value).item()
+        assert total_loss.item() == pytest.approx(expected, rel=1e-5)
+        assert "actor/distill_kl_loss" in metrics
+        assert "distill_coef" in metrics
+
+    def test_distill_disabled_by_default(self):
+        from verl_omni.workers.utils.losses import diffusion_loss
+
+        actor_cfg = _compose_actor_config(overrides=[])
+        assert actor_cfg.use_distill_loss is False
+
+        model_output, data = self._build_batch()
+        total_loss, metrics = diffusion_loss(actor_cfg, model_output, data)
+
+        pg_loss, _ = get_diffusion_loss_fn("flow_grpo").compute_loss(
+            old_log_prob=data["old_log_probs"],
+            log_prob=model_output["log_probs"],
+            advantages=data["advantages"],
+            config=actor_cfg,
+        )
+
+        assert total_loss.item() == pytest.approx(pg_loss.item(), rel=1e-5)
+        assert "actor/distill_kl_loss" not in metrics

--- a/verl_omni/trainer/config/_generated_diffusion_trainer.yaml
+++ b/verl_omni/trainer/config/_generated_diffusion_trainer.yaml
@@ -92,6 +92,9 @@ actor_rollout_ref:
     loss_scale_factor: null
     use_kl_loss: false
     kl_loss_coef: 0.001
+    use_distill_loss: false
+    distill_loss_mode: distill_kl
+    distill_loss_coef: 1.0
     ppo_epochs: 1
     shuffle: false
     data_loader_seed: 42

--- a/verl_omni/trainer/config/_generated_diffusion_trainer.yaml
+++ b/verl_omni/trainer/config/_generated_diffusion_trainer.yaml
@@ -111,6 +111,7 @@ actor_rollout_ref:
     rollout_n: ${oc.select:actor_rollout_ref.rollout.n,1}
     strategy: ${actor_rollout_ref.actor.strategy}
     log_prob_micro_batch_size_per_gpu: null
+    model_path: null
     fsdp_config:
       _target_: verl.workers.config.FSDPEngineConfig
       wrap_policy:

--- a/verl_omni/trainer/config/_generated_diffusion_veomni_trainer.yaml
+++ b/verl_omni/trainer/config/_generated_diffusion_veomni_trainer.yaml
@@ -104,6 +104,9 @@ actor_rollout_ref:
     loss_scale_factor: null
     use_kl_loss: false
     kl_loss_coef: 0.001
+    use_distill_loss: false
+    distill_loss_mode: distill_kl
+    distill_loss_coef: 1.0
     ppo_epochs: 1
     shuffle: false
     data_loader_seed: 42

--- a/verl_omni/trainer/config/_generated_diffusion_veomni_trainer.yaml
+++ b/verl_omni/trainer/config/_generated_diffusion_veomni_trainer.yaml
@@ -122,6 +122,7 @@ actor_rollout_ref:
     rollout_n: ${oc.select:actor_rollout_ref.rollout.n,1}
     strategy: veomni
     log_prob_micro_batch_size_per_gpu: null
+    model_path: null
     veomni_config:
       _target_: verl_omni.workers.config.diffusion.VeOmniDiffusionEngineConfig
       param_offload: false

--- a/verl_omni/trainer/config/diffusion/actor/diffusion_actor.yaml
+++ b/verl_omni/trainer/config/diffusion/actor/diffusion_actor.yaml
@@ -93,6 +93,15 @@ use_kl_loss: false
 # KL loss coefficient when use_kl_loss is enabled. For FlowGRPO
 kl_loss_coef: 0.001
 
+# Whether to add a teacher-anchored distillation loss (online policy distillation)
+use_distill_loss: false
+
+# Distillation loss mode: distill_kl or distill_fm_mse
+distill_loss_mode: distill_kl
+
+# Distillation loss coefficient
+distill_loss_coef: 1.0
+
 # Number of PPO epochs per batch
 ppo_epochs: 1
 

--- a/verl_omni/trainer/config/diffusion/ref/diffusion_ref.yaml
+++ b/verl_omni/trainer/config/diffusion/ref/diffusion_ref.yaml
@@ -6,3 +6,8 @@ strategy: ${actor_rollout_ref.actor.strategy}
 
 # The batch size for one forward pass in the computation of log_prob. Local batch size per GPU.
 log_prob_micro_batch_size_per_gpu: null
+
+# Optional checkpoint override for the ref model. When set, the ref worker acts as a
+# distillation teacher: it loads this checkpoint (merged weights, no LoRA) and its
+# per-step means are exposed as teacher_prev_sample_mean for distill losses.
+model_path: null

--- a/verl_omni/trainer/diffusion/diffusion_algos.py
+++ b/verl_omni/trainer/diffusion/diffusion_algos.py
@@ -1049,3 +1049,84 @@ class KLLoss(DiffusionLossFn):
             std_dev_t=model_output["std_dev_t"],
         )
         return DiffusionLossResult(loss=kl_loss, metrics=metrics)
+
+
+@register_diffusion_loss("distill_kl")
+class DistillKLLoss(DiffusionLossFn):
+    """KL divergence between student and teacher reverse-SDE means (online policy distillation)."""
+
+    required_model_output_keys = ("prev_sample_mean", "std_dev_t")
+    required_data_keys = ("teacher_prev_sample_mean",)
+
+    @classmethod
+    def compute_loss(
+        cls,
+        *,
+        prev_sample_mean: torch.Tensor,
+        teacher_prev_sample_mean: torch.Tensor,
+        std_dev_t: torch.Tensor,
+    ) -> tuple[torch.Tensor, dict[str, Any]]:
+        """Compute KL divergence given student and teacher previous sample means.
+
+        Args:
+            prev_sample_mean: (torch.Tensor) shape is (bs, s, c)
+            teacher_prev_sample_mean: (torch.Tensor) shape is (bs, s, c)
+            std_dev_t: (torch.Tensor) shape is (bs, 1, 1)
+        """
+        kl_loss = ((prev_sample_mean - teacher_prev_sample_mean) ** 2).mean(dim=(1, 2), keepdim=True) / (
+            2 * std_dev_t**2
+        )
+        metrics = {"actor/distill_kl_loss": kl_loss.mean().detach().item()}
+        return kl_loss.mean(), metrics
+
+    def __call__(
+        self,
+        *,
+        config: DiffusionActorConfig,
+        model_output: dict[str, Any],
+        data: TensorDict,
+    ) -> DiffusionLossResult:
+        distill_loss, metrics = self.compute_loss(
+            prev_sample_mean=model_output["prev_sample_mean"],
+            teacher_prev_sample_mean=data["teacher_prev_sample_mean"],
+            std_dev_t=model_output["std_dev_t"],
+        )
+        return DiffusionLossResult(loss=distill_loss, metrics=metrics)
+
+
+@register_diffusion_loss("distill_fm_mse")
+class DistillFlowMatchingMSELoss(DiffusionLossFn):
+    """MSE between student and teacher flow/noise predictions (online policy distillation)."""
+
+    required_model_output_keys = ("noise_pred",)
+    required_data_keys = ("teacher_noise_pred",)
+
+    @classmethod
+    def compute_loss(
+        cls,
+        *,
+        noise_pred: torch.Tensor,
+        teacher_noise_pred: torch.Tensor,
+    ) -> tuple[torch.Tensor, dict[str, Any]]:
+        """Compute the elementwise MSE between student and teacher predictions.
+
+        Args:
+            noise_pred: (torch.Tensor) shape is (bs, ...), e.g. (bs, s, c) or (bs, c, h, w)
+            teacher_noise_pred: (torch.Tensor) same shape as ``noise_pred``
+        """
+        mse_loss = ((noise_pred - teacher_noise_pred) ** 2).mean()
+        metrics = {"actor/distill_fm_mse_loss": mse_loss.detach().item()}
+        return mse_loss, metrics
+
+    def __call__(
+        self,
+        *,
+        config: DiffusionActorConfig,
+        model_output: dict[str, Any],
+        data: TensorDict,
+    ) -> DiffusionLossResult:
+        distill_loss, metrics = self.compute_loss(
+            noise_pred=model_output["noise_pred"],
+            teacher_noise_pred=data["teacher_noise_pred"],
+        )
+        return DiffusionLossResult(loss=distill_loss, metrics=metrics)

--- a/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
+++ b/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
@@ -1210,6 +1210,11 @@ class DirectPreferenceRayTrainer(BaseRayDiffusionTrainer):
         **kwargs,
     ):
         super().__init__(config, *args, **kwargs)
+        if self.teacher_in_ref:
+            raise NotImplementedError(
+                "ref.model_path (teacher-in-ref) is only wired for the policy-gradient trainer; "
+                "the direct-preference path consumes ref_noise_pred from the initial policy."
+            )
         self.is_offline = config.algorithm.get("sample_source", "online") == "offline"
         loss_mode = config.actor_rollout_ref.actor.diffusion_loss.loss_mode
         # DPO needs trainer-side ref noise preds; DiffusionNFT computes ref in the actor engine.

--- a/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
+++ b/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
@@ -177,7 +177,15 @@ class BaseRayDiffusionTrainer(ABC):
 
         self.role_worker_mapping = role_worker_mapping
         self.resource_pool_manager = resource_pool_manager
-        self.use_reference_policy = need_reference_policy(self.config)
+        # ref.model_path turns the ref worker into a distillation teacher; its outputs
+        # are additionally exposed as teacher_* keys.
+        self.teacher_in_ref = config.actor_rollout_ref.ref.get("model_path") is not None
+        self.use_reference_policy = need_reference_policy(self.config) or self.teacher_in_ref
+        if self.teacher_in_ref and need_reference_policy(self.config):
+            raise ValueError(
+                "ref.model_path repurposes the ref worker as the distillation teacher, which conflicts "
+                "with use_kl_loss/use_kl_in_reward needing the ref to hold the initial policy weights."
+            )
 
         self.use_rm = need_reward_model(self.config)
         self.ray_worker_group_cls = ray_worker_group_cls
@@ -191,7 +199,9 @@ class BaseRayDiffusionTrainer(ABC):
         lora_rank = config.actor_rollout_ref.model.get("lora", {}).get("rank", 0)
         if lora_rank <= 0:
             lora_rank = config.actor_rollout_ref.model.get("lora_rank", 0)
-        self.ref_in_actor = lora_rank > 0 or config.actor_rollout_ref.model.get("lora_adapter_path") is not None
+        self.ref_in_actor = (
+            lora_rank > 0 or config.actor_rollout_ref.model.get("lora_adapter_path") is not None
+        ) and not self.teacher_in_ref
 
         self._create_dataloader(train_dataset, val_dataset, collate_fn, train_sampler)
 
@@ -869,9 +879,10 @@ class PolicyGradientRayTrainer(BaseRayDiffusionTrainer):
         # gather output
         log_probs = tu.get(output, "log_probs")
         prev_sample_mean = tu.get(output, "prev_sample_mean")
-        ref_log_prob = tu.get_tensordict(
-            {"ref_log_prob": log_probs.float(), "ref_prev_sample_mean": prev_sample_mean.float()}
-        )
+        ref_output = {"ref_log_prob": log_probs.float(), "ref_prev_sample_mean": prev_sample_mean.float()}
+        if self.teacher_in_ref:
+            ref_output["teacher_prev_sample_mean"] = prev_sample_mean.float()
+        ref_log_prob = tu.get_tensordict(ref_output)
         return DataProto.from_tensordict(ref_log_prob)
 
     def _compute_old_log_prob(self, batch: DataProto) -> tuple[DataProto, Optional[float]]:

--- a/verl_omni/trainer/main_diffusion.py
+++ b/verl_omni/trainer/main_diffusion.py
@@ -141,11 +141,15 @@ class TaskRunner:
             lora_rank = config.actor_rollout_ref.model.get("lora_rank", 0)
         ref_in_actor = lora_rank > 0 or config.actor_rollout_ref.model.get("lora_adapter_path") is not None
 
+        # A teacher checkpoint override always needs a standalone ref model, even for
+        # LoRA runs where the KL ref would otherwise be the actor without adapters.
+        teacher_in_ref = config.actor_rollout_ref.ref.get("model_path") is not None
+
         if config.algorithm.sample_source == "offline":
             if not hasattr(Role, "Actor"):
                 raise ValueError("Offline training without rollout requires verl Role.Actor support.")
             role = Role.Actor
-        elif need_reference_policy(config) and not ref_in_actor:
+        elif teacher_in_ref or (need_reference_policy(config) and not ref_in_actor):
             role = Role.ActorRolloutRef
         else:
             role = Role.ActorRollout

--- a/verl_omni/workers/config/diffusion/actor.py
+++ b/verl_omni/workers/config/diffusion/actor.py
@@ -49,7 +49,16 @@ class DiffusionLossConfig(BaseConfig):
 
     def __post_init__(self):
         """Validate diffusion loss configuration."""
-        valid_modes = ["flow_grpo", "flow_dppo", "grpo_guard", "diffusion_nft", "dpo", "dance_grpo"]
+        valid_modes = [
+            "flow_grpo",
+            "flow_dppo",
+            "grpo_guard",
+            "diffusion_nft",
+            "dpo",
+            "dance_grpo",
+            "distill_kl",
+            "distill_fm_mse",
+        ]
         if self.loss_mode not in valid_modes:
             raise ValueError(f"Invalid diffusion loss_mode: {self.loss_mode}. Must be one of {valid_modes}")
         if self.adv_clip_max <= 0:
@@ -137,6 +146,9 @@ class DiffusionActorConfig(BaseConfig):
     loss_scale_factor: Optional[float] = None
     use_kl_loss: bool = False
     kl_loss_coef: float = 0.001
+    use_distill_loss: bool = False
+    distill_loss_mode: str = "distill_kl"
+    distill_loss_coef: float = 1.0
     ppo_epochs: int = 1
     shuffle: bool = False
     data_loader_seed: int = 42
@@ -161,6 +173,11 @@ class DiffusionActorConfig(BaseConfig):
         """Validate diffusion actor configuration parameters."""
         assert self.strategy != MISSING
         assert self.rollout_n != MISSING
+        valid_distill_modes = ["distill_kl", "distill_fm_mse"]
+        if self.use_distill_loss and self.distill_loss_mode not in valid_distill_modes:
+            raise ValueError(
+                f"Invalid distill_loss_mode: {self.distill_loss_mode}. Must be one of {valid_distill_modes}"
+            )
 
 
 @dataclass

--- a/verl_omni/workers/engine/fsdp/diffusers_impl.py
+++ b/verl_omni/workers/engine/fsdp/diffusers_impl.py
@@ -911,6 +911,9 @@ class PPODiffusersFSDPEngine(DiffusersFSDPEngine):
             if micro_batch.get("ref_prev_sample_mean", None) is not None:
                 data["ref_prev_sample_mean"] = micro_batch["ref_prev_sample_mean"][:, step]
 
+            if micro_batch.get("teacher_prev_sample_mean", None) is not None:
+                data["teacher_prev_sample_mean"] = micro_batch["teacher_prev_sample_mean"][:, step]
+
             if micro_batch.get("old_prev_sample_mean", None) is not None:
                 data["old_prev_sample_mean"] = micro_batch["old_prev_sample_mean"][:, step]
 
@@ -1098,6 +1101,11 @@ class DPODiffusersFSDPEngine(DiffusersFSDPEngine):
                 if ref_noise_pred.ndim == model_output["noise_pred"].ndim + 1 and ref_noise_pred.shape[1] == 1:
                     ref_noise_pred = ref_noise_pred[:, 0]
                 data["ref_noise_pred"] = ref_noise_pred
+            if micro_batch.get("teacher_noise_pred", None) is not None:
+                teacher_noise_pred = micro_batch["teacher_noise_pred"]
+                if teacher_noise_pred.ndim == model_output["noise_pred"].ndim + 1 and teacher_noise_pred.shape[1] == 1:
+                    teacher_noise_pred = teacher_noise_pred[:, 0]
+                data["teacher_noise_pred"] = teacher_noise_pred
             loss, metrics = loss_function(model_output=model_output, data=data, dp_group=self.get_data_parallel_group())
         else:
             assert forward_only, "forward_only must be True when loss_function is None"

--- a/verl_omni/workers/engine/veomni/diffusion_impl.py
+++ b/verl_omni/workers/engine/veomni/diffusion_impl.py
@@ -419,6 +419,9 @@ class VeOmniDiffusionEngine(BaseEngine):
             if micro_batch.get("ref_prev_sample_mean", None) is not None:
                 data["ref_prev_sample_mean"] = micro_batch["ref_prev_sample_mean"][:, step]
 
+            if micro_batch.get("teacher_prev_sample_mean", None) is not None:
+                data["teacher_prev_sample_mean"] = micro_batch["teacher_prev_sample_mean"][:, step]
+
             if micro_batch.get("old_prev_sample_mean", None) is not None:
                 data["old_prev_sample_mean"] = micro_batch["old_prev_sample_mean"][:, step]
 

--- a/verl_omni/workers/engine_workers.py
+++ b/verl_omni/workers/engine_workers.py
@@ -585,6 +585,8 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
                 self.config.ref.ppo_micro_batch_size_per_gpu = self.config.ref.pop(
                     "log_prob_micro_batch_size_per_gpu", None
                 )
+                # Not a dataclass field; pop before omega_conf_to_dataclass.
+                ref_model_path = self.config.ref.pop("model_path", None)
                 if not is_diffusion:
                     self.config.ref.ppo_micro_batch_size = self.config.ref.pop("log_prob_micro_batch_size", None)
                     self.config.ref.use_dynamic_bsz = self.config.ref.pop("log_prob_use_dynamic_bsz", False)
@@ -596,6 +598,14 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
             # The ref model does not need to enable MTP; force it to false.
             ref_config.model_config = deepcopy(model_config)
             ref_config.model_config.mtp = MtpConfig(enable=False)
+
+            # Teacher override: load a separate (merged, adapter-free) checkpoint.
+            if ref_model_path is not None:
+                ref_config.model_config.path = ref_model_path
+                ref_config.model_config.local_path = None
+                ref_config.model_config.lora_rank = 0
+                ref_config.model_config.lora_adapter_path = None
+                ref_config.model_config.lora = {}
 
             # construct TrainingWorkerConfig
             ref_training_config = TrainingWorkerConfig(

--- a/verl_omni/workers/engine_workers.py
+++ b/verl_omni/workers/engine_workers.py
@@ -18,6 +18,7 @@ import os
 import time
 from contextlib import nullcontext
 from copy import deepcopy
+from dataclasses import replace
 from functools import partial
 from itertools import chain
 from typing import Optional
@@ -596,16 +597,16 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
             ref_config: ActorConfig | DiffusionActorConfig = omega_conf_to_dataclass(self.config.ref)
 
             # The ref model does not need to enable MTP; force it to false.
-            ref_config.model_config = deepcopy(model_config)
-            ref_config.model_config.mtp = MtpConfig(enable=False)
-
-            # Teacher override: load a separate (merged, adapter-free) checkpoint.
-            if ref_model_path is not None:
-                ref_config.model_config.path = ref_model_path
-                ref_config.model_config.local_path = None
-                ref_config.model_config.lora_rank = 0
-                ref_config.model_config.lora_adapter_path = None
-                ref_config.model_config.lora = {}
+            if is_diffusion:
+                # DiffusionModelConfig freezes these fields; rebuild instead of mutating.
+                overrides: dict = {"mtp": MtpConfig(enable=False)}
+                # Teacher override: load a separate (merged, adapter-free) checkpoint.
+                if ref_model_path is not None:
+                    overrides.update(path=ref_model_path, local_path=None, lora_rank=0, lora_adapter_path=None, lora={})
+                ref_config.model_config = replace(deepcopy(model_config), **overrides)
+            else:
+                ref_config.model_config = deepcopy(model_config)
+                ref_config.model_config.mtp = MtpConfig(enable=False)
 
             # construct TrainingWorkerConfig
             ref_training_config = TrainingWorkerConfig(

--- a/verl_omni/workers/utils/losses.py
+++ b/verl_omni/workers/utils/losses.py
@@ -110,6 +110,14 @@ def diffusion_loss(config: DiffusionActorConfig, model_output, data: TensorDict,
                 aggregation=AggregationType.MEAN,
             )
 
+    if config.use_distill_loss:
+        loss_func = get_diffusion_loss_fn(config.distill_loss_mode)
+        loss_func.validate_inputs(loss_name=config.distill_loss_mode, model_output=model_output, data=data)
+        distill_result = loss_func(config=config, model_output=model_output, data=data)
+        loss_value += distill_result.loss * config.distill_loss_coef
+        metrics.update(Metric.from_dict(distill_result.metrics, aggregation=AggregationType.MEAN))
+        metrics["distill_coef"] = config.distill_loss_coef
+
     gradient_accumulation_steps = tu.get_non_tensor_data(data, "gradient_accumulation_steps", default=None)
     loss_value = loss_value / gradient_accumulation_steps
 


### PR DESCRIPTION
### What does this PR do?

Rough end-to-end draft for RFC #293 (Online Policy Distillation for diffusion models). This is just a draft PR to verify the idea works end-to-end and that the loss is correct before splitting. Stacks on #300 (the distillation losses) and adds the minimal teacher plumbing:

- `actor_rollout_ref.ref.model_path`: checkpoint override that turns the ref worker into the distillation teacher (forces a standalone ref for LoRA runs, where the ref would otherwise be the actor without adapters); its per-step means are exposed as `teacher_prev_sample_mean`.
- `scripts/merge_lora_teacher.py`: folds a sharded FSDP LoRA checkpoint into the base model to produce a full teacher directory.
- Drive-by fix: standalone-ref init crashed for diffusion (`FrozenInstanceError` on `model_config.mtp`) because `DiffusionModelConfig` is frozen; rebuilt via `dataclasses.replace`. This path had never been exercised (LoRA runs always took `ref_in_actor`).

### Verification (SD3.5-Medium OCR, 3 GPUs)

<img width="1650" height="600" alt="opd_e2e_curves" src="https://github.com/user-attachments/assets/57ffb81c-8c9c-46d4-818e-e34bdb52c5be" />

| model | val OCR reward (`val-core/flow_grpo/ocr/reward/mean@1`) |
|---|---|
| base SD3.5-Medium | 0.24 (0.21 after one warmup update) |
| teacher = FlowGRPO LoRA, 100 steps | 0.52 during training; 0.50 re-evaluated merged (0.57 after one warmup update) |
| student = pure `distill_kl`, 100 steps | 0.65 @ step 20; 0.55–0.59 settled |

Consecutive evals of near-identical weights differ by up to ~0.07 (32 val samples), so student vs teach
er is read as "reaches teacher level", not "exceeds". The merged-teacher re-eval matching its in-traini
ng val (0.50 vs 0.52) also validates `merge_lora_teacher.py`.

The student trains with **no reward signal in the loss** (only `distill_kl` against the teacher; verified: no policy-gradient metrics emitted) and reaches teacher level by step 20. `actor/distill_kl_loss` falls 4.5e-4 → 1.3e-5. Sanity signatures: student step-1 train reward equals the base run's (fresh start); step-1 KL is clearly positive (teacher weights ≠ base actually loaded) and decreases monotonically while reward rises.

Reproduce:

```bash
# 1. teacher: examples/flowgrpo_trainer/sd35/run_sd35_medium_ocr_lora.sh (unchanged)
# 2. merge
python scripts/merge_lora_teacher.py \
    --base_model <sd35-dir> \
    --checkpoint checkpoints/flow_grpo/sd35_medium_ocr_lora/global_step_100/actor \
    --output <teacher-dir>
# 3. student: same script plus
#    actor_rollout_ref.ref.model_path=<teacher-dir> \
#    actor_rollout_ref.actor.diffusion_loss.loss_mode=distill_kl
```

CPU tests: `pytest tests/trainer/` (116 passed), pre-commit clean.

### Design notes / split plan

- Teacher-in-ref is the smallest wiring that makes distillation runnable: the ref worker already does exactly the required computation (per-step transformer forward on the student's explored latents); only the checkpoint identity changes. `ref.model_path` + `use_kl_loss` together is rejected (one ref cannot hold both identities).
- Split per review guidance: #300 = losses (ready); this draft = teacher wiring + verification evidence. The async TeacherWorker / trajectory-caching workstream from the RFC can replace teacher-in-ref later — the losses only depend on the `teacher_*` batch keys, not on who produces them.
- Scope: teacher-in-ref emits `teacher_prev_sample_mean` on the policy-gradient path only, so this veri
fies `distill_kl`. `distill_fm_mse` targets the direct-preference path (`teacher_noise_pred`), where th
e ref worker serves as the DPO reference — repurposing it is rejected with `NotImplementedError`; that
wiring belongs to the teacher-pipeline workstream.

AI assistance was used for this PR; all changes and experiments were reviewed and run by the submitter.
