### PR TITLE
[reward, tests] fix: sample HPSv3 video frames along time

### DIFF
--- a/tests/utils/reward_score/test_hpsv3_reward_on_cpu.py
+++ b/tests/utils/reward_score/test_hpsv3_reward_on_cpu.py
@@ -1,0 +1,98 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU tests for HPSv3 reward frame extraction."""
+
+import numpy as np
+import torch
+
+from verl_omni.utils.reward_score.hpsv3_reward import _extract_frames
+
+
+def _rgb_at(image):
+    return tuple(np.asarray(image)[0, 0].tolist())
+
+
+def _fill_tchw(video, b=None):
+    if b is None:
+        video[0, :, 0, 0] = torch.tensor([0.1, 0.2, 0.3])
+        video[2, :, 0, 0] = torch.tensor([0.5, 0.6, 0.7])
+    else:
+        video[b, 0, :, 0, 0] = torch.tensor([0.1 + b * 0.1, 0.2, 0.3])
+        video[b, 3, :, 0, 0] = torch.tensor([0.5 + b * 0.1, 0.6, 0.7])
+
+
+def _fill_thwc(video, b=None):
+    if b is None:
+        video[0, 0, 0, :] = torch.tensor([0.1, 0.2, 0.3])
+        video[2, 0, 0, :] = torch.tensor([0.5, 0.6, 0.7])
+    else:
+        video[b, 0, 0, 0, :] = torch.tensor([0.1 + b * 0.1, 0.2, 0.3])
+        video[b, 3, 0, 0, :] = torch.tensor([0.5 + b * 0.1, 0.6, 0.7])
+
+
+def test_extract_frames_subsamples_per_sample_tchw_video_on_time_axis():
+    video = torch.zeros(4, 3, 2, 2)
+    _fill_tchw(video)
+
+    frames = _extract_frames(video, frame_interval=2)
+
+    assert len(frames) == 2
+    assert frames[0].size == (2, 2)
+    assert _rgb_at(frames[0]) == (26, 51, 76)
+    assert _rgb_at(frames[1]) == (128, 153, 178)
+
+
+def test_extract_frames_subsamples_per_sample_thwc_video_on_time_axis():
+    video = torch.zeros(4, 3, 4, 3)
+    _fill_thwc(video)
+
+    frames = _extract_frames(video, frame_interval=2)
+
+    assert len(frames) == 2
+    assert frames[0].size == (4, 3)
+    assert _rgb_at(frames[0]) == (26, 51, 76)
+    assert _rgb_at(frames[1]) == (128, 153, 178)
+
+
+def test_extract_frames_flattens_batched_btchw_video_after_time_subsample():
+    video = torch.zeros(2, 4, 3, 2, 2)
+    _fill_tchw(video, b=0)
+    _fill_tchw(video, b=1)
+
+    frames = _extract_frames(video, frame_interval=3)
+
+    assert len(frames) == 4
+    assert [_rgb_at(frame) for frame in frames] == [
+        (26, 51, 76),
+        (128, 153, 178),
+        (51, 51, 76),
+        (153, 153, 178),
+    ]
+
+
+def test_extract_frames_flattens_batched_bthwc_video_after_time_subsample():
+    video = torch.zeros(2, 4, 3, 4, 3)
+    _fill_thwc(video, b=0)
+    _fill_thwc(video, b=1)
+
+    frames = _extract_frames(video, frame_interval=3)
+
+    assert len(frames) == 4
+    assert frames[0].size == (4, 3)
+    assert [_rgb_at(frame) for frame in frames] == [
+        (26, 51, 76),
+        (128, 153, 178),
+        (51, 51, 76),
+        (153, 153, 178),
+    ]

--- a/verl_omni/utils/reward_score/hpsv3_reward.py
+++ b/verl_omni/utils/reward_score/hpsv3_reward.py
@@ -394,15 +394,13 @@ def _extract_frames(solution_image, frame_interval: int = 1) -> list[Image.Image
 
     elif solution_image.ndim == 4:
         if is_channels_last:
-            solution_image = solution_image.permute(3, 0, 1, 2)
-        solution_image = solution_image[:, ::frame_interval]
-        solution_image = solution_image.permute(1, 0, 2, 3)
+            solution_image = solution_image.permute(0, 3, 1, 2)
+        solution_image = solution_image[::frame_interval]
 
     elif solution_image.ndim == 5:
         if is_channels_last:
-            solution_image = solution_image.permute(0, 4, 1, 2, 3)
-        solution_image = solution_image[:, :, ::frame_interval]
-        solution_image = solution_image.permute(0, 2, 1, 3, 4)
+            solution_image = solution_image.permute(0, 1, 4, 2, 3)
+        solution_image = solution_image[:, ::frame_interval]
         solution_image = solution_image.reshape(-1, *solution_image.shape[2:])
 
     return [_to_pil_hwc(frame) for frame in solution_image]


### PR DESCRIPTION
### What does this PR do?

Fix HPSv3 reward frame extraction for generated video tensors.

Previously `_extract_frames()` treated 4D video tensors as if the channel dimension came before time after optional channels-last conversion. For common video layouts (`TCHW`, `THWC`, `BTCHW`, `BTHWC`), this sampled along the wrong axis and could pass channel slices instead of temporal frames into the HPSv3 image reward model. This PR samples along the temporal axis and flattens batched videos into individual frames before scoring.

For channels-last video tensors, this PR also normalizes `THWC` to `TCHW` and `BTHWC` to `BTCHW` before converting individual frames to PIL images, avoiding ambiguous HWC/CHW detection when frame height is 1 or 3.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here:
  - `gh pr list --repo verl-project/verl-omni --state open --search "hpsv3 reward"`
  - `gh pr list --repo verl-project/verl-omni --state open --search "HPSv3"`
  - `gh pr list --repo verl-project/verl-omni --state open --search "reward_score hpsv3"`
  - Open upstream PR #264 also touches `hpsv3_reward.py`, but it changes device auto-detection/default device behavior. This PR intentionally excludes that device-selection change and only fixes video frame extraction, so it is not a duplicate of #264.
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `vllm_omni`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `diffusion`, `omni`, `tests`, `docker`
  - If this PR involves multiple modules, separate them with `,` like `[diffusion, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][diffusion, fsdp] feat: new rollout scheduler`

### Test

Targeted unit test:

```bash
python \
  -m pytest tests/utils/reward_score/test_hpsv3_reward_on_cpu.py -q
```

Result:

```text
4 passed, 16 warnings in 53.78s
```

Static checks:

```bash
git diff --check
pre-commit run --all-files --show-diff-on-failure --color=always
```

Result:

```text
Passed
```

### API and Usage Example

No public API change.

```python
# Existing reward entrypoint stays the same.
from verl_omni.utils.reward_score.hpsv3_reward import compute_score_hpsv3
```

### Design & Code Changes

- Update `verl_omni/utils/reward_score/hpsv3_reward.py`:
  - 4D per-sample video tensors now subsample temporal axis `dim=0` for both `TCHW` and `THWC`.
  - 5D batched video tensors now subsample temporal axis `dim=1` for both `BTCHW` and `BTHWC`, then flatten `(B, T)` into frames.
  - Channels-last video layouts are normalized to channels-first before frame conversion to avoid ambiguous HWC/CHW detection for small frame heights.
- Add `tests/utils/reward_score/test_hpsv3_reward_on_cpu.py`:
  - Covers `TCHW`, `THWC`, `BTCHW`, and `BTHWC` frame extraction.
  - Folds the channels-last H=3 regression into the existing `THWC` and `BTHWC` cases.

AI assistance was used to prepare this draft. Human review is required before submitting for final review.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update the documentation.
  - N/A: no public API or user-facing usage change.
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl-omni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: targeted CPU unit tests were added under `tests/utils/reward_score/`.

