### PR TITLE
[rollout, diffusion] feat: support NFT and DPO step execution

### DIFF
--- a/docs/contributing/integrating_a_stepwise_continuous_batching_model.md
+++ b/docs/contributing/integrating_a_stepwise_continuous_batching_model.md
@@ -219,9 +219,11 @@ the full-forward path.
 Choose the live-latent dtype from the algorithm's scheduler and full-forward
 semantics, and keep it homogeneous across all in-flight requests.
 
-FlowGRPO, MixGRPO, and online DPO preserve seeded parity with their full-forward
-paths by generating the initial noise in `prompt_embeds.dtype` first and then
-casting those exact values to float32 for live step state:
+FlowGRPO and MixGRPO create their step-execution latents directly in float32.
+
+Online DPO instead generates the initial noise in `prompt_embeds.dtype` and
+then casts it to float32, matching the initial random values produced by its
+non-step path:
 
 ```python
 latents = self.prepare_latents(
@@ -235,9 +237,6 @@ latents = self.prepare_latents(
     None,
 ).float()
 ```
-
-Generating directly in float32 would consume the same seed through a different
-dtype path and would not reproduce the non-step initial latent values.
 
 Prepare the same timestep schedule used by `forward()`.
 

--- a/docs/contributing/integrating_a_stepwise_continuous_batching_model.md
+++ b/docs/contributing/integrating_a_stepwise_continuous_batching_model.md
@@ -1,6 +1,6 @@
 # How to Add Continuous Batching (Step-Execution) Support for a Diffusion Model
 
-Last updated: 07/22/2026.
+Last updated: 07/23/2026.
 
 This guide explains how to extend an existing diffusion rollout adapter so it
 supports **continuous batching through vLLM-Omni step execution**.
@@ -19,6 +19,12 @@ Qwen-Image MixGRPO reuses the same implementation and adds its own SDE-window
 initialisation:
 
 [`verl_omni/pipelines/qwen_image_mix_grpo/vllm_omni_rollout_adapter.py`](../../verl_omni/pipelines/qwen_image_mix_grpo/vllm_omni_rollout_adapter.py)
+
+Qwen-Image DiffusionNFT and online DPO are examples of algorithms that reuse
+the same engine lifecycle but preserve different training-output contracts:
+
+- [`verl_omni/pipelines/qwen_image_diffusion_nft/vllm_omni_rollout_adapter.py`](../../verl_omni/pipelines/qwen_image_diffusion_nft/vllm_omni_rollout_adapter.py)
+- [`verl_omni/pipelines/qwen_image_dpo/vllm_omni_rollout_adapter.py`](../../verl_omni/pipelines/qwen_image_dpo/vllm_omni_rollout_adapter.py)
 
 ---
 
@@ -55,7 +61,7 @@ actor_rollout_ref.rollout.max_num_seqs=16
 Do **not** create a separate package under `verl_omni/experimental`, register an
 algorithm such as `flow_grpo_stepwise`, or rewrite the configured algorithm name.
 Both execution modes use the original registration, such as `flow_grpo` or
-`mix_grpo`.
+`mix_grpo`. The same rule applies to `diffusion_nft` and `dpo`.
 
 ---
 
@@ -100,24 +106,23 @@ Before adding step execution, confirm that:
 1. The model already has a working rollout adapter registered under the normal
    algorithm name, such as `flow_grpo`.
 2. Its full-forward `forward()` or `diffuse()` path already returns the complete
-   trajectory required by training.
-3. The expected `custom_output` contract is defined. For Qwen-Image FlowGRPO and
-   MixGRPO it is:
+   rollout outputs required by training.
+3. The expected `custom_output` contract is defined. The current Qwen-Image
+   integrations use these contracts:
 
-   ```text
-   all_latents
-   all_log_probs
-   all_timesteps
-   prompt_embeds
-   prompt_embeds_mask
-   negative_prompt_embeds
-   negative_prompt_embeds_mask
-   ```
+   | Algorithm | Required algorithm-specific fields |
+   |---|---|
+   | FlowGRPO / MixGRPO | `all_latents`, `all_log_probs`, `all_timesteps` |
+   | DiffusionNFT | `latents_clean`, `train_timesteps` |
+   | Online DPO | `latents_clean` |
+
+   Every integration also preserves `prompt_embeds`, `prompt_embeds_mask`,
+   `negative_prompt_embeds`, and `negative_prompt_embeds_mask`.
 
 4. The corresponding vLLM-Omni model pipeline supports step execution.
-5. Step execution is appropriate for the algorithm. Qwen-Image DPO and
-   DiffusionNFT use different `custom_output` contracts and must be integrated
-   separately rather than forced to emit the FlowGRPO trajectory format.
+5. Step execution is appropriate for the algorithm. Algorithms with different
+   `custom_output` contracts must implement separate adapter hooks rather than
+   being forced to emit the FlowGRPO trajectory format.
 
 ---
 
@@ -211,7 +216,12 @@ the full-forward path.
 
 ### Latents and timesteps
 
-Initial latents should be created in float32:
+Choose the live-latent dtype from the algorithm's scheduler and full-forward
+semantics, and keep it homogeneous across all in-flight requests.
+
+FlowGRPO, MixGRPO, and online DPO preserve seeded parity with their full-forward
+paths by generating the initial noise in `prompt_embeds.dtype` first and then
+casting those exact values to float32 for live step state:
 
 ```python
 latents = self.prepare_latents(
@@ -219,14 +229,24 @@ latents = self.prepare_latents(
     num_channels_latents,
     height,
     width,
-    torch.float32,
+    prompt_embeds.dtype,
     self.device,
     generator,
     None,
-)
+).float()
 ```
 
+Generating directly in float32 would consume the same seed through a different
+dtype path and would not reproduce the non-step initial latent values.
+
 Prepare the same timestep schedule used by `forward()`.
+
+DiffusionNFT reuses the standard Qwen-Image denoising and scheduler methods, so
+it prepares latents in the prompt-embedding/model dtype. The standard scheduler
+returns the model-output dtype, keeping newly admitted and already-stepped
+requests compatible. If an algorithm's scheduler changes dtype after the first
+step, override `denoise_step()` and `step_scheduler()` and keep the live state in
+one explicit dtype, as the DPO adapter does.
 
 ### RoPE text lengths
 
@@ -262,6 +282,10 @@ request_scheduler.set_begin_index(0)
 
 ### SDE and log-probability state
 
+This subsection applies to trajectory-based algorithms such as FlowGRPO and
+MixGRPO. DiffusionNFT and DPO do not initialise reverse-SDE trajectory
+containers.
+
 Resolve the same sampling values used by `forward()`:
 
 ```text
@@ -277,7 +301,7 @@ across multiple engine iterations continue the same random stream.
 
 ### Required state
 
-Populate every value consumed later, including:
+Populate every shared value consumed later, including:
 
 ```text
 prompt_embeds
@@ -293,26 +317,24 @@ guidance
 img_shapes
 txt_seq_lens
 negative_txt_seq_lens
-sde_window
-noise_level
-sde_type
-logprobs
-all_latents
-all_log_probs
-all_timesteps
 ```
 
-Initialise the trajectory containers as empty lists and return `state`.
+For FlowGRPO and MixGRPO, also populate `sde_window`, `noise_level`, `sde_type`,
+`logprobs`, and initialise `all_latents`, `all_log_probs`, and `all_timesteps`
+as empty lists. DiffusionNFT and DPO only store the state required by their
+standard scheduler and final-latent output contracts. Return `state`.
 
 ---
 
 ## Step 3 — Implement `denoise_step`
 
 `denoise_step()` receives a batch assembled from multiple in-flight request
-states.
+states. Reuse the upstream model implementation when its prompt representation,
+CFG logic, attention arguments, output slicing, and precision already match the
+algorithm. DiffusionNFT follows this path.
 
-Cast the live float32 latents to the transformer's compute dtype only for the
-forward pass:
+When live state is kept in float32, cast latents to the transformer's compute
+dtype only for the forward pass:
 
 ```python
 x = input_batch.latents.to(
@@ -321,14 +343,16 @@ x = input_batch.latents.to(
 ```
 
 Build the model-specific positive and negative CFG inputs, run the transformer,
-and return the noise prediction in float32:
+and return the noise prediction in the dtype required by the scheduler. The
+FlowGRPO and DPO adapters return float32:
 
 ```python
 return noise_pred.float()
 ```
 
-Keeping the returned prediction in float32 matches the scheduler path and avoids
-precision loss in log-probability computation.
+For FlowGRPO, float32 also avoids precision loss in log-probability computation.
+For DPO, it preserves the existing full-forward scheduler behavior and keeps all
+live requests in the same dtype.
 
 An override is required when the upstream model implementation does not match
 the RL adapter's prompt representation, CFG logic, attention arguments, or
@@ -339,9 +363,10 @@ output slicing.
 ## Step 4 — Implement `step_scheduler`
 
 `step_scheduler()` must mirror one iteration of the full-forward `diffuse()`
-loop.
+loop. Reuse the upstream implementation when the algorithm only needs the final
+latent and its scheduler semantics already match, as DiffusionNFT does.
 
-It should:
+For a trajectory-based algorithm such as FlowGRPO or MixGRPO, it should:
 
 1. Read the current timestep from `state.timesteps[state.step_index]`.
 2. Resolve whether the current step is inside the SDE window.
@@ -368,10 +393,11 @@ new_latents, log_prob, _, _ = state.scheduler.step(
 state.latents = new_latents.to(torch.float32)
 ```
 
-Do not store stepped requests in bf16. Continuous batching may combine a newly
-admitted request whose latents are fp32 with older requests that have already
-advanced. Mixed live dtypes cause batch assembly failures and also break
-rollout/training log-probability parity.
+Do not mix live dtypes. Continuous batching may combine a newly admitted request
+with older requests that have already advanced. If new requests start in fp32,
+stepped requests must remain fp32; if the standard model path starts in model
+dtype, the scheduler must keep returning that dtype. Mixed live dtypes cause
+batch assembly failures and can break rollout/training parity.
 
 ---
 
@@ -381,13 +407,15 @@ rollout/training log-probability parity.
 
 It should:
 
-1. Call `super().post_decode(state, **kwargs)` to decode the final latent.
-2. Stack the trajectory lists using the same dimensions as the full-forward
+1. Decode the final latent, either through `super().post_decode()` or the
+   model's `_decode_latents()` helper.
+2. Build the exact `custom_output` required by the algorithm's full-forward
    path.
-3. Preserve all required keys, including optional negative-prompt fields.
+3. Preserve optional negative-prompt keys even when their values are `None`.
 4. Move the complete output to CPU before inter-process transfer.
 
-For immutable `DiffusionOutput` objects, use `dataclasses.replace`:
+Use `dataclasses.replace` to preserve the decoded output's existing fields while
+replacing its algorithm-specific payload:
 
 ```python
 from dataclasses import replace
@@ -414,6 +442,52 @@ tensors or initialising an unintended accelerator context.
 The step-execution output must match the full-forward output contract exactly.
 Downstream training code should not need to know which execution mode produced
 the trajectory.
+
+### DiffusionNFT output
+
+DiffusionNFT trains from the final clean latent and the inference timestep
+schedule. It reuses the upstream Qwen-Image `denoise_step()` and
+`step_scheduler()` implementations, then returns:
+
+```python
+custom_output = {
+    "latents_clean": state.latents.float(),
+    "train_timesteps": state.timesteps.unsqueeze(0).expand(
+        state.latents.shape[0], -1
+    ),
+    "prompt_embeds": state.prompt_embeds,
+    "prompt_embeds_mask": state.prompt_embeds_mask,
+    "negative_prompt_embeds": state.negative_prompt_embeds,
+    "negative_prompt_embeds_mask":
+        state.negative_prompt_embeds_mask,
+}
+```
+
+It must not emit synthetic `all_latents`, `all_log_probs`, or `all_timesteps`
+fields because DiffusionNFT training does not consume the reverse-SDE
+trajectory.
+
+### Online DPO output
+
+Online DPO trains from paired final clean latents. Its step path keeps live
+latents and scheduler inputs in float32, but returns no reverse-SDE trajectory:
+
+```python
+custom_output = {
+    "latents_clean": state.latents.float(),
+    "prompt_embeds": state.prompt_embeds,
+    "prompt_embeds_mask": state.prompt_embeds_mask,
+    "negative_prompt_embeds": state.negative_prompt_embeds,
+    "negative_prompt_embeds_mask":
+        state.negative_prompt_embeds_mask,
+}
+```
+
+Keep prompt extraction and warm-up fallback logic local to an
+algorithm-specific adapter unless multiple existing adapters require exactly
+the same behavior. Avoid adding private step-execution helpers to a broadly
+shared mixin merely to reduce duplication: doing so changes the method
+resolution order of unrelated adapters such as Qwen-Image Edit.
 
 ---
 
@@ -500,6 +574,15 @@ actor_rollout_ref:
     algorithm: mix_grpo
 ```
 
+For DiffusionNFT or online DPO, use the existing algorithm registration in the
+same way:
+
+```yaml
+actor_rollout_ref:
+  model:
+    algorithm: diffusion_nft  # or: dpo
+```
+
 No `_stepwise` suffix is required.
 
 ---
@@ -520,6 +603,8 @@ For example:
 ```text
 (QwenImagePipeline, flow_grpo)
 (QwenImagePipeline, mix_grpo)
+(QwenImagePipeline, diffusion_nft)
+(QwenImagePipeline, dpo)
 ```
 
 The same adapter class therefore provides both paths:
@@ -538,11 +623,11 @@ Current Qwen-Image scope:
 |---|---|
 | FlowGRPO | Supported |
 | MixGRPO | Supported |
-| DPO | Not covered by this integration |
-| DiffusionNFT | Not covered by this integration |
+| DiffusionNFT | Supported with final-latent/timestep output |
+| Online DPO | Supported with final-latent output |
 
-DPO and DiffusionNFT should receive separate integrations because their rollout
-outputs differ from the FlowGRPO trajectory.
+The four algorithms share the vLLM-Omni engine lifecycle, but their rollout
+adapters preserve their own scheduler precision and `custom_output` contracts.
 
 ---
 
@@ -583,15 +668,43 @@ len(all_log_probs) = len(all_timesteps)
 prompt_embeds.shape[:-1] = prompt_embeds_mask.shape
 ```
 
+For DiffusionNFT, assert that these fields are present, are tensors, and are
+non-empty:
+
+```text
+latents_clean
+train_timesteps
+prompt_embeds
+prompt_embeds_mask
+```
+
+For online DPO, assert the same contract without `train_timesteps`:
+
+```text
+latents_clean
+prompt_embeds
+prompt_embeds_mask
+```
+
+For both algorithms, keep the negative-prompt keys in `extra_fields`; they may
+be `None` when no negative prompt is supplied. Also verify that DPO live latents
+remain float32 across concurrent step-execution requests.
+
 The canonical regression test is:
 
 [`tests/workers/rollout/rollout_vllm/test_vllm_omni_generate.py`](../../tests/workers/rollout/rollout_vllm/test_vllm_omni_generate.py)
 
 Run parity checks between `step_execution=False` and `step_execution=True` for:
 
+- resolved height, width, inference steps, sigmas, guidance scales, output count,
+  and maximum sequence length;
+- seed/generator handling and initial latent values;
 - output field names and shapes;
 - fp32 stored latents;
 - prompt embedding and mask values;
+- text RoPE lengths derived from padded embedding width;
+- model-input, timestep, noise-prediction, scheduler-input, and live-state
+  dtypes at the first and subsequent steps;
 - SDE-window selection;
 - first-step `ratio_mean`, KL, and clipping metrics;
 - seeded reproducibility;
@@ -610,10 +723,13 @@ Run parity checks between `step_execution=False` and `step_execution=True` for:
 - [ ] Implement `post_decode()`.
 - [ ] Deep-copy mutable scheduler state per request.
 - [ ] Use padded embedding width for text RoPE lengths.
-- [ ] Keep live and stored trajectory latents in fp32.
+- [ ] Keep live request dtypes homogeneous across admission and scheduler steps.
+- [ ] Keep FlowGRPO/MixGRPO and DPO live latents in fp32.
 - [ ] Preserve the full `custom_output` contract.
 - [ ] Move returned tensors to CPU.
 - [ ] Mirror algorithm-specific setup in both execution paths.
+- [ ] Keep algorithm-private helpers out of shared mixins unless all consumers
+      require identical behavior.
 - [ ] Add a real-engine regression test.
 - [ ] Test both `step_execution=False` and `step_execution=True`.
 - [ ] Do not create an experimental `_stepwise` registration.

--- a/tests/workers/rollout/rollout_vllm/test_vllm_omni_generate.py
+++ b/tests/workers/rollout/rollout_vllm/test_vllm_omni_generate.py
@@ -163,8 +163,14 @@ def _assert_training_step_execution_contract(
         _assert_non_empty_tensor(value, field_name)
 
     assert output.extra_fields["latents_clean"].dtype == torch.float32
-    assert output.extra_fields["negative_prompt_embeds"] is None
-    assert output.extra_fields["negative_prompt_embeds_mask"] is None
+    negative_prompt_embeds = output.extra_fields["negative_prompt_embeds"]
+    negative_prompt_embeds_mask = output.extra_fields["negative_prompt_embeds_mask"]
+    if negative_prompt_embeds is None:
+        assert negative_prompt_embeds_mask is None
+    else:
+        _assert_non_empty_tensor(negative_prompt_embeds, "negative_prompt_embeds")
+        _assert_non_empty_tensor(negative_prompt_embeds_mask, "negative_prompt_embeds_mask")
+        assert negative_prompt_embeds.shape[:-1] == negative_prompt_embeds_mask.shape
     assert output.extra_fields["prompt_embeds"].shape[:-1] == output.extra_fields["prompt_embeds_mask"].shape
 
 

--- a/tests/workers/rollout/rollout_vllm/test_vllm_omni_generate.py
+++ b/tests/workers/rollout/rollout_vllm/test_vllm_omni_generate.py
@@ -132,6 +132,42 @@ def _assert_flow_grpo_step_execution_contract(output: DiffusionOutput) -> None:
     assert prompt_embeds.shape[:-1] == prompt_embeds_mask.shape
 
 
+def _assert_training_step_execution_contract(
+    output: DiffusionOutput,
+    *,
+    algorithm: str,
+    include_train_timesteps: bool,
+) -> None:
+    """Validate algorithm-specific Qwen-Image training tensors."""
+    expected_extra_fields = {
+        "latents_clean",
+        "prompt_embeds",
+        "prompt_embeds_mask",
+        "negative_prompt_embeds",
+        "negative_prompt_embeds_mask",
+    }
+    if include_train_timesteps:
+        expected_extra_fields.add("train_timesteps")
+
+    missing_fields = expected_extra_fields - set(output.extra_fields)
+    assert not missing_fields, f"Missing {algorithm} step-execution fields: {sorted(missing_fields)}"
+
+    required_tensors = {
+        "latents_clean": output.extra_fields["latents_clean"],
+        "prompt_embeds": output.extra_fields["prompt_embeds"],
+        "prompt_embeds_mask": output.extra_fields["prompt_embeds_mask"],
+    }
+    if include_train_timesteps:
+        required_tensors["train_timesteps"] = output.extra_fields["train_timesteps"]
+    for field_name, value in required_tensors.items():
+        _assert_non_empty_tensor(value, field_name)
+
+    assert output.extra_fields["latents_clean"].dtype == torch.float32
+    assert output.extra_fields["negative_prompt_embeds"] is None
+    assert output.extra_fields["negative_prompt_embeds_mask"] is None
+    assert output.extra_fields["prompt_embeds"].shape[:-1] == output.extra_fields["prompt_embeds_mask"].shape
+
+
 def _build_rollout_cfg(*, step_execution: bool = False) -> Any:
     from tests.utils.smoke_attention import resolve_smoke_attention_backends
 
@@ -175,7 +211,7 @@ def _build_rollout_cfg(*, step_execution: bool = False) -> Any:
     return OmegaConf.create(cfg)
 
 
-def _build_model_cfg(*, attn_backend: str | None = None) -> Any:
+def _build_model_cfg(*, attn_backend: str | None = None, algorithm: str = "flow_grpo") -> Any:
     from tests.utils.smoke_attention import resolve_smoke_attention_backends
 
     resolved_attn_backend, _ = resolve_smoke_attention_backends()
@@ -188,12 +224,12 @@ def _build_model_cfg(*, attn_backend: str | None = None) -> Any:
             "trust_remote_code": True,
             "load_tokenizer": True,
             "attn_backend": attn_backend or resolved_attn_backend,
-            "algorithm": "flow_grpo",
+            "algorithm": algorithm,
         }
     )
 
 
-def _launch_server(*, step_execution: bool = False):
+def _launch_server(*, step_execution: bool = False, algorithm: str = "flow_grpo"):
     ray.init(
         runtime_env={
             "env_vars": {
@@ -216,7 +252,7 @@ def _launch_server(*, step_execution: bool = False):
         max_concurrency=16,
     ).remote(
         config=_build_rollout_cfg(step_execution=step_execution),
-        model_config=_build_model_cfg(),
+        model_config=_build_model_cfg(algorithm=algorithm),
         rollout_mode=RolloutMode.STANDALONE,
         workers=[],
         replica_rank=0,
@@ -248,6 +284,14 @@ def init_server():
 def init_step_execution_server():
     """Function-scoped step-execution server (cannot share with request-level)."""
     server = _launch_server(step_execution=True)
+    yield server
+    _shutdown_server()
+
+
+@pytest.fixture
+def init_training_step_execution_server(request):
+    """Function-scoped NFT/DPO step-execution server."""
+    server = _launch_server(step_execution=True, algorithm=request.param)
     yield server
     _shutdown_server()
 
@@ -349,3 +393,63 @@ def test_flow_grpo_step_execution_contract(init_step_execution_server):
     assert output.stop_reason in ("completed", "aborted", None)
 
     _assert_flow_grpo_step_execution_contract(output)
+
+
+@pytest.mark.parametrize(
+    "init_training_step_execution_server",
+    ["diffusion_nft"],
+    indirect=True,
+    ids=["diffusion-nft-step-execution"],
+)
+def test_diffusion_nft_step_execution_contract(init_training_step_execution_server):
+    """Verify DiffusionNFT final-latent outputs with step_execution=True."""
+    prompt = (
+        "a detailed watercolor painting of a quiet forest stream surrounded by "
+        "mossy stones and tall green trees under soft morning sunlight"
+    )
+    output = ray.get(
+        init_training_step_execution_server.generate.remote(
+            prompt_ids=_tokenize_prompt(prompt),
+            sampling_params={"num_inference_steps": 10, "height": 512, "width": 512},
+            request_id=f"diffusion_nft_step_execution_{uuid4().hex[:8]}",
+        ),
+        timeout=600,
+    )
+
+    assert isinstance(output, DiffusionOutput)
+    assert len(output.diffusion_output) == 3
+    _assert_training_step_execution_contract(
+        output,
+        algorithm="DiffusionNFT",
+        include_train_timesteps=True,
+    )
+
+
+@pytest.mark.parametrize(
+    "init_training_step_execution_server",
+    ["dpo"],
+    indirect=True,
+    ids=["dpo-step-execution"],
+)
+def test_dpo_step_execution_contract(init_training_step_execution_server):
+    """Verify online DPO final-latent outputs with step_execution=True."""
+    prompt = (
+        "a cinematic photograph of a red tram crossing a rainy city street at "
+        "night with reflections from warm shop lights on the pavement"
+    )
+    output = ray.get(
+        init_training_step_execution_server.generate.remote(
+            prompt_ids=_tokenize_prompt(prompt),
+            sampling_params={"num_inference_steps": 10, "height": 512, "width": 512},
+            request_id=f"dpo_step_execution_{uuid4().hex[:8]}",
+        ),
+        timeout=600,
+    )
+
+    assert isinstance(output, DiffusionOutput)
+    assert len(output.diffusion_output) == 3
+    _assert_training_step_execution_contract(
+        output,
+        algorithm="DPO",
+        include_train_timesteps=False,
+    )

--- a/verl_omni/pipelines/qwen_image_diffusion_nft/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/qwen_image_diffusion_nft/vllm_omni_rollout_adapter.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 """Qwen-Image rollout adapter for DiffusionNFT."""
 
+import copy
+from dataclasses import replace
 from typing import Any
 
 import torch
@@ -20,6 +22,7 @@ from vllm_omni.diffusion.data import DiffusionOutput
 from vllm_omni.diffusion.models.qwen_image import QwenImagePipeline
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.utils.size_utils import normalize_min_aligned_size
+from vllm_omni.diffusion.worker.utils import DiffusionRequestState
 
 from verl_omni.pipelines.model_base import VllmOmniPipelineBase
 from verl_omni.pipelines.qwen_image_flow_grpo.common import (
@@ -43,6 +46,134 @@ class QwenImageDiffusionNFTPipeline(QwenImageTokenIdPromptMixin, QwenImagePipeli
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.set_progress_bar_config(disable=True)
+
+    def _extract_step_prompt_ids(self, prompt):
+        """Extract tokenized prompts, with a raw-text warm-up fallback."""
+        prompt_ids = None
+        prompt_mask = None
+        negative_prompt_ids = None
+        negative_prompt_mask = None
+        if isinstance(prompt, dict):
+            prompt_ids = prompt.get("prompt_token_ids")
+            prompt_mask = prompt.get("prompt_mask")
+            negative_prompt_ids = prompt.get("negative_prompt_ids")
+            negative_prompt_mask = prompt.get("negative_prompt_mask")
+            if prompt_ids is None and prompt.get("prompt"):
+                prompt_ids, prompt_mask = self._tokenize_step_prompt(prompt["prompt"])
+            if negative_prompt_ids is None and prompt.get("negative_prompt"):
+                negative_prompt_ids, negative_prompt_mask = self._tokenize_step_prompt(prompt["negative_prompt"])
+        elif isinstance(prompt, str):
+            prompt_ids, prompt_mask = self._tokenize_step_prompt(prompt)
+        return prompt_ids, prompt_mask, negative_prompt_ids, negative_prompt_mask
+
+    def _tokenize_step_prompt(self, text: str | list[str]):
+        """Tokenize raw text for the step-execution warm-up request."""
+        prompt = [text] if isinstance(text, str) else text
+        formatted = [self.prompt_template_encode.format(item) for item in prompt]
+        tokens = self.tokenizer(
+            formatted,
+            max_length=self.tokenizer_max_length + self.prompt_template_encode_start_idx,
+            padding=True,
+            truncation=True,
+            return_tensors="pt",
+        ).to(self.device)
+        return tokens.input_ids, tokens.attention_mask
+
+    def prepare_encode(
+        self,
+        state: DiffusionRequestState,
+        **kwargs: Any,
+    ) -> DiffusionRequestState:
+        """Initialize request-local state for step execution."""
+        sampling = state.sampling
+        prompt_ids, prompt_mask, negative_prompt_ids, negative_prompt_mask = self._extract_step_prompt_ids(state.prompt)
+        if prompt_ids is None:
+            raise ValueError(
+                f"{self.__class__.__name__}.prepare_encode requires either "
+                "'prompt_token_ids' or a text 'prompt' on state.prompt."
+            )
+
+        height = sampling.height or self.default_sample_size * self.vae_scale_factor
+        width = sampling.width or self.default_sample_size * self.vae_scale_factor
+        height, width = normalize_min_aligned_size(height, width, self.vae_scale_factor * 2)
+        num_inference_steps = sampling.num_inference_steps or 50
+        sigmas = sampling.sigmas or None
+        guidance_scale = sampling.guidance_scale if sampling.guidance_scale_provided else 1.0
+        num_images_per_prompt = sampling.num_outputs_per_prompt if sampling.num_outputs_per_prompt > 0 else 1
+        true_cfg_scale = coalesce_not_none(sampling.true_cfg_scale, 4.0)
+        max_sequence_length = sampling.max_sequence_length or 512
+
+        generator = sampling.generator
+        if generator is None and sampling.seed is not None:
+            generator = torch.Generator(device=self.device).manual_seed(sampling.seed)
+
+        ctx = self._prepare_token_id_generation_context(
+            prompt_ids=prompt_ids,
+            prompt_mask=prompt_mask,
+            negative_prompt_ids=negative_prompt_ids,
+            negative_prompt_mask=negative_prompt_mask,
+            true_cfg_scale=true_cfg_scale,
+            height=height,
+            width=width,
+            num_inference_steps=num_inference_steps,
+            sigmas=sigmas,
+            guidance_scale=guidance_scale,
+            num_images_per_prompt=num_images_per_prompt,
+            generator=generator,
+            latents=None,
+            prompt_embeds=None,
+            prompt_embeds_mask=None,
+            negative_prompt_embeds=None,
+            negative_prompt_embeds_mask=None,
+            attention_kwargs=kwargs.get("attention_kwargs"),
+            max_sequence_length=max_sequence_length,
+        )
+
+        request_scheduler = copy.deepcopy(self.scheduler)
+        request_scheduler.set_begin_index(0)
+
+        state.prompt_embeds = ctx["prompt_embeds"]
+        state.prompt_embeds_mask = ctx["prompt_embeds_mask"]
+        state.negative_prompt_embeds = ctx["negative_prompt_embeds"]
+        state.negative_prompt_embeds_mask = ctx["negative_prompt_embeds_mask"]
+        state.latents = ctx["latents"]
+        state.timesteps = ctx["timesteps"]
+        state.step_index = 0
+        state.scheduler = request_scheduler
+        state.do_true_cfg = ctx["do_true_cfg"]
+        state.guidance = ctx["guidance"]
+        state.img_shapes = ctx["img_shapes"]
+        state.txt_seq_lens = ctx["txt_seq_lens"]
+        state.negative_txt_seq_lens = ctx["negative_txt_seq_lens"]
+        state.sampling.cfg_normalize = True
+        state.extra["height"] = height
+        state.extra["width"] = width
+        return state
+
+    def post_decode(
+        self,
+        state: DiffusionRequestState,
+        **kwargs: Any,
+    ) -> DiffusionOutput:
+        """Decode step execution output with DiffusionNFT training tensors."""
+        self._current_timestep = None
+        height = state.extra["height"]
+        width = state.extra["width"]
+        output = self._decode_latents(state.latents, height, width, kwargs.get("output_type") or "pil")
+
+        latents_clean = state.latents.float()
+        return replace(
+            output,
+            custom_output={
+                "latents_clean": latents_clean,
+                "train_timesteps": state.timesteps.unsqueeze(0).expand(latents_clean.shape[0], -1),
+                "prompt_embeds": state.prompt_embeds,
+                "prompt_embeds_mask": state.prompt_embeds_mask,
+                "negative_prompt_embeds": state.negative_prompt_embeds,
+                "negative_prompt_embeds_mask": state.negative_prompt_embeds_mask,
+            },
+            to_cpu=True,
+        )
 
     def _prepare_token_id_generation_context(
         self,

--- a/verl_omni/pipelines/qwen_image_dpo/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/qwen_image_dpo/vllm_omni_rollout_adapter.py
@@ -14,6 +14,8 @@
 
 """Qwen-Image rollout-side adapter for online diffusion DPO."""
 
+import copy
+from dataclasses import replace
 from typing import Any
 
 import torch
@@ -21,6 +23,7 @@ from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.models.qwen_image import QwenImagePipeline
 from vllm_omni.diffusion.request import OmniDiffusionRequest
+from vllm_omni.diffusion.worker.utils import DiffusionRequestState
 
 from verl_omni.pipelines.model_base import VllmOmniPipelineBase
 from verl_omni.pipelines.qwen_image_flow_grpo.common import apply_true_cfg, build_img_shapes
@@ -39,6 +42,210 @@ class QwenImageDPOPipeline(QwenImagePipeline):
     def __init__(self, *, od_config: OmniDiffusionConfig, prefix: str = ""):
         super().__init__(od_config=od_config, prefix=prefix)
         self.device = get_local_device()
+
+    def _extract_step_prompt_ids(self, prompt):
+        """Extract tokenized prompts, with a raw-text warm-up fallback."""
+        prompt_ids = None
+        prompt_mask = None
+        negative_prompt_ids = None
+        negative_prompt_mask = None
+        if isinstance(prompt, dict):
+            prompt_ids = prompt.get("prompt_token_ids")
+            prompt_mask = prompt.get("prompt_mask")
+            negative_prompt_ids = prompt.get("negative_prompt_ids")
+            negative_prompt_mask = prompt.get("negative_prompt_mask")
+            if prompt_ids is None and prompt.get("prompt"):
+                prompt_ids, prompt_mask = self._tokenize_step_prompt(prompt["prompt"])
+            if negative_prompt_ids is None and prompt.get("negative_prompt"):
+                negative_prompt_ids, negative_prompt_mask = self._tokenize_step_prompt(prompt["negative_prompt"])
+        elif isinstance(prompt, str):
+            prompt_ids, prompt_mask = self._tokenize_step_prompt(prompt)
+        return prompt_ids, prompt_mask, negative_prompt_ids, negative_prompt_mask
+
+    def _tokenize_step_prompt(self, text: str | list[str]):
+        """Tokenize raw text for the step-execution warm-up request."""
+        prompt = [text] if isinstance(text, str) else text
+        formatted = [self.prompt_template_encode.format(item) for item in prompt]
+        tokens = self.tokenizer(
+            formatted,
+            max_length=self.tokenizer_max_length + self.prompt_template_encode_start_idx,
+            padding=True,
+            truncation=True,
+            return_tensors="pt",
+        ).to(self.device)
+        return tokens.input_ids, tokens.attention_mask
+
+    def prepare_encode(
+        self,
+        state: DiffusionRequestState,
+        **kwargs: Any,
+    ) -> DiffusionRequestState:
+        """Initialize request-local state for step execution."""
+        sampling = state.sampling
+        prompt_ids, prompt_mask, negative_prompt_ids, negative_prompt_mask = self._extract_step_prompt_ids(state.prompt)
+        if isinstance(prompt_ids, list):
+            prompt_ids = torch.tensor(prompt_ids, device=self.device)
+        if isinstance(negative_prompt_ids, list):
+            negative_prompt_ids = torch.tensor(negative_prompt_ids, device=self.device)
+        if prompt_ids is None:
+            raise ValueError(
+                f"{self.__class__.__name__}.prepare_encode requires either "
+                "'prompt_token_ids' or a text 'prompt' on state.prompt."
+            )
+
+        height = sampling.height or self.default_sample_size * self.vae_scale_factor
+        width = sampling.width or self.default_sample_size * self.vae_scale_factor
+        num_inference_steps = sampling.num_inference_steps or 50
+        num_images_per_prompt = sampling.num_outputs_per_prompt if sampling.num_outputs_per_prompt > 0 else 1
+        true_cfg_scale = _coalesce_not_none(sampling.true_cfg_scale, 4.0)
+        max_sequence_length = sampling.max_sequence_length or 512
+
+        generator = sampling.generator
+        if generator is None and sampling.seed is not None:
+            generator = torch.Generator(device=self.device).manual_seed(sampling.seed)
+
+        self._guidance_scale = 1.0
+        self._attention_kwargs = kwargs.get("attention_kwargs") or {}
+        self._current_timestep = None
+        self._interrupt = False
+
+        batch_size = prompt_ids.shape[0] if prompt_ids.ndim == 2 else 1
+        has_neg_prompt = negative_prompt_ids is not None
+        do_true_cfg = true_cfg_scale > 1 and has_neg_prompt
+
+        prompt_embeds, prompt_embeds_mask = self.encode_prompt(
+            prompt_ids=prompt_ids,
+            attention_mask=prompt_mask,
+            num_images_per_prompt=num_images_per_prompt,
+            max_sequence_length=max_sequence_length,
+        )
+        if do_true_cfg:
+            negative_prompt_embeds, negative_prompt_embeds_mask = self.encode_prompt(
+                prompt_ids=negative_prompt_ids,
+                attention_mask=negative_prompt_mask,
+                num_images_per_prompt=num_images_per_prompt,
+                max_sequence_length=max_sequence_length,
+            )
+        else:
+            negative_prompt_embeds = None
+            negative_prompt_embeds_mask = None
+
+        num_channels_latents = self.transformer.in_channels // 4
+        latents = self.prepare_latents(
+            batch_size * num_images_per_prompt,
+            num_channels_latents,
+            height,
+            width,
+            prompt_embeds.dtype,
+            self.device,
+            generator,
+            None,
+        ).float()
+        timesteps, _ = self.prepare_timesteps(num_inference_steps, None, latents.shape[1])
+        self._num_timesteps = len(timesteps)
+
+        if self.transformer.guidance_embeds:
+            guidance = torch.full([1], 1.0, dtype=torch.float32).expand(latents.shape[0])
+        else:
+            guidance = None
+
+        request_scheduler = copy.deepcopy(self.scheduler)
+        request_scheduler.set_begin_index(0)
+
+        state.prompt_embeds = prompt_embeds
+        state.prompt_embeds_mask = prompt_embeds_mask
+        state.negative_prompt_embeds = negative_prompt_embeds
+        state.negative_prompt_embeds_mask = negative_prompt_embeds_mask
+        state.latents = latents
+        state.timesteps = timesteps
+        state.step_index = 0
+        state.scheduler = request_scheduler
+        state.do_true_cfg = do_true_cfg
+        state.guidance = guidance
+        state.img_shapes = build_img_shapes(height, width, batch_size, self.vae_scale_factor)
+        state.txt_seq_lens = prompt_embeds_mask.sum(dim=1).tolist() if prompt_embeds_mask is not None else None
+        state.negative_txt_seq_lens = (
+            negative_prompt_embeds_mask.sum(dim=1).tolist() if negative_prompt_embeds_mask is not None else None
+        )
+        state.sampling.cfg_normalize = True
+        state.extra["height"] = height
+        state.extra["width"] = width
+        return state
+
+    def denoise_step(self, input_batch, **kwargs: Any) -> torch.Tensor | None:
+        """Run one DPO denoising pass while retaining FP32 live state."""
+        del kwargs
+        if self.interrupt:
+            return None
+
+        timestep = input_batch.timesteps
+        self._current_timestep = timestep
+        self.transformer.do_true_cfg = input_batch.do_true_cfg
+        model_latents = input_batch.latents.to(self.transformer.img_in.weight.dtype)
+        positive_kwargs, negative_kwargs, output_slice = self._build_denoise_kwargs(
+            latents=model_latents,
+            timestep=timestep,
+            guidance=input_batch.guidance,
+            prompt_embeds=input_batch.prompt_embeds,
+            prompt_embeds_mask=input_batch.prompt_embeds_mask,
+            img_shapes=input_batch.img_shapes,
+            txt_seq_lens=input_batch.txt_seq_lens,
+            do_true_cfg=input_batch.do_true_cfg,
+            negative_prompt_embeds=input_batch.negative_prompt_embeds,
+            negative_prompt_embeds_mask=input_batch.negative_prompt_embeds_mask,
+            negative_txt_seq_lens=input_batch.negative_txt_seq_lens,
+            extra_transformer_kwargs={"attention_kwargs": self.attention_kwargs, "return_dict": False},
+        )
+        noise_pred = self.predict_noise_maybe_with_cfg(
+            input_batch.do_true_cfg,
+            input_batch.true_cfg_scale,
+            positive_kwargs,
+            negative_kwargs,
+            input_batch.cfg_normalize,
+            output_slice,
+        )
+        return noise_pred.float()
+
+    def step_scheduler(
+        self,
+        state: DiffusionRequestState,
+        noise_pred: torch.Tensor,
+        **kwargs: Any,
+    ) -> None:
+        """Advance one DPO step and keep live latents in FP32."""
+        del kwargs
+        if self.interrupt:
+            return
+
+        state.latents = self.scheduler_step_maybe_with_cfg(
+            noise_pred.float(),
+            state.current_timestep,
+            state.latents.float(),
+            state.do_true_cfg,
+            per_request_scheduler=state.scheduler,
+        ).float()
+        state.step_index += 1
+
+    def post_decode(
+        self,
+        state: DiffusionRequestState,
+        **kwargs: Any,
+    ) -> DiffusionOutput:
+        """Decode step execution output with DPO training tensors."""
+        del kwargs
+        self._current_timestep = None
+        output = self._decode_latents(state.latents, state.extra["height"], state.extra["width"], "pil")
+        return replace(
+            output,
+            custom_output={
+                "latents_clean": state.latents.float(),
+                "prompt_embeds": state.prompt_embeds,
+                "prompt_embeds_mask": state.prompt_embeds_mask,
+                "negative_prompt_embeds": state.negative_prompt_embeds,
+                "negative_prompt_embeds_mask": state.negative_prompt_embeds_mask,
+            },
+            to_cpu=True,
+        )
 
     def _get_qwen_prompt_embeds(
         self,


### PR DESCRIPTION

### What does this PR do?

This PR extends Qwen-Image continuous batching (`step_execution=True`) to **DiffusionNFT** and **online DPO**, building on the existing FlowGRPO and MixGRPO integrations.

It:

- Adds request-local step-execution state preparation for DiffusionNFT and DPO.
- Preserves each algorithm's existing training-output contract:
  - DiffusionNFT: `latents_clean`, `train_timesteps`, and prompt embeddings/masks.
  - Online DPO: `latents_clean` and prompt embeddings/masks.
- Keeps DPO live latents homogeneous in float32 during continuous batching.
- Reuses the standard Qwen-Image denoising and scheduler path for DiffusionNFT.
- Supports tokenized rollout prompts and raw-text warm-up requests.
- Adds real-engine output-contract tests for both algorithms.
- Updates the step-execution integration guide with algorithm-specific state, precision, and output requirements.

No new algorithm registration or `_stepwise` variant is introduced. The existing `diffusion_nft` and `dpo` algorithm names are used.

### Checklist Before Starting

- [x] Search for similar PRs. Query: [Qwen-Image step execution PRs](https://github.com/verl-project/verl-omni/pulls?q=is%3Apr+Qwen-Image+%22step+execution%22)
- [x] Format the PR title as `[{modules}] {type}: {description}`.

### Test

#### Automated coverage

Added real-engine step-execution contract tests for DiffusionNFT and online DPO:

```bash
pytest tests/workers/rollout/rollout_vllm/test_vllm_omni_generate.py \
  -k "diffusion_nft_step_execution_contract or dpo_step_execution_contract"
```

The tests validate:

- Successful generation with `step_execution=True`.
- Presence and shape of algorithm-specific training tensors.
- Float32 `latents_clean`.
- Prompt embedding/mask consistency.
- DiffusionNFT `train_timesteps`.
- Preservation of optional negative-prompt fields.

#### DiffusionNFT training and rollout timing

The following curves show the DiffusionNFT reward and rollout time with step execution enabled.

<img width="1873" height="1279" alt="af6638f254e3d803f46749a5fd9bf900" src="https://github.com/user-attachments/assets/dec28cf3-e4b5-4c3b-880f-acdb03fa174d" />
<img width="1314" height="1279" alt="7579c7f2dcbe9e7861f6fcc3541f8ac0" src="https://github.com/user-attachments/assets/d5ebf761-50f8-439e-8c90-5d1e3367ccf9" />

Experiment configuration: `<model / GPU count / batch size / training steps / rollout settings>`

Observation: `<briefly summarize reward behavior, training stability, and rollout time>`

#### Online DPO training and rollout timing

The following curves show the online DPO reward and rollout time with step execution enabled.

<img width="1796" height="1279" alt="686bf5bad5ff4a1a5aa8d894aed03ee6" src="https://github.com/user-attachments/assets/f0a899bd-3030-4f80-bc07-b38a06df6c03" />
<img width="1279" height="1706" alt="4bd45675a53ede374854aa769ad7ebc1" src="https://github.com/user-attachments/assets/0571f865-f937-413f-8548-587cdf796177" />


Experiment configuration: `<model / GPU count / batch size / training steps / rollout settings>`

Observation: `<briefly summarize reward behavior, training stability, and rollout time>`

### API and Usage Example

No new API is introduced. Enable the existing step-execution mode and select the existing algorithm registration:

```yaml
actor_rollout_ref:
  model:
    algorithm: diffusion_nft  # or: dpo

  rollout:
    step_execution: true
    max_num_seqs: 16
```

### Design & Code Changes

#### DiffusionNFT

- Uses a shared generation-context helper for both step and non-step paths.
- Creates request-local scheduler state for continuous batching.
- Reuses the standard Qwen-Image `denoise_step()` and `step_scheduler()` implementations.
- Reconstructs the existing DiffusionNFT training payload during `post_decode()`:
  - `latents_clean`
  - `train_timesteps`
  - prompt embeddings and masks

#### Online DPO

- Adds algorithm-specific `prepare_encode()`, `denoise_step()`, `step_scheduler()`, and `post_decode()` hooks.
- Generates initial noise using the prompt-embedding dtype before converting live step state to float32.
- Casts latents to the transformer compute dtype only for model execution.
- Keeps scheduler inputs and live request latents in float32 to avoid mixed-dtype batches across concurrently scheduled requests.
- Returns the same final-latent training payload consumed by the non-step DPO path.

#### Tests and documentation

- Extends the real vLLM-Omni rollout test server to select `diffusion_nft` or `dpo`.
- Adds output-contract tests for both algorithms.
- Documents algorithm-specific precision, state, and training-output requirements.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md).
- [x] Run `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`.
- [x] Update the documentation.
- [x] Add real-engine tests covering DiffusionNFT and online DPO step execution.

Co-authored-by: GitHub Copilot
