### PR TITLE
[doc, docker] fix: correct stale setup and training guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,9 +56,10 @@ See [`docs/start/install.md`](docs/start/install.md) for optional extras.
 
 Titles must follow `[{modules}] {type}: {description}`.
 
-Valid modules: `vllm_omni`, `diffusion`, `omni`, `rollout`, `trainer`, `reward`, `model`, `algo`, `fsdp`, `ray`, `worker`, `data`, `cfg`, `ckpt`, `doc`, `ci`, `tests`, `docker`, `misc`.
-
-Valid types: `feat`, `fix`, `refactor`, `chore`, `test`.
+The [PR-title CI check](tests/special_sanity/check_pr_title.py) is the source
+of truth for valid modules and types; the
+[pull request template](.github/PULL_REQUEST_TEMPLATE.md) mirrors the current
+accepted values.
 
 Add `[BREAKING]` prefix if the PR breaks any API (CLI arguments, config, function signatures).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,7 +91,10 @@ pairs or online DiffusionNFT-style forward-process training), follow:
 Thanks for submitting a PR! To streamline reviews:
 
 - Follow our [Pull Request Template](.github/PULL_REQUEST_TEMPLATE.md) for title format and checklist.
-- Format the PR title as `[{modules}] {type}: {description}` — valid modules include `vllm_omni`, `diffusion`, `omni`, `rollout`, `trainer`, `reward`, `model`, `algo`, `fsdp`, `ray`, `worker`, `data`, `cfg`, `ckpt`, `doc`, `ci`, `tests`, `docker`, `misc`.
+- Format the PR title as `[{modules}] {type}: {description}`. The
+  [PR-title CI check](tests/special_sanity/check_pr_title.py) is the source of
+  truth for accepted modules and types; the pull request template mirrors the
+  current values.
 - Adhere to our pre-commit lint rules and ensure all checks pass.
 - Update docs for any user-facing changes.
 - Add or update tests in the CI workflows, or explain why tests aren't applicable.

--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -5,9 +5,9 @@
 #
 # Override pinned versions (defaults match pyproject.toml extras):
 #   docker build -f docker/Dockerfile.cuda -t verl-omni:gpu \
-#     --build-arg VLLM_VERSION=0.22.0 \
+#     --build-arg VLLM_VERSION=0.24.0 \
 #     --build-arg KERNELS_VERSION=0.14.1 \
-#     --build-arg VLLM_OMNI_VERSION=0.22.0 \
+#     --build-arg VLLM_OMNI_VERSION=0.24.0 \
 #     --build-arg VERL_GIT_REF=8a694930275061f52ebd538c906ef8819af56dbd .
 #
 # Build with dev extras (pytest, pre-commit, …):
@@ -18,9 +18,9 @@
 
 ARG CUDA_VERSION=13.0.2
 ARG UBUNTU_VERSION=22.04
-ARG VLLM_VERSION=0.22.0
+ARG VLLM_VERSION=0.24.0
 ARG KERNELS_VERSION=0.14.1
-ARG VLLM_OMNI_VERSION=0.22.0
+ARG VLLM_OMNI_VERSION=0.24.0
 # Default: read from .github/verl_pin.txt at build time (override with VERL_GIT_REF).
 ARG VERL_GIT_REF=
 

--- a/docs/api/trainer.rst
+++ b/docs/api/trainer.rst
@@ -50,9 +50,11 @@ Direct Preference Ray Trainer
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :class:`~verl_omni.trainer.diffusion.ray_diffusion_trainer.DirectPreferenceRayTrainer`
-is the extension point for direct-preference algorithms (DPO, DiffusionNFT, AWM)
-that train with single forward-timestep updates rather than a full multi-step
-SDE trajectory. The ``fit`` implementation is not yet available in-tree.
+implements the training loop for direct-preference algorithms (DPO,
+DiffusionNFT, AWM) that use single forward-timestep updates rather than a full
+multi-step SDE trajectory. Offline algorithms consume pre-computed rewards
+from the dataset; online algorithms generate rollouts and compute rewards
+during training.
 
 .. autoclass:: verl_omni.trainer.diffusion.ray_diffusion_trainer.DirectPreferenceRayTrainer
    :members: fit

--- a/docs/contributing/integrating_a_non_diffusers_model.md
+++ b/docs/contributing/integrating_a_non_diffusers_model.md
@@ -1,7 +1,7 @@
 (integrating_a_non_diffusers_model)=
 # How to Integrate a Non-Diffusers Model for FlowGRPO Training
 
-Last updated: 06/15/2026.
+Last updated: 07/29/2026.
 
 This guide walks you through integrating a **non-diffusers model** — a
 standalone `nn.Module` that does **not** inherit from `diffusers.ModelMixin`
@@ -345,9 +345,10 @@ pipeline's expectation. Most models will not need this —
 interface.
 
 **SDE window.** ``forward()`` must set up an SDE window (selecting a
-subset of denoising steps), compensate for any vllm-omni version-specific
-step-count quirks, and slice the trajectory to return only the
-windowed steps.
+subset of denoising steps) and slice the trajectory to return only the
+windowed steps. Keep the window indices aligned with the trajectory produced
+by the supported vllm-omni version; do not carry forward step-count
+compensation for older releases.
 
 ---
 
@@ -449,7 +450,7 @@ checklist to verify your implementation against it:
 - [ ] Wraps scheduler in `_BagelSchedulerAdapter` for 4-arg `step()` convention
 - [ ] SDE `step()` passes batched `(1, tokens, C)` tensors so log-probs match training
 - [ ] `_ensure_bagel_prompt_text()` workaround for text-prompt requirement
-- [ ] `forward()` sets up SDE window, vllm-omni 0.22 timestep compensation, returns sliced trajectory
+- [ ] `forward()` sets up the SDE window and returns the sliced trajectory
 
 ### Shared utilities (`common.py`)
 - [ ] `setup_bagel_sigmas()` — shared sigma schedule for rollout and training

--- a/docs/start/multi_node_training.md
+++ b/docs/start/multi_node_training.md
@@ -1,7 +1,7 @@
 (multi_node_training)=
 # Multi-Node Training
 
-Last updated: 06/15/2026
+Last updated: 07/29/2026
 
 Scale FlowGRPO (or any diffusion RL) training across multiple nodes. This guide
 uses the Qwen-Image OCR LoRA example to explain every change needed when moving
@@ -103,7 +103,8 @@ The environment variables accept overrides so the same script works on any
 cluster size:
 
 ```bash
-NNODES=4 GPUS_PER_NODE=8 bash run_qwen_image_ocr_lora_multi_node.sh
+NNODES=4 GPUS_PER_NODE=8 \
+  bash examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_lora_multi_node.sh
 ```
 
 ### 2. Batch-size scaling

--- a/docs/start/rollout_batching.md
+++ b/docs/start/rollout_batching.md
@@ -2,7 +2,7 @@
 (request_level_batching)=
 # Diffusion Rollout Batching
 
-Last updated: 07/22/2026.
+Last updated: 07/29/2026.
 
 vLLM-Omni can batch diffusion rollouts in two different ways. They look similar
 in config (`max_num_seqs`) but they are **different engines** and are
@@ -39,8 +39,12 @@ Do not enable both modes at once.
 
 | Recipe | Default mode |
 |---|---|
-| Qwen-Image FlowGRPO (`run_qwen_image_ocr*.sh`) | Step-wise (`step_execution=true`, `max_num_seqs=256`) |
+| Qwen-Image FlowGRPO baselines (`run_qwen_image_ocr.sh`, `run_qwen_image_ocr_lora.sh`) | Step-wise (`step_execution=true`, `max_num_seqs=256`) |
 | SD3.5 FlowGRPO (`run_sd35_medium_ocr_lora.sh`) | Request-level (`step_execution=false`, `max_num_seqs=256`, `wait_ms=10`) |
+
+Other `run_qwen_image_ocr*.sh` launchers do not all set these overrides.
+Inspect the selected launcher before assuming that step-wise batching is
+enabled.
 
 On Qwen-Image FlowGRPO e2e LoRA (32×16, 512²) the two modes were essentially
 tied (~106–108s gen). SD3.5 currently has request-level support only.
@@ -137,8 +141,7 @@ Qwen-Image). The gain comes from `max_num_seqs > 1`.
 3. Collate / split with helpers in
    [`verl_omni/pipelines/request_batch.py`](../../verl_omni/pipelines/request_batch.py).
 
-Details:
-[`integrating_a_diffusion_model.md`](../contributing/integrating_a_diffusion_model.md#request-level-batching).
+Details: {ref}`request-level-batching`.
 
 ---
 


### PR DESCRIPTION
### What does this PR do?

Correct several independent documentation and setup mismatches found while
auditing the current `main` branch:

- align the CUDA Docker defaults and examples with the vLLM/vLLM-Omni 0.24.0
  versions used by `pyproject.toml`, installation docs, and CI
- document the in-tree online/offline `DirectPreferenceRayTrainer.fit()`
  implementation
- scope the Qwen-Image step-wise batching defaults to the two launchers that
  actually enable them and repair the request-batching cross-reference
- remove stale vLLM-Omni 0.22 BAGEL timestep-compensation guidance
- make the multi-node example runnable from the repository root
- make the PR-title CI check the source of truth instead of duplicating an
  incomplete module list in `AGENTS.md` and `CONTRIBUTING.md`

This PR deliberately excludes findings in files already modified by open PRs
#305, #316, and #317.

### Duplicate-work check

This is not duplicating an existing PR. I checked the open PR file inventory
and searched the affected areas, including
[DirectPreference trainer docs](https://github.com/verl-project/verl-omni/pulls?q=is%3Apr+is%3Aopen+%22DirectPreferenceRayTrainer%22+fit+docs),
[rollout batching references](https://github.com/verl-project/verl-omni/pulls?q=is%3Apr+is%3Aopen+%22rollout+batching%22+%22request-level%22),
and
[Docker vLLM 0.22 drift](https://github.com/verl-project/verl-omni/pulls?q=is%3Apr+is%3Aopen+%22vllm+0.22%22+Docker).
No open PR covers these changed files and claims.

### Test

- `python3 tests/special_sanity/check_docs_time_info.py` — passed
- `PR_TITLE='[doc, docker] fix: correct stale setup and training guidance'
  python3 tests/special_sanity/check_pr_title.py` — passed
- `sphinx-build --keep-going -w /tmp/verl-omni-pr-sphinx.log -b html docs
  /tmp/verl-omni-pr-html` — succeeded; the repaired cross-reference resolves
  in rendered HTML and the warning count is one lower than `main`
- local Markdown/RST link scan — no new broken links; four pre-existing links
  remain in files intentionally excluded because open PRs already modify them
- `git diff --check` — passed
- `bash -n
  examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_lora_multi_node.sh`
  — passed
- static version parity check across `docker/Dockerfile.cuda`,
  `pyproject.toml`, and `docs/start/install.md` — all use 0.24.0

A Docker image build was not run because Docker CLI is unavailable in the
current environment. No Python implementation was changed.

### API and Usage Example

No API changes. The trainer API page now describes the existing `fit()`
behavior accurately.

### Design & Code Changes

This is a source-of-truth cleanup: executable source, launchers, CI title
validation, package metadata, and the current BAGEL adapter were treated as
authoritative. Duplicated mutable values were removed where possible rather
than copied again.

### AI assistance

OpenAI Codex assisted with the audit, edits, and validation. Per the repository
contribution policy, the human submitter reviewed every changed line and
confirmed the reported validation results before marking this PR ready for review.

### Checklist Before Submitting

- [x] Searched for similar open PRs and excluded overlapping files
- [x] Used a CI-valid PR title
- [x] Read the contribution and agent-instruction editing guides
- [x] Updated the relevant documentation
- [x] Ran targeted documentation, link, command, and consistency checks
- [x] Human submitter has reviewed every changed line
- [ ] Full `pre-commit run --all-files` — not run because the complete
  development/runtime dependency stack is not installed in this environment

