### PR TITLE
[trainer, tests, doc] feat: monitor v1 rollout-train consistency

### DIFF
--- a/docs/algo/rollout_correction.md
+++ b/docs/algo/rollout_correction.md
@@ -88,7 +88,7 @@ rollout backend is drifting too far — tighten the RS band or fall back to
 ## Consistency monitoring
 
 Whenever the rollout returns log-probs (`actor_rollout_ref.rollout.calculate_log_probs=true`)
-and bypass mode is off, the trainer additionally logs rollout-train consistency diagnostics
+and bypass mode is off, both the legacy and v1 trainers log rollout-train consistency diagnostics
 once per global batch — no `rollout_correction` config needed:
 
 - `rollout_corr/logprob_abs_diff_mean` / `_max` — |`old_log_probs` − `rollout_log_probs`|.

--- a/tests/trainer/diffusion/test_rollout_correction_on_cpu.py
+++ b/tests/trainer/diffusion/test_rollout_correction_on_cpu.py
@@ -392,6 +392,34 @@ class TestConsistencyMetrics:
         assert "rollout_corr/logprob_abs_diff_mean" in metrics
         assert not any("logprob_abs_diff/ts_" in k for k in metrics)
 
+    def test_batch_metrics_include_timestep_breakdown(self):
+        """The trainer-facing helper reads log-probs and timesteps from DataProto."""
+        batch = DataProto.from_dict(
+            tensors={
+                "old_log_probs": torch.tensor([[1.0, 2.0]]),
+                "rollout_log_probs": torch.tensor([[1.5, 2.0]]),
+                "all_timesteps": torch.tensor([[800.0, 700.0]]),
+            }
+        )
+
+        metrics = rollout_correction.compute_rollout_corr_metrics_from_batch(batch, bypass_mode=False)
+
+        assert metrics["rollout_corr/logprob_abs_diff_mean"] == pytest.approx(0.25)
+        assert metrics["rollout_corr/logprob_abs_diff/ts_800"] == pytest.approx(0.5)
+
+    @pytest.mark.parametrize(
+        ("bypass_mode", "include_rollout_log_probs"),
+        [(True, True), (False, False)],
+    )
+    def test_batch_metrics_skip_unavailable_comparisons(self, bypass_mode, include_rollout_log_probs):
+        """Bypass mode and batches without rollout log-probs do not emit trivial metrics."""
+        tensors = {"old_log_probs": torch.randn(2, 2)}
+        if include_rollout_log_probs:
+            tensors["rollout_log_probs"] = torch.randn(2, 2)
+        batch = DataProto.from_dict(tensors=tensors)
+
+        assert rollout_correction.compute_rollout_corr_metrics_from_batch(batch, bypass_mode=bypass_mode) == {}
+
 
 class TestConfigHelpers:
     def test_rollout_correction_enabled(self):

--- a/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
+++ b/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
@@ -1033,7 +1033,7 @@ class PolicyGradientRayTrainer(BaseRayDiffusionTrainer):
                                 metrics.update({"perf/mfu/actor_infer": old_log_prob_mfu})
                             batch = batch.union(old_log_prob)
 
-                    assert "old_log_probs" in batch.batch, f'"old_log_prob" not in {batch.batch.keys()=}'
+                    assert "old_log_probs" in batch.batch, f'"old_log_probs" not in {batch.batch.keys()=}'
 
                     metrics.update(
                         compute_rollout_corr_metrics_from_batch(

--- a/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
+++ b/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
@@ -68,7 +68,7 @@ from verl_omni.trainer.diffusion.diffusion_trainer_utils import NoOpCheckpointMa
 from verl_omni.trainer.diffusion.rollout_correction import (
     apply_bypass_mode_to_diffusion_batch,
     apply_rollout_correction_to_diffusion_batch,
-    compute_rollout_corr_metrics_from_logprobs,
+    compute_rollout_corr_metrics_from_batch,
     rollout_correction_enabled,
 )
 from verl_omni.workers.utils.padding import embeds_padding_2_no_padding
@@ -1035,16 +1035,12 @@ class PolicyGradientRayTrainer(BaseRayDiffusionTrainer):
 
                     assert "old_log_probs" in batch.batch, f'"old_log_prob" not in {batch.batch.keys()=}'
 
-                    # Consistency monitoring (needs calculate_log_probs=true); in bypass
-                    # mode old == rollout so there is nothing to compare.
-                    if not bypass_recomputing_logprobs and "rollout_log_probs" in batch.batch:
-                        metrics.update(
-                            compute_rollout_corr_metrics_from_logprobs(
-                                batch.batch["old_log_probs"],
-                                batch.batch["rollout_log_probs"],
-                                timesteps=batch.batch.get("all_timesteps", None),
-                            )
+                    metrics.update(
+                        compute_rollout_corr_metrics_from_batch(
+                            batch,
+                            bypass_mode=bool(bypass_recomputing_logprobs),
                         )
+                    )
 
                     # Decoupled-mode rollout correction (old vs rollout).
                     # In bypass mode old == rollout, so correction runs per-step in ``diffusion_loss``.

--- a/verl_omni/trainer/diffusion/rollout_correction.py
+++ b/verl_omni/trainer/diffusion/rollout_correction.py
@@ -34,6 +34,7 @@ from verl.trainer.ppo.rollout_corr_helper import (
 __all__ = [
     "apply_bypass_mode_to_diffusion_batch",
     "apply_rollout_correction_to_diffusion_batch",
+    "compute_rollout_corr_metrics_from_batch",
     "compute_rollout_corr_metrics_from_logprobs",
     "rollout_correction_enabled",
 ]
@@ -214,3 +215,22 @@ def compute_rollout_corr_metrics_from_logprobs(
             )
 
     return metrics_with_prefix
+
+
+def compute_rollout_corr_metrics_from_batch(
+    batch: DataProto,
+    *,
+    bypass_mode: bool,
+) -> dict[str, float]:
+    """Compute rollout-train consistency metrics when both log-probs are available."""
+    if bypass_mode or batch.batch is None:
+        return {}
+
+    if "old_log_probs" not in batch.batch or "rollout_log_probs" not in batch.batch:
+        return {}
+
+    return compute_rollout_corr_metrics_from_logprobs(
+        batch.batch["old_log_probs"],
+        batch.batch["rollout_log_probs"],
+        timesteps=batch.batch.get("all_timesteps", None),
+    )

--- a/verl_omni/trainer/diffusion/v1/trainer_base.py
+++ b/verl_omni/trainer/diffusion/v1/trainer_base.py
@@ -65,6 +65,7 @@ from verl_omni.trainer.diffusion.ray_diffusion_trainer import compute_advantage
 from verl_omni.trainer.diffusion.rollout_correction import (
     apply_bypass_mode_to_diffusion_batch,
     apply_rollout_correction_to_diffusion_batch,
+    compute_rollout_corr_metrics_from_batch,
     rollout_correction_enabled,
 )
 from verl_omni.trainer.diffusion.v1.tq_utils import (
@@ -288,6 +289,13 @@ class PolicyGradientDiffusionTrainerV1(ABC):
                 data = data.union(old_log_prob)
 
         assert "old_log_probs" in data.batch, f'"old_log_probs" not in {data.batch.keys()}'
+
+        metrics.update(
+            compute_rollout_corr_metrics_from_batch(
+                data,
+                bypass_mode=bypass_recomputing_logprobs,
+            )
+        )
 
         if not bypass_recomputing_logprobs and rollout_correction_enabled(rollout_corr_config):
             with marked_timer("rollout_corr", timing_raw, color="cyan"):


### PR DESCRIPTION
### What does this PR do?

Extend the rollout-train log-prob consistency monitoring added by #291 to the
diffusion trainer v1 path introduced later by #296.

- centralize the existing availability and bypass-mode checks in a
  trainer-facing `DataProto` helper
- use the same helper from both the legacy and v1 policy-gradient trainers
- preserve the existing `rollout_corr/*` metric names and per-timestep
  breakdown
- document that consistency monitoring is available in both trainer paths

This is a follow-up to #280. It does not change rollout correction, optimization
math, defaults, or accelerator-specific code.

### Duplicate-work check

This is not duplicating an existing PR. I checked:

- [open PRs referencing #280](https://github.com/verl-project/verl-omni/pulls?q=is%3Apr+is%3Aopen+280+in%3Abody)
- [open PRs for v1 rollout-train consistency](https://github.com/verl-project/verl-omni/pulls?q=is%3Apr+is%3Aopen+rollout+train+consistency+trainer+v1+logprob)
- the submitter's other open PRs and their changed paths

#291 added the monitoring call to the legacy diffusion trainer. The v1 trainer
was merged afterward in #296 and currently recomputes `old_log_probs` without
emitting the same diagnostics.

### Test

- Repository-pinned `verl` commit
  `8a694930275061f52ebd538c906ef8819af56dbd`:

  ```bash
  PYTHONPATH="$PWD:$VERL_PIN_CHECKOUT" python - <<'PY'
  # Bootstrap only the lightweight package paths so the CPU-only environment
  # does not import the optional vllm-omni runtime, then run:
  # pytest.main(["-q", "tests/trainer/diffusion/test_rollout_correction_on_cpu.py"])
  PY
  ```

  Result: `21 passed`.

- `pre-commit run ruff --files <changed Python files>` — passed.
- `pre-commit run ruff-format --files <changed Python files>` — passed.
- `pre-commit run mypy --files <changed Python files>` — passed.
- All remaining targeted pre-commit hooks passed when
  `autogen-trainer-cfg` was skipped.

The full targeted pre-commit run reaches an unrelated existing drift:
regenerating `_generated_omni_trainer.yaml` changes Omni configuration fields
even on the repository-pinned `verl` commit. That generated diff was reverted
and is not part of this PR.

### Additional A800 multi-step validation

A 5-step mechanism-level trainer-path run was completed on the current head
`7886eaf`:

- 1 × NVIDIA A800 80GB PCIe; PyTorch 2.6.0+cu124; bf16 tiny actor.
- Batch size 4; four diffusion/SDE timesteps (1000/750/500/250);
  deterministic seed `20260730`.
- Every step executed forward, backward, and an SGD update through the exact
  PR versions of `PolicyGradientDiffusionTrainerV1._step_once` and the
  rollout-correction helper.
- All expected `rollout_corr/*` metrics were finite across five steps;
  gradients and parameter updates were non-zero; computed fields persisted;
  the bypass-mode negative control emitted no consistency metrics.
- Actor loss changed from `0.02955836` to `0.02403400`;
  `logprob_abs_diff_mean` ranged from `6.2499e-05` to `3.1250e-04`.

Slurm job `261484` completed with exit `0:0`. Result SHA-256:
`9f7209010690364524bfde128a90a47a5bc7929328cadd2540d02a4d5aa40f73`;
log SHA-256:
`7cea1bfcebdd71156fb990a797588b3e53033beebe6fec429d6538017e9e111b`.
The full five-step table and protocol are in
[this PR comment](https://github.com/verl-project/verl-omni/pull/319#issuecomment-5130675735).

Scope: this validates the changed v1 trainer mechanism with a synthetic tiny
actor; it is not a substitute for the repository's full
Ray/TransferQueue/vLLM-Omni diffusion E2E or project GPU CI.

### API and Usage Example

No API or configuration changes. When rollout log-probs are enabled and bypass
mode is off, both trainer implementations now emit the existing diagnostics:

```yaml
actor_rollout_ref:
  rollout:
    calculate_log_probs: true
```

Examples include `rollout_corr/logprob_abs_diff_mean`,
`rollout_corr/logprob_abs_diff_max`, and
`rollout_corr/logprob_abs_diff/ts_{t}`.

### Design & Code Changes

`compute_rollout_corr_metrics_from_batch` owns the shared trainer-side gating:
it skips bypass mode and batches without both log-prob tensors, then delegates
all numerical work to the existing tested
`compute_rollout_corr_metrics_from_logprobs`. The legacy trainer is changed only
to use this helper; trainer v1 calls it immediately after recomputing
`old_log_probs` and before optional rollout correction.

### AI assistance

OpenAI Codex assisted with repository inspection, implementation, testing, and
PR preparation. The human submitter has reviewed every changed line and can
defend the change end-to-end.

### Checklist Before Starting

- [x] Searched for similar PRs and linked the queries above.
- [x] Formatted the PR title as `[{modules}] {type}: {description}` and ran the
      repository title validator.

### Checklist Before Submitting

- [x] Read the contribution guide and `AGENTS.md`.
- [x] Added/updated documentation.
- [x] Added CPU unit tests for the shared trainer-facing behavior.
- [x] Ran the relevant Ruff, formatting, mypy, structure, documentation,
      license, naming, and compile checks.
- [x] Human submitter has reviewed every changed line.
- [ ] Full `pre-commit run --all-files` — not completed because
      `autogen-trainer-cfg` exposes the unrelated generated Omni configuration
      drift described above; the generated diff was reverted.
