### PR TITLE
[doc] fix: quote SKILL.md description so GitHub renders front matter

### DIFF
--- a/.agents/skills/commit-and-pr/SKILL.md
+++ b/.agents/skills/commit-and-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: commit-and-pr
-description: verl-omni commit message + PR conventions and the mandatory contribution policy. MUST load before any git commit or PR creation -- enforces the [{modules}] {type}: {description} title format, commit trailers, duplicate-work checks, and AI-assistance disclosure.
+description: "verl-omni commit message + PR conventions and the mandatory contribution policy. MUST load before any git commit or PR creation -- enforces the [{modules}] {type}: {description} title format, commit trailers, duplicate-work checks, and AI-assistance disclosure."
 ---
 
 # Commit & PR Conventions


### PR DESCRIPTION
## What

Wrap the `commit-and-pr` skill's front-matter `description` value in double quotes so GitHub can render the file.

## Why

GitHub parses a Markdown file's leading `---` block as Jekyll-style YAML front matter. The `description` was an unquoted plain scalar containing `[{modules}] {type}: {description}`. The `: ` (colon-space) inside a plain scalar is ambiguous with YAML mapping `key: value` syntax, so the strict parser rejects it with *"mapping values are not allowed in this context"* and shows the **"Error in user YAML"** box reported in #327.

Claude Code's own skill loader is lenient and loads the skill regardless, which is why it worked locally and the invalid YAML went unnoticed — but it is a genuine YAML spec violation. Double-quoting the whole value makes it a valid scalar (the text contains no double quotes, so quoting is safe) and leaves the loaded description byte-identical.

Fixes #327.

## Not a duplicate

Per `CLAUDE.md` Step 0 duplicate-work checks:

```
gh issue view 327 --repo verl-project/verl-omni
gh pr list --repo verl-project/verl-omni --state open --search "327 in:body"
gh pr list --repo verl-project/verl-omni --state open --search "SKILL front matter yaml"
```

No open PR references #327 or touches this front matter.

## Scope

Scanned all 71 tracked `.md` files; 9 have YAML front matter and only this one fails `yaml.safe_load`. The other three skills and every rule/doc file parse fine — this bug is isolated to `commit-and-pr/SKILL.md`.

## Test

```
python3 -c "import yaml,io; ... yaml.safe_load(front_matter)"   # now parses; keys: name, description
pre-commit run --files .agents/skills/commit-and-pr/SKILL.md    # all hooks pass / skip (no .py); exit 0
```

Before: `yaml.safe_load` raises "mapping values are not allowed in this context" at the description line. After: parses cleanly to `{name, description}`. `pytest` was not run — this diff is a one-line docs/front-matter change with no importable code to exercise.

## AI assistance

AI assistance (Claude Code) was used for this change. A human submitter has reviewed every changed line.
