### PR TITLE
[trainer, tests] fix: persist wandb validation video media

### DIFF
--- a/tests/trainer/diffusion/test_val_video_logging_on_cpu.py
+++ b/tests/trainer/diffusion/test_val_video_logging_on_cpu.py
@@ -37,7 +37,9 @@ class _RecordingValLogger:
         self.calls.append((list(loggers), samples, step))
 
 
-def _run_val_logging(outputs, *, log_val_generations, video_fps=8, global_steps=0):
+def _run_val_logging(
+    outputs, *, log_val_generations, video_fps=8, global_steps=0, validation_data_dir=None, default_local_dir=None
+):
     """Invoke the unbound ``_maybe_log_val_generations`` with a minimal stub ``self``."""
     val_logger = _RecordingValLogger()
     stub = SimpleNamespace(
@@ -47,6 +49,8 @@ def _run_val_logging(outputs, *, log_val_generations, video_fps=8, global_steps=
                     "log_val_generations": log_val_generations,
                     "logger": ["wandb"],
                     "video_fps": video_fps,
+                    "validation_data_dir": validation_data_dir,
+                    "default_local_dir": default_local_dir,
                 }
             }
         ),
@@ -70,8 +74,8 @@ def _warm_clips(n, t=8, h=32, w=32):
 
 
 class TestMaybeLogValGenerationsWandb:
-    def test_wandb_video_gets_real_decodable_mp4_and_temp_dir_is_cleaned(self, monkeypatch):
-        """wandb.Video gets a real, decodable, correctly-colored mp4, and the temp dir is removed after log()."""
+    def test_wandb_video_gets_real_decodable_mp4_in_persistent_dir(self, monkeypatch, tmp_path):
+        """wandb.Video gets a real mp4 that remains available after log() returns."""
         captured = []
 
         class _FakeVideo:
@@ -88,7 +92,10 @@ class TestMaybeLogValGenerationsWandb:
         monkeypatch.setattr(wandb, "Video", _FakeVideo)
 
         outputs = _warm_clips(2)  # [2, T, C, H, W]
-        val_logger = _run_val_logging(outputs, log_val_generations=2)
+        validation_data_dir = tmp_path / "val"
+        val_logger = _run_val_logging(
+            outputs, log_val_generations=2, global_steps=7, validation_data_dir=str(validation_data_dir)
+        )
 
         # One wandb.Video per retained video sample, each a real mp4 tagged format=mp4.
         assert len(captured) == 2
@@ -99,19 +106,37 @@ class TestMaybeLogValGenerationsWandb:
             assert r > g > b, f"channel order not preserved in wandb mp4: R={r:.1f} G={g:.1f} B={b:.1f}"
             assert r > 128 and b < 128, f"warm frame inverted in wandb mp4: R={r:.1f} B={b:.1f}"
 
-        # tempfile.mkdtemp(prefix="val_video_") is shared across encodes and removed after log().
-        tmp_dirs = {os.path.dirname(c.path) for c in captured}
-        assert len(tmp_dirs) == 1, f"expected one shared temp dir, got {tmp_dirs}"
-        (tmp_dir,) = tmp_dirs
-        assert os.path.basename(tmp_dir).startswith("val_video_")
-        assert not os.path.exists(tmp_dir), "temp video dir was not cleaned up after logging"
+        # Files live under validation_data_dir so wandb can read them during async artifact upload.
+        media_dirs = {os.path.dirname(c.path) for c in captured}
+        expected_dir = validation_data_dir / "wandb_val_media" / "global_step_7"
+        assert media_dirs == {str(expected_dir)}
+        assert expected_dir.is_dir()
+        assert all(os.path.isfile(c.path) for c in captured)
 
         # The backend received the wrapped media (our _FakeVideo instances), not raw tensors.
         assert len(val_logger.calls) == 1
         loggers, samples, step = val_logger.calls[0]
-        assert loggers == ["wandb"] and step == 0
+        assert loggers == ["wandb"] and step == 7
         assert len(samples) == 2
         assert all(isinstance(media, _FakeVideo) for _inp, media, _score in samples)
+
+    def test_wandb_video_uses_default_local_dir_when_validation_dir_is_unset(self, monkeypatch, tmp_path):
+        captured = []
+
+        class _FakeVideo:
+            def __init__(self, data_or_path, *args, **kwargs):
+                captured.append(data_or_path)
+
+        monkeypatch.setattr(wandb, "Video", _FakeVideo)
+
+        default_local_dir = tmp_path / "run"
+        _run_val_logging(
+            _warm_clips(1), log_val_generations=1, global_steps=11, default_local_dir=str(default_local_dir)
+        )
+
+        expected_path = default_local_dir / "wandb_val_media" / "global_step_11" / "0.mp4"
+        assert captured == [str(expected_path)]
+        assert expected_path.is_file()
 
     def test_real_wandb_video_ingests_our_production_mp4(self, tmp_path):
         """The REAL wandb.Video ingests a production-path mp4 from disk (size + sha256) with no moviepy."""

--- a/tests/utils/test_tracking_on_cpu.py
+++ b/tests/utils/test_tracking_on_cpu.py
@@ -37,7 +37,7 @@ def _warm_clip(t=8, h=32, w=32):
     return clip
 
 
-def test_video_samples_become_wandb_video_with_a_real_mp4(monkeypatch):
+def test_video_samples_become_wandb_video_with_a_real_mp4_in_output_dir(monkeypatch, tmp_path):
     captured = []
 
     class _FakeVideo:
@@ -54,20 +54,46 @@ def test_video_samples_become_wandb_video_with_a_real_mp4(monkeypatch):
 
     monkeypatch.setattr(wandb, "Video", _FakeVideo)
 
+    output_dir = tmp_path / "wandb_val_media" / "global_step_3"
     samples = [(f"prompt {i}", _warm_clip(), float(i)) for i in range(2)]
+    wrapped, video_tmp_dir = wrap_val_samples_for_wandb(samples, fps=8, output_dir=str(output_dir))
+
+    assert video_tmp_dir is None
+    assert len(wrapped) == 2
+    assert len(captured) == 2
+    for (inp, media, score), c in zip(wrapped, captured, strict=True):
+        assert isinstance(media, _FakeVideo)
+        assert c.path.endswith(".mp4") and c.kwargs.get("format") == "mp4"
+        assert os.path.dirname(c.path) == str(output_dir)
+        assert os.path.isfile(c.path)
+        r, g, b = c.rgb
+        assert r > g > b and r > 128 and b < 128, f"warm frame inverted: R={r:.1f} G={g:.1f} B={b:.1f}"
+    assert os.path.isdir(output_dir)
+
+
+def test_video_samples_without_output_dir_return_cleanup_temp_dir(monkeypatch):
+    captured = []
+
+    class _FakeVideo:
+        def __init__(self, path, *args, **kwargs):
+            assert os.path.isfile(path), f"wandb.Video got a non-existent path: {path}"
+            captured.append(SimpleNamespace(path=path, kwargs=dict(kwargs)))
+
+    monkeypatch.setattr(wandb, "Video", _FakeVideo)
+
+    samples = [("prompt", _warm_clip(), 1.0)]
     wrapped, video_tmp_dir = wrap_val_samples_for_wandb(samples, fps=8)
 
     try:
-        assert len(wrapped) == 2
-        assert len(captured) == 2
-        for (inp, media, score), c in zip(wrapped, captured, strict=True):
-            assert isinstance(media, _FakeVideo)
-            assert c.path.endswith(".mp4") and c.kwargs.get("format") == "mp4"
-            r, g, b = c.rgb
-            assert r > g > b and r > 128 and b < 128, f"warm frame inverted: R={r:.1f} G={g:.1f} B={b:.1f}"
-        # One shared temp dir the caller is expected to remove.
+        assert video_tmp_dir is not None
         assert os.path.basename(video_tmp_dir).startswith("val_video_")
         assert os.path.isdir(video_tmp_dir)
+        assert len(wrapped) == 1
+        assert len(captured) == 1
+        assert captured[0].path.endswith(".mp4")
+        assert captured[0].kwargs.get("format") == "mp4"
+        assert os.path.dirname(captured[0].path) == video_tmp_dir
+        assert os.path.isfile(captured[0].path)
     finally:
         shutil.rmtree(video_tmp_dir, ignore_errors=True)
 

--- a/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
+++ b/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
@@ -395,11 +395,16 @@ class BaseRayDiffusionTrainer(ABC):
         # Take first N samples after shuffling
         samples = samples[:generations_to_log]
 
-        # Wrap retained media for wandb (after truncation, so videos are not all encoded)
+        # Wrap only retained samples; keep wandb videos in persistent storage.
         video_tmp_dir = None
         if "wandb" in self.config.trainer.logger:
+            validation_data_dir = self.config.trainer.get("validation_data_dir", None)
+            default_local_dir = self.config.trainer.get("default_local_dir", None)
+            wandb_video_dir = validation_data_dir or default_local_dir
+            if wandb_video_dir:
+                wandb_video_dir = os.path.join(wandb_video_dir, "wandb_val_media", f"global_step_{self.global_steps}")
             samples, video_tmp_dir = wrap_val_samples_for_wandb(
-                samples, fps=int(self.config.trainer.get("video_fps", 24))
+                samples, fps=int(self.config.trainer.get("video_fps", 24)), output_dir=wandb_video_dir
             )
 
         # Log to each configured logger

--- a/verl_omni/utils/tracking.py
+++ b/verl_omni/utils/tracking.py
@@ -20,25 +20,27 @@ import tempfile
 from verl_omni.utils.reward_score.reward_utils import video_tensor_to_pil_frames
 
 
-def wrap_val_samples_for_wandb(samples, fps=24):
-    """Wrap ``(input, output, score)`` tuples for ``wandb`` validation logging.
+def wrap_val_samples_for_wandb(samples, fps=24, output_dir=None):
+    """Wrap validation samples for ``wandb`` logging.
 
-    Video outputs ``[T, C, H, W]`` are encoded to a temp mp4 and passed to
-    ``wandb.Video`` by path (no moviepy); other outputs become ``wandb.Image``.
-    Returns the wrapped samples and the temp dir (``None`` if no video), which the
-    caller removes after logging.
+    Videos are encoded as mp4 files for ``wandb.Video``. Provide ``output_dir``
+    to keep them for async upload; otherwise a temp dir is returned for cleanup.
     """
     import wandb
 
+    video_dir = output_dir
     video_tmp_dir = None
     wrapped = []
     for inp, out, score in samples:
         if hasattr(out, "ndim") and out.ndim == 4:
             from diffusers.utils import export_to_video
 
-            if video_tmp_dir is None:
+            if video_dir is None:
                 video_tmp_dir = tempfile.mkdtemp(prefix="val_video_")
-            video_path = os.path.join(video_tmp_dir, f"{len(wrapped)}.mp4")
+                video_dir = video_tmp_dir
+            else:
+                os.makedirs(video_dir, exist_ok=True)
+            video_path = os.path.join(video_dir, f"{len(wrapped)}.mp4")
             export_to_video(video_tensor_to_pil_frames(out), video_path, fps=fps)
             media = wandb.Video(video_path, format="mp4")
         else:


### PR DESCRIPTION
### What does this PR do?

Fix W&B validation video logging so video media passed to `wandb.Video` remains available while W&B uploads table artifacts asynchronously.

Previously validation videos were encoded under a temporary directory and the trainer could clean that directory immediately after `wandb.log()` returned. W&B may still read media paths after that point, causing errors like `Path is not a file: /tmp/val_video_*/0.mp4`.

This PR writes validation video mp4s under a persistent run directory when available and keeps the temp-dir fallback for direct helper usage.

### Checklist Before Starting

- [x] Search for similar PRs. Queries checked:
  - https://github.com/verl-project/verl-omni/pulls?q=is%3Apr+is%3Aopen+wandb+validation+video
  - https://github.com/verl-project/verl-omni/pulls?q=is%3Apr+is%3Aopen+wandb+val+video
  - https://github.com/verl-project/verl-omni/pulls?q=is%3Apr+is%3Aopen+validation+video+media
  - https://github.com/verl-project/verl-omni/pulls?q=is%3Apr+is%3Aopen+val_video+wandb
  - https://github.com/verl-project/verl-omni/pulls?q=is%3Apr+is%3Aopen+persistent+wandb+video
  - Result: no open PRs found for these queries. No issue number was provided, so issue-specific duplicate checks were not applicable.
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `vllm_omni`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `diffusion`, `omni`, `tests`, `docker`
  - If this PR involves multiple modules, separate them with `,` like `[diffusion, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][diffusion, fsdp] feat: new rollout scheduler`

### Test

```bash
TORCH_COMPILE_DISABLE=1 TORCHINDUCTOR_DISABLE=1 \
python -m pytest -q \
  tests/utils/test_tracking_on_cpu.py \
  tests/trainer/diffusion/test_val_video_logging_on_cpu.py
```

Result:

```text
6 passed, 16 warnings in 55.11s
```

Additional validation:

```bash
python -m py_compile \
  verl_omni/trainer/diffusion/ray_diffusion_trainer.py \
  verl_omni/utils/tracking.py
```

Result: passed.

Pre-commit hooks run during commit amend and passed:

```text
ruff
ruff format
mypy
Generate and verify verl_omni/trainer/config/_generated_*.yaml
Check docs Last updated info
Check doc string coverage
Check license
Check device API usage
Check DataProto usage
Validate test structure
Check naming conventions
Compile all python files
```

### API and Usage Example

No user-facing API or config change.

Internally, `wrap_val_samples_for_wandb(..., output_dir=None)` accepts an optional output directory. The trainer passes a persistent directory under `trainer.validation_data_dir` or `trainer.default_local_dir` when W&B logging is enabled.

### Design & Code Changes

- Keep validation W&B video media under `wandb_val_media/global_step_<step>` inside the validation/run directory when possible.
- Keep the temp-directory fallback for helper callers without a persistent output directory.
- Wrap only the retained validation samples so unused videos are not encoded.
- Add CPU tests for persistent validation media, temp-dir fallback, and the `default_local_dir` fallback.

### AI assistance and human review

AI assistance (OpenAI Codex) was used for this change.

This is a draft PR. Before marking ready for review, the human submitter must review every changed line, confirm they understand and can defend the change end-to-end, and run the relevant checks.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always` (targeted pre-commit hooks passed during commit amend; all-files run is pending for draft readiness).
- [x] Add / Update the documentation. N/A: internal bug fix covered by tests.
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl-omni/tree/main/.github/workflows) to cover all the code. Added CPU tests for tracking and trainer validation logging behavior.

