### PR TITLE
[trainer, tests] fix: normalize Wan22 channels-last 6-D video before …

### DIFF
--- a/tests/trainer/diffusion/test_dump_generations_video_on_cpu.py
+++ b/tests/trainer/diffusion/test_dump_generations_video_on_cpu.py
@@ -126,3 +126,25 @@ class TestDumpGenerations:
         rows = _read_jsonl(tmp_path)
         assert len(rows) == 1
         assert rows[0]["reward"] == 0.0
+
+    def test_wan22_channels_last_singleton_video_batch(self, tmp_path):
+        """Wan22 rollout returns ``[N, 1, F, H, W, C]``; the dump must normalize it
+        to channels-first video (one mp4 per sample, frames and channel order intact)."""
+        imageio = pytest.importorskip("imageio")
+
+        outputs = torch.zeros(2, 1, 8, 16, 16, 3)  # [N, 1, F, H, W, C], solid warm frame
+        outputs[..., 0] = 0.75  # R
+        outputs[..., 1] = 0.35  # G
+        outputs[..., 2] = 0.15  # B
+        _dump(tmp_path, outputs)
+
+        visual = os.path.join(str(tmp_path), "0")
+        mp4s = sorted(f for f in os.listdir(visual) if f.endswith(".mp4"))
+        assert mp4s == ["0.mp4", "1.mp4"]
+
+        reader = imageio.get_reader(os.path.join(visual, "0.mp4"))
+        frames = [frame for frame in reader]
+        reader.close()
+        assert len(frames) == 8  # F survived as the time axis
+        r, g, b = (float(frames[4][..., c].mean()) for c in range(3))
+        assert r > g > b, f"channel order not preserved: R={r:.1f} G={g:.1f} B={b:.1f}"

--- a/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
+++ b/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
@@ -283,9 +283,17 @@ class BaseRayDiffusionTrainer(ABC):
         """Dump samples to disk as media files plus a JSONL index.
 
         ``outputs`` is a batch of images ``[N, C, H, W]`` (-> ``{i}.jpg``) or videos
-        ``[N, T, C, H, W]`` (-> ``{i}.mp4`` at ``fps``). ``max_samples`` caps how many
+        ``[N, T, C, H, W]`` (-> ``{i}.mp4`` at ``fps``). Channels-last video with a
+        singleton frame dim, ``[N, 1, F, H, W, C]`` (e.g. Wan22 rollout), is also
+        accepted and normalized to ``[N, T, C, H, W]``. ``max_samples`` caps how many
         are written (``None`` = all).
         """
+        # Wan22 rollout returns channels-last video with a singleton dim: [N, 1, F, H, W, C]
+        if outputs.ndim == 6:
+            outputs = outputs.squeeze(1)
+        if outputs.ndim == 5 and outputs.shape[-1] in (1, 3):
+            outputs = outputs.permute(0, 1, 4, 2, 3)
+
         os.makedirs(dump_path, exist_ok=True)
 
         visual_folder = os.path.join(dump_path, f"{self.global_steps}")


### PR DESCRIPTION
…dumping

BaseRayDiffusionTrainer._dump_generations only handled 4-D image batches [N, C, H, W] and 5-D channels-first video [N, T, C, H, W] (added in #311). Wan22 DanceGRPO rollout (#98) returns channels-last video with a singleton frame dim, [N, 1, F, H, W, C], which fell through to the image branch and raised (the path is only reachable with trainer.validation_data_dir set, which the official NPU recipe never sets, so it was not caught earlier).

Squeeze the singleton dim and permute to channels-first before the existing rank check, so both the video and image branches stay unchanged for their original input shapes. Add a CPU regression test covering frame count and channel order for the 6-D input.

Test: pytest -q tests/trainer/diffusion/test_dump_generations_video_on_cpu.py -> 5 passed, 16 warnings in 16.71s (run on a GPU host with the full verl-omni dependency stack, since vllm_omni has no macOS/arm64 wheel). Also verified with ruff check / ruff format --check on both changed files.

AI assistance (Claude, via CatPaw) was used for this change.

### What does this PR do?

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `vllm_omni`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `diffusion`, `omni`, `tests`, `docker`
  - If this PR involves multiple modules, separate them with `,` like `[diffusion, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][diffusion, fsdp] feat: new rollout scheduler`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update the documentation.
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl-omni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
