### PR TITLE
[ci] fix: move L3 nightly baseline download to setup job

### DIFF
--- a/.github/workflows/l3_nightly.yml
+++ b/.github/workflows/l3_nightly.yml
@@ -60,6 +60,7 @@ env:
   IMAGE: "verl-ci-cn-beijing.cr.volces.com/verlai/verl:vllm023.dev1"
   DYNAMIC_RUNNER_ENDPOINT: "https://sd7upeujs1b9g1a958pn0.apigateway-cn-beijing.volceapi.com/runner"
   BASELINE_ARTIFACT_NAME: l3-nightly-baseline
+  BASELINE_STAGING_ARTIFACT_PREFIX: l3-nightly-baseline-staging
   CURRENT_ARTIFACT_PREFIX: l3-nightly-current
   REPORT_ARTIFACT_PREFIX: l3-nightly-reports
   RUN_MODE: ${{ github.event_name == 'schedule' && 'nightly' || github.event_name == 'pull_request' && 'nightly' || github.event.inputs.mode || 'nightly' }}
@@ -82,6 +83,47 @@ jobs:
       mlp-task-id: ${{ steps.create-runner.outputs.mlp-task-id }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Download latest L3 baseline artifact
+        if: env.RUN_MODE == 'nightly'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          artifact_row="$(
+            gh api "/repos/${GITHUB_REPOSITORY}/actions/artifacts?per_page=100" --paginate \
+              --jq ".artifacts[] | select(.name == \"${BASELINE_ARTIFACT_NAME}\" and .expired == false and .workflow_run.head_branch == \"${BASELINE_BRANCH}\") | [.created_at, .id] | @tsv" \
+              | sort -r \
+              | awk 'NR == 1 { print }'
+          )"
+
+          if [ -z "${artifact_row}" ]; then
+            echo "No non-expired ${BASELINE_ARTIFACT_NAME} artifact found for branch ${BASELINE_BRANCH}."
+            echo "Create one with workflow_dispatch mode=baseline before running nightly mode."
+            exit 1
+          fi
+
+          artifact_id="$(printf '%s' "${artifact_row}" | awk '{ print $2 }')"
+          echo "Downloading ${BASELINE_ARTIFACT_NAME} artifact ${artifact_id} from branch ${BASELINE_BRANCH}."
+
+          rm -rf /tmp/l3-nightly-baseline "${OUTPUT_ROOT}/baseline"
+          mkdir -p /tmp/l3-nightly-baseline "${OUTPUT_ROOT}/baseline"
+          gh api "/repos/${GITHUB_REPOSITORY}/actions/artifacts/${artifact_id}/zip" > /tmp/l3-nightly-baseline.zip
+          unzip -q /tmp/l3-nightly-baseline.zip -d /tmp/l3-nightly-baseline
+
+          shopt -s dotglob nullglob
+          cp -a /tmp/l3-nightly-baseline/* "${OUTPUT_ROOT}/baseline/"
+
+      - name: Upload L3 baseline staging artifact
+        if: env.RUN_MODE == 'nightly'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.BASELINE_STAGING_ARTIFACT_PREFIX }}-${{ github.run_id }}
+          path: ${{ env.OUTPUT_ROOT }}/baseline
+          if-no-files-found: error
+          retention-days: 1
+
       - id: create-runner
         uses: volcengine/vemlp-github-runner@v1
         with:
@@ -120,46 +162,12 @@ jobs:
           pip3 install torchcodec librosa soundfile av
           pip3 install "transformers[mistral-common]"
 
-      - name: Download latest L3 baseline artifact
-        if: env.RUN_MODE == 'nightly' || env.RUN_MODE == 'baseline'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-
-          require_baseline=0
-          if [ "${RUN_MODE}" = "nightly" ]; then
-            require_baseline=1
-          fi
-
-          artifact_row="$(
-            gh api "/repos/${GITHUB_REPOSITORY}/actions/artifacts?per_page=100" --paginate \
-              --jq ".artifacts[] | select(.name == \"${BASELINE_ARTIFACT_NAME}\" and .expired == false and .workflow_run.head_branch == \"${BASELINE_BRANCH}\") | [.created_at, .id] | @tsv" \
-              | sort -r \
-              | awk 'NR == 1 { print }'
-          )"
-
-          if [ -z "${artifact_row}" ]; then
-            if [ "${require_baseline}" -eq 1 ]; then
-              echo "No non-expired ${BASELINE_ARTIFACT_NAME} artifact found for branch ${BASELINE_BRANCH}."
-              echo "Create one with workflow_dispatch mode=baseline before running nightly mode."
-              exit 1
-            fi
-            echo "No existing ${BASELINE_ARTIFACT_NAME} artifact; starting from an empty baseline tree."
-            mkdir -p "${OUTPUT_ROOT}/baseline"
-            exit 0
-          fi
-
-          artifact_id="$(printf '%s' "${artifact_row}" | awk '{ print $2 }')"
-          echo "Downloading ${BASELINE_ARTIFACT_NAME} artifact ${artifact_id} from branch ${BASELINE_BRANCH}."
-
-          rm -rf /tmp/l3-nightly-baseline "${OUTPUT_ROOT}/baseline"
-          mkdir -p /tmp/l3-nightly-baseline "${OUTPUT_ROOT}/baseline"
-          gh api "/repos/${GITHUB_REPOSITORY}/actions/artifacts/${artifact_id}/zip" > /tmp/l3-nightly-baseline.zip
-          unzip -q /tmp/l3-nightly-baseline.zip -d /tmp/l3-nightly-baseline
-
-          shopt -s dotglob nullglob
-          cp -a /tmp/l3-nightly-baseline/* "${OUTPUT_ROOT}/baseline/"
+      - name: Download L3 baseline from setup job
+        if: env.RUN_MODE == 'nightly'
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.BASELINE_STAGING_ARTIFACT_PREFIX }}-${{ github.run_id }}
+          path: ${{ env.OUTPUT_ROOT }}/baseline
 
       - name: Run Qwen-Image FlowGRPO L3 regression
         run: |


### PR DESCRIPTION
### What does this PR do?

Fixes L3 nightly CI failures caused by calling `gh api` on the Volcengine GPU runner, which does not ship with the GitHub CLI.

Changes:
- Move baseline artifact download from `l3_nightly_tests` (GPU runner) to `setup` (`ubuntu-latest`, where `gh` is preinstalled)
- Pass the downloaded baseline to the GPU job via a short-lived staging artifact (`l3-nightly-baseline-staging-{run_id}`).
- Skip baseline download entirely in `baseline` mode so the first bootstrap run can generate and upload `l3-nightly-baseline` without requiring an existing artifact or `gh` on the GPU runner.
- Fail fast in `setup` when nightly mode cannot find a baseline artifact, before provisioning the GPU runner.

Observed failure before this change:
- `gh: command not found` (exit 127) in the GPU job download step
- Cascading `upload-artifact` failure because baseline bootstrap never ran


### Test

CI-only workflow change; validated by manual workflow dispatch:

- [ ] `workflow_dispatch` with `mode=baseline` — should skip download, run regression, and upload `l3-nightly-baseline`
- [ ] `workflow_dispatch` with `mode=nightly` (after baseline exists) — should download baseline in `setup`, pass via staging artifact, and run strict comparison on GPU runner


### API and Usage Example

No user-facing API changes. Workflow behavior:

| Mode | Baseline download | GPU runner needs `gh` |
|------|-------------------|------------------------|
| `baseline` | Skipped | No |
| `nightly` | `setup` job via `gh api` → staging artifact → GPU job | No |

### Design & Code Changes

```mermaid
flowchart LR
    subgraph setup["setup (ubuntu-latest)"]
        A["gh api download l3-nightly-baseline"] --> B["upload staging artifact"]
        B --> C["create GPU runner"]
    end
    subgraph gpu["l3_nightly_tests (Volcengine GPU)"]
        D["download-artifact"] --> E["run L3 regression"]
    end
    setup --> gpu