### PR TITLE
[reward, perf, tests] feat: batch PickScore inference

### DIFF
--- a/tests/utils/reward_score/test_pickscore_reward_on_cpu.py
+++ b/tests/utils/reward_score/test_pickscore_reward_on_cpu.py
@@ -1,0 +1,166 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU tests for PickScore burst batching and prompt deduplication."""
+
+import asyncio
+import importlib.util
+from pathlib import Path
+
+import pytest
+import torch
+from PIL import Image
+
+
+def _load_module():
+    path = Path(__file__).parents[3] / "verl_omni/utils/reward_score/pickscore_reward.py"
+    spec = importlib.util.spec_from_file_location("pickscore_reward", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+pickscore_reward = _load_module()
+
+
+class _FakeProcessor:
+    def __init__(self):
+        self.text_batches = []
+
+    def __call__(self, *, images=None, text=None, **kwargs):
+        if images is not None:
+            return {"pixel_values": torch.stack([image.feature for image in images])}
+
+        self.text_batches.append(text)
+        features = {"same": [1.0, 0.0], "different": [0.0, 1.0]}
+        return {"input_ids": torch.tensor([features[prompt] for prompt in text])}
+
+
+class _FakeModel:
+    logit_scale = torch.tensor(0.0)
+
+    def get_image_features(self, pixel_values):
+        return pixel_values
+
+    def get_text_features(self, input_ids):
+        return input_ids
+
+
+class _FeatureImage:
+    def __init__(self, feature):
+        self.feature = torch.tensor(feature)
+
+
+def test_score_encodes_duplicate_prompts_once_and_preserves_pairing():
+    inferencer = object.__new__(pickscore_reward._PickScoreInferencer)
+    inferencer.device = "cpu"
+    inferencer.processor = _FakeProcessor()
+    inferencer.model = _FakeModel()
+
+    scores = inferencer.score(
+        ["same", "same", "different"],
+        [_FeatureImage([1.0, 0.0]), _FeatureImage([0.0, 1.0]), _FeatureImage([0.0, 1.0])],
+    )
+
+    assert inferencer.processor.text_batches == [["same", "different"]]
+    torch.testing.assert_close(scores, torch.tensor([1.0 / 26, 0.0, 1.0 / 26]))
+
+
+class _FakeInferencer:
+    def __init__(self):
+        self.batches = []
+
+    def score(self, prompts, images):
+        self.batches.append((list(prompts), list(images)))
+        return torch.tensor([float(image.getpixel((0, 0))) for image in images])
+
+
+@pytest.mark.asyncio
+async def test_consumer_batches_burst_requests_and_preserves_order(monkeypatch):
+    inferencer = _FakeInferencer()
+    queue = asyncio.Queue()
+    monkeypatch.setattr(pickscore_reward, "_score_queue", queue)
+    monkeypatch.setattr(pickscore_reward, "_consumer_started", False)
+    monkeypatch.setattr(pickscore_reward, "_consumer_task", None)
+    monkeypatch.setattr(pickscore_reward, "_consumer_lock", asyncio.Lock())
+    monkeypatch.setattr(pickscore_reward, "_PickScoreInferencer", lambda device: inferencer)
+
+    scores = await asyncio.gather(
+        *(
+            pickscore_reward.compute_score_pickscore(
+                data_source="test",
+                solution_image=Image.new("L", (1, 1), index),
+                ground_truth="shared prompt",
+                extra_info={},
+                device="cpu",
+            )
+            for index in range(4)
+        )
+    )
+    queue.put_nowait((None, None, None))
+    await pickscore_reward._consumer_task
+
+    assert scores == [
+        {"score": 0.0, "pickscore_raw": 0.0},
+        {"score": 1.0, "pickscore_raw": 1.0},
+        {"score": 2.0, "pickscore_raw": 2.0},
+        {"score": 3.0, "pickscore_raw": 3.0},
+    ]
+    assert len(inferencer.batches) == 1
+    assert inferencer.batches[0][0] == ["shared prompt"] * 4
+
+
+@pytest.mark.asyncio
+async def test_consumer_caps_each_micro_batch(monkeypatch):
+    inferencer = _FakeInferencer()
+    queue = asyncio.Queue()
+    monkeypatch.setattr(pickscore_reward, "_inferencer", inferencer)
+    monkeypatch.setattr(pickscore_reward, "_score_queue", queue)
+    monkeypatch.setattr(pickscore_reward, "_MAX_BATCH_SIZE", 2)
+
+    consumer = asyncio.create_task(pickscore_reward._consumer_loop())
+    futures = []
+    for index in range(5):
+        future = asyncio.get_running_loop().create_future()
+        futures.append(future)
+        queue.put_nowait(("prompt", Image.new("L", (1, 1), index), future))
+    queue.put_nowait((None, None, None))
+
+    assert await asyncio.gather(*futures) == [0.0, 1.0, 2.0, 3.0, 4.0]
+    await consumer
+    assert [len(prompts) for prompts, _ in inferencer.batches] == [2, 2, 1]
+
+
+@pytest.mark.asyncio
+async def test_consumer_isolates_invalid_image_from_batch(monkeypatch):
+    inferencer = _FakeInferencer()
+    queue = asyncio.Queue()
+    monkeypatch.setattr(pickscore_reward, "_inferencer", inferencer)
+    monkeypatch.setattr(pickscore_reward, "_score_queue", queue)
+
+    consumer = asyncio.create_task(pickscore_reward._consumer_loop())
+    futures = [asyncio.get_running_loop().create_future() for _ in range(3)]
+    queue.put_nowait(("prompt", Image.new("L", (1, 1), 1), futures[0]))
+    queue.put_nowait(("prompt", object(), futures[1]))
+    queue.put_nowait(("prompt", Image.new("L", (1, 1), 3), futures[2]))
+    queue.put_nowait((None, None, None))
+
+    results = await asyncio.gather(*futures, return_exceptions=True)
+    await consumer
+
+    assert results[0] == 1.0
+    assert isinstance(results[1], AssertionError)
+    assert results[2] == 3.0
+    assert len(inferencer.batches) == 1
+    assert inferencer.batches[0][0] == ["prompt", "prompt"]

--- a/verl_omni/utils/reward_score/pickscore_reward.py
+++ b/verl_omni/utils/reward_score/pickscore_reward.py
@@ -26,6 +26,7 @@ logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "INFO"))
 
 _PROCESSOR_PATH = "laion/CLIP-ViT-H-14-laion2B-s32B-b79K"
 _MODEL_PATH = "yuvalkirstain/PickScore_v1"
+_MAX_BATCH_SIZE = 16
 
 _inferencer = None
 _score_queue = asyncio.Queue()
@@ -57,6 +58,10 @@ class _PickScoreInferencer:
 
     @torch.no_grad()
     def score(self, prompts: list[str], images: list[Image.Image]) -> torch.Tensor:
+        unique_prompts = list(dict.fromkeys(prompts))
+        prompt_to_index = {prompt: index for index, prompt in enumerate(unique_prompts)}
+        prompt_indices = [prompt_to_index[prompt] for prompt in prompts]
+
         image_inputs = self.processor(
             images=images,
             padding=True,
@@ -67,7 +72,7 @@ class _PickScoreInferencer:
         image_inputs = {k: v.to(device=self.device) for k, v in image_inputs.items()}
 
         text_inputs = self.processor(
-            text=prompts,
+            text=unique_prompts,
             padding=True,
             truncation=True,
             max_length=77,
@@ -80,6 +85,7 @@ class _PickScoreInferencer:
 
         text_embs = _feature_tensor(self.model.get_text_features(**text_inputs))
         text_embs = text_embs / text_embs.norm(p=2, dim=-1, keepdim=True)
+        text_embs = text_embs[prompt_indices]
 
         logit_scale = self.model.logit_scale.exp()
         scores = logit_scale * (text_embs @ image_embs.T)
@@ -100,26 +106,65 @@ def _to_pil_hwc(image) -> Image.Image:
     return image
 
 
-def _score_one(prompt: str, solution_image) -> float:
-    """Called from thread pool.  All heavy work (PIL conversion + CLIP inference)
-    happens here so the event loop is never blocked."""
-    pil_image = _to_pil_hwc(solution_image)
-    scores = _inferencer.score([prompt], [pil_image])
-    return scores[0].item()
+def _score_batch(requests) -> list[float | Exception]:
+    """Convert and score a batch in a thread so the event loop is never blocked."""
+    results = [None] * len(requests)
+    prompts = []
+    images = []
+    valid_indices = []
+
+    for index, (prompt, solution_image, _) in enumerate(requests):
+        try:
+            images.append(_to_pil_hwc(solution_image))
+            prompts.append(prompt)
+            valid_indices.append(index)
+        except Exception as e:
+            results[index] = e
+
+    if valid_indices:
+        try:
+            scores = _inferencer.score(prompts, images).tolist()
+            for index, score in zip(valid_indices, scores, strict=True):
+                results[index] = score
+        except Exception as e:
+            for index in valid_indices:
+                results[index] = e
+
+    return results
 
 
 async def _consumer_loop():
     loop = asyncio.get_running_loop()
     while True:
-        prompt, solution_image, future = await _score_queue.get()
-        if prompt is None:
+        request = await _score_queue.get()
+        if request[0] is None:
             break
-        try:
-            raw_score = await loop.run_in_executor(None, _score_one, prompt, solution_image)
-            future.set_result(raw_score)
-        except Exception as e:
-            logger.exception("PickScore inference failed")
-            future.set_exception(e)
+
+        requests = [request]
+        should_stop = False
+        await asyncio.sleep(0)
+        while len(requests) < _MAX_BATCH_SIZE:
+            try:
+                request = _score_queue.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+            if request[0] is None:
+                should_stop = True
+                break
+            requests.append(request)
+
+        results = await loop.run_in_executor(None, _score_batch, requests)
+        for (_, _, future), result in zip(requests, results, strict=True):
+            if future.done():
+                continue
+            if isinstance(result, Exception):
+                logger.error("PickScore inference failed", exc_info=(type(result), result, result.__traceback__))
+                future.set_exception(result)
+            else:
+                future.set_result(result)
+
+        if should_stop:
+            break
 
 
 async def _ensure_consumer(device: str):


### PR DESCRIPTION
### What does this PR do?

PickScore requests were previously processed one at a time, even though the reward loop submits samples concurrently. This change collects each ready burst into a bounded micro-batch of up to 16 requests and deduplicates repeated prompts before text encoding.

The original score contract is preserved: results are returned in request order, each prompt remains paired with its image, invalid image conversion fails only that request, and public configuration and return values are unchanged.

This does not duplicate an existing contribution. Searches performed before submission:

- https://github.com/verl-project/verl-omni/pulls?q=is%3Apr+is%3Aopen+PickScore+batching
- https://github.com/verl-project/verl-omni/issues?q=is%3Aissue+is%3Aopen+PickScore

AI assistance was used. The human submitter has completed the repository-required line-by-line review.

### Checklist Before Starting

- [x] Search for similar PRs. Query links are included above.
- [x] Format the PR title as `[{modules}] {type}: {description}`.

### Test

CPU unit tests:

```text
python -m pytest -q --asyncio-mode=auto \
  tests/utils/reward_score/test_pickscore_reward_on_cpu.py \
  tests/utils/reward_score/test_choice_reward_on_cpu.py \
  tests/utils/reward_score/test_latent_http_scorer_client_on_cpu.py \
  tests/utils/reward_score/test_reward_utils_on_cpu.py

22 passed in 2.24s
```

Repository checks:

```text
SKIP=autogen-trainer-cfg pre-commit run --all-files --show-diff-on-failure

All executed hooks passed. autogen-trainer-cfg was skipped because the local
validation environment did not contain the repository-pinned verl package;
this PR does not change trainer configuration or generated YAML.
```

Real-model GPU validation on one NVIDIA A800 80GB PCIe, PyTorch 2.6.0+cu124, Transformers 5.9.0, float32, 512x512 images, batch size 16, five measured repeats after warm-up:

| Metric | main | this PR |
|---|---:|---:|
| Median latency per 16 requests | 0.7853 s | 0.4556 s |
| Median throughput | 20.37 images/s | 35.12 images/s |
| Peak allocated memory | 3.76 GiB | 3.99 GiB |
| Peak reserved memory | 4.156 GiB | 4.156 GiB |

- Median speedup: **1.724x**
- Latency reduction: **41.98%**
- Throughput increase: **72.37%**
- Maximum score absolute difference: **1.0133e-6**
- `torch.allclose(rtol=1e-4, atol=1e-5)`: passed
- Mechanism checks: main used 16 singleton image/text calls; this PR used one image batch of 16 and one unique prompt encoding per burst.

The A800 run used production source SHA256 `b87ba51a7ea00a494b1b735eac7f2dd63e5fa24a4aebf7b410304e898bf77591`, which matches the production file in this commit.

### API and Usage Example

No API or configuration changes. Existing callers continue to use `compute_score_pickscore` unchanged.

### Design & Code Changes

- collect currently queued requests after one event-loop yield, capped at 16;
- preprocess and infer valid images as one batch while isolating conversion failures;
- encode each distinct prompt once, then expand embeddings back to request order;
- add CPU tests for prompt deduplication, ordering, batch capping, and invalid-image isolation.

### Checklist Before Submitting

- [x] Read the contribution guide.
- [x] Run relevant formatting, linting, type, structure, license, and compile checks.
- [x] Add CPU tests collected by the existing `*_on_cpu.py` CI convention.
- [x] Documentation is not applicable because no API, configuration, model-support, or workflow contract changes.
- [x] Human submitter has reviewed every changed line before marking the PR ready.
