### PR TITLE
[rollout] fix: preserve rank-local ZMQ routes for LoRA weight updates

### DIFF
--- a/tests/workers/rollout/rollout_vllm/test_zmq_utils.py
+++ b/tests/workers/rollout/rollout_vllm/test_zmq_utils.py
@@ -1,0 +1,80 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from verl.workers.rollout.vllm_rollout import bucketed_weight_transfer
+
+from verl_omni.workers.rollout.vllm_rollout.utils import vLLMOmniColocateWorkerExtension
+from verl_omni.workers.rollout.vllm_rollout.zmq_utils import make_update_zmq_handle, make_update_zmq_id
+
+
+def test_update_id_is_unique_when_the_same_step_is_retried():
+    assert make_update_zmq_id(7, 2) == "step-7-seq-2"
+    assert make_update_zmq_id(7, 2) != make_update_zmq_id(7, 3)
+
+
+def test_shared_update_id_preserves_rank_specific_routes():
+    update_id = "step-7-seq-2"
+    rank_0 = "ipc:///tmp/rl-colocate-zmq-job-replica-0-rank-0.sock"
+    rank_1 = "ipc:///tmp/rl-colocate-zmq-job-replica-0-rank-1.sock"
+
+    rank_0_handle = make_update_zmq_handle(rank_0, update_id)
+    rank_1_handle = make_update_zmq_handle(rank_1, update_id)
+
+    assert rank_0_handle == "ipc:///tmp/rl-colocate-zmq-job-replica-0-rank-0-update-step-7-seq-2.sock"
+    assert rank_1_handle == "ipc:///tmp/rl-colocate-zmq-job-replica-0-rank-1-update-step-7-seq-2.sock"
+    assert rank_0_handle != rank_1_handle
+    assert rank_0_handle != make_update_zmq_handle(rank_0, "step-7-seq-3")
+
+
+def test_non_ipc_handle_is_unchanged():
+    handle = "tcp://127.0.0.1:5555"
+
+    assert make_update_zmq_handle(handle, "step-7-seq-2") == handle
+
+
+def test_worker_receivers_resolve_shared_update_id_from_their_rank_local_handles():
+    received_handles = []
+
+    class FakeReceiver:
+        def __init__(self, zmq_handle, device, use_shm):
+            received_handles.append(zmq_handle)
+
+        def receive_weights(self, on_bucket_received):
+            on_bucket_received([])
+
+    update_id = "step-7-seq-2"
+    base_handles = [
+        "ipc:///tmp/rl-colocate-zmq-job-replica-0-rank-0.sock",
+        "ipc:///tmp/rl-colocate-zmq-job-replica-0-rank-1.sock",
+    ]
+    with patch.object(bucketed_weight_transfer, "BucketedWeightReceiver", FakeReceiver):
+        for base_handle in base_handles:
+            worker = SimpleNamespace(
+                device="npu",
+                _pending_lora_peft_config=None,
+                _get_zmq_handle=lambda base_handle=base_handle: base_handle,
+                _get_standard_weight_model_and_config=lambda: None,
+                load_weights=lambda weights: None,
+            )
+            vLLMOmniColocateWorkerExtension.update_weights_from_ipc(
+                worker,
+                use_shm=True,
+                zmq_update_id=update_id,
+            )
+
+    assert received_handles == [make_update_zmq_handle(handle, update_id) for handle in base_handles]
+    assert len(set(received_handles)) == len(base_handles)

--- a/verl_omni/workers/engine_workers.py
+++ b/verl_omni/workers/engine_workers.py
@@ -65,6 +65,7 @@ from verl_omni.workers.config import (
     DiffusionModelConfig,
     OmniModelConfig,
 )
+from verl_omni.workers.rollout.vllm_rollout.zmq_utils import make_update_zmq_handle, make_update_zmq_id
 from verl_omni.workers.utils.losses import diffusion_loss
 
 logger = logging.getLogger(__file__)
@@ -93,19 +94,6 @@ def _with_routing_replay_flag(enabled: bool):
         return wrapper
 
     return decorator
-
-
-def _make_update_zmq_handle(base_handle: str, global_steps: int | None) -> str:
-    """Return a per-update IPC handle so repeated LoRA syncs cannot collide."""
-    if not base_handle.startswith("ipc://"):
-        return base_handle
-
-    path = base_handle.removeprefix("ipc://")
-    if path.endswith(".sock"):
-        path = path[: -len(".sock")]
-    step = "none" if global_steps is None else str(global_steps)
-    unique_suffix = f"-step-{step}-pid-{os.getpid()}-{time.time_ns()}"
-    return f"ipc://{path}{unique_suffix}.sock"
 
 
 class TrainingWorker(Worker, DistProfilerExtension):
@@ -742,6 +730,7 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
             self.base_sync_done: bool = "dummy" not in self.config.rollout.load_format
             self.layered_summon = self.config.rollout.get("layered_summon", False)
             self.peft_merge: bool = model_config.lora.get("merge", False)
+            self._zmq_update_seq = 0
 
         # 4. build checkpoint engine
         if "actor" in self.role:
@@ -1017,10 +1006,14 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
             offload_task = asyncio.create_task(asyncio.to_thread(self._offload_actor_and_empty_cache, timings))
 
             # Use ZMQ IPC to transfer LoRA weights, bypassing Ray serialization.
-            # The _execute_method call only carries a small metadata dict (peft_config,
-            # base_sync_done, use_shm) — tensor data goes through the ZMQ socket.
+            # Broadcast only the update id. Each vLLM worker combines it with its
+            # rank-local base handle, preserving the one-sender/one-receiver route.
             sync_start = time.perf_counter()
-            zmq_handle = _make_update_zmq_handle(self.rollout.zmq_handle, global_steps)
+            # update_weights is dispatched ONE_TO_ALL, so every actor rank advances
+            # this sequence exactly once for the same LoRA update.
+            zmq_update_id = make_update_zmq_id(global_steps, self._zmq_update_seq)
+            self._zmq_update_seq += 1
+            zmq_handle = make_update_zmq_handle(self.rollout.zmq_handle, zmq_update_id)
             future = await self.rollout._execute_method(
                 "update_weights_from_ipc",
                 non_block=True,
@@ -1028,7 +1021,7 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
                     "peft_config": peft_config,
                     "base_sync_done": True,
                     "use_shm": self.rollout.use_shm,
-                    "zmq_handle": zmq_handle,
+                    "zmq_update_id": zmq_update_id,
                 },
             )
             bucket_size_mb = self.config.rollout.checkpoint_engine.update_weights_bucket_megabytes

--- a/verl_omni/workers/rollout/vllm_rollout/utils.py
+++ b/verl_omni/workers/rollout/vllm_rollout/utils.py
@@ -20,6 +20,7 @@ from verl.workers.rollout.vllm_rollout.utils import VLLM_LORA_INT_ID, VLLM_LORA_
 from vllm_omni.diffusion.worker.diffusion_worker import CustomPipelineWorkerExtension
 
 from verl_omni.utils.vllm_omni import OmniTensorLoRARequest, VLLMOmniHijack
+from verl_omni.workers.rollout.vllm_rollout.zmq_utils import make_update_zmq_handle
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
@@ -82,7 +83,7 @@ class vLLMOmniColocateWorkerExtension(CustomPipelineWorkerExtension):
         peft_config: dict = None,
         base_sync_done=False,
         use_shm: bool = False,
-        zmq_handle: str | None = None,
+        zmq_update_id: str | None = None,
     ):
         """Update the weights of the rollout model.
 
@@ -101,8 +102,11 @@ class vLLMOmniColocateWorkerExtension(CustomPipelineWorkerExtension):
             self._pending_lora_peft_config = None
 
         assert self.device is not None
+        zmq_handle = self._get_zmq_handle()
+        if zmq_update_id is not None:
+            zmq_handle = make_update_zmq_handle(zmq_handle, zmq_update_id)
         receiver = BucketedWeightReceiver(
-            zmq_handle=zmq_handle or self._get_zmq_handle(),
+            zmq_handle=zmq_handle,
             device=self.device,
             use_shm=use_shm,
         )

--- a/verl_omni/workers/rollout/vllm_rollout/zmq_utils.py
+++ b/verl_omni/workers/rollout/vllm_rollout/zmq_utils.py
@@ -1,0 +1,30 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def make_update_zmq_id(global_steps: int | None, update_seq: int) -> str:
+    """Return an id that is unique for each weight update in a worker lifetime."""
+    step = "none" if global_steps is None else str(global_steps)
+    return f"step-{step}-seq-{update_seq}"
+
+
+def make_update_zmq_handle(base_handle: str, update_id: str) -> str:
+    """Append a per-update id while preserving the job/rank-specific base handle."""
+    if not base_handle.startswith("ipc://"):
+        return base_handle
+
+    path = base_handle.removeprefix("ipc://")
+    if path.endswith(".sock"):
+        path = path[: -len(".sock")]
+    return f"ipc://{path}-update-{update_id}.sock"


### PR DESCRIPTION
### What does this PR do?

This PR fixes a deadlock during colocated LoRA weight synchronization when the
rollout uses tensor parallelism greater than one, while preserving the
per-update ZMQ IPC endpoint isolation introduced by #303.

#### Regression introduced by #303

#303 added a unique `zmq_handle` for every LoRA update to prevent consecutive
updates from reusing an old IPC endpoint. That goal is preserved by this PR.

However, #303 passed the actor-side rollout rank 0's complete handle through
`collective_rpc`:

```python
kwargs={"zmq_handle": zmq_handle}
```

Only rollout rank 0 invokes the RPC, and the RPC broadcasts the same kwargs to
every vLLM-Omni TP worker. With rollout TP greater than one, all receivers
therefore connected to rank 0's endpoint instead of their own rank-local
endpoints:

```text
actor rank 0 sender ----+----> vLLM rank 0 receiver
                        +----> vLLM rank 1 receiver
                        +----> vLLM rank 2 receiver

actor rank 1 sender ----------> no receiver
actor rank 2 sender ----------> no receiver
```

ZMQ REQ/REP is not a broadcast transport. Multiple REP receivers connected to
one REQ endpoint compete for messages, so different weight buckets and the
terminal bucket can be consumed by different TP ranks. The rank that receives
the terminal bucket exits the receive loop and enters `all_gather_object`, while
the other ranks remain blocked in `recv_pyobj()`. This eventually causes the
observed HCCL timeout and also makes later collective RPCs such as `wake_up`
fail.

The nightly test added by #303 used `tensor_model_parallel_size=1`, so it did
not exercise multiple receivers competing for the same endpoint. Reverting the
#303 ZMQ change restored the original rank-local one-to-one routing, which
further isolated the regression to the complete-handle broadcast.

#### Fix

The fix broadcasts only a shared `zmq_update_id`. Each actor sender and
vLLM-Omni receiver combines that ID with its own existing job-, replica-, and
rank-specific base handle:

```text
actor rank 0 -> ...-rank-0-update-step-N-seq-M.sock -> vLLM rank 0
actor rank 1 -> ...-rank-1-update-step-N-seq-M.sock -> vLLM rank 1
```

The update sequence also keeps repeated updates at the same global step on
different IPC endpoints. This retains #303's protection against endpoint reuse
without making multiple TP receivers compete for one address.

Related PR: #303.

### Checklist Before Starting

- [x] Search for similar PRs. Query: [open ZMQ `update_weights_from_ipc` PRs](https://github.com/verl-project/verl-omni/pulls?q=is%3Apr+is%3Aopen+ZMQ+update_weights_from_ipc). No matching open PR was found.
- [x] Format the PR title as `[{modules}] {type}: {description}` (validated with `tests/special_sanity/check_pr_title.py`).

### Test

#### NPU TP>1 validation

Validated by the submitter with an NPU rollout using tensor parallelism greater
than one.

Before the fix:

```text
actor_rollout_update_weights -> update_weights_from_ipc stalled
AclrtSynchronizeStreamWithTimeout
error code: 107020
torch.distributed.all_gather_object(statuses, status)
```

The failure occurred after approximately 1866 seconds. After applying this
patch, the LoRA weight update completed successfully and the workers proceeded
past the following collective without the ZMQ/HCCL timeout.

#### Unit coverage

Added focused tests for:

- distinct update IDs when the same global step is retried;
- distinct IPC endpoints for different TP ranks receiving the same update ID;
- sender/receiver rank-local endpoint agreement;
- worker-side `update_weights_from_ipc` resolution from each worker's local base
  handle; and
- unchanged behavior for non-IPC endpoints.

Focused test command:

```bash
python3 -m pytest -q \
  tests/workers/rollout/rollout_vllm/test_zmq_utils.py
```

The focused pytest command was not run in the local authoring environment
because that environment does not have `pytest` or the complete runtime
dependencies installed. The submitter's NPU TP>1 run provides the end-to-end
runtime validation.

Static checks run successfully:

```bash
ruff check \
  verl_omni/workers/engine_workers.py \
  verl_omni/workers/rollout/vllm_rollout/utils.py \
  verl_omni/workers/rollout/vllm_rollout/zmq_utils.py \
  tests/workers/rollout/rollout_vllm/test_zmq_utils.py

ruff format --check \
  verl_omni/workers/engine_workers.py \
  verl_omni/workers/rollout/vllm_rollout/utils.py \
  verl_omni/workers/rollout/vllm_rollout/zmq_utils.py \
  tests/workers/rollout/rollout_vllm/test_zmq_utils.py

python3 -m compileall -q \
  verl_omni/workers/engine_workers.py \
  verl_omni/workers/rollout/vllm_rollout/utils.py \
  verl_omni/workers/rollout/vllm_rollout/zmq_utils.py \
  tests/workers/rollout/rollout_vllm/test_zmq_utils.py

git diff --check
```

### API and Usage Example

No user-facing configuration or API changes are introduced. Existing LoRA
rollout configurations continue to work without modification.

`zmq_update_id` is internal metadata used only between the colocated actor
weight-update path and vLLM-Omni worker extension.

### Design & Code Changes

#### `verl_omni/workers/engine_workers.py`

- Replace the per-rank independently generated complete RPC handle with a
  shared `zmq_update_id`.
- Maintain a monotonically increasing update sequence in each colocated rollout
  worker. `update_weights` is dispatched `ONE_TO_ALL`, so actor ranks advance
  the same sequence for each LoRA update.
- Build each sender's final endpoint from its own
  `self.rollout.zmq_handle + zmq_update_id`.
- Pass only `zmq_update_id` through `collective_rpc`; do not broadcast rollout
  rank 0's complete endpoint.

#### `verl_omni/workers/rollout/vllm_rollout/utils.py`

- Make every vLLM-Omni worker start from its own `self._get_zmq_handle()`.
- Append the shared update ID locally so TP workers receive the same update
  generation while retaining distinct rank-specific endpoints.

#### `verl_omni/workers/rollout/vllm_rollout/zmq_utils.py`

- Add shared helpers for generating a per-update ID and appending it to an IPC
  base handle.
- Keep non-IPC endpoint behavior unchanged.

#### `tests/workers/rollout/rollout_vllm/test_zmq_utils.py`

- Add focused regression tests for repeated-update uniqueness, TP-rank endpoint
  isolation, non-IPC compatibility, and worker-side rank-local resolution.