### PR TITLE
[cfg] fix: fix generated omni yaml

### DIFF
--- a/scripts/print_cfg.py
+++ b/scripts/print_cfg.py
@@ -11,6 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
+
+from hydra.core.hydra_config import HydraConfig
+from omegaconf import OmegaConf
+
 try:
     import hydra
 except ImportError as e:
@@ -24,6 +29,15 @@ def main(config):
     Args:
         config_dict: Hydra configuration dictionary containing training parameters.
     """
+    config_name = HydraConfig.get().job.config_name
+
+    raw_path = os.path.join("verl_omni/trainer/config", f"{config_name}.yaml")
+    if os.path.exists(raw_path):
+        raw = OmegaConf.load(raw_path)
+        raw.pop("defaults", None)
+        raw.pop("hydra", None)
+        config = OmegaConf.merge(raw, config)
+
     print(config)
 
 

--- a/scripts/print_cfg.py
+++ b/scripts/print_cfg.py
@@ -13,11 +13,11 @@
 # limitations under the License.
 import os
 
-from hydra.core.hydra_config import HydraConfig
 from omegaconf import OmegaConf
 
 try:
     import hydra
+    from hydra.core.hydra_config import HydraConfig
 except ImportError as e:
     raise ImportError("Please install hydra-core via 'pip install hydra-core' and retry.") from e
 
@@ -29,11 +29,14 @@ def main(config):
     Args:
         config_dict: Hydra configuration dictionary containing training parameters.
     """
+    import verl_omni
+
     config_name = HydraConfig.get().job.config_name
 
     # Omni configs inherit from verl's ppo_trainer. Reverse-merge the raw YAML
     # so keys absent from the structured schema survive in the printed output.
-    raw_path = os.path.join("verl_omni/trainer/config", f"{config_name}.yaml")
+    config_dir = os.path.join(os.path.dirname(verl_omni.__file__), "trainer", "config")
+    raw_path = os.path.join(config_dir, f"{config_name}.yaml")
     if os.path.exists(raw_path):
         raw = OmegaConf.load(raw_path)
         raw.pop("defaults", None)

--- a/scripts/print_cfg.py
+++ b/scripts/print_cfg.py
@@ -31,6 +31,8 @@ def main(config):
     """
     config_name = HydraConfig.get().job.config_name
 
+    # Omni configs inherit from verl's ppo_trainer. Reverse-merge the raw YAML
+    # so keys absent from the structured schema survive in the printed output.
     raw_path = os.path.join("verl_omni/trainer/config", f"{config_name}.yaml")
     if os.path.exists(raw_path):
         raw = OmegaConf.load(raw_path)

--- a/tests/workers/config/test_print_cfg_on_cpu.py
+++ b/tests/workers/config/test_print_cfg_on_cpu.py
@@ -1,0 +1,96 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU tests for the print_cfg.py reverse-merge fix.
+
+Ensures that the full config composition (hydra omni_trainer + raw YAML
+reverse-merge) preserves keys defined in ``omni_trainer.yaml`` even when
+they are not present in verl's structured ``ppo_trainer`` schema.
+"""
+
+import os
+import tempfile
+
+import pytest
+import yaml
+from hydra import compose, initialize_config_dir
+from omegaconf import OmegaConf
+
+import verl_omni
+
+_OMNI_CONFIG_DIR = os.path.join(os.path.dirname(verl_omni.__file__), "trainer", "config")
+
+
+@pytest.fixture(scope="module")
+def _composed_cfg():
+    """Return the hydra-composed omni_trainer config (cached per module)."""
+    # The omni_trainer.yaml already has hydra.searchpath: [pkg://verl.trainer.config]
+    # so defaults like ppo_trainer resolve against the installed verl package.
+    with initialize_config_dir(config_dir=_OMNI_CONFIG_DIR, version_base=None):
+        return compose(config_name="omni_trainer")
+
+
+class TestReverseMergePreservesRawKeys:
+    """Verify that OmegaConf.merge(raw, composed) keeps keys from the raw
+    YAML that are absent from the hydra-composed DictConfig.
+
+    This is the core logic added to ``scripts/print_cfg.py`` to fix the
+    generated-config CI check.
+    """
+
+    def test_extra_top_level_key_survives(self, _composed_cfg):
+        raw = OmegaConf.create({"_test_extra_key": 1})
+        merged = OmegaConf.merge(raw, _composed_cfg)
+        assert merged._test_extra_key == 1
+
+    def test_extra_nested_key_survives(self, _composed_cfg):
+        raw = OmegaConf.create({"trainer": {"v1": {"test_struct_fix_field": {"value": 42}}}})
+        merged = OmegaConf.merge(raw, _composed_cfg)
+        assert OmegaConf.select(merged, "trainer.v1.test_struct_fix_field.value") == 42
+
+    def test_existing_key_is_overridden_by_composed(self, _composed_cfg):
+        raw = OmegaConf.create({"trainer": {"total_epochs": 999}})
+        merged = OmegaConf.merge(raw, _composed_cfg)
+        # Composed value wins (the second arg); raw's 999 is replaced by the
+        # real default from ppo_trainer.
+        assert merged.trainer.total_epochs == _composed_cfg.trainer.total_epochs
+
+
+class TestEndToEndWithInjectedField:
+    """End-to-end test: inject a synthetic key into omni_trainer.yaml, compose
+    with hydra, apply the reverse merge, and verify the key is visible.
+    """
+
+    def test_injected_field_survives_reverse_merge(self, _composed_cfg):
+        # Load the *real* omni_trainer.yaml as a plain dict so we can inject
+        # a synthetic field that verl's schema has never seen.
+        raw_path = os.path.join(_OMNI_CONFIG_DIR, "omni_trainer.yaml")
+        with open(raw_path) as fh:
+            raw_dict = yaml.safe_load(fh)
+
+        raw_dict.setdefault("trainer", {}).setdefault("v1", {})
+        raw_dict["trainer"]["v1"]["_test_ci_guard_field"] = {"enabled": True, "count": 7}
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as tf:
+            yaml.dump(raw_dict, tf)
+            tmp_path = tf.name
+
+        try:
+            raw = OmegaConf.load(tmp_path)
+            merged = OmegaConf.merge(raw, _composed_cfg)
+            assert OmegaConf.select(merged, "trainer.v1._test_ci_guard_field.enabled") is True
+            assert OmegaConf.select(merged, "trainer.v1._test_ci_guard_field.count") == 7
+            # Existing keys from the composed config are still present.
+            assert merged.trainer.v1.trainer_mode == _composed_cfg.trainer.v1.trainer_mode
+        finally:
+            os.unlink(tmp_path)


### PR DESCRIPTION
### What does this PR do?
The generated yaml should be the golden reference for all training script, but previously it is not.

- Fixed the problem that CI failed to check if the generated omni yaml is the latest.
- Added regression tests

The bug is found in #341 and #324 

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `vllm_omni`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `diffusion`, `omni`, `tests`, `docker`
  - If this PR involves multiple modules, separate them with `,` like `[diffusion, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][diffusion, fsdp] feat: new rollout scheduler`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update the documentation.
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl-omni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
