### PR TITLE
[trainer, rollout] Support pickscore for DiffusionOPD

### DIFF
--- a/docs/examples/config.md
+++ b/docs/examples/config.md
@@ -95,6 +95,8 @@ actor_rollout_ref:
     exclude_modules: null
     lora_adapter_path: null
     policy_state_adapters: ["default"]
+    teacher_adapter_path: null
+    teacher_adapter_name: teacher
     lora_dtype: null
     fsdp_layer_prefixes: ["transformer_blocks."]
     # pipeline / algo mirror rollout (see below)
@@ -115,6 +117,9 @@ actor_rollout_ref:
 - `actor_rollout_ref.model.exclude_modules`: Modules excluded from LoRA.
 - `actor_rollout_ref.model.lora_adapter_path`: Pre-trained LoRA adapter for continued training.
 - `actor_rollout_ref.model.policy_state_adapters`: Named LoRA policy states required by the algorithm. `"reference"` disables adapters.
+- `actor_rollout_ref.model.teacher_adapter_path`: Path to a frozen teacher LoRA adapter for on-policy distillation (OPD). When set, the adapter is loaded onto the actor's own backbone (single-backbone multi-LoRA) and queried at the student's rollout states; it never receives gradients.
+- `actor_rollout_ref.model.teacher_adapter_name`: Name of the teacher PEFT adapter (default `teacher`); must differ from `default` / `reference`.
+- `actor_rollout_ref.model.teacher_adapters`: Multi-task OPD (DiffusionOPD) teacher list — one frozen teacher LoRA per task, e.g. `[{name: aes, path: ..., guidance_scale: 4.5}, {name: ocr, path: ..., guidance_scale: 4.5}, {name: geneval, path: ..., guidance_scale: 1.0}]`. Each teacher is loaded as a frozen `teacher_<name>` PEFT adapter; teacher inference selects the adapter (and CFG `guidance_scale`) matching the batch's `task_id`. Overrides `teacher_adapter_path` when set.
 - `actor_rollout_ref.model.lora_dtype`: Convert LoRA params to a dtype (e.g. `fp32`, `bf16`); `null` = no conversion.
 - `actor_rollout_ref.model.fsdp_layer_prefixes`: FSDP layer name prefixes for LoRA layered summon (default `["transformer_blocks."]`).
 - `actor_rollout_ref.model.pipeline` / `algo`: Mirrored from `actor_rollout_ref.rollout.pipeline` / `algo` via `oc.select`; prefer overriding the rollout copies.
@@ -143,6 +148,8 @@ actor_rollout_ref:
     use_distill_loss: false
     distill_loss_mode: distill_kl
     distill_loss_coef: 1.0
+    opd_only: false
+    mopd: false
 ```
 
 #### `diffusion_loss` — `DiffusionLossConfig`
@@ -164,6 +171,8 @@ actor_rollout_ref:
 - `actor_rollout_ref.actor.use_distill_loss`: Enable teacher-anchored online policy distillation.
 - `actor_rollout_ref.actor.distill_loss_mode`: `distill_kl` or `distill_fm_mse`.
 - `actor_rollout_ref.actor.distill_loss_coef`: Distillation loss coefficient.
+- `actor_rollout_ref.actor.opd_only`: On-policy distillation only mode (DiffusionOPD). When `true`, the trainer skips the reward / old-log-prob / reference / advantage phases and trains the student purely against the frozen teacher's per-step transition mean via `distill_kl` (paper Alg. 1). Requires `use_distill_loss=true` and `actor_rollout_ref.model.teacher_adapter_path` (or `teacher_adapters`) set. Under the default ODE sampler (`noise_level=0`) the closed-form KL specializes to the squared-L2 surrogate `0.5*||mu_student - mu_teacher||^2` (paper Eq. 12).
+- `actor_rollout_ref.actor.mopd`: Multi-task OPD (DiffusionOPD) mode. Requires `opd_only=true` and at least two `model.teacher_adapters`. Combined with `data.task_train_files` (one list of files per task), the trainer builds a multi-task round-robin dataset: each dataloader batch is one full task cycle (`batch_size_per_task` samples per task), and each task's rows are distilled against that task's teacher (with its own CFG `guidance_scale`). Set `data.mopd_batch_size_per_task` (default `gen_batch_size // num_tasks`) and keep `ppo_mini_batch_size = data.gen_batch_size` with `ppo_epochs=1` so one optimizer step covers the whole round-robin cycle (gradient accumulation G = M).
 - `actor_rollout_ref.actor.rollout_correction.*`: Per-actor mirror of `algorithm.rollout_correction` (used when `bypass_mode=True` for per-step RS inside `diffusion_loss`).
 
 Shared PPO / FSDP / optim fields (`ppo_mini_batch_size`, `ppo_epochs`, `optim.lr`, `fsdp_config`, …) follow upstream verl — see the [verl Config Explanation](https://verl.readthedocs.io/en/latest/examples/config.html).

--- a/examples/flowgrpo_trainer/sd35/run_sd35_medium_mopd_lora.sh
+++ b/examples/flowgrpo_trainer/sd35/run_sd35_medium_mopd_lora.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# SD3.5-Medium multi-task On-Policy Distillation (MOPD / DiffusionOPD) recipe.
+#
+# Reproduces Stage 2 of "DiffusionOPD" (arXiv:2605.15055) inside verl-omni: three frozen
+# task-specific teacher LoRAs (Aesthetics/PickScore, OCR, GenEval) are loaded onto the
+# actor's own SD3.5-M backbone as `teacher_<name>` PEFT adapters. The student rolls out
+# its own denoising trajectory on a round-robin curriculum over the three task datasets
+# (one batch per task per round), and at every visited state the corresponding teacher is
+# evaluated with its own CFG guidance scale. The student is trained purely against the
+# teachers' per-step transition means via the closed-form KL loss (`distill_kl`, paper
+# Eq. 11/12); no reward model / PPO / advantage is used (OPD-only mode).
+#
+# Per the paper's Algorithm 1, the round-robin cycle covers all M tasks before a single
+# optimizer step: `data.gen_batch_size = M * data.mopd_batch_size_per_task` and
+# `actor_rollout_ref.actor.ppo_mini_batch_size = data.gen_batch_size` (with ppo_epochs=1)
+# so each `update_actor` call is one task cycle with one gradient step.
+#
+# Default sampler is the deterministic ODE (noise_level=0), under which the per-step
+# closed-form reverse-KL specializes to the squared-L2 surrogate 0.5*||mu_s - mu_t||^2
+# (paper Eq. 12) — the SD3.5-M OPD default in the reference implementation.
+#
+# Prerequisites:
+#   * The three released teacher LoRAs (official DiffusionOPD repo):
+#       quanhaol/Aes-Teacher, quanhaol/OCR-Teacher, quanhaol/GenEval-Teacher.
+#     Pre-download them (e.g. `huggingface-cli download <repo>`) and override the paths via
+#     AES_TEACHER_PATH / OCR_TEACHER_PATH / GENEVAL_TEACHER_PATH if not using the HF hub.
+#   * Per-task parquet datasets of prompts (e.g. Pick-a-Pic train split for the Aes teacher,
+#     the FlowGRPO OCR split, and the FlowGRPO GenEval split).
+#
+# Reference scripts:
+#   - DiffusionOPD/scripts/single_node/mopd.sh            (reference implementation)
+#   - run_sd35_medium_sopd_aes_lora.sh                    (single-teacher OPD base)
+set -x
+
+WORKSPACE=${OPD_WORKSPACE:-${WORKSPACE:-$HOME}}
+aes_train_path=${AES_TRAIN_PATH:-$WORKSPACE/data/pickscore/sd3/train.parquet}
+aes_val_path=${AES_VAL_PATH:-$WORKSPACE/data/pickscore/sd3/test.parquet}
+ocr_train_path=${OCR_TRAIN_PATH:-$WORKSPACE/data/ocr/sd3/train.parquet}
+ocr_val_path=${OCR_VAL_PATH:-$WORKSPACE/data/ocr/sd3/test.parquet}
+geneval_train_path=${GENEVAL_TRAIN_PATH:-$WORKSPACE/data/geneval/sd3/train.parquet}
+geneval_val_path=${GENEVAL_VAL_PATH:-$WORKSPACE/data/geneval/sd3/test.parquet}
+
+model_name=stabilityai/stable-diffusion-3.5-medium
+aes_teacher_path=${AES_TEACHER_PATH:-quanhaol/Aes-Teacher}
+ocr_teacher_path=${OCR_TEACHER_PATH:-quanhaol/OCR-Teacher}
+geneval_teacher_path=${GENEVAL_TEACHER_PATH:-quanhaol/GenEval-Teacher}
+
+NUM_GPUS_ACTOR_ROLLOUT=${NUM_GPUS_ACTOR_ROLLOUT:-2}
+ROLLOUT_TP=1
+IMAGE_RESOLUTION=${IMAGE_RESOLUTION:-512}
+TOTAL_TRAINING_STEPS=${TOTAL_TRAINING_STEPS:-100}
+ATTN_BACKEND=${ATTN_BACKEND:-native}
+
+NUM_TASKS=3
+BATCH_SIZE_PER_TASK=${BATCH_SIZE_PER_TASK:-8}
+GEN_BATCH_SIZE=$((NUM_TASKS * BATCH_SIZE_PER_TASK))
+
+MAX_NUM_SEQS=${MAX_NUM_SEQS:-256}
+REQUEST_BATCH_MAX_WAIT_MS=${REQUEST_BATCH_MAX_WAIT_MS:-10}
+ROLLOUT_ATTN_BACKEND=${ROLLOUT_ATTN_BACKEND:-TORCH_SDPA}
+
+if [ "${FA3:-0}" = "1" ]; then
+    ATTN_BACKEND="_flash_3_varlen_hub"
+    ROLLOUT_ATTN_BACKEND=FLASH_ATTN_3_HUB
+fi
+
+ENGINE=vllm_omni
+
+# SD3 uses a joint CLIP-L/G + T5-XXL prompt encoding; the extra tokenizers mirror the
+# FlowGRPO SD3.5 recipe so rollout and training-side prompt embeds stay consistent.
+custom_chat_template='{% for message in messages %}{% if message['\''role'\''] == '\''user'\'' %}{{ message['\''content'\''] }}{% endif %}{% endfor %}'
+
+python3 -m verl_omni.trainer.main_diffusion \
+    data.task_train_files="[[$aes_train_path],[$ocr_train_path],[$geneval_train_path]]" \
+    data.task_val_files="[[$aes_val_path],[$ocr_val_path],[$geneval_val_path]]" \
+    data.gen_batch_size=$GEN_BATCH_SIZE \
+    data.mopd_batch_size_per_task=$BATCH_SIZE_PER_TASK \
+    data.val_max_samples=32 \
+    data.max_prompt_length=512 \
+    data.truncation=error \
+    data.seed=42 \
+    actor_rollout_ref.model.algorithm=flow_grpo \
+    actor_rollout_ref.model.path=$model_name \
+    actor_rollout_ref.model.custom_chat_template="\"$custom_chat_template\"" \
+    'actor_rollout_ref.model.extra_tokenizers={clip: {path: tokenizer, max_length: 77}, t5: {path: tokenizer_3, max_length: 256}}' \
+    actor_rollout_ref.model.attn_backend=$ATTN_BACKEND \
+    actor_rollout_ref.rollout.rollout_attn_backend=$ROLLOUT_ATTN_BACKEND \
+    actor_rollout_ref.model.lora_rank=32 \
+    actor_rollout_ref.model.lora_alpha=64 \
+    actor_rollout_ref.model.target_modules="['to_q','to_k','to_v','to_out.0','add_q_proj','add_k_proj','add_v_proj','to_add_out']" \
+    'actor_rollout_ref.model.teacher_adapters=[{name: aes, path: '"$aes_teacher_path"', guidance_scale: 4.5},{name: ocr, path: '"$ocr_teacher_path"', guidance_scale: 4.5},{name: geneval, path: '"$geneval_teacher_path"', guidance_scale: 1.0}]' \
+    actor_rollout_ref.rollout.rollout_attn_backend=$ROLLOUT_ATTN_BACKEND \
+    actor_rollout_ref.actor.optim.lr=1e-4 \
+    actor_rollout_ref.actor.optim.weight_decay=0.0001 \
+    actor_rollout_ref.actor.ppo_mini_batch_size=$GEN_BATCH_SIZE \
+    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=8 \
+    actor_rollout_ref.actor.ppo_epochs=1 \
+    actor_rollout_ref.actor.use_kl_loss=False \
+    actor_rollout_ref.actor.kl_loss_coef=0.0 \
+    actor_rollout_ref.actor.use_distill_loss=True \
+    actor_rollout_ref.actor.distill_loss_mode=distill_kl \
+    actor_rollout_ref.actor.distill_loss_coef=1.0 \
+    actor_rollout_ref.actor.opd_only=True \
+    actor_rollout_ref.actor.mopd=True \
+    actor_rollout_ref.actor.fsdp_config.param_offload=False \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=False \
+    actor_rollout_ref.actor.fsdp_config.model_dtype=bfloat16 \
+    actor_rollout_ref.actor.strategy=fsdp2 \
+    actor_rollout_ref.actor.fsdp_config.ulysses_sequence_parallel_size=1 \
+    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=8 \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=$ROLLOUT_TP \
+    actor_rollout_ref.rollout.name=$ENGINE \
+    actor_rollout_ref.rollout.n=8 \
+    actor_rollout_ref.rollout.seed=42 \
+    actor_rollout_ref.rollout.agent.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT / ROLLOUT_TP)) \
+    actor_rollout_ref.rollout.load_format=safetensors \
+    actor_rollout_ref.rollout.pipeline.height=$IMAGE_RESOLUTION \
+    actor_rollout_ref.rollout.pipeline.width=$IMAGE_RESOLUTION \
+    actor_rollout_ref.rollout.pipeline.num_inference_steps=10 \
+    actor_rollout_ref.rollout.pipeline.guidance_scale=4.5 \
+    actor_rollout_ref.rollout.pipeline.max_sequence_length=256 \
+    actor_rollout_ref.rollout.algo.noise_level=0.0 \
+    actor_rollout_ref.rollout.algo.sde_type="cps" \
+    actor_rollout_ref.rollout.algo.sde_window_size=3 \
+    actor_rollout_ref.rollout.algo.sde_window_range="[0,5]" \
+    ++actor_rollout_ref.rollout.engine_kwargs.vllm_omni.max_num_seqs=${MAX_NUM_SEQS} \
+    ++actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
+    actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=40 \
+    actor_rollout_ref.rollout.val_kwargs.algo.noise_level=0.0 \
+    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=8 \
+    reward.reward_model.enable=False \
+    trainer.logger='["console", "wandb"]' \
+    trainer.project_name=opd \
+    trainer.experiment_name=sd35_medium_mopd_aes_ocr_geneval \
+    trainer.log_val_generations=8 \
+    trainer.val_before_train=False \
+    trainer.n_gpus_per_node=$NUM_GPUS_ACTOR_ROLLOUT \
+    trainer.nnodes=1 \
+    trainer.save_freq=100 \
+    trainer.test_freq=-1 \
+    trainer.total_epochs=15 \
+    trainer.total_training_steps=$TOTAL_TRAINING_STEPS \
+    "$@"

--- a/examples/flowgrpo_trainer/sd35/run_sd35_medium_sopd_aes_lora.sh
+++ b/examples/flowgrpo_trainer/sd35/run_sd35_medium_sopd_aes_lora.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# SD3.5-Medium single-teacher On-Policy Distillation (SOPD) recipe.
+#
+# Reproduces the single-teacher OPD experiment from "DiffusionOPD" (arXiv:2605.15055)
+# inside verl-omni: a frozen task-specific teacher LoRA (here, the Aesthetics teacher
+# `quanhaol/Aes-Teacher`) is loaded onto the actor's own SD3.5-M backbone as a second
+# PEFT adapter and queried at the student's rollout states. The student is trained
+# purely against the teacher's per-step transition mean via the closed-form KL loss
+# (`distill_kl`); no reward model / PPO / advantage is used (OPD-only mode).
+#
+# Default sampler is the deterministic ODE (noise_level=0), under which the per-step
+# closed-form reverse-KL specializes to the squared-L2 surrogate 0.5*||mu_s - mu_t||^2
+# (paper Eq. 12) — this is the SD3.5-M OPD default in the reference implementation.
+#
+# Prerequisites:
+#   * Pre-download the Aes teacher LoRA: `huggingface-cli download quanhaol/Aes-Teacher`
+#     and pass its local path via TEACHER_ADAPTER_PATH (or let HF hub resolve it).
+#   * A parquet dataset of text prompts (e.g. Pick-a-Pic train split, which the Aes
+#     teacher was trained on). Set PICKSCORE_TRAIN_PATH / PICKSCORE_VAL_PATH.
+#
+# Reference scripts:
+#   - DiffusionOPD/scripts/single_node/sopd.sh           (reference implementation)
+#   - run_sd35_medium_ocr_lora.sh                         (FlowGRPO SD3.5 base)
+set -x
+
+WORKSPACE=${OPD_WORKSPACE:-${WORKSPACE:-$HOME}}
+pickscore_train_path=${PICKSCORE_TRAIN_PATH:-$WORKSPACE/data/pickscore/sd3/train.parquet}
+pickscore_val_path=${PICKSCORE_VAL_PATH:-$WORKSPACE/data/pickscore/sd3/test.parquet}
+
+model_name=stabilityai/stable-diffusion-3.5-medium
+teacher_adapter_path=${TEACHER_ADAPTER_PATH:-quanhaol/Aes-Teacher}
+
+NUM_GPUS_ACTOR_ROLLOUT=2
+ROLLOUT_TP=1
+IMAGE_RESOLUTION=${IMAGE_RESOLUTION:-512}
+TOTAL_TRAINING_STEPS=${TOTAL_TRAINING_STEPS:-100}
+ATTN_BACKEND=${ATTN_BACKEND:-native}
+
+MAX_NUM_SEQS=${MAX_NUM_SEQS:-256}
+REQUEST_BATCH_MAX_WAIT_MS=${REQUEST_BATCH_MAX_WAIT_MS:-10}
+ROLLOUT_ATTN_BACKEND=${ROLLOUT_ATTN_BACKEND:-TORCH_SDPA}
+
+if [ "${FA3:-0}" = "1" ]; then
+    ATTN_BACKEND="_flash_3_varlen_hub"
+    ROLLOUT_ATTN_BACKEND=FLASH_ATTN_3_HUB
+fi
+
+ENGINE=vllm_omni
+
+# SD3 uses a joint CLIP-L/G + T5-XXL prompt encoding; the extra tokenizers mirror the
+# FlowGRPO SD3.5 recipe so rollout and training-side prompt embeds stay consistent.
+custom_chat_template='{% for message in messages %}{% if message['\''role'\''] == '\''user'\'' %}{{ message['\''content'\''] }}{% endif %}{% endfor %}'
+
+python3 -m verl_omni.trainer.main_diffusion \
+    data.train_files=$pickscore_train_path \
+    data.val_files=$pickscore_val_path \
+    data.train_batch_size=8 \
+    data.val_max_samples=32 \
+    data.max_prompt_length=512 \
+    data.truncation=error \
+    data.seed=42 \
+    actor_rollout_ref.model.algorithm=flow_grpo \
+    actor_rollout_ref.model.path=$model_name \
+    actor_rollout_ref.model.custom_chat_template="\"$custom_chat_template\"" \
+    'actor_rollout_ref.model.extra_tokenizers={clip: {path: tokenizer, max_length: 77}, t5: {path: tokenizer_3, max_length: 256}}' \
+    actor_rollout_ref.model.attn_backend=$ATTN_BACKEND \
+    actor_rollout_ref.rollout.rollout_attn_backend=$ROLLOUT_ATTN_BACKEND \
+    actor_rollout_ref.model.lora_rank=32 \
+    actor_rollout_ref.model.lora_alpha=64 \
+    actor_rollout_ref.model.target_modules="['to_q','to_k','to_v','to_out.0','add_q_proj','add_k_proj','add_v_proj','to_add_out']" \
+    actor_rollout_ref.model.teacher_adapter_path=$teacher_adapter_path \
+    actor_rollout_ref.rollout.rollout_attn_backend=$ROLLOUT_ATTN_BACKEND \
+    actor_rollout_ref.actor.optim.lr=1e-4 \
+    actor_rollout_ref.actor.optim.weight_decay=0.0001 \
+    actor_rollout_ref.actor.ppo_mini_batch_size=4 \
+    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=8 \
+    actor_rollout_ref.actor.use_kl_loss=False \
+    actor_rollout_ref.actor.kl_loss_coef=0.0 \
+    actor_rollout_ref.actor.use_distill_loss=True \
+    actor_rollout_ref.actor.distill_loss_mode=distill_kl \
+    actor_rollout_ref.actor.distill_loss_coef=1.0 \
+    actor_rollout_ref.actor.opd_only=True \
+    actor_rollout_ref.actor.fsdp_config.param_offload=False \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=False \
+    actor_rollout_ref.actor.fsdp_config.model_dtype=bfloat16 \
+    actor_rollout_ref.actor.strategy=fsdp2 \
+    actor_rollout_ref.actor.fsdp_config.ulysses_sequence_parallel_size=1 \
+    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=8 \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=$ROLLOUT_TP \
+    actor_rollout_ref.rollout.name=$ENGINE \
+    actor_rollout_ref.rollout.n=8 \
+    actor_rollout_ref.rollout.seed=42 \
+    actor_rollout_ref.rollout.agent.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT / ROLLOUT_TP)) \
+    actor_rollout_ref.rollout.load_format=safetensors \
+    actor_rollout_ref.rollout.pipeline.height=$IMAGE_RESOLUTION \
+    actor_rollout_ref.rollout.pipeline.width=$IMAGE_RESOLUTION \
+    actor_rollout_ref.rollout.pipeline.num_inference_steps=10 \
+    actor_rollout_ref.rollout.pipeline.guidance_scale=4.5 \
+    actor_rollout_ref.rollout.pipeline.max_sequence_length=256 \
+    actor_rollout_ref.rollout.algo.noise_level=0.0 \
+    actor_rollout_ref.rollout.algo.sde_type="cps" \
+    actor_rollout_ref.rollout.algo.sde_window_size=3 \
+    actor_rollout_ref.rollout.algo.sde_window_range="[0,5]" \
+    ++actor_rollout_ref.rollout.engine_kwargs.vllm_omni.max_num_seqs=${MAX_NUM_SEQS} \
+    ++actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
+    actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=40 \
+    actor_rollout_ref.rollout.val_kwargs.algo.noise_level=0.0 \
+    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=8 \
+    reward.reward_model.enable=False \
+    trainer.logger='["console", "wandb"]' \
+    trainer.project_name=opd \
+    trainer.experiment_name=sd35_medium_sopd_aes_lora \
+    trainer.log_val_generations=8 \
+    trainer.val_before_train=False \
+    trainer.n_gpus_per_node=$NUM_GPUS_ACTOR_ROLLOUT \
+    trainer.nnodes=1 \
+    trainer.save_freq=100 \
+    trainer.test_freq=-1 \
+    trainer.total_epochs=15 \
+    trainer.total_training_steps=$TOTAL_TRAINING_STEPS \
+    "$@"

--- a/tests/trainer/diffusion/test_diffusion_mopd_wiring_on_cpu.py
+++ b/tests/trainer/diffusion/test_diffusion_mopd_wiring_on_cpu.py
@@ -1,0 +1,258 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU tests for multi-task On-Policy Distillation (DiffusionOPD, arXiv:2605.15055).
+
+Covers:
+- ``MultiTaskRLDataset``: per-sample ``task_id`` / ``teacher_name`` tagging and global
+  index <-> (task, local index) mapping.
+- ``RoundRobinBatchSampler``: every batch (MOPD round) covers all tasks with equal
+  ``batch_size_per_task`` representation.
+- Config validation: ``mopd=True`` requires ``opd_only=True`` / ``use_distill_loss=True``
+  and ``DiffusionModelConfig`` accepts the ``teacher_adapters`` list.
+- ``DistillKLLoss`` with per-task teacher means (the MOPD multi-teacher loss path).
+"""
+
+import numpy as np
+import pytest
+import torch
+from torch.utils.data import Dataset
+
+from verl_omni.utils.dataset.multi_task_dataset import MultiTaskRLDataset, RoundRobinBatchSampler
+
+
+class _PromptDataset(Dataset):
+    def __init__(self, prompts):
+        self.prompts = prompts
+
+    def __len__(self):
+        return len(self.prompts)
+
+    def __getitem__(self, idx):
+        return {"prompt": self.prompts[idx], "dummy_tensor": torch.tensor([0], dtype=torch.uint8)}
+
+
+# ---------------------------------------------------------------------------
+# MultiTaskRLDataset
+# ---------------------------------------------------------------------------
+
+
+class TestMultiTaskDataset:
+    def _make_dataset(self):
+        tasks = [_PromptDataset([f"a_{i}" for i in range(10)]), _PromptDataset([f"b_{i}" for i in range(6)])]
+        return MultiTaskRLDataset(tasks, task_names=["aes", "ocr"])
+
+    def test_len_and_task_tags(self):
+        ds = self._make_dataset()
+        assert len(ds) == 16
+        # global 0..9 -> task 0, global 10..15 -> task 1
+        item0 = ds[0]
+        assert item0["task_id"] == 0 and item0["teacher_name"] == "aes"
+        item_mid = ds[9]
+        assert item_mid["task_id"] == 0
+        item_last = ds[15]
+        assert item_last["task_id"] == 1 and item_last["teacher_name"] == "ocr"
+        # underlying prompt is preserved
+        assert ds[10]["prompt"] == "b_0"
+
+    def test_local_index_mapping(self):
+        ds = self._make_dataset()
+        task_id, local = ds.local_index(12)
+        assert task_id == 1 and local == 2
+        task_id, local = ds.local_index(7)
+        assert task_id == 0 and local == 7
+
+    def test_requires_two_tasks(self):
+        with pytest.raises(AssertionError):
+            MultiTaskRLDataset([_PromptDataset(["x"])])
+
+
+class TestRoundRobinSampler:
+    def _make_dataset(self):
+        tasks = [_PromptDataset([f"a_{i}" for i in range(10)]), _PromptDataset([f"b_{i}" for i in range(6)])]
+        return MultiTaskRLDataset(tasks, task_names=["aes", "ocr"])
+
+    def test_batch_covers_all_tasks_evenly(self):
+        ds = self._make_dataset()
+        sampler = RoundRobinBatchSampler(ds, batch_size_per_task=4, seed=42)
+        indices = list(sampler)
+        # 2 tasks * 4 samples * 2 rounds (max_task_len=10 // 4 = 2)
+        assert len(indices) == 2 * 4 * 2
+
+        # Every round contains exactly 4 samples from each task.
+        round_size = 2 * 4
+        for r in range(2):
+            round_indices = indices[r * round_size : (r + 1) * round_size]
+            round_task_ids = [ds.task_of(idx) for idx in round_indices]
+            assert round_task_ids.count(0) == 4
+            assert round_task_ids.count(1) == 4
+
+        # All returned indices are in range.
+        assert all(0 <= idx < len(ds) for idx in indices)
+
+    def test_deterministic_given_seed(self):
+        ds = self._make_dataset()
+        a = list(RoundRobinBatchSampler(ds, batch_size_per_task=4, seed=7))
+        b = list(RoundRobinBatchSampler(ds, batch_size_per_task=4, seed=7))
+        assert a == b
+
+
+# ---------------------------------------------------------------------------
+# Config validation
+# ---------------------------------------------------------------------------
+
+
+class TestMopdConfigValidation:
+    def test_mopd_requires_opd_only(self):
+        from verl_omni.workers.config.diffusion import FSDPDiffusionActorConfig
+
+        with pytest.raises(ValueError, match="mopd=True requires opd_only=True"):
+            FSDPDiffusionActorConfig(
+                strategy="fsdp",
+                rollout_n=1,
+                mopd=True,
+                opd_only=False,
+                use_distill_loss=True,
+            )
+
+    def test_mopd_accepts_valid_config(self):
+        from verl_omni.workers.config.diffusion import FSDPDiffusionActorConfig
+
+        cfg = FSDPDiffusionActorConfig(
+            strategy="fsdp",
+            rollout_n=1,
+            mopd=True,
+            opd_only=True,
+            use_distill_loss=True,
+            distill_loss_mode="distill_kl",
+        )
+        assert cfg.mopd is True and cfg.opd_only is True
+
+
+class TestTeacherAdaptersModelConfig:
+    def _make_model_dir(self, tmp_path):
+        import json
+
+        model_dir = tmp_path / "sd35"
+        model_dir.mkdir()
+        (model_dir / "model_index.json").write_text(json.dumps({"_class_name": "StableDiffusion3Pipeline"}))
+        transformer_dir = model_dir / "transformer"
+        transformer_dir.mkdir()
+        (transformer_dir / "config.json").write_text(json.dumps({"in_channels": 16}))
+        return model_dir
+
+    def test_teacher_adapters_defaults_empty(self, tmp_path):
+        from verl_omni.workers.config import DiffusionModelConfig
+
+        model_dir = self._make_model_dir(tmp_path)
+        cfg = DiffusionModelConfig(
+            path=str(model_dir),
+            algorithm="flow_grpo",
+            load_tokenizer=False,
+            attn_backend="native",
+        )
+        assert cfg.teacher_adapters == []
+
+    def test_teacher_adapters_settable(self, tmp_path):
+        from verl_omni.workers.config import DiffusionModelConfig
+
+        model_dir = self._make_model_dir(tmp_path)
+        cfg = DiffusionModelConfig(
+            path=str(model_dir),
+            algorithm="flow_grpo",
+            load_tokenizer=False,
+            attn_backend="native",
+            teacher_adapters=[
+                {"name": "aes", "path": "quanhaol/Aes-Teacher", "guidance_scale": 4.5},
+                {"name": "ocr", "path": "some/ocr-teacher", "guidance_scale": 4.5},
+                {"name": "geneval", "path": "some/geneval-teacher", "guidance_scale": 1.0},
+            ],
+        )
+        assert len(cfg.teacher_adapters) == 3
+        assert cfg.teacher_adapters[0]["name"] == "aes"
+        assert cfg.teacher_adapters[2]["guidance_scale"] == 1.0
+
+
+# ---------------------------------------------------------------------------
+# DistillKLLoss with per-task teacher means (MOPD multi-teacher loss path)
+# ---------------------------------------------------------------------------
+
+
+class TestMopdDistillLoss:
+    def test_per_task_teacher_means_match_student_for_one_task(self):
+        """When the student already matches the teacher of one task, the loss is low."""
+        from verl_omni.trainer.diffusion.diffusion_algos import DistillKLLoss
+
+        torch.manual_seed(0)
+        bsz, timesteps, dim = 8, 16, 3
+        student_mean = torch.randn(bsz, timesteps, dim)
+
+        # Two task groups in one batch; the task-0 teacher matches the student, the
+        # task-1 teacher differs, simulating the MOPD round-robin batch.
+        teacher_prev_sample_mean = student_mean.clone()
+        teacher_prev_sample_mean[4:] = teacher_prev_sample_mean[4:] + 2.0
+        std_dev_t = torch.zeros(bsz, 1, 1)  # ODE regime -> squared-L2 surrogate
+
+        loss, metrics = DistillKLLoss.compute_loss(
+            prev_sample_mean=student_mean,
+            teacher_prev_sample_mean=teacher_prev_sample_mean,
+            std_dev_t=std_dev_t,
+        )
+
+        # ODE surrogate: 0.5 * ||mu_s - mu_t||^2. Rows 0-3 contribute 0; rows 4-7 -> 2.0 each.
+        assert loss.item() == pytest.approx(1.0, rel=1e-5)
+        assert "actor/distill_kl_loss" in metrics
+
+    def test_loss_finite_for_mopd_batch(self):
+        from verl_omni.trainer.diffusion.diffusion_algos import DistillKLLoss
+
+        torch.manual_seed(1)
+        bsz, timesteps, dim = 24, 10, 4  # M=3 tasks x 8 prompts x 10 denoise steps
+        student_mean = torch.randn(bsz, timesteps, dim)
+        teacher_prev_sample_mean = student_mean + 0.1 * torch.randn_like(student_mean)
+        std_dev_t = torch.zeros(bsz, 1, 1)
+
+        loss, _ = DistillKLLoss.compute_loss(
+            prev_sample_mean=student_mean,
+            teacher_prev_sample_mean=teacher_prev_sample_mean,
+            std_dev_t=std_dev_t,
+        )
+        assert torch.isfinite(loss)
+        assert loss.item() >= 0.0
+
+
+# ---------------------------------------------------------------------------
+# MOPD teacher-inference reassembly helper (mask scatter/gather)
+# ---------------------------------------------------------------------------
+
+
+class TestMopdTeacherReassembly:
+    def test_scatter_back_preserves_row_order(self):
+        """Per-task teacher means computed on row subsets must scatter back to the
+        original row order (the logic inside ``_compute_mopd_teacher_log_prob``)."""
+        torch.manual_seed(3)
+        bsz, timesteps, dim = 12, 8, 3
+        full_teacher_mean = torch.randn(bsz, timesteps, dim)
+
+        task_ids = np.array([0, 0, 1, 1, 1, 0, 2, 2, 0, 1, 2, 2])
+        per_task = {}
+        for task_id in np.unique(task_ids):
+            mask = task_ids == task_id
+            # simulate the per-task teacher output on the subset rows
+            per_task[int(task_id)] = (mask, full_teacher_mean[mask].clone())
+
+        reassembled = torch.zeros_like(full_teacher_mean)
+        for _, (mask, prev_sample_mean) in per_task.items():
+            reassembled[torch.from_numpy(mask)] = prev_sample_mean
+
+        assert torch.allclose(reassembled, full_teacher_mean)

--- a/tests/trainer/diffusion/test_diffusion_opd_wiring_on_cpu.py
+++ b/tests/trainer/diffusion/test_diffusion_opd_wiring_on_cpu.py
@@ -1,0 +1,282 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU tests for the OPD-only training path (DiffusionOPD, arXiv:2605.15055).
+
+Covers:
+- ``DistillKLLoss`` ODE regime (``std_dev_t == 0`` -> squared-L2 surrogate, paper Eq. 12).
+- ``diffusion_loss`` OPD-only short-circuit: primary policy-gradient loss skipped, only the
+  distillation term contributes, and no ``old_log_probs`` / ``advantages`` are required.
+- Config validation: ``opd_only=True`` requires ``use_distill_loss=True``.
+- ``DiffusionModelConfig`` accepts ``teacher_adapter_path`` / ``teacher_adapter_name``.
+"""
+
+import os
+
+import pytest
+import torch
+
+from verl_omni.trainer.diffusion.diffusion_algos import DistillKLLoss
+from verl_omni.workers.config import DiffusionModelConfig
+
+# ---------------------------------------------------------------------------
+# DistillKLLoss ODE regime (std_dev_t == 0)
+# ---------------------------------------------------------------------------
+
+
+class TestDistillKLOdeRegime:
+    def test_ode_zero_variance_uses_squared_l2_surrogate(self):
+        """When std_dev_t == 0 the KL degenerates to 0.5 * ||mu_s - mu_t||^2 (paper Eq. 12)."""
+        mean = torch.zeros(4, 16, 3)
+        teacher_mean = torch.full((4, 16, 3), 2.0)
+        std_dev_t = torch.zeros(4, 1, 1)
+
+        loss, _ = DistillKLLoss.compute_loss(
+            prev_sample_mean=mean,
+            teacher_prev_sample_mean=teacher_mean,
+            std_dev_t=std_dev_t,
+        )
+
+        # 0.5 * (2.0)^2 = 2.0
+        assert loss.item() == pytest.approx(2.0, rel=1e-5)
+
+    def test_ode_does_not_return_nan_or_inf(self):
+        mean = torch.randn(4, 16, 3)
+        teacher_mean = torch.randn(4, 16, 3)
+        std_dev_t = torch.zeros(4, 1, 1)
+
+        loss, _ = DistillKLLoss.compute_loss(
+            prev_sample_mean=mean,
+            teacher_prev_sample_mean=teacher_mean,
+            std_dev_t=std_dev_t,
+        )
+
+        assert torch.isfinite(loss)
+        assert loss.item() >= 0.0
+
+    def test_ode_identical_means_gives_zero(self):
+        mean = torch.randn(4, 16, 3)
+        std_dev_t = torch.zeros(4, 1, 1)
+
+        loss, _ = DistillKLLoss.compute_loss(
+            prev_sample_mean=mean,
+            teacher_prev_sample_mean=mean.clone(),
+            std_dev_t=std_dev_t,
+        )
+
+        assert loss.item() == pytest.approx(0.0, abs=1e-6)
+
+    def test_sde_unchanged_for_nonzero_variance(self):
+        """The SDE closed-form (paper Eq. 11) is preserved when std_dev_t > 0."""
+        mean = torch.zeros(4, 16, 3)
+        teacher_mean = torch.full((4, 16, 3), 2.0)
+        std_dev_t = torch.ones(4, 1, 1)
+
+        loss, _ = DistillKLLoss.compute_loss(
+            prev_sample_mean=mean,
+            teacher_prev_sample_mean=teacher_mean,
+            std_dev_t=std_dev_t,
+        )
+
+        # KL = ||Δ||^2 / (2 σ²) = 4 / 2 = 2.0
+        assert loss.item() == pytest.approx(2.0, rel=1e-5)
+
+    def test_mixed_batch_sde_and_ode(self):
+        """A batch mixing SDE (σ>0) and ODE (σ=0) rows routes each correctly."""
+        mean = torch.zeros(2, 16, 3)
+        teacher_mean = torch.full((2, 16, 3), 2.0)
+        std_dev_t = torch.tensor([[[1.0]], [[0.0]]])  # row 0 SDE, row 1 ODE
+
+        loss, _ = DistillKLLoss.compute_loss(
+            prev_sample_mean=mean,
+            teacher_prev_sample_mean=teacher_mean,
+            std_dev_t=std_dev_t,
+        )
+
+        # mean over batch: (2.0 + 2.0) / 2 = 2.0
+        assert loss.item() == pytest.approx(2.0, rel=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# diffusion_loss OPD-only short-circuit
+# ---------------------------------------------------------------------------
+
+
+def _compose_actor_config(overrides):
+    from hydra import compose, initialize_config_dir
+    from verl.utils.config import omega_conf_to_dataclass
+
+    import verl_omni
+
+    config_dir = os.path.join(os.path.dirname(verl_omni.__file__), "trainer/config/diffusion/actor")
+    with initialize_config_dir(config_dir=config_dir, version_base=None):
+        cfg = compose(
+            config_name="dp_diffusion_actor",
+            overrides=["strategy=fsdp", "ppo_micro_batch_size_per_gpu=4", *overrides],
+        )
+    return omega_conf_to_dataclass(cfg)
+
+
+class TestOpdOnlyLoss:
+    def _build_batch_no_pg_signals(self):
+        """Batch without old_log_probs / advantages (OPD-only)."""
+        from verl.utils import tensordict_utils as tu
+
+        torch.manual_seed(0)
+        model_output = {
+            "prev_sample_mean": torch.randn(4, 16, 3),
+            "std_dev_t": torch.zeros(4, 1, 1),  # ODE regime
+        }
+        data = tu.get_tensordict(
+            {
+                "teacher_prev_sample_mean": torch.randn(4, 16, 3),
+            }
+        )
+        tu.assign_non_tensor(data, gradient_accumulation_steps=1, sp_size=1)
+        return model_output, data
+
+    def test_opd_only_returns_only_distill_term(self):
+        from verl_omni.workers.utils.losses import diffusion_loss
+
+        actor_cfg = _compose_actor_config(
+            overrides=[
+                "use_distill_loss=true",
+                "distill_loss_mode=distill_kl",
+                "distill_loss_coef=1.0",
+                "opd_only=true",
+            ]
+        )
+        assert actor_cfg.opd_only is True
+        model_output, data = self._build_batch_no_pg_signals()
+
+        total_loss, metrics = diffusion_loss(actor_cfg, model_output, data)
+
+        distill_loss_value, _ = DistillKLLoss.compute_loss(
+            prev_sample_mean=model_output["prev_sample_mean"],
+            teacher_prev_sample_mean=data["teacher_prev_sample_mean"],
+            std_dev_t=model_output["std_dev_t"],
+        )
+        assert total_loss.item() == pytest.approx(distill_loss_value.item(), rel=1e-5)
+        assert "actor/distill_kl_loss" in metrics
+
+    def test_opd_only_works_without_old_log_probs(self):
+        """OPD-only must not require old_log_probs / advantages on the batch."""
+        from verl_omni.workers.utils.losses import diffusion_loss
+
+        actor_cfg = _compose_actor_config(
+            overrides=["use_distill_loss=true", "opd_only=true"]
+        )
+        model_output, data = self._build_batch_no_pg_signals()
+
+        # Must not raise despite the missing policy-gradient signals.
+        total_loss, _ = diffusion_loss(actor_cfg, model_output, data)
+        assert torch.isfinite(total_loss)
+
+    def test_non_opd_still_requires_old_log_probs(self):
+        """Sanity: without opd_only, the default flow_grpo path still needs the PG signals
+        (this guards against accidentally making the primary loss optional in normal mode)."""
+        from verl.utils import tensordict_utils as tu
+
+        from verl_omni.workers.utils.losses import diffusion_loss
+
+        actor_cfg = _compose_actor_config(overrides=[])
+        assert actor_cfg.opd_only is False
+
+        torch.manual_seed(1)
+        model_output = {
+            "log_probs": torch.randn(4),
+            "prev_sample_mean": torch.randn(4, 16, 3),
+            "std_dev_t": torch.ones(4, 1, 1),
+        }
+        data = tu.get_tensordict(
+            {
+                "old_log_probs": torch.randn(4),
+                "advantages": torch.randn(4),
+            }
+        )
+        tu.assign_non_tensor(data, gradient_accumulation_steps=1, sp_size=1)
+
+        total_loss, _ = diffusion_loss(actor_cfg, model_output, data)
+        assert torch.isfinite(total_loss)
+
+
+# ---------------------------------------------------------------------------
+# Config validation
+# ---------------------------------------------------------------------------
+
+
+class TestOpdConfigValidation:
+    def test_opd_only_requires_distill_loss(self):
+        from verl_omni.workers.config.diffusion import FSDPDiffusionActorConfig
+
+        with pytest.raises(ValueError, match="opd_only=True requires use_distill_loss"):
+            FSDPDiffusionActorConfig(
+                strategy="fsdp",
+                rollout_n=1,
+                opd_only=True,
+                use_distill_loss=False,
+            )
+
+    def test_opd_only_accepts_valid_config(self):
+        from verl_omni.workers.config.diffusion import FSDPDiffusionActorConfig
+
+        cfg = FSDPDiffusionActorConfig(
+            strategy="fsdp",
+            rollout_n=1,
+            opd_only=True,
+            use_distill_loss=True,
+            distill_loss_mode="distill_kl",
+        )
+        assert cfg.opd_only is True
+
+
+# ---------------------------------------------------------------------------
+# DiffusionModelConfig teacher fields
+# ---------------------------------------------------------------------------
+
+
+class TestTeacherModelConfigFields:
+    def _make_model_dir(self, tmp_path):
+        import json
+
+        model_dir = tmp_path / "sd35"
+        model_dir.mkdir()
+        (model_dir / "model_index.json").write_text(json.dumps({"_class_name": "StableDiffusion3Pipeline"}))
+        transformer_dir = model_dir / "transformer"
+        transformer_dir.mkdir()
+        (transformer_dir / "config.json").write_text(json.dumps({"in_channels": 16}))
+        return model_dir
+
+    def test_defaults(self, tmp_path):
+        model_dir = self._make_model_dir(tmp_path)
+        cfg = DiffusionModelConfig(
+            path=str(model_dir),
+            algorithm="flow_grpo",
+            load_tokenizer=False,
+            attn_backend="native",
+        )
+        assert cfg.teacher_adapter_path is None
+        assert cfg.teacher_adapter_name == "teacher"
+
+    def test_settable(self, tmp_path):
+        model_dir = self._make_model_dir(tmp_path)
+        cfg = DiffusionModelConfig(
+            path=str(model_dir),
+            algorithm="flow_grpo",
+            load_tokenizer=False,
+            attn_backend="native",
+            teacher_adapter_path="quanhaol/Aes-Teacher",
+            teacher_adapter_name="teacher",
+        )
+        assert cfg.teacher_adapter_path == "quanhaol/Aes-Teacher"
+        assert cfg.teacher_adapter_name == "teacher"

--- a/verl_omni/agent_loop/diffusion_agent_loop.py
+++ b/verl_omni/agent_loop/diffusion_agent_loop.py
@@ -185,7 +185,11 @@ class DiffusionAgentLoopWorker:
             task_sampling_params = sampling_params.copy()
             if per_rollout_seeds is not None:
                 task_sampling_params["seed"] = per_rollout_seeds[i]
-            tasks.append(asyncio.create_task(self._run_agent_loop(task_sampling_params, **kwargs)))
+            tasks.append(
+                asyncio.create_task(
+                    self._run_agent_loop(task_sampling_params, is_validate=is_validate, **kwargs)
+                )
+            )
         outputs = await asyncio.gather(*tasks)
 
         output = self._postprocess(outputs, input_non_tensor_batch=batch.non_tensor_batch)
@@ -197,6 +201,7 @@ class DiffusionAgentLoopWorker:
         sampling_params: dict[str, Any],
         *,
         agent_name: str,
+        is_validate: bool = False,
         **kwargs,
     ) -> _InternalDiffusionAgentLoopOutput:
         assert agent_name in _agent_loop_registry, (
@@ -215,9 +220,9 @@ class DiffusionAgentLoopWorker:
             extra_tokenizer_map=self.model_config.extra_tokenizer_map,
         )
         output: DiffusionAgentLoopOutput = await agent_loop.run(sampling_params, **kwargs)
-        return await self._agent_loop_postprocess(output, **kwargs)
+        return await self._agent_loop_postprocess(output, is_validate=is_validate, **kwargs)
 
-    async def _agent_loop_postprocess(self, output, **kwargs) -> _InternalDiffusionAgentLoopOutput:
+    async def _agent_loop_postprocess(self, output, is_validate: bool = False, **kwargs) -> _InternalDiffusionAgentLoopOutput:
         """Perform post-processing operations on the output of each individual agent loop."""
         # Pad extra tensor outputs from vllm-omni (e.g. prompt embeddings).
         extra_fields = {}
@@ -260,6 +265,7 @@ class DiffusionAgentLoopWorker:
             prompts=prompt_ids,
             responses=response_diffusion_output,
             kwargs=kwargs,
+            is_validate=is_validate,
         )
 
         if "reward_extra_info" in output.extra_fields:
@@ -275,9 +281,17 @@ class DiffusionAgentLoopWorker:
             extra_fields=extra_fields,
         )
 
-    async def _compute_score(self, output, prompts, responses, kwargs):
+    async def _compute_score(self, output, prompts, responses, kwargs, is_validate: bool = False):
         """Compute reward score for single sample."""
         enable_async_reward = self.reward_loop_worker_handles is not None
+
+        # On-policy distillation (OPD) only mode: training rollouts carry no reward
+        # signal (the student is trained purely against the frozen teacher's per-step
+        # transition mean). Skip reward computation there entirely, but still score
+        # validation batches so evaluation metrics (e.g. PickScore) are logged.
+        opd_only = bool(self.config.actor_rollout_ref.actor.get("opd_only", False))
+        if opd_only and not is_validate:
+            return
 
         if output.reward_score is None and enable_async_reward:
             timing = {}

--- a/verl_omni/pipelines/sd3_flow_grpo/diffusers_training_adapter.py
+++ b/verl_omni/pipelines/sd3_flow_grpo/diffusers_training_adapter.py
@@ -20,6 +20,7 @@ import torch
 from diffusers import ModelMixin
 from tensordict import TensorDict
 from verl.utils.device import get_device_name
+from verl.utils import tensordict_utils as tu
 
 from verl_omni.pipelines.model_base import DiffusionModelBase
 from verl_omni.pipelines.schedulers import FlowMatchSDEDiscreteScheduler
@@ -126,7 +127,12 @@ class StableDiffusion3FlowGRPO(DiffusionModelBase):
             pooled_prompt_embeds=micro_batch["pooled_prompt_embeds"],
         )
 
-        guidance_scale = model_config.pipeline.guidance_scale
+        # On-policy distillation: a per-call ``guidance_scale`` override (non-tensor batch
+        # metadata) lets teacher inference run each teacher with its own CFG scale while the
+        # student rollout / training keeps ``pipeline.guidance_scale``.
+        guidance_scale = tu.get_non_tensor_data(
+            micro_batch, "guidance_scale", default=model_config.pipeline.guidance_scale
+        )
         if guidance_scale is None:
             guidance_scale = 0.0
         if guidance_scale > 1.0:
@@ -161,7 +167,11 @@ class StableDiffusion3FlowGRPO(DiffusionModelBase):
         timesteps = scheduler_inputs["all_timesteps"]
 
         noise_pred = cls.forward(module, model_config, model_inputs)
-        guidance_scale = model_config.pipeline.guidance_scale
+        # Per-call guidance-scale override for on-policy distillation teacher inference
+        # (non-tensor batch metadata, see ``prepare_model_inputs``).
+        guidance_scale = tu.get_non_tensor_data(
+            scheduler_inputs, "guidance_scale", default=model_config.pipeline.guidance_scale
+        )
         if guidance_scale is not None and guidance_scale > 1.0:
             if negative_model_inputs is None:
                 raise ValueError("SD3 CFG requires negative model inputs when guidance_scale > 1.")

--- a/verl_omni/trainer/config/_generated_diffusion_trainer.yaml
+++ b/verl_omni/trainer/config/_generated_diffusion_trainer.yaml
@@ -95,6 +95,7 @@ actor_rollout_ref:
     use_distill_loss: false
     distill_loss_mode: distill_kl
     distill_loss_coef: 1.0
+    opd_only: false
     ppo_epochs: 1
     shuffle: false
     data_loader_seed: 42
@@ -292,6 +293,8 @@ actor_rollout_ref:
     lora_adapter_path: null
     policy_state_adapters:
     - default
+    teacher_adapter_path: null
+    teacher_adapter_name: teacher
     lora_dtype: null
     fsdp_layer_prefixes:
     - transformer_blocks.

--- a/verl_omni/trainer/config/_generated_diffusion_veomni_trainer.yaml
+++ b/verl_omni/trainer/config/_generated_diffusion_veomni_trainer.yaml
@@ -107,6 +107,7 @@ actor_rollout_ref:
     use_distill_loss: false
     distill_loss_mode: distill_kl
     distill_loss_coef: 1.0
+    opd_only: false
     ppo_epochs: 1
     shuffle: false
     data_loader_seed: 42
@@ -333,6 +334,8 @@ actor_rollout_ref:
     lora_adapter_path: null
     policy_state_adapters:
     - default
+    teacher_adapter_path: null
+    teacher_adapter_name: teacher
     lora_dtype: null
     fsdp_layer_prefixes:
     - transformer_blocks.

--- a/verl_omni/trainer/config/diffusion/actor/diffusion_actor.yaml
+++ b/verl_omni/trainer/config/diffusion/actor/diffusion_actor.yaml
@@ -102,6 +102,16 @@ distill_loss_mode: distill_kl
 # Distillation loss coefficient
 distill_loss_coef: 1.0
 
+# On-policy distillation (OPD) only mode: train the student purely against the frozen
+# teacher's per-step transition mean, skipping the policy-gradient primary loss and the
+# reward / old-log-prob / advantage phases. Requires use_distill_loss=true.
+opd_only: false
+
+# Multi-task OPD (DiffusionOPD) mode: round-robin over task datasets with per-task teacher
+# distillation, accumulating gradients over a full task cycle before one optimizer step.
+# Requires opd_only=true and >=2 model.teacher_adapters.
+mopd: false
+
 # Number of PPO epochs per batch
 ppo_epochs: 1
 

--- a/verl_omni/trainer/config/diffusion/model/diffusion_model.yaml
+++ b/verl_omni/trainer/config/diffusion/model/diffusion_model.yaml
@@ -69,6 +69,20 @@ lora_adapter_path: null
 # Named LoRA policy states required by the algorithm. "reference" disables adapters.
 policy_state_adapters: ["default"]
 
+# Path to a frozen teacher LoRA adapter for on-policy distillation (OPD).
+# When set, the adapter is loaded onto the actor's own backbone and frozen; teacher
+# inference is triggered by the trainer via the ``use_lora_adapter`` metadata.
+teacher_adapter_path: null
+
+# Name of the teacher PEFT adapter used by OPD teacher inference.
+teacher_adapter_name: teacher
+
+# Multi-task OPD (DiffusionOPD): list of frozen teacher LoRA adapters, one per task.
+# Each entry: {name, path, guidance_scale}. When set, each teacher is loaded as a frozen
+# `teacher_<name>` PEFT adapter and teacher inference selects the adapter matching the
+# batch's task_id (overrides the single `teacher_adapter_path`).
+teacher_adapters: []
+
 # Convert LoRA parameters to a target dtype for numerical stability (e.g., "fp32", "bf16").
 # Default null means no conversion.
 lora_dtype: null

--- a/verl_omni/trainer/diffusion/diffusion_algos.py
+++ b/verl_omni/trainer/diffusion/diffusion_algos.py
@@ -1053,7 +1053,18 @@ class KLLoss(DiffusionLossFn):
 
 @register_diffusion_loss("distill_kl")
 class DistillKLLoss(DiffusionLossFn):
-    """KL divergence between student and teacher reverse-SDE means (online policy distillation)."""
+    """KL divergence between student and teacher reverse-SDE means (online policy distillation).
+
+    Stochastic (SDE) regime: the per-step transition variance ``std_dev_t`` is shared by the
+    student and teacher Gaussians, so the reverse KL has the closed form
+    ``||mu_student - mu_teacher||^2 / (2 * std_dev_t^2)`` (paper Eq. 11/14).
+
+    Deterministic (ODE) regime: when ``std_dev_t == 0`` the kernels degenerate to point masses,
+    distribution matching reduces to direct transition matching, and the objective becomes the
+    squared-L2 surrogate ``0.5 * ||mu_student - mu_teacher||^2`` (paper Eq. 12). Without this
+    branch the SDE formula would divide by zero whenever the rollout uses ``noise_level=0``
+    (the default SD3.5-M OPD config), producing NaNs.
+    """
 
     required_model_output_keys = ("prev_sample_mean", "std_dev_t")
     required_data_keys = ("teacher_prev_sample_mean",)
@@ -1069,13 +1080,24 @@ class DistillKLLoss(DiffusionLossFn):
         """Compute KL divergence given student and teacher previous sample means.
 
         Args:
-            prev_sample_mean: (torch.Tensor) shape is (bs, s, c)
-            teacher_prev_sample_mean: (torch.Tensor) shape is (bs, s, c)
+            prev_sample_mean: (torch.Tensor) shape is (bs, s, c) for images (or (bs, s, c, t) video)
+            teacher_prev_sample_mean: (torch.Tensor) shape is (bs, s, c) for images (or (bs, s, c, t) video)
             std_dev_t: (torch.Tensor) shape is (bs, 1, 1)
         """
-        kl_loss = ((prev_sample_mean - teacher_prev_sample_mean) ** 2).mean(dim=(1, 2), keepdim=True) / (
-            2 * std_dev_t**2
-        )
+        delta_sq = (prev_sample_mean - teacher_prev_sample_mean) ** 2
+        # Average over the non-batch leading dims (matches the convention used by ``KLLoss``).
+        delta_sq_mean = delta_sq.mean(dim=tuple(range(1, delta_sq.ndim)), keepdim=True)
+        sigma_sq = std_dev_t ** 2
+
+        # SDE closed-form: ||mu_s - mu_t||^2 / (2 sigma^2).
+        sde_kl = delta_sq_mean / (2 * sigma_sq.clamp(min=1e-12))
+        # ODE surrogate: 0.5 * ||mu_s - mu_t||^2.
+        ode_l2 = 0.5 * delta_sq_mean
+
+        # Use the squared-L2 surrogate wherever the transition variance is (effectively) zero.
+        ode_mask = sigma_sq <= 1e-12
+        kl_loss = torch.where(ode_mask, ode_l2, sde_kl)
+
         metrics = {"actor/distill_kl_loss": kl_loss.mean().detach().item()}
         return kl_loss.mean(), metrics
 

--- a/verl_omni/trainer/diffusion/diffusion_metric_utils.py
+++ b/verl_omni/trainer/diffusion/diffusion_metric_utils.py
@@ -43,7 +43,11 @@ def compute_data_metrics_diffusion(batch: DataProto) -> dict[str, Any]:
             - critic/advantages/mean, max, min: Element-wise advantage statistics over B*T, when available
             - critic/returns/mean, max, min: Element-wise return statistics over B*T, when available
     """
-    sample_level_rewards = batch.batch["sample_level_rewards"]
+    sample_level_rewards = batch.batch.get("sample_level_rewards", None)
+    if sample_level_rewards is None:
+        # OPD-only batches carry no rewards; report only the reward-free statistics below.
+        return {}
+
     if sample_level_rewards.ndim > 1:
         sequence_reward = sample_level_rewards.mean(dim=1)  # [B]
     else:
@@ -156,8 +160,11 @@ def compute_throughput_metrics_diffusion(batch: DataProto, timing_raw: dict[str,
     """
     if "advantages" in batch.batch:
         batch_size = batch.batch["advantages"].shape[0]
-    else:
+    elif "sample_level_rewards" in batch.batch:
         batch_size = batch.batch["sample_level_rewards"].shape[0]
+    else:
+        # OPD-only batches carry neither advantages nor rewards; use the row count.
+        batch_size = len(batch)
     time = timing_raw["step"]
     return {
         "perf/total_num_images": batch_size,

--- a/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
+++ b/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
@@ -820,10 +820,18 @@ class BaseRayDiffusionTrainer(ABC):
         self.enable_agent_reward_loop = not self.use_rm or self.config.reward.reward_model.enable_resource_pool
 
         # if enable_agent_reward_loop, we directly pass reward_loop_workers to agent loop manager
-        # to stream reward computation with actor rollout
-        reward_loop_worker_handles = (
-            self.reward_loop_manager.reward_loop_workers if self.enable_agent_reward_loop else None
-        )
+        # to stream reward computation with actor rollout.
+        # OPD-only mode has NO reward signal at all: the student is trained purely against the
+        # frozen teacher's per-step transition mean (``distill_kl``), and the reward phase is
+        # short-circuited in ``fit``. Never hand reward workers to the agent loop in that case,
+        # otherwise every generated sample is dispatched to a rule-based reward function
+        # (``default_compute_score_image``) that is not registered for the task data source.
+        if self.opd_only:
+            reward_loop_worker_handles = None
+        else:
+            reward_loop_worker_handles = (
+                self.reward_loop_manager.reward_loop_workers if self.enable_agent_reward_loop else None
+            )
 
         self.llm_server_manager = LLMServerManager.create(
             config=self.config,

--- a/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
+++ b/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
@@ -821,17 +821,14 @@ class BaseRayDiffusionTrainer(ABC):
 
         # if enable_agent_reward_loop, we directly pass reward_loop_workers to agent loop manager
         # to stream reward computation with actor rollout.
-        # OPD-only mode has NO reward signal at all: the student is trained purely against the
-        # frozen teacher's per-step transition mean (``distill_kl``), and the reward phase is
-        # short-circuited in ``fit``. Never hand reward workers to the agent loop in that case,
-        # otherwise every generated sample is dispatched to a rule-based reward function
-        # (``default_compute_score_image``) that is not registered for the task data source.
-        if self.opd_only:
-            reward_loop_worker_handles = None
-        else:
-            reward_loop_worker_handles = (
-                self.reward_loop_manager.reward_loop_workers if self.enable_agent_reward_loop else None
-            )
+        # OPD-only mode has NO reward signal during training, but we still hand the reward
+        # workers to the agent loop so validation batches get scored (eval metrics such as
+        # PickScore are logged via ``_validate``). The agent loop itself skips scoring on
+        # OPD *training* rollouts (``opd_only and not is_validate``), so training stays
+        # reward-free while validation metrics keep working.
+        reward_loop_worker_handles = (
+            self.reward_loop_manager.reward_loop_workers if self.enable_agent_reward_loop else None
+        )
 
         self.llm_server_manager = LLMServerManager.create(
             config=self.config,

--- a/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
+++ b/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
@@ -1276,6 +1276,9 @@ class PolicyGradientRayTrainer(BaseRayDiffusionTrainer):
                         # frozen teacher's per-step transition mean. ``diffusion_loss`` will
                         # short-circuit the primary loss when ``opd_only`` is set, so only the
                         # ``distill_kl`` term contributes.
+                        # No reward is extracted in this mode, so default to an empty
+                        # ``reward_extra_infos_dict`` for metric / rollout-data logging below.
+                        reward_extra_infos_dict: dict = {}
                         with marked_timer("teacher_log_prob", timing_raw, color="olive"):
                             teacher_log_prob = self._compute_teacher_log_prob(batch)
                             batch = batch.union(teacher_log_prob)

--- a/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
+++ b/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
@@ -199,6 +199,69 @@ class BaseRayDiffusionTrainer(ABC):
             lora_rank = config.actor_rollout_ref.model.get("lora_rank", 0)
         self.ref_in_actor = lora_rank > 0 or config.actor_rollout_ref.model.get("lora_adapter_path") is not None
 
+        # On-policy distillation (OPD) flags.
+        self.opd_only = bool(config.actor_rollout_ref.actor.get("opd_only", False))
+        self.mopd = bool(config.actor_rollout_ref.actor.get("mopd", False))
+
+        # Teacher adapter configs. Multi-task OPD (DiffusionOPD) uses a list of
+        # ``{name, path, guidance_scale}`` dicts (``model.teacher_adapters``); single-teacher
+        # OPD keeps the ``teacher_adapter_path`` / ``teacher_adapter_name`` pair.
+        teacher_adapters = config.actor_rollout_ref.model.get("teacher_adapters", None) or []
+        if teacher_adapters:
+            self._teacher_configs = [
+                {
+                    "name": str(t.get("name", f"teacher_{i}")),
+                    "path": t.get("path"),
+                    "guidance_scale": float(t["guidance_scale"]) if t.get("guidance_scale") is not None else None,
+                }
+                for i, t in enumerate(teacher_adapters)
+            ]
+        else:
+            teacher_path = config.actor_rollout_ref.model.get("teacher_adapter_path", None)
+            self._teacher_configs = (
+                [
+                    {
+                        "name": config.actor_rollout_ref.model.get("teacher_adapter_name", "teacher"),
+                        "path": teacher_path,
+                        "guidance_scale": None,
+                    }
+                ]
+                if teacher_path is not None
+                else []
+            )
+        self.use_teacher = len(self._teacher_configs) > 0
+        self._teacher_name_to_guidance = {t["name"]: t["guidance_scale"] for t in self._teacher_configs}
+        if self.opd_only:
+            if not self.use_teacher:
+                raise ValueError(
+                    "opd_only=True requires at least one frozen teacher: set "
+                    "actor_rollout_ref.model.teacher_adapters (MOPD) or "
+                    "actor_rollout_ref.model.teacher_adapter_path (SOPD)."
+                )
+            if not bool(config.actor_rollout_ref.actor.get("use_distill_loss", False)):
+                raise ValueError("opd_only=True requires actor_rollout_ref.actor.use_distill_loss=true.")
+            if lora_rank <= 0:
+                raise ValueError(
+                    "opd_only=True currently requires LoRA training (actor_rollout_ref.model.lora_rank>0) "
+                    "so the teacher can be loaded as a frozen PEFT adapter on the actor's backbone."
+                )
+            if self.mopd:
+                if len(self._teacher_configs) < 2:
+                    raise ValueError(
+                        "mopd=True requires at least two model.teacher_adapters (one per task)."
+                    )
+                task_train_files = config.data.get("task_train_files", None)
+                if not task_train_files:
+                    raise ValueError(
+                        "mopd=True requires data.task_train_files "
+                        "(one list of data files per task, aligned with model.teacher_adapters)."
+                    )
+                if len(task_train_files) != len(self._teacher_configs):
+                    raise ValueError(
+                        f"mopd=True requires len(data.task_train_files) == len(model.teacher_adapters), "
+                        f"got {len(task_train_files)} task datasets and {len(self._teacher_configs)} teachers."
+                    )
+
         self._create_dataloader(train_dataset, val_dataset, collate_fn, train_sampler)
 
         self.checkpoint_manager = None
@@ -209,6 +272,46 @@ class BaseRayDiffusionTrainer(ABC):
         """
         # TODO: we have to make sure the batch size is divisible by the dp size
         from verl_omni.utils.dataset.rl_dataset import create_rl_dataset, create_rl_sampler, get_collate_fn
+
+        # Multi-task OPD (DiffusionOPD): build one RL dataset per task plus a round-robin
+        # sampler so each dataloader batch (one MOPD round) contains ``batch_size_per_task``
+        # samples from every task, tagged with ``task_id`` / ``teacher_name``.
+        if train_dataset is None and self.config.data.get("task_train_files", None):
+            from verl_omni.utils.dataset.multi_task_dataset import (
+                RoundRobinBatchSampler,
+                create_multi_task_rl_datasets,
+            )
+
+            teacher_names = [t["name"] for t in self._teacher_configs]
+            train_dataset = create_multi_task_rl_datasets(
+                task_files=self.config.data.get("task_train_files"),
+                data_config=self.config.data,
+                tokenizer=self.tokenizer,
+                processor=self.processor,
+                task_names=teacher_names,
+                max_samples=self.config.data.get("train_max_samples", -1),
+            )
+            if self.config.data.get("task_val_files", None):
+                val_dataset = create_multi_task_rl_datasets(
+                    task_files=self.config.data.get("task_val_files"),
+                    data_config=self.config.data,
+                    tokenizer=self.tokenizer,
+                    processor=self.processor,
+                    task_names=teacher_names,
+                    max_samples=self.config.data.get("val_max_samples", -1),
+                    is_train=False,
+                )
+            gen_batch_size = self.config.data.get("gen_batch_size", self.config.data.train_batch_size)
+            batch_size_per_task = self.config.data.get("mopd_batch_size_per_task", None)
+            if batch_size_per_task is None:
+                batch_size_per_task = max(1, int(gen_batch_size) // len(teacher_names))
+            self._mopd_batch_size = int(batch_size_per_task) * len(teacher_names)
+            if train_sampler is None:
+                train_sampler = RoundRobinBatchSampler(
+                    train_dataset,
+                    batch_size_per_task=batch_size_per_task,
+                    seed=self.config.data.get("seed", 42),
+                )
 
         if train_dataset is None:
             train_dataset = create_rl_dataset(
@@ -235,9 +338,15 @@ class BaseRayDiffusionTrainer(ABC):
 
         num_workers = self.config.data["dataloader_num_workers"]
 
+        # Multi-task OPD: the dataloader batch size is exactly one MOPD round
+        # (M tasks x batch_size_per_task), matching the round-robin sampler.
+        dataloader_batch_size = getattr(self, "_mopd_batch_size", None)
+        if dataloader_batch_size is None:
+            dataloader_batch_size = self.config.data.get("gen_batch_size", self.config.data.train_batch_size)
+
         self.train_dataloader = StatefulDataLoader(
             dataset=self.train_dataset,
-            batch_size=self.config.data.get("gen_batch_size", self.config.data.train_batch_size),
+            batch_size=dataloader_batch_size,
             num_workers=num_workers,
             drop_last=True,
             collate_fn=collate_fn,
@@ -934,6 +1043,112 @@ class PolicyGradientRayTrainer(BaseRayDiffusionTrainer):
         old_log_prob_mfu = tu.get(output, "metrics").get("mfu")
         return DataProto.from_tensordict(old_log_prob), old_log_prob_mfu
 
+    def _compute_teacher_log_prob(self, batch: DataProto) -> DataProto:
+        """Run the frozen OPD teacher(s) at the student's visited rollout states.
+
+        SOPD (single teacher): activates the teacher PEFT adapter
+        (``actor_rollout_ref.model.teacher_adapter_name``) on the actor's own backbone over
+        the whole batch, mirroring ``_compute_ref_log_prob``.
+
+        MOPD (DiffusionOPD): every row carries a ``task_id`` / ``teacher_name`` tag (set by
+        the multi-task round-robin dataset). Rows are grouped per task and each task's
+        teacher adapter (with its own CFG ``guidance_scale``) is evaluated at those rows;
+        the per-task ``prev_sample_mean`` are reassembled into a full
+        ``teacher_prev_sample_mean`` consumed by the ``distill_kl`` loss.
+        """
+        if self.mopd:
+            return self._compute_mopd_teacher_log_prob(batch)
+
+        batch_td = batch.to_tensordict()
+        batch_td = embeds_padding_2_no_padding(batch_td)
+        teacher_adapter_name = self.config.actor_rollout_ref.model.get("teacher_adapter_name", "teacher")
+        metadata = {
+            "compute_loss": False,
+            "height": self.config.actor_rollout_ref.model.pipeline.height,
+            "width": self.config.actor_rollout_ref.model.pipeline.width,
+            "vae_scale_factor": self.config.actor_rollout_ref.model.get("vae_scale_factor", 8),
+            "use_lora_adapter": teacher_adapter_name,
+        }
+        # Optional single-teacher CFG scale override (falls back to pipeline.guidance_scale).
+        teacher_gs = self._teacher_name_to_guidance.get(teacher_adapter_name)
+        if teacher_gs is not None:
+            metadata["guidance_scale"] = teacher_gs
+        tu.assign_non_tensor(batch_td, **metadata)
+        output = self.actor_rollout_wg.infer_actor_batch(batch_td)
+        prev_sample_mean = tu.get(output, "prev_sample_mean")
+        if prev_sample_mean is None:
+            raise RuntimeError(
+                "OPD teacher inference did not return `prev_sample_mean`. Ensure the rollout batch "
+                "carries `all_latents`/`all_timesteps` and the SD3 training adapter is registered."
+            )
+        teacher_td = tu.get_tensordict({"teacher_prev_sample_mean": prev_sample_mean.float()})
+        return DataProto.from_tensordict(teacher_td)
+
+    def _compute_mopd_teacher_log_prob(self, batch: DataProto) -> DataProto:
+        """Multi-task OPD teacher inference: one forward pass per task over its own rows.
+
+        Each row of ``batch`` is tagged with ``task_id`` (aligned with
+        ``model.teacher_adapters``); rows are grouped per task and evaluated with that
+        task's frozen teacher adapter and CFG ``guidance_scale``. The per-task
+        ``prev_sample_mean`` are scattered back into the original row order so the rest of
+        the OPD pipeline (``distill_kl``) sees a single ``(B, T, ...)`` tensor.
+        """
+        if "task_id" not in batch.non_tensor_batch:
+            raise RuntimeError(
+                "MOPD teacher inference requires `task_id` per sample. Use the multi-task "
+                "round-robin dataset (data.task_train_files) with mopd=True."
+            )
+        task_ids = np.asarray(batch.non_tensor_batch["task_id"], dtype=np.int64)
+        if task_ids.ndim != 1 or task_ids.shape[0] != len(batch):
+            raise RuntimeError(
+                f"MOPD `task_id` must be 1-D of length {len(batch)}, got shape {task_ids.shape}."
+            )
+        task_ids = task_ids.flatten()
+
+        height = self.config.actor_rollout_ref.model.pipeline.height
+        width = self.config.actor_rollout_ref.model.pipeline.width
+        vae_scale_factor = self.config.actor_rollout_ref.model.get("vae_scale_factor", 8)
+
+        per_task = {}
+        for task_id in np.unique(task_ids):
+            teacher_cfg = self._teacher_configs[int(task_id)]
+            teacher_adapter_name = f"teacher_{teacher_cfg['name']}"
+            mask = task_ids == task_id
+            sub_batch = batch[mask]
+            sub_td = sub_batch.to_tensordict()
+            sub_td = embeds_padding_2_no_padding(sub_td)
+            metadata = {
+                "compute_loss": False,
+                "height": height,
+                "width": width,
+                "vae_scale_factor": vae_scale_factor,
+                "use_lora_adapter": teacher_adapter_name,
+            }
+            if teacher_cfg["guidance_scale"] is not None:
+                metadata["guidance_scale"] = teacher_cfg["guidance_scale"]
+            tu.assign_non_tensor(sub_td, **metadata)
+            output = self.actor_rollout_wg.infer_actor_batch(sub_td)
+            prev_sample_mean = tu.get(output, "prev_sample_mean")
+            if prev_sample_mean is None:
+                raise RuntimeError(
+                    f"MOPD teacher inference (task {teacher_cfg['name']!r}, adapter "
+                    f"{teacher_adapter_name!r}) did not return `prev_sample_mean`."
+                )
+            per_task[int(task_id)] = (mask, prev_sample_mean.float())
+
+        # Reassemble the full tensor in original row order.
+        _, first_mean = next(iter(per_task.values()))
+        full_mean = torch.zeros(
+            (len(batch),) + tuple(first_mean.shape[1:]),
+            dtype=first_mean.dtype,
+            device=first_mean.device,
+        )
+        for task_id, (mask, prev_sample_mean) in per_task.items():
+            full_mean[torch.from_numpy(mask)] = prev_sample_mean
+
+        teacher_td = tu.get_tensordict({"teacher_prev_sample_mean": full_mean})
+        return DataProto.from_tensordict(teacher_td)
+
     def fit(self):
         """
         The training loop of FlowGRPO.
@@ -1047,81 +1262,95 @@ class PolicyGradientRayTrainer(BaseRayDiffusionTrainer):
                     batch = batch.repeat(repeat_times=self.config.actor_rollout_ref.rollout.n, interleave=True)
                     batch = batch.union(gen_batch_output)
 
-                    with marked_timer("reward", timing_raw, color="yellow"):
-                        # compute reward model score
-                        if self.use_rm and "rm_scores" not in batch.batch.keys():
-                            if curr_step_profile:
-                                self.reward_loop_manager.start_profile()
-                            batch_reward = self._compute_reward_colocate(batch)
-                            if curr_step_profile:
-                                self.reward_loop_manager.stop_profile()
-                            batch = batch.union(batch_reward)
+                    if self.opd_only:
+                        # On-policy distillation (OPD) only: skip the reward / old-log-prob /
+                        # reference / advantage phases and train the student purely against the
+                        # frozen teacher's per-step transition mean. ``diffusion_loss`` will
+                        # short-circuit the primary loss when ``opd_only`` is set, so only the
+                        # ``distill_kl`` term contributes.
+                        with marked_timer("teacher_log_prob", timing_raw, color="olive"):
+                            teacher_log_prob = self._compute_teacher_log_prob(batch)
+                            batch = batch.union(teacher_log_prob)
+                    else:
+                        with marked_timer("reward", timing_raw, color="yellow"):
+                            # compute reward model score
+                            if self.use_rm and "rm_scores" not in batch.batch.keys():
+                                if curr_step_profile:
+                                    self.reward_loop_manager.start_profile()
+                                batch_reward = self._compute_reward_colocate(batch)
+                                if curr_step_profile:
+                                    self.reward_loop_manager.stop_profile()
+                                batch = batch.union(batch_reward)
 
-                        # extract reward_tensor and reward_extra_infos_dict for training
-                        reward_tensor, reward_extra_infos_dict = extract_reward(batch)
+                            # extract reward_tensor and reward_extra_infos_dict for training
+                            reward_tensor, reward_extra_infos_dict = extract_reward(batch)
 
-                    # Bypass mode: skip old_log_prob recompute (2 policies).
-                    # Decoupled mode: recompute old_log_probs as proximal anchor (3 policies).
-                    rollout_corr_config = self.config.algorithm.get("rollout_correction", None)
-                    bypass_recomputing_logprobs = rollout_corr_config and rollout_corr_config.get("bypass_mode", False)
-                    if bypass_recomputing_logprobs:  # Use `rollout_log_probs`
-                        apply_bypass_mode_to_diffusion_batch(batch)
-                    else:  # Recompute old_log_probs
-                        with marked_timer("old_log_prob", timing_raw, color="blue"):
-                            old_log_prob, old_log_prob_mfu = self._compute_old_log_prob(batch)
-                            if old_log_prob_mfu is not None:
-                                metrics.update({"perf/mfu/actor_infer": old_log_prob_mfu})
-                            batch = batch.union(old_log_prob)
-
-                    assert "old_log_probs" in batch.batch, f'"old_log_probs" not in {batch.batch.keys()=}'
-
-                    metrics.update(
-                        compute_rollout_corr_metrics_from_batch(
-                            batch,
-                            bypass_mode=bool(bypass_recomputing_logprobs),
+                        # Bypass mode: skip old_log_prob recompute (2 policies).
+                        # Decoupled mode: recompute old_log_probs as proximal anchor (3 policies).
+                        rollout_corr_config = self.config.algorithm.get("rollout_correction", None)
+                        bypass_recomputing_logprobs = (
+                            rollout_corr_config and rollout_corr_config.get("bypass_mode", False)
                         )
-                    )
+                        if bypass_recomputing_logprobs:  # Use `rollout_log_probs`
+                            apply_bypass_mode_to_diffusion_batch(batch)
+                        else:  # Recompute old_log_probs
+                            with marked_timer("old_log_prob", timing_raw, color="blue"):
+                                old_log_prob, old_log_prob_mfu = self._compute_old_log_prob(batch)
+                                if old_log_prob_mfu is not None:
+                                    metrics.update({"perf/mfu/actor_infer": old_log_prob_mfu})
+                                batch = batch.union(old_log_prob)
 
-                    # Decoupled-mode rollout correction (old vs rollout).
-                    # In bypass mode old == rollout, so correction runs per-step in ``diffusion_loss``.
-                    if not bypass_recomputing_logprobs and rollout_correction_enabled(rollout_corr_config):
-                        with marked_timer("rollout_corr", timing_raw, color="cyan"):
-                            batch, rollout_corr_metrics = apply_rollout_correction_to_diffusion_batch(
-                                batch, rollout_corr_config
+                        assert "old_log_probs" in batch.batch, f'"old_log_probs" not in {batch.batch.keys()=}'
+
+                        metrics.update(
+                            compute_rollout_corr_metrics_from_batch(
+                                batch,
+                                bypass_mode=bool(bypass_recomputing_logprobs),
                             )
-                            metrics.update(rollout_corr_metrics)
-
-                    if self.use_reference_policy:
-                        # compute reference log_prob
-                        with marked_timer(str(Role.RefPolicy), timing_raw, color="olive"):
-                            ref_log_prob = self._compute_ref_log_prob(batch)
-                            batch = batch.union(ref_log_prob)
-
-                    with marked_timer("adv", timing_raw, color="brown"):
-                        # we combine with rule-based rm
-                        reward_extra_infos_dict: dict[str, list]
-                        batch.batch["sample_level_scores"] = reward_tensor
-
-                        if reward_extra_infos_dict:
-                            batch.non_tensor_batch.update({k: np.array(v) for k, v in reward_extra_infos_dict.items()})
-
-                        num_timesteps = batch.batch["old_log_probs"].shape[1]
-                        batch.batch["sample_level_rewards"] = batch.batch["sample_level_scores"].expand(
-                            -1, num_timesteps
                         )
 
-                        # compute advantages, executed on the driver process
-                        norm_adv_by_std_in_grpo = self.config.algorithm.get(
-                            "norm_adv_by_std_in_grpo", True
-                        )  # GRPO adv normalization factor
+                        # Decoupled-mode rollout correction (old vs rollout).
+                        # In bypass mode old == rollout, so correction runs per-step in ``diffusion_loss``.
+                        if not bypass_recomputing_logprobs and rollout_correction_enabled(rollout_corr_config):
+                            with marked_timer("rollout_corr", timing_raw, color="cyan"):
+                                batch, rollout_corr_metrics = apply_rollout_correction_to_diffusion_batch(
+                                    batch, rollout_corr_config
+                                )
+                                metrics.update(rollout_corr_metrics)
 
-                        batch = compute_advantage(
-                            batch,
-                            adv_estimator=self.config.algorithm.adv_estimator,
-                            norm_adv_by_std_in_grpo=norm_adv_by_std_in_grpo,
-                            global_std=self.config.algorithm.global_std,
-                            config=self.config.algorithm,
-                        )
+                        if self.use_reference_policy:
+                            # compute reference log_prob
+                            with marked_timer(str(Role.RefPolicy), timing_raw, color="olive"):
+                                ref_log_prob = self._compute_ref_log_prob(batch)
+                                batch = batch.union(ref_log_prob)
+
+                        with marked_timer("adv", timing_raw, color="brown"):
+                            # we combine with rule-based rm
+                            reward_extra_infos_dict: dict[str, list]
+                            batch.batch["sample_level_scores"] = reward_tensor
+
+                            if reward_extra_infos_dict:
+                                batch.non_tensor_batch.update(
+                                    {k: np.array(v) for k, v in reward_extra_infos_dict.items()}
+                                )
+
+                            num_timesteps = batch.batch["old_log_probs"].shape[1]
+                            batch.batch["sample_level_rewards"] = batch.batch["sample_level_scores"].expand(
+                                -1, num_timesteps
+                            )
+
+                            # compute advantages, executed on the driver process
+                            norm_adv_by_std_in_grpo = self.config.algorithm.get(
+                                "norm_adv_by_std_in_grpo", True
+                            )  # GRPO adv normalization factor
+
+                            batch = compute_advantage(
+                                batch,
+                                adv_estimator=self.config.algorithm.adv_estimator,
+                                norm_adv_by_std_in_grpo=norm_adv_by_std_in_grpo,
+                                global_std=self.config.algorithm.global_std,
+                                config=self.config.algorithm,
+                            )
 
                     # update actor
                     with marked_timer("update_actor", timing_raw, color="red"):
@@ -1199,7 +1428,9 @@ class PolicyGradientRayTrainer(BaseRayDiffusionTrainer):
                 # collect metrics
                 metrics.update(compute_data_metrics_diffusion(batch=batch))
                 n_gpus = self.resource_pool_manager.get_n_gpus()
-                num_images = batch.batch["advantages"].shape[0]
+                # OPD-only batches carry no ``advantages`` / ``sample_level_rewards``; fall back
+                # to the number of rows (prompts x rollout.n) for throughput accounting.
+                num_images = len(batch)
                 metrics.update(compute_timing_metrics_diffusion(timing_raw=timing_raw, num_images=num_images))
                 metrics.update(compute_throughput_metrics_diffusion(batch=batch, timing_raw=timing_raw, n_gpus=n_gpus))
                 metrics.update(compute_reward_extra_metrics_diffusion(reward_extra_infos_dict))

--- a/verl_omni/utils/dataset/multi_task_dataset.py
+++ b/verl_omni/utils/dataset/multi_task_dataset.py
@@ -1,0 +1,159 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Multi-task round-robin data for DiffusionOPD (arXiv:2605.15055).
+
+Stage 2 of DiffusionOPD samples prompts from every task's dataset in a round-robin
+fashion: each MOPD round visits each task exactly once (``batch_size_per_task`` samples
+per task), so the training step covers a full task cycle before a single optimizer step
+(gradient accumulation G = M, paper Algorithm 1).
+
+This module provides:
+- :class:`MultiTaskRLDataset`: concatenates M per-task RL datasets and tags every sample
+  with its ``task_id`` (int) and ``teacher_name`` (str). The collate_fn turns these into
+  object arrays in ``DataProto.non_tensor_batch`` so the trainer can route each sample to
+  its task-specific teacher during on-policy distillation.
+- :class:`RoundRobinBatchSampler`: yields one batch per round containing equal
+  ``batch_size_per_task`` samples from every task.
+"""
+
+import numpy as np
+import torch
+from omegaconf import DictConfig
+from torch.utils.data import Dataset, Sampler
+
+from verl_omni.utils.dataset.rl_dataset import create_rl_dataset
+
+__all__ = ["MultiTaskRLDataset", "RoundRobinBatchSampler", "create_multi_task_rl_datasets"]
+
+
+class MultiTaskRLDataset(Dataset):
+    """Concatenation of M task datasets with per-sample task tags."""
+
+    def __init__(self, task_datasets: list[Dataset], task_names: list[str] | None = None):
+        assert len(task_datasets) >= 2, "MultiTaskRLDataset requires at least two task datasets."
+        self.task_datasets = task_datasets
+        self.num_tasks = len(task_datasets)
+        if task_names is None:
+            task_names = [f"task_{i}" for i in range(self.num_tasks)]
+        assert len(task_names) == self.num_tasks, (
+            f"task_names ({len(task_names)}) must match the number of tasks ({self.num_tasks})."
+        )
+        self.task_names = list(task_names)
+        self.task_lens = [len(ds) for ds in task_datasets]
+        self.cum_lens = np.cumsum([0] + self.task_lens)
+        if any(length <= 0 for length in self.task_lens):
+            raise ValueError(f"All task datasets must be non-empty, got lengths {self.task_lens}.")
+
+    def __len__(self) -> int:
+        return int(self.cum_lens[-1])
+
+    def task_of(self, idx: int) -> int:
+        """Return the task id of a global index."""
+        return int(np.searchsorted(self.cum_lens, idx, side="right") - 1)
+
+    def local_index(self, idx: int) -> tuple[int, int]:
+        """Map a global index to ``(task_id, local_index_within_task)``."""
+        task_id = self.task_of(idx)
+        return task_id, int(idx - self.cum_lens[task_id])
+
+    def __getitem__(self, idx: int):
+        task_id, local_idx = self.local_index(idx)
+        item = self.task_datasets[task_id][local_idx]
+        # Task tags flow through the default collate_fn as object arrays
+        # (``DataProto.non_tensor_batch``) and are consumed by the trainer's
+        # per-task teacher inference.
+        item = {**item, "task_id": task_id, "teacher_name": self.task_names[task_id]}
+        return item
+
+
+class RoundRobinBatchSampler(Sampler):
+    """Yield samples in a round-robin order over tasks for DiffusionOPD.
+
+    One MOPD round emits ``batch_size_per_task`` samples from every task (task 0, then
+    task 1, ...), so a dataloader configured with ``batch_size = M * batch_size_per_task``
+    produces exactly one batch per round, i.e. one full task cycle per training step
+    (paper Algorithm 1: gradient accumulation over a full round-robin cycle).
+    """
+
+    def __init__(
+        self,
+        dataset: MultiTaskRLDataset,
+        batch_size_per_task: int,
+        seed: int = 42,
+    ):
+        assert isinstance(dataset, MultiTaskRLDataset)
+        self.dataset = dataset
+        self.num_tasks = dataset.num_tasks
+        self.batch_size_per_task = int(batch_size_per_task)
+        assert self.batch_size_per_task >= 1, "batch_size_per_task must be >= 1"
+        self.seed = seed
+        self.epoch = 0
+
+        # Base the number of rounds on the longest task so every task is visited on
+        # every round; shorter tasks are sampled with replacement across rounds.
+        max_task_len = max(dataset.task_lens)
+        self.num_rounds = max(1, max_task_len // self.batch_size_per_task)
+
+    def __len__(self) -> int:
+        # Total number of samples the sampler emits; the dataloader then chunks them
+        # into ``num_rounds`` batches of size ``M * batch_size_per_task``.
+        return self.num_rounds * self.num_tasks * self.batch_size_per_task
+
+    def set_epoch(self, epoch: int) -> None:
+        self.epoch = epoch
+
+    def __iter__(self):
+        g = torch.Generator()
+        g.manual_seed(self.seed + self.epoch)
+        for _ in range(self.num_rounds):
+            for t in range(self.num_tasks):
+                task_len = self.dataset.task_lens[t]
+                if task_len >= self.batch_size_per_task:
+                    chosen = torch.randperm(task_len, generator=g)[: self.batch_size_per_task].tolist()
+                else:
+                    chosen = torch.randint(0, task_len, (self.batch_size_per_task,), generator=g).tolist()
+                yield from (self.dataset.cum_lens[t] + i for i in chosen)
+
+
+def create_multi_task_rl_datasets(
+    task_files: list[list[str]],
+    data_config: DictConfig,
+    tokenizer,
+    processor,
+    task_names: list[str] | None = None,
+    max_samples: int = -1,
+    is_train: bool = True,
+) -> MultiTaskRLDataset:
+    """Build one RL dataset per task and wrap them in a :class:`MultiTaskRLDataset`.
+
+    Args:
+        task_files: One list of data file paths per task (``data.task_train_files``).
+        data_config: The ``data`` hydra config.
+        tokenizer / processor: Passed through to ``create_rl_dataset``.
+        task_names: Optional per-task names (defaults to the teacher adapter names).
+        max_samples: Optional cap per task dataset.
+        is_train: Whether these are training (True) or validation (False) datasets.
+    """
+    datasets = [
+        create_rl_dataset(
+            files,
+            data_config,
+            tokenizer,
+            processor,
+            is_train=is_train,
+            max_samples=max_samples,
+        )
+        for files in task_files
+    ]
+    return MultiTaskRLDataset(datasets, task_names=task_names)

--- a/verl_omni/utils/reward_score/__init__.py
+++ b/verl_omni/utils/reward_score/__init__.py
@@ -15,7 +15,7 @@
 """Visual (image) reward scoring functions for VeRL-Omni."""
 
 
-def default_compute_score_image(
+async def default_compute_score_image(
     data_source,
     solution_image,
     ground_truth,
@@ -29,7 +29,8 @@ def default_compute_score_image(
         solution_image: The generated image, as a ``torch.Tensor`` in shape
             ``(C, H, W)`` or ``(N, C, H, W)``.
         ground_truth (str): Ground-truth answer (may be unused for rule-based
-            rewards such as ``jpeg_compressibility``).
+            rewards such as ``jpeg_compressibility``; for PickScore it carries
+            the text prompt used for scoring).
         extra_info (dict, optional): Additional metadata passed by the reward
             manager.
 
@@ -43,6 +44,19 @@ def default_compute_score_image(
         from verl_omni.utils.reward_score import jpeg_compressibility
 
         res = jpeg_compressibility.compute_score(solution_image)
+    elif "pickscore" in str(data_source).lower():
+        # PickScore (e.g. data_source "flow_grpo/pickscore_sfw" or any
+        # path-based variant containing "pickscore"). Async scorer backed by
+        # CLIP-H (laion/CLIP-ViT-H-14 + yuvalkirstain/PickScore_v1).
+        from verl_omni.utils.reward_score.pickscore_reward import compute_score_pickscore
+
+        return await compute_score_pickscore(
+            data_source=data_source,
+            solution_image=solution_image,
+            ground_truth=ground_truth,
+            extra_info=extra_info,
+            **kwargs,
+        )
     else:
         raise NotImplementedError(f"Reward function is not implemented for {data_source=}")
 

--- a/verl_omni/workers/config/diffusion/actor.py
+++ b/verl_omni/workers/config/diffusion/actor.py
@@ -149,6 +149,18 @@ class DiffusionActorConfig(BaseConfig):
     use_distill_loss: bool = False
     distill_loss_mode: str = "distill_kl"
     distill_loss_coef: float = 1.0
+
+    # On-policy distillation (OPD) only mode: skip the policy-gradient primary loss and the
+    # reward / old-log-prob / advantage phases, training the student purely against the frozen
+    # teacher's per-step transition mean via the distillation term. Requires use_distill_loss=True.
+    opd_only: bool = False
+
+    # Multi-task OPD (DiffusionOPD) mode: round-robin over task-specific datasets (one batch
+    # per task per round) with per-task teacher distillation, accumulating gradients over a
+    # full task cycle before a single optimizer step. Requires opd_only=True and at least two
+    # ``model.teacher_adapters``.
+    mopd: bool = False
+
     ppo_epochs: int = 1
     shuffle: bool = False
     data_loader_seed: int = 42
@@ -178,6 +190,10 @@ class DiffusionActorConfig(BaseConfig):
             raise ValueError(
                 f"Invalid distill_loss_mode: {self.distill_loss_mode}. Must be one of {valid_distill_modes}"
             )
+        if self.opd_only and not self.use_distill_loss:
+            raise ValueError("opd_only=True requires use_distill_loss=True (OPD trains via the distillation term).")
+        if self.mopd and not self.opd_only:
+            raise ValueError("mopd=True requires opd_only=True (DiffusionOPD distills via the distillation term).")
 
 
 @dataclass

--- a/verl_omni/workers/config/diffusion/model.py
+++ b/verl_omni/workers/config/diffusion/model.py
@@ -102,6 +102,23 @@ class DiffusionModelConfig(BaseConfig):
     # Named LoRA policy states required by the algorithm. "reference" uses disabled adapters.
     policy_state_adapters: tuple[str, ...] = ("default",)
 
+    # On-policy distillation (OPD): path to a frozen teacher LoRA adapter that is loaded
+    # onto the actor's own backbone (single-backbone multi-LoRA). During teacher inference
+    # the adapter is temporarily activated via ``use_adapter``; it is never trained.
+    teacher_adapter_path: Optional[str] = None
+
+    # Name of the teacher PEFT adapter used by OPD teacher inference. Must differ from
+    # ``"default"`` and ``"reference"``.
+    teacher_adapter_name: str = "teacher"
+
+    # Multi-task on-policy distillation (DiffusionOPD, arXiv:2605.15055): a list of frozen
+    # teacher LoRA adapters, one per task. Each entry is a dict with keys
+    # ``{"name": str, "path": str, "guidance_scale": float}``. Every teacher is loaded as a
+    # frozen ``teacher_<name>`` PEFT adapter on the shared backbone, and teacher inference
+    # selects the adapter (and guidance scale) matching the batch's ``task_id``. When set,
+    # ``teacher_adapter_path`` / ``teacher_adapter_name`` are ignored (MOPD path).
+    teacher_adapters: list[dict[str, Any]] = field(default_factory=list)
+
     # dtype to convert LoRA parameters to (e.g., "fp32", "bf16"). Default None means no conversion.
     lora_dtype: Optional[str] = None
 

--- a/verl_omni/workers/engine/fsdp/diffusers_impl.py
+++ b/verl_omni/workers/engine/fsdp/diffusers_impl.py
@@ -790,9 +790,16 @@ class DiffusersFSDPEngine(LoRAAdapterMixin, BaseEngine, ABC):
         output_lst = []
         ctx = torch.no_grad() if forward_only else nullcontext()
 
+        # On-policy distillation: per-call CFG scale override (one scalar per batch; each
+        # MOPD teacher pass targets a single task). Re-assign onto every micro-batch so the
+        # pipeline adapter can read it from ``scheduler_inputs``.
+        guidance_scale = tu.get_non_tensor_data(data, "guidance_scale", default=None)
+
         for micro_batch in micro_batches:
             micro_batch = micro_batch.to(get_device_id())
             tu.assign_non_tensor(micro_batch, gradient_accumulation_steps=gradient_accumulation_steps)
+            if guidance_scale is not None:
+                tu.assign_non_tensor(micro_batch, guidance_scale=guidance_scale)
             meta_info_lst = {"model_output": [], "loss": [], "metrics": []}
             # Forward and backward for each timestep
             with ctx:
@@ -888,11 +895,16 @@ class PPODiffusersFSDPEngine(DiffusersFSDPEngine):
 
         if loss_function is not None:
             data = tu.get_tensordict(
-                {
-                    "old_log_probs": micro_batch["old_log_probs"][:, step],
-                    "advantages": micro_batch["advantages"][:, step],
-                },
+                {},
             )
+            # ``old_log_probs`` / ``advantages`` are only required by the policy-gradient
+            # primary loss. They are absent in OPD-only mode, where the engine forward step
+            # runs purely to compute the student ``prev_sample_mean``/``std_dev_t`` against the
+            # frozen teacher ``teacher_prev_sample_mean``.
+            if micro_batch.get("old_log_probs", None) is not None:
+                data["old_log_probs"] = micro_batch["old_log_probs"][:, step]
+            if micro_batch.get("advantages", None) is not None:
+                data["advantages"] = micro_batch["advantages"][:, step]
             tu.assign_non_tensor(
                 data,
                 gradient_accumulation_steps=tu.get_non_tensor_data(

--- a/verl_omni/workers/engine/lora_adapter_mixin.py
+++ b/verl_omni/workers/engine/lora_adapter_mixin.py
@@ -23,6 +23,83 @@ from verl.utils.py_functional import convert_to_regular_types
 logger = logging.getLogger(__name__)
 
 
+def load_peft_adapter_into(module, adapter_path: str, adapter_name: str = "default") -> None:
+    """Load a pretrained PEFT LoRA adapter directory into ``module``.
+
+    Works with both module flavours used by verl-omni engines:
+
+    - PEFT ``PeftModel`` (e.g. non-diffusers backends) which exposes ``load_adapter``;
+    - diffusers models using ``PeftAdapterMixin`` (e.g. ``SD3Transformer2DModel`` on
+      diffusers>=0.37), which expose ``add_adapter`` / ``set_adapter`` / ``use_adapter``
+      but *not* PEFT's ``load_adapter``.
+
+    For the ``PeftAdapterMixin`` path we mirror ``NonDiffusersModelBase.load_lora_adapter``:
+    read ``adapter_config.json``, inject the adapter, then copy the
+    ``adapter_model.safetensors`` weights into the freshly created parameters.
+    Mismatched keys are warned about but do not raise.
+    """
+    if hasattr(module, "load_adapter"):
+        # PEFT PeftModel path (or a diffusers version that exposes load_adapter).
+        module.load_adapter(adapter_path, adapter_name=adapter_name)
+        return
+
+    import json
+    import os
+
+    from peft import LoraConfig, get_peft_model_state_dict
+    from safetensors.torch import load_file as safetensors_load_file
+
+    adapter_config_path = os.path.join(adapter_path, "adapter_config.json")
+    adapter_weights_path = os.path.join(adapter_path, "adapter_model.safetensors")
+    if not os.path.isfile(adapter_config_path):
+        raise FileNotFoundError(f"LoRA adapter config not found at {adapter_config_path}")
+    if not os.path.isfile(adapter_weights_path):
+        raise FileNotFoundError(f"LoRA adapter weights not found at {adapter_weights_path}")
+
+    if not hasattr(module, "add_adapter"):
+        raise AttributeError(
+            f"Module {type(module).__name__} supports neither PEFT load_adapter nor "
+            "add_adapter; cannot load pretrained LoRA adapter."
+        )
+
+    with open(adapter_config_path) as f:
+        lora_config = LoraConfig.from_dict(json.load(f))
+    module.add_adapter(lora_config, adapter_name=adapter_name)
+
+    adapter_state_dict = safetensors_load_file(adapter_weights_path)
+    current_state = get_peft_model_state_dict(module, adapter_name=adapter_name)
+
+    # PEFT checkpoints may carry a ``base_model.model.`` prefix; strip it to align
+    # with the module's own parameter names (diffusers saves use no prefix).
+    loadable = {}
+    for key, value in adapter_state_dict.items():
+        norm_key = key[len("base_model.model.") :] if key.startswith("base_model.model.") else key
+        if norm_key in current_state:
+            loadable[norm_key] = value
+
+    missing = [k for k in current_state if k not in loadable]
+    unexpected = [
+        k
+        for k in adapter_state_dict
+        if not k.startswith("base_model.model.") and k not in current_state and k not in loadable
+    ]
+    if missing:
+        logger.warning(
+            "LoRA adapter %r: %d keys in model but not in checkpoint; they keep initial values.",
+            adapter_name,
+            len(missing),
+        )
+    if unexpected:
+        logger.warning(
+            "LoRA adapter %r: %d keys in checkpoint but not in model; they are ignored.",
+            adapter_name,
+            len(unexpected),
+        )
+
+    for key, value in loadable.items():
+        current_state[key].copy_(value)
+
+
 class LoRAAdapterMixin:
     """Backend-agnostic helpers for named PEFT/LoRA policy adapters."""
 
@@ -36,7 +113,7 @@ class LoRAAdapterMixin:
             print(f"Loading pre-trained LoRA adapter to from: {lora_adapter_path}")
             local_adapter_path = copy_to_local(lora_adapter_path, use_shm=self.model_config.use_shm)
 
-            module.load_lora_adapter(local_adapter_path)
+            load_peft_adapter_into(module, local_adapter_path, adapter_name="default")
             peft_config = getattr(module, "peft_config", {}).get("default", None)
             for adapter_name in extra_adapters:
                 if peft_config is not None and adapter_name not in getattr(module, "peft_config", {}):
@@ -81,8 +158,6 @@ class LoRAAdapterMixin:
         if teacher_adapters:
             from verl.utils.fs import copy_to_local
 
-            if not hasattr(module, "load_adapter"):
-                raise AttributeError("Module does not support PEFT load_adapter; cannot load teacher LoRA.")
             teacher_names = [t.get("name", "teacher") for t in teacher_adapters]
             if len(set(teacher_names)) != len(teacher_names):
                 raise ValueError(f"Teacher adapter names must be unique, got {teacher_names}.")
@@ -95,7 +170,7 @@ class LoRAAdapterMixin:
                     )
                 teacher_adapter_path = teacher.get("path")
                 local_teacher_path = copy_to_local(teacher_adapter_path, use_shm=self.model_config.use_shm)
-                module.load_adapter(local_teacher_path, adapter_name=teacher_adapter_name)
+                load_peft_adapter_into(module, local_teacher_path, adapter_name=teacher_adapter_name)
                 # Freeze the teacher adapter parameters in-place.
                 for n, p in module.named_parameters():
                     if teacher_adapter_name in n.split("."):

--- a/verl_omni/workers/engine/lora_adapter_mixin.py
+++ b/verl_omni/workers/engine/lora_adapter_mixin.py
@@ -23,6 +23,46 @@ from verl.utils.py_functional import convert_to_regular_types
 logger = logging.getLogger(__name__)
 
 
+def _lora_config_from_dict(config_dict: dict):
+    """Build a ``LoraConfig`` from an ``adapter_config.json`` dict.
+
+    ``LoraConfig.from_dict`` is not exposed by every PEFT version, so try it
+    first and fall back to explicit construction using only the fields the
+    installed ``LoraConfig`` actually accepts (introspected from its
+    constructor signature).
+    """
+    from peft import LoraConfig
+
+    from_dict = getattr(LoraConfig, "from_dict", None)
+    if from_dict is not None:
+        try:
+            return from_dict(config_dict)
+        except (AttributeError, TypeError, ValueError, KeyError):
+            pass
+
+    import inspect
+
+    candidate = {
+        "r": int(config_dict.get("r", 32)),
+        "lora_alpha": int(config_dict.get("lora_alpha", 64)),
+        "target_modules": config_dict.get("target_modules", "all-linear"),
+        "lora_dropout": float(config_dict.get("lora_dropout", 0.0)),
+        "bias": config_dict.get("bias", "none"),
+        "fan_in_fan_out": bool(config_dict.get("fan_in_fan_out", False)),
+        "modules_to_save": config_dict.get("modules_to_save", None),
+        "init_lora_weights": config_dict.get("init_lora_weights", "gaussian"),
+    }
+    # Forward optional fields only when present in the JSON AND supported by
+    # the installed LoraConfig (avoids unknown-kwarg errors on older PEFT).
+    for key in ("use_rslora", "use_dora", "lora_bias", "layer_replication", "runtimes"):
+        if key in config_dict:
+            candidate[key] = config_dict[key]
+
+    sig_params = inspect.signature(LoraConfig.__init__).parameters
+    kwargs = {k: v for k, v in candidate.items() if k in sig_params}
+    return LoraConfig(**kwargs)
+
+
 def load_peft_adapter_into(module, adapter_path: str, adapter_name: str = "default") -> None:
     """Load a pretrained PEFT LoRA adapter directory into ``module``.
 
@@ -46,7 +86,7 @@ def load_peft_adapter_into(module, adapter_path: str, adapter_name: str = "defau
     import json
     import os
 
-    from peft import LoraConfig, get_peft_model_state_dict
+    from peft import get_peft_model_state_dict
     from safetensors.torch import load_file as safetensors_load_file
 
     adapter_config_path = os.path.join(adapter_path, "adapter_config.json")
@@ -63,7 +103,7 @@ def load_peft_adapter_into(module, adapter_path: str, adapter_name: str = "defau
         )
 
     with open(adapter_config_path) as f:
-        lora_config = LoraConfig.from_dict(json.load(f))
+        lora_config = _lora_config_from_dict(json.load(f))
     module.add_adapter(lora_config, adapter_name=adapter_name)
 
     adapter_state_dict = safetensors_load_file(adapter_weights_path)

--- a/verl_omni/workers/engine/lora_adapter_mixin.py
+++ b/verl_omni/workers/engine/lora_adapter_mixin.py
@@ -58,6 +58,56 @@ class LoRAAdapterMixin:
         if "default" in policy_state_adapters and hasattr(module, "set_adapter"):
             module.set_adapter("default")
 
+        # On-policy distillation (OPD): load frozen teacher LoRA adapter(s) onto the same
+        # backbone. Teachers are activated only transiently during teacher inference
+        # (see ``use_adapter``); their parameters never receive gradients.
+        #
+        # Multi-task OPD (DiffusionOPD, arXiv:2605.15055): ``teacher_adapters`` is a list of
+        # ``{"name", "path", "guidance_scale"}`` dicts; each teacher is loaded as a frozen
+        # ``teacher_<name>`` PEFT adapter. The single-teacher ``teacher_adapter_path`` /
+        # ``teacher_adapter_name`` pair remains supported for backward compatibility (SOPD).
+        teacher_adapters = getattr(self.model_config, "teacher_adapters", None) or []
+        if teacher_adapters:
+            teacher_adapters = list(teacher_adapters)
+        elif getattr(self.model_config, "teacher_adapter_path", None) is not None:
+            teacher_adapters = [
+                {
+                    "name": getattr(self.model_config, "teacher_adapter_name", "teacher"),
+                    "path": self.model_config.teacher_adapter_path,
+                    "guidance_scale": None,
+                }
+            ]
+
+        if teacher_adapters:
+            from verl.utils.fs import copy_to_local
+
+            if not hasattr(module, "load_adapter"):
+                raise AttributeError("Module does not support PEFT load_adapter; cannot load teacher LoRA.")
+            teacher_names = [t.get("name", "teacher") for t in teacher_adapters]
+            if len(set(teacher_names)) != len(teacher_names):
+                raise ValueError(f"Teacher adapter names must be unique, got {teacher_names}.")
+            for teacher in teacher_adapters:
+                teacher_adapter_name = teacher.get("name", "teacher")
+                if teacher_adapter_name in ("default", "reference"):
+                    raise ValueError(
+                        f"teacher_adapter_name {teacher_adapter_name!r} collides with reserved names; "
+                        "use a distinct name (e.g. 'teacher')."
+                    )
+                teacher_adapter_path = teacher.get("path")
+                local_teacher_path = copy_to_local(teacher_adapter_path, use_shm=self.model_config.use_shm)
+                module.load_adapter(local_teacher_path, adapter_name=teacher_adapter_name)
+                # Freeze the teacher adapter parameters in-place.
+                for n, p in module.named_parameters():
+                    if teacher_adapter_name in n.split("."):
+                        p.requires_grad_(False)
+                logger.info(
+                    "OPD: loaded frozen teacher LoRA adapter %r from %s (adapter_name=%r)",
+                    teacher_adapter_name, teacher_adapter_path, teacher_adapter_name,
+                )
+            # Restore the student ("default") adapter as active.
+            if hasattr(module, "set_adapter"):
+                module.set_adapter("default")
+
         lora_dtype = getattr(self.model_config, "lora_dtype", None)
         if lora_dtype is not None:
             from peft.tuners.tuners_utils import BaseTunerLayer

--- a/verl_omni/workers/engine/veomni/diffusion_impl.py
+++ b/verl_omni/workers/engine/veomni/diffusion_impl.py
@@ -454,9 +454,16 @@ class VeOmniDiffusionEngine(BaseEngine):
         output_lst = []
         ctx = torch.no_grad() if forward_only else nullcontext()
 
+        # On-policy distillation: per-call CFG scale override (one scalar per batch; each
+        # MOPD teacher pass targets a single task). Re-assign onto every micro-batch so the
+        # pipeline adapter can read it from ``scheduler_inputs``.
+        guidance_scale = tu.get_non_tensor_data(data, "guidance_scale", default=None)
+
         for micro_batch in micro_batches:
             micro_batch = micro_batch.to(get_device_id())
             tu.assign_non_tensor(micro_batch, gradient_accumulation_steps=gradient_accumulation_steps)
+            if guidance_scale is not None:
+                tu.assign_non_tensor(micro_batch, guidance_scale=guidance_scale)
             meta_info_lst = {"model_output": [], "loss": [], "metrics": []}
             with ctx:
                 for step in range(num_timesteps):

--- a/verl_omni/workers/engine_workers.py
+++ b/verl_omni/workers/engine_workers.py
@@ -468,6 +468,7 @@ class TrainingWorker(Worker, DistProfilerExtension):
         compute_loss = tu.get(data, key="compute_loss", default=True)
         disable_auto_offload = tu.get(data, key="disable_auto_offload", default=False)
         no_lora_adapter = tu.pop(data, key="no_lora_adapter", default=False)
+        use_lora_adapter = tu.pop(data, key="use_lora_adapter", default=None)
         images_seqlens = tu.get(data, key="images_seqlens", default=None)
         diffusion_flops_meta = collect_diffusion_flops_meta(
             self.flops_counter,
@@ -490,13 +491,31 @@ class TrainingWorker(Worker, DistProfilerExtension):
         # for sft training, we need to compute loss in eval
         loss_function = self.loss_fn if compute_loss else None
 
+        # Select the active PEFT adapter for this inference pass. ``use_lora_adapter`` (a
+        # named adapter, e.g. the OPD "teacher") takes precedence over ``no_lora_adapter``
+        # (which disables all adapters, used by the reference policy).
+        adapter_ctx = nullcontext()
+        if use_lora_adapter is not None:
+            if not hasattr(self.engine, "use_adapter"):
+                raise RuntimeError(
+                    f"Engine {type(self.engine).__name__} has no use_adapter(); cannot apply "
+                    f"use_lora_adapter={use_lora_adapter!r}."
+                )
+            adapter_ctx = self.engine.use_adapter(use_lora_adapter)
+        elif no_lora_adapter:
+            if not hasattr(self.engine, "disable_adapter"):
+                raise RuntimeError(
+                    f"Engine {type(self.engine).__name__} has no disable_adapter(); cannot "
+                    "apply no_lora_adapter=True."
+                )
+            adapter_ctx = self.engine.disable_adapter()
+
         with (
             self.engine.eval_mode(disable_auto_offload=disable_auto_offload),
             Timer(name="eval_batch", logger=None) as timer,
+            adapter_ctx,
         ):
-            adapter_ctx = self.engine.disable_adapter() if no_lora_adapter else nullcontext()
-            with adapter_ctx:
-                output = self.engine.infer_batch(data, loss_function=loss_function)
+            output = self.engine.infer_batch(data, loss_function=loss_function)
         delta_time = timer.last
 
         if self.engine.is_mp_src_rank_with_outputs():

--- a/verl_omni/workers/utils/losses.py
+++ b/verl_omni/workers/utils/losses.py
@@ -77,26 +77,32 @@ def diffusion_loss(config: DiffusionActorConfig, model_output, data: TensorDict,
     loss_mode = config.diffusion_loss.get("loss_mode", "flow_grpo")
     loss_func = get_diffusion_loss_fn(loss_mode)
 
-    # Rollout Correction bypass mode only applies to log-prob policy-gradient losses.
-    if "log_probs" in loss_func.required_model_output_keys:
-        log_prob = model_output["log_probs"]
-        old_log_prob = data["old_log_probs"]
-        rc_cfg = config.rollout_correction
-        # Rollout Correction bypass mode: compute IS/RS weights per-step and
-        # stash ``rollout_is_weights`` into ``data`` before loss dispatch.
-        if rc_cfg.bypass_mode:
-            _apply_bypass_rc(log_prob, old_log_prob, rc_cfg, data, metrics)
+    # On-policy distillation (OPD) only mode: the batch carries no reward / old-log-prob /
+    # advantage tensors, so the policy-gradient primary loss cannot be computed. Skip it and
+    # let the ``use_distill_loss`` term below be the sole training signal (paper Alg. 1).
+    if getattr(config, "opd_only", False):
+        loss_value = torch.zeros((), device=model_output["prev_sample_mean"].device)
+    else:
+        # Rollout Correction bypass mode only applies to log-prob policy-gradient losses.
+        if "log_probs" in loss_func.required_model_output_keys:
+            log_prob = model_output["log_probs"]
+            old_log_prob = data["old_log_probs"]
+            rc_cfg = config.rollout_correction
+            # Rollout Correction bypass mode: compute IS/RS weights per-step and
+            # stash ``rollout_is_weights`` into ``data`` before loss dispatch.
+            if rc_cfg.bypass_mode:
+                _apply_bypass_rc(log_prob, old_log_prob, rc_cfg, data, metrics)
 
-    loss_func.validate_inputs(loss_name=loss_mode, model_output=model_output, data=data)
-    loss_result = loss_func(config=config, model_output=model_output, data=data)
-    loss_value = loss_result.loss
-    metrics_values = loss_result.metrics
+        loss_func.validate_inputs(loss_name=loss_mode, model_output=model_output, data=data)
+        loss_result = loss_func(config=config, model_output=model_output, data=data)
+        loss_value = loss_result.loss
+        metrics_values = loss_result.metrics
 
-    metrics_values = Metric.from_dict(metrics_values, aggregation=AggregationType.MEAN)
+        metrics_values = Metric.from_dict(metrics_values, aggregation=AggregationType.MEAN)
 
-    metrics.update(metrics_values)
-    if loss_result.add_loss_metric:
-        metrics["actor/loss"] = Metric(value=loss_value, aggregation=AggregationType.MEAN)
+        metrics.update(metrics_values)
+        if loss_result.add_loss_metric:
+            metrics["actor/loss"] = Metric(value=loss_value, aggregation=AggregationType.MEAN)
 
     if config.use_kl_loss:
         loss_func = get_diffusion_loss_fn("kl")


### PR DESCRIPTION
### What does this PR do?

This PR adds initial support for **DiffusionOPD** (arXiv:2605.15055) — the **Stage 2**
(multi-task on-policy distillation) of the two-stage paradigm — to the FlowGRPO diffusion
trainer, following the reference implementation in [`ali-vilab/DiffusionOPD`](https://github.com/ali-vilab/DiffusionOPD).

Concretely, it:

- Adds a reward-free **OPD-only training mode** (`actor.opd_only=True`): the trainer skips
  the reward / old-log-prob / reference / advantage phases and trains the student purely
  against the frozen teacher's per-step transition mean via the closed-form `distill_kl`
  loss (paper Eq. 11 / Eq. 12).
- Adds a **multi-task (MOPD) round-robin curriculum** (`actor.mopd=True`): one batch per
  task per round over `data.task_train_files`, with gradient accumulation over a full task
  cycle (`G = M`) before a single optimizer step (paper Algorithm 1).
- Loads frozen task-specific teacher LoRAs onto the actor's own SD3.5-M backbone as
  `teacher_<name>` PEFT adapters (single-backbone multi-LoRA), evaluated at the student's
  visited rollout states with each teacher's own CFG `guidance_scale`.
- Ships SD3.5-Medium recipes for **MOPD** (Aes + OCR + GenEval) and **SOPD** (single
  teacher), CPU wiring tests, and documentation.

> **Out of scope (initial support):** Stage 1 (teacher training with GRPO-Guard /
> DiffusionNFT) is not implemented here; this PR assumes pre-trained teacher checkpoints
> (e.g. `quanhaol/Aes-Teacher`, `quanhaol/OCR-Teacher`, `quanhaol/GenEval-Teacher`).

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `vllm_omni`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `diffusion`, `omni`, `tests`, `docker`
  - If this PR involves multiple modules, separate them with `,` like `[diffusion, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][diffusion, fsdp] feat: new rollout scheduler`

### Test

- **CPU unit tests** (run on CI, no GPU needed):
  ```
  pytest tests/trainer/diffusion/test_diffusion_mopd_wiring_on_cpu.py
  pytest tests/trainer/diffusion/test_diffusion_opd_wiring_on_cpu.py
  ```
  Coverage: `MultiTaskRLDataset` length / task tags / index mapping, `RoundRobinBatchSampler`
  evenness & determinism, `opd_only`/`mopd` config validation, per-task `distill_kl` loss,
  MOPD teacher `prev_sample_mean` scatter-back row order.
- **GPU smoke (to be run):** `examples/flowgrpo_trainer/sd35/run_sd35_medium_mopd_lora.sh`
  end-to-end on 2 GPUs (wiring check), then a full run.
- **Reference results** (from the paper, for calibration): min-max-normalized **Average
  0.929** vs. 0.763 (Multi-Task GRPO-Guard), 0.715 (Multi-Task NFT), 0.851 (Cascade NFT),
  at ~85.75h + 11.26h wall-clock (teachers + OPD).

### API and Usage Example

New config fields (all optional, additive):

- `actor_rollout_ref.model.teacher_adapters` — list of `{name, path, guidance_scale}` per task
- `actor_rollout_ref.model.teacher_adapter_path` / `teacher_adapter_name` — single-teacher (SOPD)
- `actor_rollout_ref.actor.opd_only` — reward-free OPD-only training
- `actor_rollout_ref.actor.mopd` — multi-task round-robin distillation
- `data.task_train_files` / `task_val_files` — one list of files per task
- `data.mopd_batch_size_per_task` — samples per task per round (default `gen_batch_size // num_tasks`)

Usage (see `examples/flowgrpo_trainer/sd35/run_sd35_medium_mopd_lora.sh`):

```bash
python3 -m verl_omni.trainer.main_diffusion \
    data.task_train_files="[[aes_train],[ocr_train],[geneval_train]]" \
    data.task_val_files="[[aes_val],[ocr_val],[geneval_val]]" \
    data.gen_batch_size=24 \
    data.mopd_batch_size_per_task=8 \
    actor_rollout_ref.model.path=stabilityai/stable-diffusion-3.5-medium \
    actor_rollout_ref.model.lora_rank=32 \
    actor_rollout_ref.model.lora_alpha=64 \
    'actor_rollout_ref.model.teacher_adapters=[{name: aes, path: quanhaol/Aes-Teacher, guidance_scale: 4.5},{name: ocr, path: quanhaol/OCR-Teacher, guidance_scale: 4.5},{name: geneval, path: quanhaol/GenEval-Teacher, guidance_scale: 1.0}]' \
    actor_rollout_ref.actor.opd_only=True \
    actor_rollout_ref.actor.mopd=True \
    actor_rollout_ref.actor.use_distill_loss=True \
    actor_rollout_ref.actor.distill_loss_mode=distill_kl \
    actor_rollout_ref.actor.ppo_mini_batch_size=24 \
    actor_rollout_ref.actor.ppo_epochs=1 \
    reward.reward_model.enable=False \
    actor_rollout_ref.rollout.algo.noise_level=0.0
```

### Design & Code Changes

**Algorithm.** DiffusionOPD decouples multi-task RL into single-task teacher training
(Stage 1, out of scope) and multi-task on-policy distillation (Stage 2). The student rolls
out its own trajectory; at every visited state the corresponding frozen teacher is evaluated
and the student matches the teacher's per-step transition mean via the closed-form reverse KL
(`||μ_s − μ_t||² / (2σ²)`), which specializes to `½·||μ_s − μ_t||²` under the ODE sampler
(`noise_level=0`). Gradient accumulation `G = M` over the round-robin cycle makes each
optimizer step reflect the full task set.

```mermaid
flowchart TD
    subgraph Data["Multi-task data (M tasks)"]
        D1["MultiTaskRLDataset<br/>(M task datasets, tagged with task_id / teacher_name)"]
        D2["RoundRobinBatchSampler<br/>(one batch = M × batch_size_per_task per round)"]
    end
    subgraph Step["Training step — fit() with opd_only=True"]
        T1["1 · Student rollout<br/>(own trajectory · ODE, noise_level=0)"]
        T2["2 · Teacher forward at visited states<br/>(teacher_&lt;name&gt; adapter + per-teacher CFG)"]
        T3["3 · distill_kl loss<br/>||μ_s − μ_t||² / (2σ²) → ODE: ½·||μ_s − μ_t||²"]
        T4["4 · One optimizer step<br/>(gradient accumulation G = M)"]
    end
    subgraph Model["Actor backbone (single-backbone multi-LoRA)"]
        A1["trainable 'default' LoRA — student"]
        A2["frozen teacher_aes · teacher_ocr · teacher_geneval"]
    end
    D1 --> D2 --> T1 --> T2 --> T3 --> T4
    T1 -. "student pass" .-> A1
    T2 -. "teacher pass" .-> A2
```

**Key design decisions.** Teachers as frozen PEFT adapters on the actor's own backbone (no
extra teacher GPUs); one optimizer step per full round-robin cycle; closed-form KL over
PPO-style policy gradients (lower variance, valid for both SDE and ODE); OPD-only loop
skips reward/old-log-prob/reference/advantage (much cheaper than a PPO step), while
validation can still score the student (e.g. PickScore); per-teacher CFG `guidance_scale`
override; robust frozen-LoRA loading across PEFT `PeftModel` and diffusers
`PeftAdapterMixin` paths.

**Files changed (23, ~+1,665 / −115):**

- **New**
  - `verl_omni/utils/dataset/multi_task_dataset.py` — `MultiTaskRLDataset`,
    `RoundRobinBatchSampler`, `create_multi_task_rl_datasets`
  - `tests/trainer/diffusion/test_diffusion_mopd_wiring_on_cpu.py`
  - `tests/trainer/diffusion/test_diffusion_opd_wiring_on_cpu.py`
  - `examples/flowgrpo_trainer/sd35/run_sd35_medium_mopd_lora.sh`
  - `examples/flowgrpo_trainer/sd35/run_sd35_medium_sopd_aes_lora.sh`

- **Modified**
  - `verl_omni/trainer/diffusion/ray_diffusion_trainer.py` — teacher config parsing &
    validation; multi-task dataloader; `_compute_teacher_log_prob` /
    `_compute_mopd_teacher_log_prob` (per-task teacher forward + scatter-back); OPD-only
    `fit()` skipping reward/old-log-prob/reference/advantage; `reward_extra_infos_dict` fix
  - `verl_omni/trainer/diffusion/diffusion_algos.py` — `DistillKLLoss`: closed-form KL with
    ODE surrogate branch (avoids div-by-zero at `noise_level=0`)
  - `verl_omni/workers/engine/lora_adapter_mixin.py` — `load_peft_adapter_into`,
    `_lora_config_from_dict`, frozen teacher adapter loading
  - `verl_omni/workers/utils/losses.py` — `opd_only` short-circuit of the primary loss
  - `verl_omni/workers/engine_workers.py` — `use_lora_adapter` adapter context during `infer_batch`
  - `verl_omni/pipelines/sd3_flow_grpo/diffusers_training_adapter.py`,
    `verl_omni/workers/engine/veomni/diffusion_impl.py`,
    `verl_omni/workers/engine/fsdp/diffusers_impl.py` — per-call `guidance_scale` override;
    `teacher_prev_sample_mean` plumbing
  - `verl_omni/trainer/diffusion/diffusion_metric_utils.py` — reward-free batch handling
  - `verl_omni/agent_loop/diffusion_agent_loop.py`,
    `verl_omni/utils/reward_score/__init__.py` — OPD training stays reward-free; validation
    scoring (PickScore) preserved; async pickscore dispatch
  - `verl_omni/workers/config/diffusion/actor.py`, `model.py`, generated YAMLs —
    `opd_only`, `mopd`, `teacher_adapters`, `teacher_adapter_path`, `teacher_adapter_name`
  - `docs/examples/config.md` — document the new fields

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update the documentation.
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl-omni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
