### PR TITLE
[rollout] feat: support prompt embedding cache for diffusion rollouts

### DIFF
--- a/docs/contributing/integrating_prompt_embedding_cache.md
+++ b/docs/contributing/integrating_prompt_embedding_cache.md
@@ -1,0 +1,232 @@
+# Integrating the Diffusion Prompt-Embedding Cache
+
+Last updated: 08/13/2026.
+
+This guide defines the contract for making a diffusion rollout pipeline
+compatible with vLLM-Omni's prompt-embedding cache. The cache wraps
+`pipeline.encode_prompt()` and reuses its inference outputs across requests
+with the same cache key. It is disabled by default.
+
+The vLLM-Omni implementation and the authoritative cache-key rules are in
+[vllm-project/vllm-omni#2962](https://github.com/vllm-project/vllm-omni/pull/2962).
+Read that implementation before introducing a new `encode_prompt()` signature
+or forwarding a new argument through an existing one.
+
+## Primary Correctness Requirement
+
+Prompt caching must not change the semantic output of `encode_prompt()`.
+Whether the wrapper is disabled, takes a miss, or takes a hit, the pipeline must
+receive the same inference result that the pre-cache implementation produced.
+For prompt embeddings and masks this includes:
+
+- numerical values;
+- device;
+- dtype;
+- batch shape;
+- maximum-sequence-length truncation behavior;
+- `num_images_per_prompt` or `num_videos_per_prompt` expansion behavior.
+
+The cache stores detached outputs, so downstream rollout code must treat prompt
+embeddings and masks as read-only. Do not add in-place mutations after
+`encode_prompt()`. A miss executes the underlying method and stores its output;
+a hit returns that stored value. The observable inference values and shapes must
+remain identical in both cases.
+
+Explicit Tensor inputs remain supported for compatibility, but they bypass the
+cache. Precomputed prompt embeddings also retain their existing path and must
+not be converted back to token IDs just to make a cache key.
+
+## Cache-Key Contract
+
+vLLM-Omni binds the actual positional and keyword arguments to the
+`encode_prompt()` signature, applies defaults, and builds a key from every
+bound argument. A call is cacheable only when every bound argument is safe to
+serialize as a key and no precomputed embedding argument is supplied.
+
+Supported key values are recursively composed from:
+
+- `None`, `str`, `int`, `float`, `bool`, and `bytes`;
+- `torch.device` and `torch.dtype`;
+- NumPy scalar values;
+- `list` and `tuple` containing only supported values;
+- `dict` whose values contain only supported values.
+
+`torch.Tensor`, PIL images, NumPy arrays, custom objects, and a list, tuple, or
+dictionary containing any of them are not cacheable. If any bound
+`encode_prompt()` argument is not cacheable, vLLM-Omni bypasses the cache for
+the entire call rather than building a partial key. Therefore, a list is not
+the only supported input type, but token IDs and masks should normally be kept
+as lists at the `encode_prompt()` boundary instead of tensors.
+
+Calls with a non-`None` `prompt_embeds`, `negative_prompt_embeds`,
+`pooled_prompt_embeds`, `negative_pooled_prompt_embeds`, `prompt_embeds_mask`,
+or `negative_prompt_embeds_mask` also bypass the cache. They are already
+precomputed-output paths and caching them would retain large tensor values
+without avoiding text-encoder work.
+
+All arguments that can affect text encoding must be included in the
+`encode_prompt()` call and be considered when auditing key eligibility. This
+includes, where the pipeline uses them:
+
+- positive prompt IDs and masks;
+- negative prompt IDs and masks;
+- maximum sequence length;
+- output multiplicity such as `num_images_per_prompt` or
+  `num_videos_per_prompt`;
+- every other non-default argument that changes the text-encoding result.
+
+Do not drop a semantic argument merely to make a call cacheable. Instead,
+represent it with a supported value type or allow that call to bypass the cache.
+
+## Required Pipeline Changes
+
+Do not update only one visible `encode_prompt()` call. Trace every path that
+supplies IDs, masks, or text to the text encoder.
+
+1. **Request batching:** For token-ID adapters, use the list-preserving path in
+   [`request_batch.py`](../../verl_omni/pipelines/request_batch.py) before
+   cacheable calls only. When the cache is enabled,
+   `collate_prompt_rows(..., preserve_lists=True)` and
+   `collate_prompt_mask(..., preserve_lists=True)` batch and pad list values
+   without converting them to tensors before the cache wrapper. When it is
+   disabled or not installed, preserve the original tensor collation path.
+2. **Adapter boundary:** Make `forward()` and, if implemented,
+   `prepare_encode()` accept the forms the cacheable path can produce: flat
+   lists, batched lists, and existing Tensor inputs. Compute batch size without
+   forcing a list through early tensorization.
+3. **`encode_prompt()` implementation:** Accept the supported list forms and
+   convert IDs and masks to tensors on `self.device` inside `encode_prompt()`,
+   after the wrapper has built or looked up the key. The conversion must
+   canonicalize list and Tensor inputs to the same tensors used by the
+   pre-cache implementation.
+4. **Raw-text fallback:** When a step-execution path tokenizes raw text, return
+   token lists while `self._prompt_embed_cache.enabled` is true. Preserve its
+   existing Tensor tokenizer/device path when the cache is disabled.
+5. **Special cases:** Preserve precomputed embedding bypasses. For an empty
+   negative prompt, construct negative IDs and masks in the same compatible
+   representation as the positive prompt rather than introducing an early
+   Tensor only on the cacheable path.
+
+The cache configuration must be exposed through
+`DiffusionRolloutConfig` and forwarded by
+[`vllm_omni_async_server.py`](../../verl_omni/workers/rollout/vllm_rollout/vllm_omni_async_server.py)
+to `AsyncOmni`:
+
+```yaml
+actor_rollout_ref:
+  rollout:
+    enable_prompt_embed_cache: true
+    prompt_embed_cache_size: 32
+```
+
+`prompt_embed_cache_size` is per diffusion worker, must be positive, and uses
+least-recently-used eviction.
+
+## Current Reference Paths
+
+The current integration audits every token-ID rollout path that reaches
+`encode_prompt()`:
+
+| Pipeline | Required cache-compatible paths |
+| --- | --- |
+| Qwen-Image FlowGRPO | [`qwen_image_flow_grpo/vllm_omni_rollout_adapter.py`](../../verl_omni/pipelines/qwen_image_flow_grpo/vllm_omni_rollout_adapter.py): request-batch collation, normal `forward()`, raw-text `_tokenize_text_prompt()`, and step-execution `prepare_encode()`. |
+| Qwen-Image MixGRPO | Reuses the Qwen-Image FlowGRPO rollout adapter and inherits the same changes. |
+| Qwen-Image DiffusionNFT | [`qwen_image_diffusion_nft/vllm_omni_rollout_adapter.py`](../../verl_omni/pipelines/qwen_image_diffusion_nft/vllm_omni_rollout_adapter.py): step-execution `prepare_encode()` and `_tokenize_step_prompt()`. List-to-Tensor conversion is owned by the shared [`QwenImageTokenIdPromptMixin`](../../verl_omni/pipelines/qwen_image_flow_grpo/common.py). |
+| Qwen-Image online DPO | [`qwen_image_dpo/vllm_omni_rollout_adapter.py`](../../verl_omni/pipelines/qwen_image_dpo/vllm_omni_rollout_adapter.py): normal `forward()` retains compatible IDs and masks through each `encode_prompt()` call. |
+
+Use this table as an audit checklist for a new model. A model can omit paths it
+does not implement, but every text-encoding path it does implement must obey
+the same input-key and output-parity contracts.
+
+## Routing Affinity for Repeated Rollouts
+
+Cache entries are private to each rollout replica. The trainer expands each
+input prompt into `n` samples with `DataProto.repeat(..., interleave=True)`, so
+the `n` samples keep the same source `uid`.
+
+With affinity disabled, `DiffusionSingleTurnAgentLoop` uses a fresh
+`uuid4().hex` request ID for every sample. This is exactly the pre-affinity
+behavior. Because every ID is new, the global load balancer has no sticky entry
+and assigns each sample independently to the replica with the fewest in-flight
+requests. The `n` samples of one prompt can therefore be spread across
+replicas, each with a separate prompt cache.
+
+Enable affinity only for a measured repeated-rollout workload:
+
+```yaml
+actor_rollout_ref:
+  rollout:
+    enable_prompt_embed_cache: true
+    prompt_embed_cache_size: 128
+    enable_prompt_embed_cache_routing_affinity: true
+```
+
+When both options are enabled, the diffusion agent loop instead uses the
+source prompt's stable `uid` as the request ID. The first sample of each prompt
+group is still assigned to the currently least-loaded replica. The load
+balancer records that `uid -> replica` mapping, so the remaining `n - 1`
+samples for that prompt group return to the same replica and reuse its local
+entry. With `n=16` and an otherwise empty cache, the ideal bound is one miss
+and fifteen hits per prompt on that replica.
+
+This changes scheduling granularity, not the global load-balancing objective:
+with `x` prompts and `n` samples per prompt, different prompt groups are still
+assigned approximately evenly across replicas, while all `n` samples of a
+single prompt remain together. It is not a hash-based fixed assignment and it
+does not send every prompt to one predetermined replica.
+
+Affinity changes only request routing; it must not affect token IDs, prompt
+embeddings, sampling parameters, or model weights. It is disabled by default
+and has no effect unless prompt caching is enabled.
+
+Do not enable affinity solely to increase hit rate. Its possible cost is
+group-level rather than sample-level balancing: a small number of prompts,
+large `n`, or materially different per-prompt generation costs can leave one
+replica with a heavier prompt group while others finish sooner. The same risk
+applies if the same global load balancer is used to route AR reward-model
+requests: a prompt group's AR reward work is kept together instead of being
+sample-balanced. This option changes only requests through
+`DiffusionSingleTurnAgentLoop`; it does not by itself alter independently
+managed reward workers. Measure per-replica prompt-group count, queue time, and
+throughput in the deployment that will use affinity, and leave it disabled when
+the group-level tail cost exceeds the cache benefit.
+
+## Step Execution
+
+Prompt caching and step execution are compatible. For a new request,
+step-execution `prepare_encode()` must call the wrapped `encode_prompt()` with
+cacheable inputs. Later denoising steps reuse request-local prompt embeddings
+and do not re-encode the prompt. The cache applies across requests handled by
+the same worker.
+
+```yaml
+actor_rollout_ref:
+  rollout:
+    step_execution: true
+    enable_prompt_embed_cache: true
+    prompt_embed_cache_size: 32
+```
+
+## Validation Checklist
+
+Add CPU coverage for all supported pipeline paths. At minimum, verify:
+
+- Tensor, flat-list, and batched-list token IDs and masks where supported;
+- normal `forward()`, step execution, and raw-text fallback paths;
+- positive and negative prompts, empty negative prompts, and precomputed
+  embedding bypasses;
+- cache-disabled wrapper execution, cache miss, and cache hit;
+- exact post-`encode_prompt()` output parity against the pre-cache behavior and
+  exact miss-versus-hit parity for values, device, dtype, masks, and shapes.
+
+Use `rtol=0, atol=0` when outputs are expected to be identical. For performance
+work, inspect per-worker cache `hits`, `misses`, and `bypassed` counts; do not
+infer cache use solely from end-to-end generation timing.
+
+## Performance Scope
+
+The cache helps only when the same cacheable text-encoding call reaches the
+same worker again. Unique prompts, short prompts, large replica counts without
+affinity, and work dominated by denoising or reward evaluation can make the
+end-to-end gain small. Treat cache support as a compatibility feature until a
+target workload demonstrates a material benefit.

--- a/docs/index.md
+++ b/docs/index.md
@@ -119,6 +119,7 @@ api/utils.rst
 contributing/editing-agent-instructions.md
 contributing/ci_cd.md
 contributing/testing_guide.md
+contributing/integrating_prompt_embedding_cache.md
 contributing/integrating_an_omni_model.md
 contributing/integrating_a_diffusion_model.md
 contributing/integrating_an_i2i_diffusion_model.md

--- a/tests/agent_loop/test_diffusion_agent_loop_correctness_on_cpu.py
+++ b/tests/agent_loop/test_diffusion_agent_loop_correctness_on_cpu.py
@@ -27,6 +27,7 @@ from verl_omni.agent_loop.diffusion_agent_loop import (
     _pad_prompt_extra_field,
 )
 from verl_omni.agent_loop.diffusion_agent_loop_tq import DiffusionAgentLoopWorkerTQ
+from verl_omni.agent_loop.single_turn_agent_loop import DiffusionSingleTurnAgentLoop
 
 
 class _FakeRemoteComputeScore:
@@ -48,6 +49,42 @@ class _DummyDiffusionAgentLoopWorker:
 
     def __init__(self, reward_loop_worker_handle: _FakeRewardLoopWorkerHandle):
         self.reward_loop_worker_handles = [reward_loop_worker_handle]
+
+
+@pytest.mark.parametrize(
+    ("cache_enabled", "affinity_enabled", "expected_request_id"),
+    [
+        (True, True, "sample-uid"),
+        (True, False, None),
+        (False, True, None),
+    ],
+)
+def test_prompt_cache_routing_affinity(cache_enabled, affinity_enabled, expected_request_id):
+    agent_loop = object.__new__(DiffusionSingleTurnAgentLoop)
+    agent_loop.rollout_config = SimpleNamespace(
+        enable_prompt_embed_cache=cache_enabled,
+        enable_prompt_embed_cache_routing_affinity=affinity_enabled,
+    )
+
+    request_id = agent_loop._get_routing_request_id("sample-uid")
+
+    if expected_request_id is None:
+        assert request_id != "sample-uid"
+    else:
+        assert request_id == expected_request_id
+
+
+def test_prompt_cache_routing_affinity_requires_sample_uid():
+    agent_loop = object.__new__(DiffusionSingleTurnAgentLoop)
+    agent_loop.rollout_config = SimpleNamespace(
+        enable_prompt_embed_cache=True,
+        enable_prompt_embed_cache_routing_affinity=True,
+    )
+
+    first_request_id = agent_loop._get_routing_request_id(None)
+    second_request_id = agent_loop._get_routing_request_id(None)
+
+    assert first_request_id != second_request_id
 
 
 @pytest.mark.parametrize(

--- a/tests/pipelines/test_prompt_embed_cache_on_cpu.py
+++ b/tests/pipelines/test_prompt_embed_cache_on_cpu.py
@@ -587,6 +587,7 @@ def test_flow_forward_preserves_input_path_through_encode_prompt(use_tensors):
 
     pipeline = SimpleNamespace(
         device=torch.device("cpu"),
+        _prompt_embed_cache=SimpleNamespace(enabled=True),
         default_sample_size=2,
         vae_scale_factor=8,
         transformer=SimpleNamespace(in_channels=4),

--- a/tests/pipelines/test_prompt_embed_cache_on_cpu.py
+++ b/tests/pipelines/test_prompt_embed_cache_on_cpu.py
@@ -1,0 +1,655 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU tests for prompt-embedding cache adapter boundaries."""
+
+from types import MethodType, SimpleNamespace
+
+import pytest
+import torch
+
+
+def _record_encode_prompt(calls):
+    def encode_prompt(**kwargs):
+        calls.append((kwargs["prompt_ids"], kwargs["attention_mask"]))
+        return torch.zeros(1, 2, 4), torch.ones(1, 2, dtype=torch.long)
+
+    return encode_prompt
+
+
+def test_prompt_collators_preserve_lists_only_when_requested():
+    from verl_omni.pipelines.request_batch import collate_prompt_mask, collate_prompt_rows
+
+    prompts = [
+        {"prompt_token_ids": [1, 2], "prompt_mask": [1, 1]},
+        {"prompt_token_ids": [3], "prompt_mask": [1]},
+    ]
+    tensor_rows, tensor_lengths = collate_prompt_rows(
+        prompts,
+        ("prompt_token_ids",),
+        None,
+        device=torch.device("cpu"),
+        field_name="prompt_token_ids",
+    )
+    list_rows, lengths = collate_prompt_rows(
+        prompts,
+        ("prompt_token_ids",),
+        None,
+        device=torch.device("cpu"),
+        field_name="prompt_token_ids",
+        preserve_lists=True,
+    )
+    default_rows, default_lengths = collate_prompt_rows(
+        prompts,
+        ("prompt_token_ids",),
+        [[1, 2], [3, 0]],
+        device=torch.device("cpu"),
+        field_name="prompt_token_ids",
+        preserve_lists=True,
+    )
+    list_mask = collate_prompt_mask(
+        prompts,
+        ("prompt_mask",),
+        None,
+        device=torch.device("cpu"),
+        field_name="prompt_mask",
+        token_lengths=lengths,
+        target_seq_len=2,
+        preserve_lists=True,
+    )
+    tensor_mask = collate_prompt_mask(
+        prompts,
+        ("prompt_mask",),
+        None,
+        device=torch.device("cpu"),
+        field_name="prompt_mask",
+        token_lengths=tensor_lengths,
+        target_seq_len=2,
+    )
+    derived_tensor_mask = collate_prompt_mask(
+        [{}, {}],
+        ("prompt_mask",),
+        None,
+        device=torch.device("cpu"),
+        field_name="prompt_mask",
+        token_lengths=tensor_lengths,
+        target_seq_len=2,
+    )
+
+    assert isinstance(tensor_rows, torch.Tensor)
+    assert torch.equal(tensor_rows, torch.tensor([[1, 2], [3, 0]], dtype=torch.long))
+    assert tensor_rows.dtype == torch.long
+    assert tensor_lengths == [2, 1]
+    assert torch.equal(tensor_mask, torch.tensor([[True, True], [True, False]]))
+    assert tensor_mask.dtype == torch.bool
+    assert torch.equal(derived_tensor_mask, tensor_mask)
+    assert list_rows == [[1, 2], [3, 0]]
+    assert default_rows == [[1, 2], [3, 0]]
+    assert default_lengths == [2, 2]
+    assert list_mask == [[True, True], [True, False]]
+
+    tensor_default_rows, tensor_default_lengths = collate_prompt_rows(
+        prompts,
+        ("prompt_token_ids",),
+        torch.tensor([[1, 2], [3, 0]]),
+        device=torch.device("cpu"),
+        field_name="prompt_token_ids",
+        preserve_lists=True,
+    )
+    tensor_prompt_rows, tensor_prompt_lengths = collate_prompt_rows(
+        [
+            {"prompt_token_ids": torch.tensor([1, 2])},
+            {"prompt_token_ids": torch.tensor([3])},
+        ],
+        ("prompt_token_ids",),
+        None,
+        device=torch.device("cpu"),
+        field_name="prompt_token_ids",
+        preserve_lists=True,
+    )
+    tensor_prompt_mask = collate_prompt_mask(
+        [
+            {"prompt_mask": torch.tensor([True, True])},
+            {"prompt_mask": torch.tensor([True])},
+        ],
+        ("prompt_mask",),
+        None,
+        device=torch.device("cpu"),
+        field_name="prompt_mask",
+        token_lengths=tensor_prompt_lengths,
+        target_seq_len=2,
+        preserve_lists=True,
+    )
+
+    assert torch.equal(tensor_default_rows, torch.tensor([[1, 2], [3, 0]]))
+    assert tensor_default_lengths == [2, 2]
+    assert torch.equal(tensor_prompt_rows, torch.tensor([[1, 2], [3, 0]]))
+    assert tensor_prompt_lengths == [2, 1]
+    assert torch.equal(tensor_prompt_mask, torch.tensor([[True, True], [True, False]]))
+
+
+def test_qwen_encode_prompt_preserves_previous_tensor_inputs():
+    pytest.importorskip("vllm_omni")
+
+    from verl_omni.pipelines.qwen_image_diffusion_nft.vllm_omni_rollout_adapter import (
+        QwenImageDiffusionNFTPipeline,
+    )
+    from verl_omni.pipelines.qwen_image_dpo.vllm_omni_rollout_adapter import QwenImageDPOPipeline
+    from verl_omni.pipelines.qwen_image_flow_grpo.common import QwenImageTokenIdPromptMixin
+    from verl_omni.pipelines.qwen_image_flow_grpo.vllm_omni_rollout_adapter import QwenImagePipelineWithLogProb
+
+    assert QwenImageDiffusionNFTPipeline.encode_prompt is QwenImageTokenIdPromptMixin.encode_prompt
+
+    def make_get_prompt_embeds(encoded_inputs):
+        def get_prompt_embeds(prompt_ids, attention_mask=None):
+            encoded_inputs["prompt_ids"] = prompt_ids
+            encoded_inputs["attention_mask"] = attention_mask
+            return torch.zeros(1, 2, 4), torch.ones(1, 2, dtype=torch.long)
+
+        return get_prompt_embeds
+
+    for pipeline_class in (QwenImageTokenIdPromptMixin, QwenImagePipelineWithLogProb, QwenImageDPOPipeline):
+        encoded_inputs = {}
+        pipeline = SimpleNamespace(
+            device=torch.device("cpu"), _get_qwen_prompt_embeds=make_get_prompt_embeds(encoded_inputs)
+        )
+        pipeline_class.encode_prompt(pipeline, prompt_ids=[[1, 2]], attention_mask=[[1, 1]])
+
+        assert torch.equal(encoded_inputs["prompt_ids"], torch.tensor([[1, 2]], dtype=torch.long))
+        assert torch.equal(encoded_inputs["attention_mask"], torch.tensor([[1, 1]], dtype=torch.long))
+        assert encoded_inputs["prompt_ids"].device.type == "cpu"
+        assert encoded_inputs["attention_mask"].device.type == "cpu"
+
+        pipeline_class.encode_prompt(
+            pipeline,
+            prompt_ids=torch.tensor([[1, 2]]),
+            attention_mask=torch.tensor([[True, True]]),
+        )
+
+        assert torch.equal(encoded_inputs["prompt_ids"], torch.tensor([[1, 2]], dtype=torch.long))
+        assert torch.equal(encoded_inputs["attention_mask"], torch.tensor([[True, True]], dtype=torch.bool))
+
+        pipeline_class.encode_prompt(
+            pipeline,
+            prompt_ids=[[1, 2]],
+            attention_mask=torch.tensor([[True, False]]),
+        )
+
+        assert torch.equal(encoded_inputs["prompt_ids"], torch.tensor([[1, 2]], dtype=torch.long))
+        assert torch.equal(encoded_inputs["attention_mask"], torch.tensor([[True, False]], dtype=torch.bool))
+
+
+def test_flow_encode_prompt_accepts_packed_lists_and_tensors():
+    pytest.importorskip("vllm_omni")
+
+    from verl_omni.pipelines.qwen_image_flow_grpo.vllm_omni_rollout_adapter import QwenImagePipelineWithLogProb
+
+    encoded_inputs = {}
+
+    def get_prompt_embeds(prompt_ids, attention_mask=None):
+        encoded_inputs["prompt_ids"] = prompt_ids
+        encoded_inputs["attention_mask"] = attention_mask
+        return torch.zeros(2, 2, 4), torch.ones(2, 2, dtype=torch.long)
+
+    pipeline = SimpleNamespace(device=torch.device("cpu"), _get_qwen_prompt_embeds=get_prompt_embeds)
+    for prompt_ids, attention_mask in (
+        ([[1, 2], [3, 0]], [[True, True], [True, False]]),
+        (torch.tensor([[1, 2], [3, 0]]), torch.tensor([[True, True], [True, False]])),
+    ):
+        QwenImagePipelineWithLogProb.encode_prompt(
+            pipeline,
+            prompt_ids=prompt_ids,
+            attention_mask=attention_mask,
+        )
+
+        assert torch.equal(encoded_inputs["prompt_ids"], torch.tensor([[1, 2], [3, 0]], dtype=torch.long))
+        assert torch.equal(
+            encoded_inputs["attention_mask"], torch.tensor([[True, True], [True, False]], dtype=torch.bool)
+        )
+        assert encoded_inputs["prompt_ids"].device.type == "cpu"
+        assert encoded_inputs["attention_mask"].device.type == "cpu"
+
+
+@pytest.mark.parametrize("use_tensors", [False, True])
+def test_qwen_encode_prompt_preserves_output_semantics_after_tensorization(use_tensors):
+    pytest.importorskip("vllm_omni")
+
+    from verl_omni.pipelines.qwen_image_dpo.vllm_omni_rollout_adapter import QwenImageDPOPipeline
+    from verl_omni.pipelines.qwen_image_flow_grpo.common import QwenImageTokenIdPromptMixin
+    from verl_omni.pipelines.qwen_image_flow_grpo.vllm_omni_rollout_adapter import QwenImagePipelineWithLogProb
+
+    base_embeds = torch.arange(24, dtype=torch.float32).reshape(2, 3, 4)
+    base_mask = torch.tensor([[1, 1, 0], [1, 0, 0]], dtype=torch.long)
+
+    for pipeline_class in (QwenImageTokenIdPromptMixin, QwenImagePipelineWithLogProb, QwenImageDPOPipeline):
+
+        def get_prompt_embeds(prompt_ids, attention_mask=None):
+            assert torch.equal(prompt_ids, torch.tensor([[1, 2, 0], [3, 0, 0]], dtype=torch.long))
+            assert torch.equal(attention_mask, torch.tensor([[True, True, False], [True, False, False]]))
+            return base_embeds.clone(), base_mask.clone()
+
+        pipeline = SimpleNamespace(device=torch.device("cpu"), _get_qwen_prompt_embeds=get_prompt_embeds)
+        prompt_ids = [[1, 2, 0], [3, 0, 0]]
+        attention_mask = [[True, True, False], [True, False, False]]
+        if use_tensors:
+            prompt_ids = torch.tensor(prompt_ids)
+            attention_mask = torch.tensor(attention_mask)
+        prompt_embeds, prompt_embeds_mask = pipeline_class.encode_prompt(
+            pipeline,
+            prompt_ids=prompt_ids,
+            attention_mask=attention_mask,
+            num_images_per_prompt=2,
+            max_sequence_length=2,
+        )
+
+        expected_embeds = base_embeds[:, :2].repeat_interleave(2, dim=0)
+        expected_mask = base_mask[:, :2].repeat_interleave(2, dim=0)
+        torch.testing.assert_close(prompt_embeds, expected_embeds)
+        torch.testing.assert_close(prompt_embeds_mask, expected_mask)
+        assert prompt_embeds.shape == (4, 2, 4)
+        assert prompt_embeds_mask.shape == (4, 2)
+        assert prompt_embeds.dtype == base_embeds.dtype
+        assert prompt_embeds_mask.dtype == base_mask.dtype
+
+
+def test_qwen_encode_prompt_accepts_precomputed_embeds_without_prompt_ids():
+    pytest.importorskip("vllm_omni")
+
+    from verl_omni.pipelines.qwen_image_dpo.vllm_omni_rollout_adapter import QwenImageDPOPipeline
+    from verl_omni.pipelines.qwen_image_flow_grpo.common import QwenImageTokenIdPromptMixin
+    from verl_omni.pipelines.qwen_image_flow_grpo.vllm_omni_rollout_adapter import QwenImagePipelineWithLogProb
+
+    prompt_embeds = torch.zeros(1, 2, 4)
+    prompt_embeds_mask = torch.ones(1, 2, dtype=torch.long)
+
+    for pipeline_class in (QwenImageTokenIdPromptMixin, QwenImagePipelineWithLogProb, QwenImageDPOPipeline):
+        output_embeds, output_mask = pipeline_class.encode_prompt(
+            SimpleNamespace(device=torch.device("cpu")),
+            prompt_ids=None,
+            prompt_embeds=prompt_embeds,
+            prompt_embeds_mask=prompt_embeds_mask,
+        )
+
+        assert torch.equal(output_embeds, prompt_embeds)
+        assert torch.equal(output_mask, prompt_embeds_mask)
+
+
+def test_qwen_list_inputs_hit_vllm_prompt_cache():
+    pytest.importorskip("vllm_omni")
+    from vllm_omni.diffusion.cache.prompt_embed_cache import install_prompt_embed_cache
+
+    from verl_omni.pipelines.qwen_image_dpo.vllm_omni_rollout_adapter import QwenImageDPOPipeline
+    from verl_omni.pipelines.qwen_image_flow_grpo.common import QwenImageTokenIdPromptMixin
+    from verl_omni.pipelines.qwen_image_flow_grpo.vllm_omni_rollout_adapter import QwenImagePipelineWithLogProb
+
+    for pipeline_class in (QwenImageTokenIdPromptMixin, QwenImagePipelineWithLogProb, QwenImageDPOPipeline):
+        encoder_calls = 0
+
+        def get_prompt_embeds(prompt_ids, attention_mask=None):
+            nonlocal encoder_calls
+            encoder_calls += 1
+            batch_size = prompt_ids.shape[0] if prompt_ids.ndim == 2 else 1
+            return torch.zeros(batch_size, 2, 4), torch.ones(batch_size, 2, dtype=torch.long)
+
+        pipeline = SimpleNamespace(device=torch.device("cpu"), _get_qwen_prompt_embeds=get_prompt_embeds)
+        pipeline.encode_prompt = MethodType(pipeline_class.encode_prompt, pipeline)
+        cache = install_prompt_embed_cache(pipeline, enabled=True)
+        assert cache is not None
+
+        prompt_ids = [[1, 2], [3, 4]] if pipeline_class is QwenImagePipelineWithLogProb else [1, 2]
+        attention_mask = [[1, 1], [1, 1]] if pipeline_class is QwenImagePipelineWithLogProb else [1, 1]
+        for _ in range(2):
+            pipeline.encode_prompt(prompt_ids=prompt_ids, attention_mask=attention_mask)
+
+        changed_prompt_ids = [[1, 3], [3, 4]] if pipeline_class is QwenImagePipelineWithLogProb else [1, 3]
+        changed_attention_mask = [[1, 0], [1, 1]] if pipeline_class is QwenImagePipelineWithLogProb else [1, 0]
+        pipeline.encode_prompt(prompt_ids=changed_prompt_ids, attention_mask=attention_mask)
+        pipeline.encode_prompt(prompt_ids=prompt_ids, attention_mask=changed_attention_mask)
+        tensor_attention_mask = torch.tensor(attention_mask)
+        pipeline.encode_prompt(prompt_ids=prompt_ids, attention_mask=tensor_attention_mask)
+
+        assert encoder_calls == 4
+        assert cache.stats() == {"size": 3, "max_size": 32, "hits": 1, "misses": 3, "bypassed": 1}
+
+
+@pytest.mark.parametrize(
+    "cache_enabled",
+    [None, False, True],
+    ids=["not-installed", "disabled", "enabled"],
+)
+def test_step_prompt_tokenizers_follow_prompt_cache_mode(cache_enabled):
+    pytest.importorskip("vllm_omni")
+
+    from verl_omni.pipelines.qwen_image_diffusion_nft.vllm_omni_rollout_adapter import (
+        QwenImageDiffusionNFTPipeline,
+    )
+    from verl_omni.pipelines.qwen_image_dpo.vllm_omni_rollout_adapter import QwenImageDPOPipeline
+    from verl_omni.pipelines.qwen_image_flow_grpo.vllm_omni_rollout_adapter import QwenImagePipelineWithLogProb
+
+    class Tokenizer:
+        def __init__(self):
+            self.calls = []
+            self.to_calls = []
+
+        def __call__(self, *_args, **kwargs):
+            self.calls.append((_args, kwargs))
+            if kwargs.get("return_tensors") == "pt":
+                input_ids = torch.tensor([[1, 2], [3, 4]])
+                attention_mask = torch.tensor([[1, 1], [1, 1]])
+            else:
+                input_ids = [[1, 2], [3, 4]]
+                attention_mask = [[1, 1], [1, 1]]
+
+            encoding = SimpleNamespace(input_ids=input_ids, attention_mask=attention_mask)
+
+            def to(device):
+                self.to_calls.append(device)
+                return encoding
+
+            encoding.to = to
+            return encoding
+
+    tokenizers = (
+        QwenImageDiffusionNFTPipeline._tokenize_step_prompt,
+        QwenImageDPOPipeline._tokenize_step_prompt,
+        QwenImagePipelineWithLogProb._tokenize_text_prompt,
+    )
+    for tokenize_prompt in tokenizers:
+        tokenizer = Tokenizer()
+        pipeline = SimpleNamespace(
+            prompt_template_encode="wrapped:{}",
+            prompt_template_encode_start_idx=34,
+            tokenizer_max_length=2,
+            tokenizer=tokenizer,
+            device=torch.device("cpu"),
+            _prompt_embed_cache=None if cache_enabled is None else SimpleNamespace(enabled=cache_enabled),
+        )
+        prompt_ids, prompt_mask = tokenize_prompt(pipeline, ["first", "second"])
+        if cache_enabled:
+            assert prompt_ids == [[1, 2], [3, 4]]
+            assert prompt_mask == [[1, 1], [1, 1]]
+            assert tokenizer.to_calls == []
+        else:
+            torch.testing.assert_close(prompt_ids, torch.tensor([[1, 2], [3, 4]]))
+            torch.testing.assert_close(prompt_mask, torch.tensor([[1, 1], [1, 1]]))
+            assert tokenizer.to_calls == [torch.device("cpu")]
+        assert tokenizer.calls == [
+            (
+                (["wrapped:first", "wrapped:second"],),
+                {
+                    "max_length": 36,
+                    "padding": True,
+                    "truncation": True,
+                    **({} if cache_enabled else {"return_tensors": "pt"}),
+                },
+            )
+        ]
+
+
+@pytest.mark.parametrize("use_tensors", [False, True])
+def test_dpo_prepare_encode_preserves_input_path_and_batch_size(use_tensors):
+    pytest.importorskip("vllm_omni")
+
+    from verl_omni.pipelines.qwen_image_dpo.vllm_omni_rollout_adapter import QwenImageDPOPipeline
+
+    class StopAfterLatents(Exception):
+        pass
+
+    calls = []
+    latent_batch_sizes = []
+
+    def encode_prompt(**kwargs):
+        calls.append((kwargs["prompt_ids"], kwargs["attention_mask"]))
+        return torch.zeros(2, 2, 4), torch.ones(2, 2, dtype=torch.long)
+
+    def prepare_latents(batch_size, *_args):
+        latent_batch_sizes.append(batch_size)
+        raise StopAfterLatents
+
+    prompt_ids = torch.tensor([[1, 2], [3, 4]]) if use_tensors else [[1, 2], [3, 4]]
+    prompt_mask = torch.tensor([[1, 1], [1, 1]]) if use_tensors else [[1, 1], [1, 1]]
+
+    pipeline = SimpleNamespace(
+        device=torch.device("cpu"),
+        default_sample_size=2,
+        vae_scale_factor=8,
+        transformer=SimpleNamespace(in_channels=4),
+        _extract_step_prompt_ids=lambda _prompt: (prompt_ids, prompt_mask, None, None),
+        encode_prompt=encode_prompt,
+        prepare_latents=prepare_latents,
+    )
+    sampling = SimpleNamespace(
+        height=None,
+        width=None,
+        num_inference_steps=None,
+        num_outputs_per_prompt=1,
+        true_cfg_scale=2.0,
+        max_sequence_length=None,
+        generator=None,
+        seed=None,
+    )
+    state = SimpleNamespace(sampling=sampling, prompt={})
+
+    with pytest.raises(StopAfterLatents):
+        QwenImageDPOPipeline.prepare_encode(pipeline, state)
+
+    if use_tensors:
+        assert torch.equal(calls[0][0], prompt_ids)
+        assert torch.equal(calls[0][1], prompt_mask)
+    else:
+        assert calls == [(prompt_ids, prompt_mask)]
+    assert latent_batch_sizes == [2]
+
+
+@pytest.mark.parametrize("use_tensors", [False, True])
+def test_nft_prepare_context_preserves_input_path_and_batch_size(use_tensors):
+    pytest.importorskip("vllm_omni")
+
+    from verl_omni.pipelines.qwen_image_diffusion_nft.vllm_omni_rollout_adapter import (
+        QwenImageDiffusionNFTPipeline,
+    )
+
+    calls = []
+    latent_batch_sizes = []
+
+    def prepare_latents(batch_size, *_args):
+        latent_batch_sizes.append(batch_size)
+        return torch.zeros(batch_size, 1, 1)
+
+    pipeline = SimpleNamespace(
+        device=torch.device("cpu"),
+        vae_scale_factor=8,
+        transformer=SimpleNamespace(in_channels=4, guidance_embeds=False),
+        check_cfg_parallel_validity=lambda *_: None,
+        encode_prompt=_record_encode_prompt(calls),
+        prepare_latents=prepare_latents,
+        prepare_timesteps=lambda *_: (torch.tensor([1]), 1),
+    )
+    prompt_ids = torch.tensor([[1, 2], [3, 4]]) if use_tensors else [[1, 2], [3, 4]]
+    prompt_mask = torch.tensor([[1, 1], [1, 1]]) if use_tensors else [[1, 1], [1, 1]]
+    negative_prompt_ids = torch.tensor([[5, 6], [7, 8]]) if use_tensors else [[5, 6], [7, 8]]
+    negative_prompt_mask = torch.tensor([[1, 1], [1, 1]]) if use_tensors else [[1, 1], [1, 1]]
+    QwenImageDiffusionNFTPipeline._prepare_token_id_generation_context(
+        pipeline,
+        prompt_ids=prompt_ids,
+        prompt_mask=prompt_mask,
+        negative_prompt_ids=negative_prompt_ids,
+        negative_prompt_mask=negative_prompt_mask,
+        true_cfg_scale=2.0,
+        height=16,
+        width=16,
+        num_inference_steps=1,
+        sigmas=None,
+        guidance_scale=1.0,
+        num_images_per_prompt=1,
+        generator=None,
+        latents=None,
+        prompt_embeds=None,
+        prompt_embeds_mask=None,
+        negative_prompt_embeds=None,
+        negative_prompt_embeds_mask=None,
+        attention_kwargs=None,
+        max_sequence_length=2,
+    )
+
+    if use_tensors:
+        assert torch.equal(calls[0][0], prompt_ids)
+        assert torch.equal(calls[0][1], prompt_mask)
+        assert torch.equal(calls[1][0], negative_prompt_ids)
+        assert torch.equal(calls[1][1], negative_prompt_mask)
+    else:
+        assert calls == [(prompt_ids, prompt_mask), (negative_prompt_ids, negative_prompt_mask)]
+    assert latent_batch_sizes == [2]
+
+
+def test_dpo_forward_passes_list_inputs_to_encode_prompt():
+    pytest.importorskip("vllm_omni")
+
+    from verl_omni.pipelines.qwen_image_dpo.vllm_omni_rollout_adapter import QwenImageDPOPipeline
+
+    class StopAfterPromptEncoding(Exception):
+        pass
+
+    def stop_after_prompt_encoding(*_):
+        raise StopAfterPromptEncoding
+
+    calls = []
+    pipeline = SimpleNamespace(
+        device=torch.device("cpu"),
+        default_sample_size=2,
+        vae_scale_factor=8,
+        transformer=SimpleNamespace(in_channels=4),
+        encode_prompt=_record_encode_prompt(calls),
+        prepare_latents=stop_after_prompt_encoding,
+    )
+    sampling_params = SimpleNamespace(
+        height=None,
+        width=None,
+        num_inference_steps=None,
+        max_sequence_length=None,
+        generator=None,
+        seed=None,
+        true_cfg_scale=None,
+        num_outputs_per_prompt=None,
+    )
+    request = SimpleNamespace(
+        prompts=[
+            {
+                "prompt_token_ids": [1, 2],
+                "prompt_mask": [1, 1],
+                "negative_prompt_ids": [3, 4],
+                "negative_prompt_mask": [1, 1],
+            }
+        ],
+        sampling_params=sampling_params,
+    )
+
+    with pytest.raises(StopAfterPromptEncoding):
+        QwenImageDPOPipeline.forward(pipeline, request, true_cfg_scale=2.0)
+
+    assert calls == [([1, 2], [1, 1]), ([3, 4], [1, 1])]
+
+
+@pytest.mark.parametrize("use_tensors", [False, True])
+def test_flow_forward_preserves_input_path_through_encode_prompt(use_tensors):
+    pytest.importorskip("vllm_omni")
+
+    from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
+
+    from verl_omni.pipelines.qwen_image_flow_grpo.vllm_omni_rollout_adapter import QwenImagePipelineWithLogProb
+
+    class StopAfterPromptEncoding(Exception):
+        pass
+
+    calls = []
+    latent_batch_sizes = []
+
+    def encode_prompt(**kwargs):
+        prompt_ids = kwargs["prompt_ids"]
+        attention_mask = kwargs["attention_mask"]
+        calls.append((prompt_ids, attention_mask))
+        batch_size = len(prompt_ids)
+        return torch.zeros(batch_size, 2, 4), torch.ones(batch_size, 2, dtype=torch.long)
+
+    def prepare_latents(batch_size, *_args):
+        latent_batch_sizes.append(batch_size)
+        raise StopAfterPromptEncoding
+
+    pipeline = SimpleNamespace(
+        device=torch.device("cpu"),
+        default_sample_size=2,
+        vae_scale_factor=8,
+        transformer=SimpleNamespace(in_channels=4),
+        encode_prompt=encode_prompt,
+        prepare_latents=prepare_latents,
+    )
+    sampling = SimpleNamespace(
+        height=None,
+        width=None,
+        num_inference_steps=None,
+        sigmas=None,
+        max_sequence_length=None,
+        output_type=None,
+        extra_args={},
+        generator=None,
+        seed=None,
+        true_cfg_scale=2.0,
+        guidance_scale_provided=False,
+        num_outputs_per_prompt=1,
+        latents=None,
+    )
+
+    def prompt_value(value, *, dtype=None):
+        return torch.tensor(value, dtype=dtype) if use_tensors else value
+
+    request_batch = DiffusionRequestBatch(
+        requests=[
+            SimpleNamespace(
+                request_id="request-0",
+                prompt={
+                    "prompt_token_ids": prompt_value([1, 2]),
+                    "prompt_mask": prompt_value([1, 1]),
+                    "negative_prompt_ids": prompt_value([]),
+                    "negative_prompt_mask": prompt_value([], dtype=torch.bool),
+                },
+                sampling_params=sampling,
+                kv_sender_info=None,
+            ),
+            SimpleNamespace(
+                request_id="request-1",
+                prompt={
+                    "prompt_token_ids": prompt_value([3]),
+                    "prompt_mask": prompt_value([1]),
+                    "negative_prompt_ids": prompt_value([4]),
+                    "negative_prompt_mask": prompt_value([1]),
+                },
+                sampling_params=sampling,
+                kv_sender_info=None,
+            ),
+        ]
+    )
+
+    with pytest.raises(StopAfterPromptEncoding):
+        QwenImagePipelineWithLogProb.forward(pipeline, request_batch)
+
+    if use_tensors:
+        assert torch.equal(calls[0][0], torch.tensor([[1, 2], [3, 0]]))
+        assert torch.equal(calls[0][1], torch.tensor([[True, True], [True, False]]))
+        assert torch.equal(calls[1][0], torch.tensor([[0], [4]]))
+        assert torch.equal(calls[1][1], torch.tensor([[False], [True]]))
+    else:
+        assert calls == [
+            ([[1, 2], [3, 0]], [[True, True], [True, False]]),
+            ([[0], [4]], [[False], [True]]),
+        ]
+    assert latent_batch_sizes == [2]

--- a/tests/workers/config/test_diffusion_config_on_cpu.py
+++ b/tests/workers/config/test_diffusion_config_on_cpu.py
@@ -186,6 +186,21 @@ class TestDiffusionRolloutConfig:
         with pytest.raises(ValueError, match="max_prompt_embed_length must be positive"):
             DiffusionRolloutConfig(name="vllm_omni", max_prompt_embed_length=value)
 
+    def test_prompt_embed_cache_config(self):
+        cfg = DiffusionRolloutConfig(
+            name="vllm_omni",
+            enable_prompt_embed_cache=True,
+            prompt_embed_cache_size=64,
+            enable_prompt_embed_cache_routing_affinity=True,
+        )
+        assert cfg.enable_prompt_embed_cache is True
+        assert cfg.prompt_embed_cache_size == 64
+        assert cfg.enable_prompt_embed_cache_routing_affinity is True
+
+    def test_invalid_prompt_embed_cache_size_raises(self):
+        with pytest.raises(ValueError, match="prompt_embed_cache_size must be positive"):
+            DiffusionRolloutConfig(name="vllm_omni", prompt_embed_cache_size=0)
+
     def test_invalid_rollout_adapter_raises(self):
         with pytest.raises(ValueError, match="Invalid diffusion rollout rollout_adapter"):
             DiffusionRolloutConfig(name="vllm_omni", rollout_adapter="bogus")

--- a/verl_omni/agent_loop/single_turn_agent_loop.py
+++ b/verl_omni/agent_loop/single_turn_agent_loop.py
@@ -34,6 +34,14 @@ class DiffusionSingleTurnAgentLoop(AgentLoopBase):
         super().__init__(*args, **kwargs)
         self.extra_tokenizer_map = extra_tokenizer_map or {}
 
+    def _get_routing_request_id(self, sample_uid: Any | None) -> str:
+        use_prompt_cache_affinity = bool(
+            self.rollout_config.enable_prompt_embed_cache
+            and self.rollout_config.enable_prompt_embed_cache_routing_affinity
+            and sample_uid is not None
+        )
+        return str(sample_uid) if use_prompt_cache_affinity else uuid4().hex
+
     async def _tokenize_per_encoder(self, messages: list[dict]) -> dict[str, list[int]]:
         """Tokenize the rendered prompt once per configured text-encoder tokenizer.
 
@@ -114,7 +122,7 @@ class DiffusionSingleTurnAgentLoop(AgentLoopBase):
         metrics = {}
         with simple_timer("generate_sequences", metrics):
             output = await self.server_manager.generate(
-                request_id=uuid4().hex,
+                request_id=self._get_routing_request_id(kwargs.get("uid")),
                 prompt_ids=prompt_ids,
                 sampling_params=sampling_params,
                 image_data=images,

--- a/verl_omni/pipelines/qwen_image_diffusion_nft/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/qwen_image_diffusion_nft/vllm_omni_rollout_adapter.py
@@ -70,13 +70,18 @@ class QwenImageDiffusionNFTPipeline(QwenImageTokenIdPromptMixin, QwenImagePipeli
         """Tokenize raw text for the step-execution warm-up request."""
         prompt = [text] if isinstance(text, str) else text
         formatted = [self.prompt_template_encode.format(item) for item in prompt]
+        prompt_embed_cache = getattr(self, "_prompt_embed_cache", None)
+        use_prompt_embed_cache = bool(prompt_embed_cache is not None and prompt_embed_cache.enabled)
+        tokenizer_kwargs = {} if use_prompt_embed_cache else {"return_tensors": "pt"}
         tokens = self.tokenizer(
             formatted,
             max_length=self.tokenizer_max_length + self.prompt_template_encode_start_idx,
             padding=True,
             truncation=True,
-            return_tensors="pt",
-        ).to(self.device)
+            **tokenizer_kwargs,
+        )
+        if not use_prompt_embed_cache:
+            tokens = tokens.to(self.device)
         return tokens.input_ids, tokens.attention_mask
 
     def prepare_encode(
@@ -180,10 +185,10 @@ class QwenImageDiffusionNFTPipeline(QwenImageTokenIdPromptMixin, QwenImagePipeli
     def _prepare_token_id_generation_context(
         self,
         *,
-        prompt_ids: torch.Tensor,
-        prompt_mask: torch.Tensor | None,
-        negative_prompt_ids: torch.Tensor | None,
-        negative_prompt_mask: torch.Tensor | None,
+        prompt_ids: torch.Tensor | list[int] | list[list[int]] | None,
+        prompt_mask: torch.Tensor | list[int] | list[bool] | list[list[int]] | list[list[bool]] | None,
+        negative_prompt_ids: torch.Tensor | list[int] | list[list[int]] | None,
+        negative_prompt_mask: torch.Tensor | list[int] | list[bool] | list[list[int]] | list[list[bool]] | None,
         true_cfg_scale: float,
         height: int,
         width: int,
@@ -205,13 +210,11 @@ class QwenImageDiffusionNFTPipeline(QwenImageTokenIdPromptMixin, QwenImagePipeli
         self._current_timestep = None
         self._interrupt = False
 
-        if isinstance(prompt_ids, list):
-            prompt_ids = torch.tensor(prompt_ids, device=self.device)
-        if isinstance(negative_prompt_ids, list):
-            negative_prompt_ids = torch.tensor(negative_prompt_ids, device=self.device)
-
         if prompt_ids is not None:
-            batch_size = prompt_ids.shape[0] if prompt_ids.ndim == 2 else 1
+            if isinstance(prompt_ids, torch.Tensor):
+                batch_size = prompt_ids.shape[0] if prompt_ids.ndim == 2 else 1
+            else:
+                batch_size = len(prompt_ids) if prompt_ids and isinstance(prompt_ids[0], list) else 1
         elif prompt_embeds is not None:
             batch_size = prompt_embeds.shape[0]
         else:
@@ -288,10 +291,10 @@ class QwenImageDiffusionNFTPipeline(QwenImageTokenIdPromptMixin, QwenImagePipeli
     def forward(
         self,
         req: OmniDiffusionRequest,
-        prompt_ids: torch.Tensor | list[int] | None = None,
-        prompt_mask: torch.Tensor | None = None,
-        negative_prompt_ids: torch.Tensor | list[int] | None = None,
-        negative_prompt_mask: torch.Tensor | None = None,
+        prompt_ids: torch.Tensor | list[int] | list[list[int]] | None = None,
+        prompt_mask: torch.Tensor | list[int] | list[bool] | list[list[int]] | list[list[bool]] | None = None,
+        negative_prompt_ids: torch.Tensor | list[int] | list[list[int]] | None = None,
+        negative_prompt_mask: torch.Tensor | list[int] | list[bool] | list[list[int]] | list[list[bool]] | None = None,
         true_cfg_scale: float = 4.0,
         height: int | None = None,
         width: int | None = None,

--- a/verl_omni/pipelines/qwen_image_dpo/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/qwen_image_dpo/vllm_omni_rollout_adapter.py
@@ -66,13 +66,18 @@ class QwenImageDPOPipeline(QwenImagePipeline):
         """Tokenize raw text for the step-execution warm-up request."""
         prompt = [text] if isinstance(text, str) else text
         formatted = [self.prompt_template_encode.format(item) for item in prompt]
+        prompt_embed_cache = getattr(self, "_prompt_embed_cache", None)
+        use_prompt_embed_cache = bool(prompt_embed_cache is not None and prompt_embed_cache.enabled)
+        tokenizer_kwargs = {} if use_prompt_embed_cache else {"return_tensors": "pt"}
         tokens = self.tokenizer(
             formatted,
             max_length=self.tokenizer_max_length + self.prompt_template_encode_start_idx,
             padding=True,
             truncation=True,
-            return_tensors="pt",
-        ).to(self.device)
+            **tokenizer_kwargs,
+        )
+        if not use_prompt_embed_cache:
+            tokens = tokens.to(self.device)
         return tokens.input_ids, tokens.attention_mask
 
     def prepare_encode(
@@ -83,10 +88,6 @@ class QwenImageDPOPipeline(QwenImagePipeline):
         """Initialize request-local state for step execution."""
         sampling = state.sampling
         prompt_ids, prompt_mask, negative_prompt_ids, negative_prompt_mask = self._extract_step_prompt_ids(state.prompt)
-        if isinstance(prompt_ids, list):
-            prompt_ids = torch.tensor(prompt_ids, device=self.device)
-        if isinstance(negative_prompt_ids, list):
-            negative_prompt_ids = torch.tensor(negative_prompt_ids, device=self.device)
         if prompt_ids is None:
             raise ValueError(
                 f"{self.__class__.__name__}.prepare_encode requires either "
@@ -109,7 +110,10 @@ class QwenImageDPOPipeline(QwenImagePipeline):
         self._current_timestep = None
         self._interrupt = False
 
-        batch_size = prompt_ids.shape[0] if prompt_ids.ndim == 2 else 1
+        if isinstance(prompt_ids, torch.Tensor):
+            batch_size = prompt_ids.shape[0] if prompt_ids.ndim == 2 else 1
+        else:
+            batch_size = len(prompt_ids) if prompt_ids and isinstance(prompt_ids[0], list) else 1
         has_neg_prompt = negative_prompt_ids is not None
         do_true_cfg = true_cfg_scale > 1 and has_neg_prompt
 
@@ -282,19 +286,34 @@ class QwenImageDPOPipeline(QwenImagePipeline):
 
     def encode_prompt(
         self,
-        prompt_ids: torch.Tensor,
-        attention_mask: torch.Tensor | None = None,
+        prompt_ids: torch.Tensor | list[int] | list[list[int]] | None,
+        attention_mask: torch.Tensor | list[int] | list[bool] | list[list[int]] | list[list[bool]] | None = None,
         num_images_per_prompt: int = 1,
         prompt_embeds: torch.Tensor | None = None,
         prompt_embeds_mask: torch.Tensor | None = None,
         max_sequence_length: int = 1024,
     ):
-        prompt_ids = prompt_ids.unsqueeze(0) if prompt_ids.ndim == 1 else prompt_ids
-        attention_mask = (
-            attention_mask.unsqueeze(0) if attention_mask is not None and attention_mask.ndim == 1 else attention_mask
-        )
-
         if prompt_embeds is None:
+            if prompt_ids is None:
+                raise ValueError("`prompt_ids` must be provided when `prompt_embeds` is None.")
+            if isinstance(prompt_ids, list):
+                prompt_ids = torch.tensor(prompt_ids, device=self.device, dtype=torch.long)
+            elif isinstance(prompt_ids, torch.Tensor):
+                prompt_ids = prompt_ids.to(self.device)
+            else:
+                raise TypeError("`prompt_ids` must be a tensor or list.")
+            if isinstance(attention_mask, list):
+                attention_mask = torch.tensor(attention_mask, device=self.device)
+            elif isinstance(attention_mask, torch.Tensor):
+                attention_mask = attention_mask.to(self.device)
+            elif attention_mask is not None:
+                raise TypeError("`attention_mask` must be a tensor or list.")
+            prompt_ids = prompt_ids.unsqueeze(0) if prompt_ids.ndim == 1 else prompt_ids
+            attention_mask = (
+                attention_mask.unsqueeze(0)
+                if attention_mask is not None and attention_mask.ndim == 1
+                else attention_mask
+            )
             prompt_embeds, prompt_embeds_mask = self._get_qwen_prompt_embeds(prompt_ids, attention_mask=attention_mask)
 
         prompt_embeds = prompt_embeds[:, :max_sequence_length]
@@ -309,10 +328,10 @@ class QwenImageDPOPipeline(QwenImagePipeline):
     def forward(
         self,
         req: OmniDiffusionRequest,
-        prompt_ids: torch.Tensor | list[int] | None = None,
-        prompt_mask: torch.Tensor | None = None,
-        negative_prompt_ids: torch.Tensor | list[int] | None = None,
-        negative_prompt_mask: torch.Tensor | None = None,
+        prompt_ids: torch.Tensor | list[int] | list[list[int]] | None = None,
+        prompt_mask: torch.Tensor | list[int] | list[bool] | list[list[int]] | list[list[bool]] | None = None,
+        negative_prompt_ids: torch.Tensor | list[int] | list[list[int]] | None = None,
+        negative_prompt_mask: torch.Tensor | list[int] | list[bool] | list[list[int]] | list[list[bool]] | None = None,
         true_cfg_scale: float = 4.0,
         height: int | None = None,
         width: int | None = None,
@@ -358,16 +377,14 @@ class QwenImageDPOPipeline(QwenImagePipeline):
         self._interrupt = False
 
         if prompt_ids is not None:
-            if isinstance(prompt_ids, list):
-                prompt_ids = torch.tensor(prompt_ids, device=self.device)
-            batch_size = prompt_ids.shape[0] if prompt_ids.ndim == 2 else 1
+            if isinstance(prompt_ids, torch.Tensor):
+                batch_size = prompt_ids.shape[0] if prompt_ids.ndim == 2 else 1
+            else:
+                batch_size = len(prompt_ids) if prompt_ids and isinstance(prompt_ids[0], list) else 1
         elif prompt_embeds is not None:
             batch_size = prompt_embeds.shape[0]
         else:
             return DiffusionOutput(output=None)
-
-        if isinstance(negative_prompt_ids, list):
-            negative_prompt_ids = torch.tensor(negative_prompt_ids, device=self.device)
 
         has_neg_prompt = negative_prompt_ids is not None or (
             negative_prompt_embeds is not None and negative_prompt_embeds_mask is not None

--- a/verl_omni/pipelines/qwen_image_flow_grpo/common.py
+++ b/verl_omni/pipelines/qwen_image_flow_grpo/common.py
@@ -80,8 +80,8 @@ class QwenImageTokenIdPromptMixin:
 
     def encode_prompt(
         self,
-        prompt_ids: torch.Tensor | None,
-        attention_mask: torch.Tensor | None = None,
+        prompt_ids: torch.Tensor | list[int] | list[list[int]] | None,
+        attention_mask: torch.Tensor | list[int] | list[bool] | list[list[int]] | list[list[bool]] | None = None,
         num_images_per_prompt: int = 1,
         prompt_embeds: torch.Tensor | None = None,
         prompt_embeds_mask: torch.Tensor | None = None,
@@ -90,6 +90,18 @@ class QwenImageTokenIdPromptMixin:
         if prompt_embeds is None:
             if prompt_ids is None:
                 raise ValueError("`prompt_ids` must be provided when `prompt_embeds` is None.")
+            if isinstance(prompt_ids, list):
+                prompt_ids = torch.tensor(prompt_ids, device=self.device, dtype=torch.long)
+            elif isinstance(prompt_ids, torch.Tensor):
+                prompt_ids = prompt_ids.to(self.device)
+            else:
+                raise TypeError("`prompt_ids` must be a tensor or list.")
+            if isinstance(attention_mask, list):
+                attention_mask = torch.tensor(attention_mask, device=self.device)
+            elif isinstance(attention_mask, torch.Tensor):
+                attention_mask = attention_mask.to(self.device)
+            elif attention_mask is not None:
+                raise TypeError("`attention_mask` must be a tensor or list.")
             prompt_ids = prompt_ids.unsqueeze(0) if prompt_ids.ndim == 1 else prompt_ids
             attention_mask = (
                 attention_mask.unsqueeze(0)

--- a/verl_omni/pipelines/qwen_image_flow_grpo/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/qwen_image_flow_grpo/vllm_omni_rollout_adapter.py
@@ -110,8 +110,8 @@ class QwenImagePipelineWithLogProb(QwenImageTokenIdPromptMixin, QwenImagePipelin
 
     def encode_prompt(
         self,
-        prompt_ids: torch.Tensor,
-        attention_mask: torch.Tensor | None = None,
+        prompt_ids: torch.Tensor | list[int] | list[list[int]] | None,
+        attention_mask: torch.Tensor | list[int] | list[bool] | list[list[int]] | list[list[bool]] | None = None,
         num_images_per_prompt: int = 1,
         prompt_embeds: torch.Tensor | None = None,
         prompt_embeds_mask: torch.Tensor | None = None,
@@ -120,8 +120,8 @@ class QwenImagePipelineWithLogProb(QwenImageTokenIdPromptMixin, QwenImagePipelin
         """Encode text prompt token IDs into dense embeddings.
 
         Args:
-            prompt_ids (torch.Tensor): Token IDs of shape ``(B, L)`` or ``(L,)``.
-            attention_mask (torch.Tensor, *optional*): Boolean mask of shape
+            prompt_ids (torch.Tensor | list): Token IDs of shape ``(B, L)`` or ``(L,)``.
+            attention_mask (torch.Tensor | list, *optional*): Boolean mask of shape
                 ``(B, L)`` for *prompt_ids*; inferred as all-ones when ``None``.
             num_images_per_prompt (int): Number of images to generate per prompt;
                 embeddings are repeated accordingly.
@@ -138,12 +138,27 @@ class QwenImagePipelineWithLogProb(QwenImageTokenIdPromptMixin, QwenImagePipelin
                 ``(B * num_images_per_prompt, L, D)`` and
                 ``(B * num_images_per_prompt, L)`` respectively.
         """
-        prompt_ids = prompt_ids.unsqueeze(0) if prompt_ids.ndim == 1 else prompt_ids
-        attention_mask = (
-            attention_mask.unsqueeze(0) if attention_mask is not None and attention_mask.ndim == 1 else attention_mask
-        )
-
         if prompt_embeds is None:
+            if prompt_ids is None:
+                raise ValueError("`prompt_ids` must be provided when `prompt_embeds` is None.")
+            if isinstance(prompt_ids, list):
+                prompt_ids = torch.tensor(prompt_ids, device=self.device, dtype=torch.long)
+            elif isinstance(prompt_ids, torch.Tensor):
+                prompt_ids = prompt_ids.to(self.device)
+            else:
+                raise TypeError("`prompt_ids` must be a tensor or list.")
+            if isinstance(attention_mask, list):
+                attention_mask = torch.tensor(attention_mask, device=self.device)
+            elif isinstance(attention_mask, torch.Tensor):
+                attention_mask = attention_mask.to(self.device)
+            elif attention_mask is not None:
+                raise TypeError("`attention_mask` must be a tensor or list.")
+            prompt_ids = prompt_ids.unsqueeze(0) if prompt_ids.ndim == 1 else prompt_ids
+            attention_mask = (
+                attention_mask.unsqueeze(0)
+                if attention_mask is not None and attention_mask.ndim == 1
+                else attention_mask
+            )
             prompt_embeds, prompt_embeds_mask = self._get_qwen_prompt_embeds(prompt_ids, attention_mask=attention_mask)
 
         prompt_embeds = prompt_embeds[:, :max_sequence_length]
@@ -187,13 +202,18 @@ class QwenImagePipelineWithLogProb(QwenImageTokenIdPromptMixin, QwenImagePipelin
         """Tokenize a text prompt using the Qwen chat template (parent behavior)."""
         prompt = [text] if isinstance(text, str) else text
         txt = [self.prompt_template_encode.format(e) for e in prompt]
+        prompt_embed_cache = getattr(self, "_prompt_embed_cache", None)
+        use_prompt_embed_cache = bool(prompt_embed_cache is not None and prompt_embed_cache.enabled)
+        tokenizer_kwargs = {} if use_prompt_embed_cache else {"return_tensors": "pt"}
         tokens = self.tokenizer(
             txt,
             max_length=self.tokenizer_max_length + self.prompt_template_encode_start_idx,
             padding=True,
             truncation=True,
-            return_tensors="pt",
-        ).to(self.device)
+            **tokenizer_kwargs,
+        )
+        if not use_prompt_embed_cache:
+            tokens = tokens.to(self.device)
         return tokens.input_ids, tokens.attention_mask
 
     def prepare_encode(
@@ -213,12 +233,6 @@ class QwenImagePipelineWithLogProb(QwenImageTokenIdPromptMixin, QwenImagePipelin
         prompt_ids, prompt_mask, negative_prompt_ids, negative_prompt_mask = self._extract_prompt_ids(
             [state.prompt] if state.prompt is not None else []
         )
-
-        # Normalize list inputs to tensors on device.
-        if isinstance(prompt_ids, list):
-            prompt_ids = torch.tensor(prompt_ids, device=self.device)
-        if isinstance(negative_prompt_ids, list):
-            negative_prompt_ids = torch.tensor(negative_prompt_ids, device=self.device)
 
         if prompt_ids is None:
             raise ValueError(
@@ -244,10 +258,10 @@ class QwenImagePipelineWithLogProb(QwenImageTokenIdPromptMixin, QwenImagePipelin
         self._current_timestep = None
         self._interrupt = False
 
-        if prompt_ids is not None:
+        if isinstance(prompt_ids, torch.Tensor):
             batch_size = prompt_ids.shape[0] if prompt_ids.ndim == 2 else 1
         else:
-            batch_size = 1
+            batch_size = len(prompt_ids) if prompt_ids and isinstance(prompt_ids[0], list) else 1
 
         has_neg_prompt = negative_prompt_ids is not None
         do_true_cfg = true_cfg_scale > 1 and has_neg_prompt
@@ -642,10 +656,10 @@ class QwenImagePipelineWithLogProb(QwenImageTokenIdPromptMixin, QwenImagePipelin
     def forward(
         self,
         req: OmniDiffusionRequest | DiffusionRequestBatch,
-        prompt_token_ids: torch.Tensor | list[int] | None = None,
-        prompt_mask: torch.Tensor | None = None,
-        negative_prompt_ids: torch.Tensor | list[int] | None = None,
-        negative_prompt_mask: torch.Tensor | None = None,
+        prompt_token_ids: torch.Tensor | list[int] | list[list[int]] | None = None,
+        prompt_mask: torch.Tensor | list[int] | list[bool] | list[list[int]] | list[list[bool]] | None = None,
+        negative_prompt_ids: torch.Tensor | list[int] | list[list[int]] | None = None,
+        negative_prompt_mask: torch.Tensor | list[int] | list[bool] | list[list[int]] | list[list[bool]] | None = None,
         true_cfg_scale: float = 4.0,
         height: int | None = None,
         width: int | None = None,
@@ -678,12 +692,12 @@ class QwenImagePipelineWithLogProb(QwenImageTokenIdPromptMixin, QwenImagePipelin
         Args:
             req (OmniDiffusionRequest | DiffusionRequestBatch): One rollout request
                 or a request batch containing prompts and sampling parameters.
-            prompt_token_ids (torch.Tensor | list[int], *optional*): Token IDs for
-                the positive prompt.
-            prompt_mask (torch.Tensor, *optional*): Attention mask for *prompt_token_ids*.
-            negative_prompt_ids (torch.Tensor | list[int], *optional*): Token IDs
-                for the negative prompt used in True-CFG.
-            negative_prompt_mask (torch.Tensor, *optional*): Attention mask for
+            prompt_token_ids (torch.Tensor | list[int] | list[list[int]], *optional*): Token IDs
+                for the positive prompt.
+            prompt_mask (torch.Tensor | list, *optional*): Attention mask for *prompt_token_ids*.
+            negative_prompt_ids (torch.Tensor | list[int] | list[list[int]], *optional*): Token
+                IDs for the negative prompt used in True-CFG.
+            negative_prompt_mask (torch.Tensor | list, *optional*): Attention mask for
                 *negative_prompt_ids*.
             true_cfg_scale (float): Classifier-free guidance scale; CFG is
                 disabled when ``<= 1``.
@@ -729,12 +743,16 @@ class QwenImagePipelineWithLogProb(QwenImageTokenIdPromptMixin, QwenImagePipelin
         request_batch = req if isinstance(req, DiffusionRequestBatch) else DiffusionRequestBatch(requests=[req])
         return_batch = isinstance(req, DiffusionRequestBatch)
         prompts = request_batch.prompts
+        prompt_embed_cache = getattr(self, "_prompt_embed_cache", None)
+        use_prompt_embed_cache = bool(prompt_embed_cache is not None and prompt_embed_cache.enabled)
+        # The prompt cache wraps encode_prompt, so keep token inputs as lists until that boundary.
         prompt_token_ids, prompt_token_lengths = _collate_prompt_rows(
             prompts,
             ("prompt_token_ids", "prompt_ids"),
             prompt_token_ids,
             device=self.device,
             field_name="prompt_token_ids",
+            preserve_lists=use_prompt_embed_cache,
         )
         prompt_mask = _collate_prompt_mask(
             prompts,
@@ -743,7 +761,8 @@ class QwenImagePipelineWithLogProb(QwenImageTokenIdPromptMixin, QwenImagePipelin
             device=self.device,
             field_name="prompt_mask",
             token_lengths=prompt_token_lengths,
-            target_seq_len=None if prompt_token_ids is None else int(prompt_token_ids.shape[1]),
+            target_seq_len=max(prompt_token_lengths) if prompt_token_lengths else None,
+            preserve_lists=use_prompt_embed_cache,
         )
         negative_prompt_ids, negative_prompt_lengths = _collate_prompt_rows(
             prompts,
@@ -751,6 +770,7 @@ class QwenImagePipelineWithLogProb(QwenImageTokenIdPromptMixin, QwenImagePipelin
             negative_prompt_ids,
             device=self.device,
             field_name="negative_prompt_ids",
+            preserve_lists=use_prompt_embed_cache,
         )
         negative_prompt_mask = _collate_prompt_mask(
             prompts,
@@ -759,7 +779,8 @@ class QwenImagePipelineWithLogProb(QwenImageTokenIdPromptMixin, QwenImagePipelin
             device=self.device,
             field_name="negative_prompt_mask",
             token_lengths=negative_prompt_lengths,
-            target_seq_len=None if negative_prompt_ids is None else int(negative_prompt_ids.shape[1]),
+            target_seq_len=max(negative_prompt_lengths) if negative_prompt_lengths else None,
+            preserve_lists=use_prompt_embed_cache,
         )
 
         sampling_params = request_batch.sampling_params_list[0]
@@ -797,9 +818,10 @@ class QwenImagePipelineWithLogProb(QwenImageTokenIdPromptMixin, QwenImagePipelin
         self._interrupt = False
 
         if prompt_token_ids is not None:
-            if isinstance(prompt_token_ids, list):
-                prompt_token_ids = torch.tensor(prompt_token_ids, device=self.device)
-            batch_size = prompt_token_ids.shape[0] if prompt_token_ids.ndim == 2 else 1
+            if isinstance(prompt_token_ids, torch.Tensor):
+                batch_size = prompt_token_ids.shape[0] if prompt_token_ids.ndim == 2 else 1
+            else:
+                batch_size = len(prompt_token_ids)
         elif prompt_embeds is not None:
             batch_size = prompt_embeds.shape[0]
         else:

--- a/verl_omni/pipelines/request_batch.py
+++ b/verl_omni/pipelines/request_batch.py
@@ -100,19 +100,66 @@ def _rows_from_default(
 def collate_prompt_rows(
     prompts: list[Any],
     aliases: tuple[str, ...],
-    default_value: torch.Tensor | list[int] | None,
+    default_value: torch.Tensor | list[int] | list[list[int]] | None,
     *,
     device: torch.device,
     field_name: str,
     pad_value: int = 0,
-) -> tuple[torch.Tensor | None, list[int] | None]:
-    """Pad and stack per-request 1D prompt fields into a batched ``(N, L)`` tensor.
+    preserve_lists: bool = False,
+) -> tuple[torch.Tensor | list[list[int]] | None, list[int] | None]:
+    """Pad and stack per-request 1D prompt fields into batched rows.
 
     Looks up each field via ``aliases`` on the prompt (or its
     ``additional_information``). When ``default_value`` is set it is used for
-    the whole batch instead. Returns ``(None, None)`` if no request provides
-    the field.
+    the whole batch instead. By default rows are returned as a tensor on
+    ``device``; set ``preserve_lists=True`` to preserve list inputs for a
+    caller that must process them before tensorization. Explicit tensor inputs
+    retain the original tensor collation path. Returns ``(None, None)`` if no
+    request provides the field.
     """
+    if preserve_lists:
+        if default_value is None:
+            rows = [_get_prompt_field(prompt, aliases) for prompt in prompts]
+        elif isinstance(default_value, list):
+            rows = default_value if default_value and isinstance(default_value[0], list) else [default_value]
+        elif isinstance(default_value, torch.Tensor):
+            return collate_prompt_rows(
+                prompts,
+                aliases,
+                default_value,
+                device=device,
+                field_name=field_name,
+                pad_value=pad_value,
+            )
+        else:
+            raise TypeError(f"Request-batch {field_name} must be a tensor or list.")
+
+        if not any(row is not None for row in rows):
+            return None, None
+        if not all(row is not None for row in rows):
+            raise ValueError(f"Cannot batch requests with a mix of provided and missing {field_name}.")
+        if any(isinstance(row, torch.Tensor) for row in rows):
+            return collate_prompt_rows(
+                prompts,
+                aliases,
+                default_value,
+                device=device,
+                field_name=field_name,
+                pad_value=pad_value,
+            )
+        if any(not isinstance(row, list) or (row and isinstance(row[0], list)) for row in rows):
+            raise TypeError(f"Request-batch {field_name} rows must be flat lists.")
+        if len(prompts) > 1 and len(rows) != len(prompts):
+            raise ValueError(
+                f"Batched {field_name} default must have one row per request; "
+                f"got {len(rows)} rows for {len(prompts)} requests."
+            )
+
+        typed_rows = [list(row) for row in rows if row is not None]
+        target_len = max(len(row) for row in typed_rows)
+        lengths = [len(row) for row in typed_rows]
+        return [row + [pad_value] * (target_len - len(row)) for row in typed_rows], lengths
+
     default_rows, default_lengths = _rows_from_default(default_value, device=device, field_name=field_name)
     if default_rows is not None:
         if len(prompts) > 1 and default_rows.shape[0] != len(prompts):
@@ -154,13 +201,14 @@ def collate_prompt_rows(
 def collate_prompt_mask(
     prompts: list[Any],
     aliases: tuple[str, ...],
-    default_value: torch.Tensor | list[int] | None,
+    default_value: torch.Tensor | list[int] | list[bool] | list[list[int]] | list[list[bool]] | None,
     *,
     device: torch.device,
     field_name: str,
     token_lengths: list[int] | None,
     target_seq_len: int | None,
-) -> torch.Tensor | None:
+    preserve_lists: bool = False,
+) -> torch.Tensor | list[list[bool]] | None:
     """Build a boolean attention mask for a packed request batch.
 
     Prefers an explicit mask field from ``prompts`` / ``default_value``. If
@@ -174,8 +222,15 @@ def collate_prompt_mask(
         device=device,
         field_name=field_name,
         pad_value=0,
+        preserve_lists=preserve_lists,
     )
     if mask is not None:
+        if isinstance(mask, list):
+            mask = [[value != 0 for value in row] for row in mask]
+            if target_seq_len is not None:
+                mask = [row[:target_seq_len] + [False] * max(target_seq_len - len(row), 0) for row in mask]
+            return mask
+
         mask = mask != 0
         if target_seq_len is not None:
             if mask.shape[1] < target_seq_len:
@@ -188,6 +243,9 @@ def collate_prompt_mask(
 
     if token_lengths is None or target_seq_len is None:
         return None
+
+    if preserve_lists:
+        return [[column < row_len for column in range(target_seq_len)] for row_len in token_lengths]
 
     mask = torch.zeros((len(token_lengths), target_seq_len), dtype=torch.bool, device=device)
     for idx, row_len in enumerate(token_lengths):

--- a/verl_omni/trainer/config/_generated_diffusion_trainer.yaml
+++ b/verl_omni/trainer/config/_generated_diffusion_trainer.yaml
@@ -213,6 +213,9 @@ actor_rollout_ref:
       enable: false
     engine_kwargs:
       vllm_omni: {}
+    enable_prompt_embed_cache: false
+    prompt_embed_cache_size: 32
+    enable_prompt_embed_cache_routing_affinity: false
     val_kwargs:
       _target_: verl_omni.workers.config.diffusion.DiffusionSamplingConfig
       'n': 1

--- a/verl_omni/trainer/config/_generated_diffusion_veomni_trainer.yaml
+++ b/verl_omni/trainer/config/_generated_diffusion_veomni_trainer.yaml
@@ -254,6 +254,9 @@ actor_rollout_ref:
       enable: false
     engine_kwargs:
       vllm_omni: {}
+    enable_prompt_embed_cache: false
+    prompt_embed_cache_size: 32
+    enable_prompt_embed_cache_routing_affinity: false
     val_kwargs:
       _target_: verl_omni.workers.config.diffusion.DiffusionSamplingConfig
       'n': 1

--- a/verl_omni/trainer/config/diffusion/rollout/diffusion_rollout.yaml
+++ b/verl_omni/trainer/config/diffusion/rollout/diffusion_rollout.yaml
@@ -134,6 +134,15 @@ engine_kwargs:
   # vllm-omni engine config
   vllm_omni: {}
 
+# Reuse text-encoder outputs for repeated diffusion prompts.
+enable_prompt_embed_cache: false
+
+# Maximum number of prompt embeddings cached per diffusion worker.
+prompt_embed_cache_size: 32
+
+# Route repeated rollouts for one sample to the same worker when prompt cache is enabled.
+enable_prompt_embed_cache_routing_affinity: false
+
 # Sampling parameters used during validation (diffusion-specific).
 val_kwargs:
 

--- a/verl_omni/workers/config/diffusion/rollout.py
+++ b/verl_omni/workers/config/diffusion/rollout.py
@@ -166,6 +166,10 @@ class DiffusionRolloutConfig(BaseConfig):
     # step-execution mode.
     step_execution: bool = False
 
+    enable_prompt_embed_cache: bool = False
+    prompt_embed_cache_size: int = 32
+    enable_prompt_embed_cache_routing_affinity: bool = False
+
     # note that the logprob computation should belong to the actor
     log_prob_micro_batch_size_per_gpu: Optional[int] = None
     log_prob_use_dynamic_bsz: bool = False
@@ -235,6 +239,9 @@ class DiffusionRolloutConfig(BaseConfig):
             raise ValueError(
                 f"Invalid diffusion rollout rollout_adapter: {self.rollout_adapter}. Must be one of ['default', 'old']."
             )
+
+        if self.prompt_embed_cache_size <= 0:
+            raise ValueError(f"prompt_embed_cache_size must be positive, got {self.prompt_embed_cache_size}.")
 
         if self.pipeline_model_parallel_size > 1:
             if self.name == "vllm_omni":

--- a/verl_omni/workers/rollout/vllm_rollout/vllm_omni_async_server.py
+++ b/verl_omni/workers/rollout/vllm_rollout/vllm_omni_async_server.py
@@ -340,6 +340,9 @@ class vLLMOmniHttpServer(vLLMHttpServer):
                     )
                     engine_args["max_num_seqs"] = 1
 
+            engine_args["enable_prompt_embed_cache"] = self.config.enable_prompt_embed_cache
+            engine_args["prompt_embed_cache_size"] = self.config.prompt_embed_cache_size
+
         if getattr(self.config, "step_execution", False):
             engine_args["step_execution"] = True
 


### PR DESCRIPTION
### What does this PR do?

This PR integrates vLLM-Omni's prompt embedding cache with verl-omni diffusion rollouts.

vLLM-Omni applies the cache wrapper around `encode_prompt()`. Previously, several
verl-omni adapters converted pre-tokenized prompt IDs and attention masks to tensors
before that boundary. Those tensor inputs bypassed the list-based cache-key path, so
repeated prompts were encoded again even when the cache was enabled.

This PR keeps two execution paths. With prompt caching disabled, the existing
tokenizer-to-tensor path is retained unchanged. With prompt caching enabled,
token IDs and masks remain list-like until `encode_prompt()`, where the existing
tensor conversion occurs after the wrapper has built its cache key. It covers:

- Qwen-Image FlowGRPO and MixGRPO (through the shared FlowGRPO adapter)
- Qwen-Image DiffusionNFT
- Qwen-Image online DPO
- Wan2.2 DanceGRPO

The adapters continue to accept explicit tensor inputs. We verified that both
paths preserve the output produced after `encode_prompt()` relative to the
pre-change implementation: prompt embeddings and masks retain the same values,
device, dtype, and batch/output contract. Precomputed prompt embeddings
continue to bypass token encoding.

The cache is disabled by default, so existing configurations do not enable it
implicitly.

For repeated rollouts, this PR also provides an opt-in routing-affinity mode.
When both the cache and affinity are enabled, all repeated generations derived
from one trainer sample use that sample's stable `uid` as the rollout request
ID. The load balancer can then route them to the same rollout replica, where
they share its worker-local cache. Without affinity, each generation uses a new
UUID and may be distributed across replicas; each replica then needs its own
first cache miss for the same prompt.

Related vLLM-Omni implementation: [vllm-project/vllm-omni#2962](https://github.com/vllm-project/vllm-omni/pull/2962).

### Checklist Before Starting

- [x] Search for similar PRs. Query: [prompt embedding cache PRs](https://github.com/verl-project/verl-omni/pulls?q=is%3Apr+%22prompt+embed%22+cache)
- [x] Format the PR title as `[{modules}] {type}: {description}`.

### Test

The new CPU tests cover:

- Default tensor collation and opt-in list-preserving collation.
- Flat and packed/batched token-ID lists.
- List and tensor inputs at each adapter boundary.
- Preservation of tokenizer batch dimensions.
- Exact post-`encode_prompt()` parity with the pre-change output for both the
  cache-disabled tensor path and cache-enabled list path, including embeddings,
  masks, shape, dtype, and device.
- Cache hits for repeated list-valued Qwen-Image and Wan prompts.
- `prompt_ids=None` with precomputed prompt embeddings.
- DPO and DiffusionNFT request preparation without early tensorization.
- FlowGRPO forwarding list inputs through the cache boundary.
- Wan empty-negative-prompt handling for both list and tensor inputs.
- Configuration defaults and rejection of non-positive cache sizes.
- Cache-routing request IDs: random by default, stable per sample only when
  both prompt caching and routing affinity are enabled (covered by the separate
  agent-loop CPU tests).

Focused test command:

```bash
PYTHONPATH=/path/to/verl:/path/to/vllm-omni \
pytest -q \
  tests/pipelines/test_prompt_embed_cache_on_cpu.py \
  tests/workers/config/test_diffusion_config_on_cpu.py
```

Validation results:

- `git diff --check origin/main...HEAD`: passed.
- The focused suite completed with `46 passed` against the compatible local
  vLLM-Omni checkout used while developing the adapter changes.
- A later rerun against a different local vLLM-Omni revision stopped during test
  collection because that checkout no longer exports
  `vllm_omni.diffusion.worker.utils.DiffusionRequestState`. No test assertion was
  reached in that rerun; CI should use the repository's compatible pinned
  vLLM-Omni revision.

#### Performance evidence

The evaluation dataset used for the measurements below has short prompts, with
an average prompt length of only about 20--30 tokens. Text encoding therefore
accounts for a relatively small fraction of end-to-end generation and step time.
Based on the current comparison, this PR provides prompt-cache compatibility,
but the end-to-end gain is limited and it is not recommended as a priority
optimization. Workloads with longer prompts or more expensive text encoders may
benefit more, but that has not been measured here.

##### FlowGRPO

<img width="2904" height="1279" alt="65b4ee316bda2ba3b22d5e42299b9876" src="https://github.com/user-attachments/assets/8eaf1ddb-e35a-4cf1-a197-236d0d7cb0ac" />


##### DiffusionNFT

<img width="2046" height="1279" alt="bb88eb87474cf9cfd3940bd45839db01" src="https://github.com/user-attachments/assets/395c64d8-466a-4972-b456-351e69dac209" />

This DiffusionNFT plot is from the OCR dataset with each prompt repeated 10
times. In my assessment, the observed end-to-end improvement is small for this
workload. The repeated prompts do not make text encoding the dominant cost, and
replica-local cache routing limits how much of the repeated work can be reused.

These measurements do not by themselves establish the cache hit rate. Cache
entries are private to a rollout replica, so a repeated-prompt workload should
enable routing affinity when it needs repeated generations of one sample to
reuse the same replica-local entry.


### API and Usage Example

Enable the cache in the diffusion rollout configuration:

```yaml
actor_rollout_ref:
  rollout:
    enable_prompt_embed_cache: true
    prompt_embed_cache_size: 32
    enable_prompt_embed_cache_routing_affinity: true
```

Equivalent Hydra overrides:

```bash
actor_rollout_ref.rollout.enable_prompt_embed_cache=true \
actor_rollout_ref.rollout.prompt_embed_cache_size=32 \
actor_rollout_ref.rollout.enable_prompt_embed_cache_routing_affinity=true
```

`prompt_embed_cache_size` must be positive. The default configuration is:

```yaml
enable_prompt_embed_cache: false
prompt_embed_cache_size: 32
enable_prompt_embed_cache_routing_affinity: false
```

Routing affinity is meaningful only together with
`enable_prompt_embed_cache=true`. It does not change prompt values, sampling
parameters, or model weights; it only replaces the per-generation random
request ID with the repeated sample's `uid` for rollout-server routing.

### Design & Code Changes

#### Cache configuration

- Adds `enable_prompt_embed_cache` and `prompt_embed_cache_size` to
  `DiffusionRolloutConfig` and the generated trainer configurations.
- Validates that `prompt_embed_cache_size` is positive.
- Passes the cache enable and size options through `vLLMOmniHttpServer` to
  `AsyncOmni`.
- Adds `enable_prompt_embed_cache_routing_affinity`, disabled by default. The
  diffusion agent loop uses a sample's stable `uid` as the request ID only when
  it and prompt caching are both enabled; this is a verl-omni routing change,
  not an `AsyncOmni` cache-engine option. All other requests retain random
  UUIDs.

#### Prompt boundary

- Adds opt-in `preserve_lists=True` support to request-batch prompt-ID and mask
  collation. The default collation behavior remains tensor-based.
- Keeps pre-tokenized IDs and masks as lists through request preparation when they
  must participate in the prompt-cache key.
- Converts list inputs to device tensors only inside each adapter's or shared
  mixin's `encode_prompt()` implementation, after the cache wrapper has
  inspected the arguments.
- Retains the existing tensor path for callers that explicitly provide tensors.

#### Existing validated precedent: SD3.5 FlowGRPO

SD3.5 FlowGRPO already follows the same delayed-tensorization pattern in its
token-ID prompt-encoding boundary. Its `encode_prompt_from_token_ids()` path
accepts Python token-ID lists and converts them to device `torch.long` tensors
inside the CLIP and T5 encoding helpers, rather than before prompt encoding.

The existing `tests/pipelines/test_sd3_token_id_prompt_on_cpu.py` parity tests
compare this path with vLLM-Omni's text-based `encode_prompt()` and require exact
equality (`rtol=0`, `atol=0`). They also cover batch dimensions,
`num_images_per_prompt`, empty prompts, padding, and truncation. This provides an
already validated model-level precedent for moving list-to-tensor conversion into
the prompt-encoding boundary.

#### Adapter compatibility

- Preserves single-prompt and packed/batched prompt shapes.
- Computes batch size from either tensors or nested lists without hard-coding it.
- Preserves Qwen-Image True-CFG and Wan empty-negative-prompt behavior.
- Does not change the final prompt embedding or attention-mask contracts consumed
  by the denoising pipelines.
