### PR TITLE
[rollout, diffusion] fix: preserve final prompt embedding length

### DIFF
--- a/examples/flowgrpo_trainer/sd35/run_sd35_medium_drm_lora.sh
+++ b/examples/flowgrpo_trainer/sd35/run_sd35_medium_drm_lora.sh
@@ -73,6 +73,7 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.rollout.pipeline.num_inference_steps=10 \
     actor_rollout_ref.rollout.pipeline.guidance_scale=1.0 \
     actor_rollout_ref.rollout.pipeline.max_sequence_length=256 \
+    actor_rollout_ref.rollout.max_prompt_embed_length=333 \
     +actor_rollout_ref.rollout.pipeline.output_type=latent \
     actor_rollout_ref.rollout.algo.noise_level=0.8 \
     actor_rollout_ref.rollout.algo.sde_type=cps \

--- a/examples/flowgrpo_trainer/sd35/run_sd35_medium_ocr_lora.sh
+++ b/examples/flowgrpo_trainer/sd35/run_sd35_medium_ocr_lora.sh
@@ -82,6 +82,7 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.rollout.pipeline.num_inference_steps=10 \
     actor_rollout_ref.rollout.pipeline.guidance_scale=1.0 \
     actor_rollout_ref.rollout.pipeline.max_sequence_length=256 \
+    actor_rollout_ref.rollout.max_prompt_embed_length=333 \
     actor_rollout_ref.rollout.algo.noise_level=0.8 \
     actor_rollout_ref.rollout.algo.sde_type="cps" \
     actor_rollout_ref.rollout.algo.sde_window_size=3 \

--- a/examples/flowgrpo_trainer/sd35/run_sd35_medium_ocr_lora_v1.sh
+++ b/examples/flowgrpo_trainer/sd35/run_sd35_medium_ocr_lora_v1.sh
@@ -81,6 +81,7 @@ python3 -m verl_omni.trainer.main_diffusion_v1 \
     actor_rollout_ref.rollout.pipeline.num_inference_steps=10 \
     actor_rollout_ref.rollout.pipeline.guidance_scale=1.0 \
     actor_rollout_ref.rollout.pipeline.max_sequence_length=256 \
+    actor_rollout_ref.rollout.max_prompt_embed_length=333 \
     actor_rollout_ref.rollout.algo.noise_level=0.8 \
     actor_rollout_ref.rollout.algo.sde_type="cps" \
     actor_rollout_ref.rollout.algo.sde_window_size=3 \

--- a/examples/flowgrpo_trainer/sd35/run_sd35_medium_ocr_lora_v1_separate_async.sh
+++ b/examples/flowgrpo_trainer/sd35/run_sd35_medium_ocr_lora_v1_separate_async.sh
@@ -149,6 +149,7 @@ python3 -m verl_omni.trainer.main_diffusion_v1 \
     actor_rollout_ref.rollout.pipeline.num_inference_steps=10 \
     actor_rollout_ref.rollout.pipeline.guidance_scale=1.0 \
     actor_rollout_ref.rollout.pipeline.max_sequence_length=256 \
+    actor_rollout_ref.rollout.max_prompt_embed_length=333 \
     actor_rollout_ref.rollout.algo.noise_level=0.8 \
     actor_rollout_ref.rollout.algo.sde_type="cps" \
     actor_rollout_ref.rollout.algo.sde_window_size=3 \

--- a/tests/agent_loop/test_diffusion_agent_loop_correctness_on_cpu.py
+++ b/tests/agent_loop/test_diffusion_agent_loop_correctness_on_cpu.py
@@ -21,7 +21,11 @@ from verl.experimental.agent_loop.agent_loop import AgentLoopMetrics
 from verl.protocol import DataProto
 
 from verl_omni.agent_loop import diffusion_agent_loop_tq
-from verl_omni.agent_loop.diffusion_agent_loop import DiffusionAgentLoopOutput, DiffusionAgentLoopWorker
+from verl_omni.agent_loop.diffusion_agent_loop import (
+    DiffusionAgentLoopOutput,
+    DiffusionAgentLoopWorker,
+    _pad_prompt_extra_field,
+)
 from verl_omni.agent_loop.diffusion_agent_loop_tq import DiffusionAgentLoopWorkerTQ
 
 
@@ -44,6 +48,35 @@ class _DummyDiffusionAgentLoopWorker:
 
     def __init__(self, reward_loop_worker_handle: _FakeRewardLoopWorkerHandle):
         self.reward_loop_worker_handles = [reward_loop_worker_handle]
+
+
+@pytest.mark.parametrize(
+    ("key", "value", "expected_shape"),
+    [
+        ("prompt_embeds", torch.ones(2, 4), (3, 4)),
+        ("negative_prompt_embeds", torch.ones(2, 4), (3, 4)),
+        ("prompt_embeds_mask", torch.ones(2), (3,)),
+        ("negative_prompt_embeds_mask", torch.ones(2), (3,)),
+    ],
+)
+def test_pad_prompt_extra_field_pads_without_truncation(key, value, expected_shape):
+    padded = _pad_prompt_extra_field(key, value, target_length=3)
+
+    assert padded.shape == expected_shape
+    assert torch.equal(padded[:2], value)
+    assert torch.count_nonzero(padded[2:]) == 0
+
+
+@pytest.mark.parametrize(
+    ("key", "value"),
+    [
+        ("prompt_embeds", torch.ones(4, 2)),
+        ("prompt_embeds_mask", torch.ones(4)),
+    ],
+)
+def test_pad_prompt_extra_field_rejects_truncation(key, value):
+    with pytest.raises(ValueError, match="exceeds max_prompt_embed_length=3"):
+        _pad_prompt_extra_field(key, value, target_length=3)
 
 
 @pytest.mark.asyncio

--- a/tests/pipelines/test_sd3_token_id_prompt_on_cpu.py
+++ b/tests/pipelines/test_sd3_token_id_prompt_on_cpu.py
@@ -108,6 +108,7 @@ def test_token_id_encode_matches_text_encode(pipeline, num_images_per_prompt):
     (ref_embeds, ref_pooled), (embeds, pooled) = _encode_both_paths(pipeline, prompts, num_images_per_prompt)
 
     assert embeds.shape == ref_embeds.shape
+    assert embeds.shape[1] == pipeline.tokenizer_max_length + T5_MAX_SEQUENCE_LENGTH
     assert pooled.shape == ref_pooled.shape
     torch.testing.assert_close(embeds, ref_embeds, rtol=0.0, atol=0.0)
     torch.testing.assert_close(pooled, ref_pooled, rtol=0.0, atol=0.0)

--- a/tests/workers/config/test_diffusion_config_on_cpu.py
+++ b/tests/workers/config/test_diffusion_config_on_cpu.py
@@ -180,6 +180,11 @@ class TestDiffusionRolloutConfig:
         assert cfg.pipeline.max_sequence_length == 256
         assert cfg.max_prompt_embed_length == 333
 
+    @pytest.mark.parametrize("value", [0, -1])
+    def test_prompt_embed_length_must_be_positive(self, value):
+        with pytest.raises(ValueError, match="max_prompt_embed_length must be positive"):
+            DiffusionRolloutConfig(name="vllm_omni", max_prompt_embed_length=value)
+
     def test_invalid_rollout_adapter_raises(self):
         with pytest.raises(ValueError, match="Invalid diffusion rollout rollout_adapter"):
             DiffusionRolloutConfig(name="vllm_omni", rollout_adapter="bogus")

--- a/tests/workers/config/test_diffusion_config_on_cpu.py
+++ b/tests/workers/config/test_diffusion_config_on_cpu.py
@@ -22,6 +22,7 @@ from verl_omni.workers.config.diffusion.actor import (
 )
 from verl_omni.workers.config.diffusion.model import DiffusionModelConfig
 from verl_omni.workers.config.diffusion.rollout import (
+    DiffusionPipelineConfig,
     DiffusionRolloutAlgoConfig,
     DiffusionRolloutConfig,
     DiffusionSamplingConfig,
@@ -168,6 +169,17 @@ class TestDiffusionSamplingConfig:
 
 
 class TestDiffusionRolloutConfig:
+    def test_prompt_embed_length_is_independent_from_encoder_length(self):
+        pipeline = DiffusionPipelineConfig(max_sequence_length=256)
+        cfg = DiffusionRolloutConfig(
+            name="vllm_omni",
+            pipeline=pipeline,
+            max_prompt_embed_length=333,
+        )
+
+        assert cfg.pipeline.max_sequence_length == 256
+        assert cfg.max_prompt_embed_length == 333
+
     def test_invalid_rollout_adapter_raises(self):
         with pytest.raises(ValueError, match="Invalid diffusion rollout rollout_adapter"):
             DiffusionRolloutConfig(name="vllm_omni", rollout_adapter="bogus")

--- a/verl_omni/agent_loop/diffusion_agent_loop.py
+++ b/verl_omni/agent_loop/diffusion_agent_loop.py
@@ -46,6 +46,26 @@ def _config_to_sampling_dict(config: Optional[BaseConfig]) -> dict:
     return {k: v for k, v in config.items() if not k.startswith("_")}
 
 
+def _pad_prompt_extra_field(key: str, value: torch.Tensor, target_length: int) -> torch.Tensor:
+    if key in {"prompt_embeds", "negative_prompt_embeds"}:
+        current_length = int(value.shape[0])
+        if current_length > target_length:
+            raise ValueError(
+                f"{key} sequence length {current_length} exceeds max_prompt_embed_length={target_length}. "
+                "Configure max_prompt_embed_length for the final embedding sequence, not only one text encoder."
+            )
+        return F.pad(value, (0, 0, 0, target_length - current_length), value=0)
+    if key in {"prompt_embeds_mask", "negative_prompt_embeds_mask"}:
+        current_length = int(value.shape[0])
+        if current_length > target_length:
+            raise ValueError(
+                f"{key} sequence length {current_length} exceeds max_prompt_embed_length={target_length}. "
+                "Configure max_prompt_embed_length for the final embedding sequence, not only one text encoder."
+            )
+        return F.pad(value, (0, target_length - current_length), value=0)
+    return value
+
+
 class DiffusionAgentLoopOutput(BaseModel):
     """Agent loop output."""
 
@@ -118,7 +138,11 @@ class DiffusionAgentLoopWorker:
         self.tokenizer = self.model_config.tokenizer
         self.processor = self.model_config.processor
 
-        self.max_prompt_embed_length = self.rollout_config.pipeline.max_sequence_length
+        self.max_prompt_embed_length = (
+            self.rollout_config.max_prompt_embed_length or self.rollout_config.pipeline.max_sequence_length
+        )
+        if self.max_prompt_embed_length <= 0:
+            raise ValueError(f"max_prompt_embed_length must be positive, got {self.max_prompt_embed_length}.")
 
         agent_loop_config_path = self.rollout_config.agent.agent_loop_config_path
         if agent_loop_config_path:
@@ -228,12 +252,7 @@ class DiffusionAgentLoopWorker:
         extra_fields = {}
         for k, v in output.extra_fields.items():
             if isinstance(v, torch.Tensor):
-                if k in ["prompt_embeds", "negative_prompt_embeds"]:
-                    pad_tuple = (0, 0, 0, self.max_prompt_embed_length - v.shape[0])
-                    v = F.pad(v, pad_tuple, value=0)
-                elif k in ["prompt_embeds_mask", "negative_prompt_embeds_mask"]:
-                    pad_tuple = (0, self.max_prompt_embed_length - v.shape[0])
-                    v = F.pad(v, pad_tuple, value=0)
+                v = _pad_prompt_extra_field(k, v, self.max_prompt_embed_length)
                 extra_fields[k] = v.unsqueeze(0)
             else:
                 extra_fields[k] = v

--- a/verl_omni/agent_loop/diffusion_agent_loop.py
+++ b/verl_omni/agent_loop/diffusion_agent_loop.py
@@ -138,9 +138,9 @@ class DiffusionAgentLoopWorker:
         self.tokenizer = self.model_config.tokenizer
         self.processor = self.model_config.processor
 
-        self.max_prompt_embed_length = (
-            self.rollout_config.max_prompt_embed_length or self.rollout_config.pipeline.max_sequence_length
-        )
+        self.max_prompt_embed_length = self.rollout_config.max_prompt_embed_length
+        if self.max_prompt_embed_length is None:
+            self.max_prompt_embed_length = self.rollout_config.pipeline.max_sequence_length
         if self.max_prompt_embed_length <= 0:
             raise ValueError(f"max_prompt_embed_length must be positive, got {self.max_prompt_embed_length}.")
 

--- a/verl_omni/trainer/config/_generated_diffusion_trainer.yaml
+++ b/verl_omni/trainer/config/_generated_diffusion_trainer.yaml
@@ -181,6 +181,7 @@ actor_rollout_ref:
     nnodes: 0
     n_gpus_per_node: ${oc.select:trainer.n_gpus_per_node,8}
     prompt_length: ${oc.select:data.max_prompt_length,512}
+    max_prompt_embed_length: null
     dtype: bfloat16
     rollout_attn_backend: FLASH_ATTN_3_HUB
     gpu_memory_utilization: 0.5

--- a/verl_omni/trainer/config/_generated_diffusion_veomni_trainer.yaml
+++ b/verl_omni/trainer/config/_generated_diffusion_veomni_trainer.yaml
@@ -222,6 +222,7 @@ actor_rollout_ref:
     nnodes: 0
     n_gpus_per_node: ${oc.select:trainer.n_gpus_per_node,8}
     prompt_length: ${oc.select:data.max_prompt_length,512}
+    max_prompt_embed_length: null
     dtype: bfloat16
     rollout_attn_backend: FLASH_ATTN_3_HUB
     gpu_memory_utilization: 0.5

--- a/verl_omni/trainer/config/diffusion/rollout/diffusion_rollout.yaml
+++ b/verl_omni/trainer/config/diffusion/rollout/diffusion_rollout.yaml
@@ -26,6 +26,10 @@ n_gpus_per_node: ${oc.select:trainer.n_gpus_per_node,8}
 # same as data.max_prompt_length if it exists
 prompt_length: ${oc.select:data.max_prompt_length,512}
 
+# Final prompt-embedding sequence length after combining all text encoders.
+# null falls back to pipeline.max_sequence_length for single-encoder models.
+max_prompt_embed_length: null
+
 # for vllm-omni rollout
 # Rollout model parameters type. Align with actor model's FSDP/Megatron type.
 dtype: bfloat16

--- a/verl_omni/workers/config/diffusion/rollout.py
+++ b/verl_omni/workers/config/diffusion/rollout.py
@@ -177,6 +177,10 @@ class DiffusionRolloutConfig(BaseConfig):
 
     def __post_init__(self):
         """Validate the diffusion rollout config"""
+        if self.max_prompt_embed_length is not None and self.max_prompt_embed_length <= 0:
+            raise ValueError(
+                f"max_prompt_embed_length must be positive when set, got {self.max_prompt_embed_length}."
+            )
         if self.mode == "sync":
             raise ValueError(
                 "Rollout mode 'sync' has been removed. Please set "

--- a/verl_omni/workers/config/diffusion/rollout.py
+++ b/verl_omni/workers/config/diffusion/rollout.py
@@ -95,6 +95,10 @@ class DiffusionRolloutConfig(BaseConfig):
 
     prompt_length: int = 512
 
+    # Final prompt-embedding sequence length after combining all text encoders.
+    # Falls back to pipeline.max_sequence_length for single-encoder models.
+    max_prompt_embed_length: Optional[int] = None
+
     dtype: str = "bfloat16"
     gpu_memory_utilization: float = 0.5
     enforce_eager: bool = False

--- a/verl_omni/workers/config/diffusion/rollout.py
+++ b/verl_omni/workers/config/diffusion/rollout.py
@@ -178,9 +178,7 @@ class DiffusionRolloutConfig(BaseConfig):
     def __post_init__(self):
         """Validate the diffusion rollout config"""
         if self.max_prompt_embed_length is not None and self.max_prompt_embed_length <= 0:
-            raise ValueError(
-                f"max_prompt_embed_length must be positive when set, got {self.max_prompt_embed_length}."
-            )
+            raise ValueError(f"max_prompt_embed_length must be positive when set, got {self.max_prompt_embed_length}.")
         if self.mode == "sync":
             raise ValueError(
                 "Rollout mode 'sync' has been removed. Please set "


### PR DESCRIPTION
### What does this PR do?

This PR prevents diffusion agent-loop post-processing from silently truncating multi-encoder prompt embeddings.

SD3.5 combines 77 CLIP token positions with 256 T5 positions, producing a 333-token prompt embedding. The agent loop previously reused `pipeline.max_sequence_length=256` as the final embedding length. This resulted in negative padding (`256 - 333 = -77`), which PyTorch interpreted as cropping the final 77 T5 positions before actor training.

The rollout transformer and rollout log-prob computation used the full 333-token conditioning, while actor replay received only 256 tokens. This broke rollout/training log-prob consistency and reduced actor compute.

The change:

- adds an independent `max_prompt_embed_length` rollout setting
- keeps the per-encoder T5 `max_sequence_length` at 256
- rejects oversized embeddings instead of silently cropping them
- configures SD3.5 recipes with a final embedding length of 333
- adds config, agent-loop, and SD3 regression tests

### Checklist Before Starting

- [x] Searched for similar PRs: https://github.com/verl-project/verl-omni/pulls?q=is%3Apr+is%3Aopen+SD3+prompt+embedding+length
- [x] No open issue or pull request was found that fixes SD3 final prompt-embedding truncation.
- [x] Formatted the PR title as `[rollout, diffusion] fix: preserve final prompt embedding length`.

### Test

Focused CPU tests:

```bash
python -m pytest -q \
  tests/agent_loop/test_diffusion_agent_loop_correctness_on_cpu.py \
  tests/workers/config/test_diffusion_config_on_cpu.py \
  tests/pipelines/test_sd3_token_id_prompt_on_cpu.py
```

Result:

```text
42 passed
```

Config documentation test:

```bash
python -m pytest -q tests/special_sanity/test_config_docs.py
```

Result:

```text
1 passed
```

Full pre-commit suite:

```bash
pre-commit run --all-files \
  --show-diff-on-failure \
  --color=always
```

Result:

```text
ruff: passed
ruff format: passed
mypy: passed
generated config verification: passed
docs/license/device/DataProto/structure/naming checks: passed
compileall: passed
```

GPU smoke test:

- 1-step SD3.5 FlowGRPO completed successfully on 8×H20
- `max_prompt_embed_length = 333`
- `ratio_mean = 0.999999779`
- `ratio_std = 5.50e-6`
- `ppo_kl = 2.28e-7`
- `log_ppl_diff = 2.28e-7`
- `ppl_ratio = 1.000000238`

These metrics confirm that rollout and actor replay remain aligned after preserving the full prompt embedding.

### API and Usage Example

`max_sequence_length` remains the maximum sequence length for an individual text encoder. Models whose final prompt embedding combines multiple encoder sequences can configure the final length independently:

```yaml
actor_rollout_ref:
  rollout:
    pipeline:
      # T5 sequence length
      max_sequence_length: 256

    # Final SD3 sequence: 77 CLIP + 256 T5
    max_prompt_embed_length: 333
```

Equivalent Hydra overrides:

```bash
actor_rollout_ref.rollout.pipeline.max_sequence_length=256 \
actor_rollout_ref.rollout.max_prompt_embed_length=333
```

Single-encoder models remain backward compatible: when `max_prompt_embed_length` is `null`, the agent loop falls back to `pipeline.max_sequence_length`.

### Design & Code Changes

#### Separate encoder and final embedding lengths

Adds `max_prompt_embed_length: Optional[int] = None` to `DiffusionRolloutConfig`.

The agent loop resolves the final target length as:

```python
max_prompt_embed_length = rollout_config.max_prompt_embed_length
if max_prompt_embed_length is None:
    max_prompt_embed_length = rollout_config.pipeline.max_sequence_length
```

This preserves existing behavior for single-encoder models while allowing SD3.5 to represent its combined CLIP+T5 sequence correctly.

#### Fail closed instead of silently truncating

Prompt embeddings and masks are padded only when they are shorter than the configured target.

If an embedding is longer than `max_prompt_embed_length`, the agent loop now raises a descriptive `ValueError` instead of passing a negative padding value to `F.pad()`.

#### SD3.5 recipe updates

SD3.5 recipes now configure:

```text
max_sequence_length = 256
max_prompt_embed_length = 333
```

#### Regression coverage

The tests cover:

- padding prompt embeddings and masks to the configured target
- rejecting embedding and mask truncation
- independent encoder and final embedding lengths
- exact SD3 CLIP+T5 output-length parity
- generated config synchronization

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md).
- [x] Applied pre-commit checks: `pre-commit run --all-files --show-diff-on-failure --color=always`.
- [x] Updated rollout configuration documentation and SD3.5 example recipes.
- [x] Added CPU regression tests under existing CI-discovered test suites. No workflow change is required because these test files are already collected by the CPU CI jobs.
- [x] Ran an SD3.5 GPU smoke test and recorded rollout/training consistency metrics.

### AI Assistance

AI assistance was used to investigate the issue, draft the fix and tests, and prepare this PR description. I reviewed all changed lines and ran the reported tests.