### PR TITLE
[recipe, doc] feat: add Qwen3-Omni MMK12 NPU recipe

### DIFF
--- a/examples/gspo_trainer/README.md
+++ b/examples/gspo_trainer/README.md
@@ -195,11 +195,21 @@ bash examples/gspo_trainer/qwen3_omni/run_qwen3_omni_thinker_gspo_lora_mmk12_v1.
 
 For Ascend NPU training, use the NPU variant:
 
-```bash
+~~~bash
 TRAIN_FILE=$HOME/data/mmk12/train.parquet \
 VAL_FILE=$HOME/data/mmk12/test.parquet \
 bash examples/gspo_trainer/qwen3_omni/run_qwen3_omni_thinker_gspo_lora_mmk12_v1_npu.sh
-```
+~~~
+
+Override the model, dataset, or MMK12 reward scorer path without editing the script:
+
+~~~bash
+MODEL_PATH=/path/to/Qwen3-Omni-30B-A3B-Instruct \
+TRAIN_FILE=/path/to/train.parquet \
+VAL_FILE=/path/to/test.parquet \
+REWARD_FUNCTION_PATH=/path/to/custom_reward.py \
+bash examples/gspo_trainer/qwen3_omni/run_qwen3_omni_thinker_gspo_lora_mmk12_v1_npu.sh
+~~~
 
 Compared with the GPU script, the NPU variant includes two important Ascend
 settings:
@@ -209,7 +219,6 @@ settings:
   captured by the rollout engine. Capturing too many shapes can cause runtime
   errors, so keep this list sparse. The current script uses capture sizes
   `[1,2,4,16,64,128,512,1024,2048,3072,4096]`.
-
 The script registers the custom reward scorer internally (no yaml edits
 required). Override LR or other fields via "$@" extras:
 

--- a/examples/gspo_trainer/README.md
+++ b/examples/gspo_trainer/README.md
@@ -193,6 +193,23 @@ VAL_FILE=$HOME/data/mmk12/test.parquet \
 bash examples/gspo_trainer/qwen3_omni/run_qwen3_omni_thinker_gspo_lora_mmk12_v1.sh
 ```
 
+For Ascend NPU training, use the NPU variant:
+
+```bash
+TRAIN_FILE=$HOME/data/mmk12/train.parquet \
+VAL_FILE=$HOME/data/mmk12/test.parquet \
+bash examples/gspo_trainer/qwen3_omni/run_qwen3_omni_thinker_gspo_lora_mmk12_v1_npu.sh
+```
+
+Compared with the GPU script, the NPU variant includes two important Ascend
+settings:
+
+- `export VLLM_ASCEND_ENABLE_NZ=0` disables the NZ format in vLLM Ascend.
+- `actor_rollout_ref.rollout.cudagraph_capture_sizes` limits the graph shapes
+  captured by the rollout engine. Capturing too many shapes can cause runtime
+  errors, so keep this list sparse. The current script uses capture sizes
+  `[1,2,4,16,64,128,512,1024,2048,3072,4096]`.
+
 The script registers the custom reward scorer internally (no yaml edits
 required). Override LR or other fields via "$@" extras:
 

--- a/examples/gspo_trainer/qwen3_omni/run_qwen3_omni_thinker_gspo_lora_mmk12_v1_npu.sh
+++ b/examples/gspo_trainer/qwen3_omni/run_qwen3_omni_thinker_gspo_lora_mmk12_v1_npu.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Qwen3-Omni Thinker GSPO + LoRA training on MMK12 with omni V1 trainer.
+# Data preparation (run once):
+#   pip install math-verify
+#   python examples/gspo_trainer/data_process/mmk12.py \
+#       --local_dataset_path <path_to_raw_mmk12> \
+#       --local_save_dir ~/data/mmk12
+#
+# Runtime dependencies (all Ray worker nodes):
+#   pip install math-verify    # required by mmk12_reward.py
+#   pip install qwen-vl-utils  # required for multimodal data processing
+
+set -x
+
+export VLLM_ASCEND_ENABLE_NZ=0
+# Make verl_omni available to Ray workers
+export VERL_USE_EXTERNAL_MODULES=verl_omni
+
+MODEL_PATH=${MODEL_PATH:-"$HOME/models/Qwen/Qwen3-Omni-30B-A3B-Instruct"}
+TRAIN_FILE=${TRAIN_FILE:-"$HOME/data/mmk12/train.parquet"}
+VAL_FILE=${VAL_FILE:-"$HOME/data/mmk12/test.parquet"}
+REWARD_FUNCTION_PATH=${REWARD_FUNCTION_PATH:-"verl_omni/utils/reward_score/mmk12_reward.py"}
+
+python3 -m verl_omni.trainer.main_omni \
+    data.train_files="${TRAIN_FILE}" \
+    data.val_files="${VAL_FILE}" \
+    data.train_batch_size=128 \
+    data.max_prompt_length=4096 \
+    data.max_response_length=12288 \
+    data.truncation='error' \
+    data.filter_overlong_prompts=true \
+    actor_rollout_ref.model.path="${MODEL_PATH}" \
+    actor_rollout_ref.model.lora_rank=32 \
+    actor_rollout_ref.model.lora_alpha=64 \
+    actor_rollout_ref.model.lora_dtype=float32 \
+    actor_rollout_ref.model.lora.merge=True \
+    actor_rollout_ref.model.enable_gradient_checkpointing=True \
+    actor_rollout_ref.model.use_remove_padding=True \
+    actor_rollout_ref.model.exclude_modules=".*talker.*|.*code2wav.*|.*code_predictor.*|.*visual.*|.*audio_tower.*" \
+    actor_rollout_ref.model.target_modules="['q_proj','k_proj','v_proj','o_proj']" \
+    actor_rollout_ref.actor.freeze_vision_tower=true \
+    actor_rollout_ref.actor.strategy=fsdp2 \
+    actor_rollout_ref.actor.optim.lr=3e-6 \
+    actor_rollout_ref.actor.optim.weight_decay=0.01 \
+    actor_rollout_ref.actor.optim.clip_grad=1.0 \
+    actor_rollout_ref.actor.ppo_mini_batch_size=16 \
+    actor_rollout_ref.actor.use_dynamic_bsz=True \
+    actor_rollout_ref.actor.ppo_max_token_len_per_gpu=30720 \
+    actor_rollout_ref.actor.use_kl_loss=false \
+    actor_rollout_ref.actor.policy_loss.loss_mode=gspo \
+    actor_rollout_ref.actor.clip_ratio_low=3e-4 \
+    actor_rollout_ref.actor.clip_ratio_high=4e-4 \
+    actor_rollout_ref.actor.clip_ratio_c=10.0 \
+    actor_rollout_ref.actor.loss_agg_mode=seq-mean-token-mean \
+    actor_rollout_ref.actor.fsdp_config.model_dtype=bfloat16 \
+    actor_rollout_ref.actor.fsdp_config.param_offload=true \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=true \
+    actor_rollout_ref.rollout.n=16 \
+    actor_rollout_ref.rollout.cudagraph_capture_sizes="[1,2,4,16,64,128,512,1024,2048,3072,4096]" \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=2 \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.8 \
+    actor_rollout_ref.rollout.load_format=safetensors \
+    actor_rollout_ref.rollout.prompt_length=4160 \
+    actor_rollout_ref.rollout.log_prob_use_dynamic_bsz=True \
+    actor_rollout_ref.rollout.log_prob_max_token_len_per_gpu=30720 \
+    actor_rollout_ref.rollout.enable_prefix_caching=False \
+    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.output_mode="ar" \
+    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.pipeline_name="qwen3_omni_moe" \
+    actor_rollout_ref.rollout.val_kwargs.n=1 \
+    actor_rollout_ref.rollout.val_kwargs.temperature=1.0 \
+    actor_rollout_ref.rollout.val_kwargs.top_p=0.7 \
+    actor_rollout_ref.ref.log_prob_use_dynamic_bsz=True \
+    actor_rollout_ref.ref.log_prob_max_token_len_per_gpu=30720 \
+    actor_rollout_ref.ref.fsdp_config.param_offload=true \
+    actor_rollout_ref.ref.fsdp_config.model_dtype=bfloat16 \
+    algorithm.adv_estimator=grpo \
+    algorithm.use_kl_in_reward=False \
+    reward.reward_manager.source=register \
+    reward.reward_manager.name=naive \
+    reward.custom_reward_function.path="${REWARD_FUNCTION_PATH}" \
+    reward.custom_reward_function.name=compute_score \
+    trainer.val_before_train=false \
+    trainer.balance_batch=True \
+    trainer.critic_warmup=0 \
+    trainer.logger='["console","tensorboard"]' \
+    trainer.project_name=gspo \
+    trainer.experiment_name=qwen3_omni_thinker_lora_mmk12 \
+    trainer.n_gpus_per_node=16 \
+    trainer.nnodes=1 \
+    trainer.save_freq=50 \
+    trainer.test_freq=10 \
+    trainer.total_epochs=10 \
+    "$@"


### PR DESCRIPTION
### What does this PR do?

This PR adds a dedicated Ascend NPU launch script for Qwen3-Omni Thinker GSPO
LoRA training on MMK12 and documents how to use it.

The NPU recipe follows the existing MMK12 V1 configuration while adding the
runtime settings needed by the validated Ascend setup:

- Sets `VLLM_ASCEND_ENABLE_NZ=0` for the vLLM Ascend rollout.
- Uses a sparse `cudagraph_capture_sizes` list because capturing too many graph
  shapes can cause runtime errors.
- Makes the MMK12 reward function path configurable through
  `REWARD_FUNCTION_PATH`, while preserving the existing scorer as the default.
- Configures the recipe for 16 NPUs and TensorBoard logging.
- Documents the NPU launch command and the graph-capture consideration in the
  GSPO trainer README.

This is an example and documentation change. It does not modify trainer,
rollout, model, or reward-scoring implementation code.

### Checklist Before Starting

- [x] Search for similar PRs. No matching open PR was found for
  [MMK12 NPU](https://github.com/verl-project/verl-omni/pulls?q=is%3Apr+is%3Aopen+MMK12+NPU)
  or
  [Qwen3-Omni Ascend](https://github.com/verl-project/verl-omni/pulls?q=is%3Apr+is%3Aopen+Qwen3-Omni+Ascend).
- [x] Format the PR title as `[{modules}] {type}: {description}`. The proposed
  title passes `tests/special_sanity/check_pr_title.py`.

### Test

The following static checks passed:

```bash
bash -n examples/gspo_trainer/qwen3_omni/run_qwen3_omni_thinker_gspo_lora_mmk12_v1_npu.sh
git diff --check origin/main...HEAD
PR_TITLE='[recipe, doc] feat: add Qwen3-Omni MMK12 NPU recipe' \
  python3 tests/special_sanity/check_pr_title.py
```

A focused pre-commit run passed the documentation, docstring, license, device
API, DataProto, test-structure, naming, and compile-all hooks. The global
`autogen-trainer-cfg` hook could not complete because the current Python
environment does not provide `omegaconf`; no generated configuration is changed
by this PR.

End-to-end NPU training results will be added before requesting review.

#### NPU training results

<img width="4096" height="2486" alt="439618b6364b10274f468538fa039d3e" src="https://github.com/user-attachments/assets/09c7bbba-9d97-4e9e-b9d5-f7c98a1eb5a9" />


Experiment configuration: `<model / NPU count / batch size / training steps / rollout settings>`

Observation: `<summarize reward behavior, training stability, and other key metrics>`

### API and Usage Example

Launch the Ascend NPU recipe with the default MMK12 reward scorer:

```bash
TRAIN_FILE=$HOME/data/mmk12/train.parquet \
VAL_FILE=$HOME/data/mmk12/test.parquet \
bash examples/gspo_trainer/qwen3_omni/run_qwen3_omni_thinker_gspo_lora_mmk12_v1_npu.sh
```

The model, dataset, and reward scorer paths can be overridden without editing
the script:

```bash
MODEL_PATH=/path/to/Qwen3-Omni-30B-A3B-Instruct \
TRAIN_FILE=/path/to/train.parquet \
VAL_FILE=/path/to/test.parquet \
REWARD_FUNCTION_PATH=/path/to/custom_reward.py \
bash examples/gspo_trainer/qwen3_omni/run_qwen3_omni_thinker_gspo_lora_mmk12_v1_npu.sh
```

Additional Hydra overrides can still be appended to the command.

### Design & Code Changes

#### NPU recipe

- Adds
  `examples/gspo_trainer/qwen3_omni/run_qwen3_omni_thinker_gspo_lora_mmk12_v1_npu.sh`.
- Keeps the existing MMK12 preprocessing and `compute_score` reward contract.
- Adds Ascend rollout environment and graph-capture settings without changing
  the GPU recipe.

#### Documentation

- Adds the NPU launch command to `examples/gspo_trainer/README.md`.
- Explains why the capture-size list is intentionally sparse.
