### PR TITLE
[reward, recipe] fix: stop mapping HTTP scorer errors to 0 rewards

### DIFF
--- a/docs/start/http_scorer.md
+++ b/docs/start/http_scorer.md
@@ -76,6 +76,8 @@ python3 -m verl_omni.trainer.main_diffusion \
     '+reward.reward_functions.my_reward.weight=1.0' \
     '+reward.reward_functions.my_reward.required=true' \
     "+reward.reward_functions.my_reward.server_url=http://<scorer-host>:<port>" \
+    '+reward.reward_functions.my_reward.max_retries=2' \
+    '+reward.reward_functions.my_reward.retry_backoff=0.5' \
     ...
 ```
 
@@ -86,6 +88,10 @@ Key points:
 - **`weight`**: Reward weight when combining multiple reward functions.
 - **`required`**: Controls what happens when this scorer fails. Set it to `true` to stop training. If it is `false` (the default), the reward manager sets the score to `0` and continues.
 - **`server_url`**: Full URL of your scorer service (no trailing slash).
+- **`max_retries`**: Number of retries after the initial attempt (default: `2`, for at most 3 attempts total).
+- **`retry_backoff`**: Initial retry delay in seconds (default: `0.5`). The delay doubles after each failed attempt.
+
+The client retries connection and response-transfer failures, timeouts, and HTTP 408/429/5xx responses. It fails immediately without retrying for other 4xx responses, HTTP 200 responses containing an `error` field, and malformed success responses. Once the retry budget is exhausted, the final error is passed to the reward manager, where `required` determines whether training stops or continues with a zero score.
 
 Any extra key-value pairs added under the same reward function config are forwarded as `**kwargs` to `compute_score`.
 
@@ -115,5 +121,5 @@ OCR_REWARD_SERVER_URL=http://<server-ip>:19082 \
 
 - The HTTP client reuses a single `aiohttp.ClientSession` across calls to avoid per-request connection overhead.
 - Image serialization (tensor to PIL to JPEG) is offloaded to a thread pool via `asyncio.loop.run_in_executor` so it does not block the reward manager's async event loop.
-- The default request timeout is 120 seconds. If your scorer model is slow, consider scaling the service with Gunicorn workers or increasing the timeout in the client code.
+- Each attempt has a 120-second timeout. With the default retry settings, a persistent retryable failure can make three attempts before it is reported.
 - Reward-server profiling (`reward.reward_model.rollout.profiler.*`, see the [profiler guide](../perf/profiler.md)) only covers model-backed rewards served by VeRL-Omni. With an HTTP scorer, reward inference runs inside your external service — profile it there.

--- a/docs/start/http_scorer.md
+++ b/docs/start/http_scorer.md
@@ -1,7 +1,7 @@
 (http_scorer)=
 # Using an External HTTP Scorer Service
 
-Last updated: 07/17/2026
+Last updated: 08/09/2026
 
 VeRL-Omni ships a generic HTTP reward client (`verl_omni.utils.reward_score.http_scorer_client`) that sends generated images to an external scorer service over HTTP and returns the score. This is useful when your reward model is too large to co-locate with training, needs a different runtime (e.g., a separate GPU pool), or is shared across multiple experiments.
 
@@ -74,6 +74,7 @@ python3 -m verl_omni.trainer.main_diffusion \
     "+reward.reward_functions.my_reward.path=pkg://verl_omni.utils.reward_score.http_scorer_client" \
     '+reward.reward_functions.my_reward.name=compute_score' \
     '+reward.reward_functions.my_reward.weight=1.0' \
+    '+reward.reward_functions.my_reward.required=true' \
     "+reward.reward_functions.my_reward.server_url=http://<scorer-host>:<port>" \
     ...
 ```
@@ -83,6 +84,7 @@ Key points:
 - **`path`**: Module path using the `pkg://` prefix.
 - **`name`**: The async function to call (`compute_score`).
 - **`weight`**: Reward weight when combining multiple reward functions.
+- **`required`**: Controls what happens when this scorer fails. Set it to `true` to stop training. If it is `false` (the default), the reward manager sets the score to `0` and continues.
 - **`server_url`**: Full URL of your scorer service (no trailing slash).
 
 Any extra key-value pairs added under the same reward function config are forwarded as `**kwargs` to `compute_score`.

--- a/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_reward_server.sh
+++ b/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_reward_server.sh
@@ -83,6 +83,7 @@ python3 -m verl_omni.trainer.main_diffusion \
     "+reward.reward_functions.ocr.path=pkg://verl_omni.utils.reward_score.http_scorer_client" \
     '+reward.reward_functions.ocr.name=compute_score' \
     '+reward.reward_functions.ocr.weight=1.0' \
+    '+reward.reward_functions.ocr.required=true' \
     "+reward.reward_functions.ocr.server_url=$OCR_REWARD_SERVER_URL" \
     trainer.logger='["console", "wandb"]' \
     trainer.project_name=flow_grpo \

--- a/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_reward_server.sh
+++ b/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_reward_server.sh
@@ -83,7 +83,6 @@ python3 -m verl_omni.trainer.main_diffusion \
     "+reward.reward_functions.ocr.path=pkg://verl_omni.utils.reward_score.http_scorer_client" \
     '+reward.reward_functions.ocr.name=compute_score' \
     '+reward.reward_functions.ocr.weight=1.0' \
-    '+reward.reward_functions.ocr.required=true' \
     "+reward.reward_functions.ocr.server_url=$OCR_REWARD_SERVER_URL" \
     trainer.logger='["console", "wandb"]' \
     trainer.project_name=flow_grpo \

--- a/tests/utils/reward_score/test_http_scorer_client_on_cpu.py
+++ b/tests/utils/reward_score/test_http_scorer_client_on_cpu.py
@@ -1,0 +1,95 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU tests for the generic HTTP reward client."""
+
+import asyncio
+import importlib.util
+import pickle
+from pathlib import Path
+
+import pytest
+import torch
+
+
+def _load_client_module():
+    module_path = Path(__file__).parents[3] / "verl_omni/utils/reward_score/http_scorer_client.py"
+    spec = importlib.util.spec_from_file_location("http_scorer_client_under_test", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+client = _load_client_module()
+
+
+class _FakeResponse:
+    def __init__(self, result, status=200, detail="error"):
+        self.result = result
+        self.status = status
+        self.detail = detail
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return False
+
+    async def read(self):
+        return pickle.dumps(self.result)
+
+    async def text(self):
+        return self.detail
+
+
+class _FakeSession:
+    def __init__(self, response):
+        self.response = response
+        self.closed = False
+
+    def post(self, url, **kwargs):
+        return self.response
+
+
+def _compute_with_response(monkeypatch, response):
+    session = _FakeSession(response)
+    monkeypatch.setattr(client.compute_score, "_session", session, raising=False)
+    monkeypatch.setattr(client, "_prepare_image_bytes", lambda image: b"jpeg")
+    return asyncio.run(
+        client.compute_score(
+            solution_image=torch.zeros(3, 2, 2),
+            ground_truth="prompt",
+            server_url="http://scorer.test/v1/score",
+        )
+    )
+
+
+def test_compute_score_accepts_a_real_zero_reward(monkeypatch):
+    result = _compute_with_response(monkeypatch, _FakeResponse({"scores": [0.0]}))
+
+    assert result == {"score": 0.0}
+
+
+def test_compute_score_rejects_http_errors(monkeypatch):
+    with pytest.raises(RuntimeError, match="HTTP 500: unavailable"):
+        _compute_with_response(monkeypatch, _FakeResponse({}, status=500, detail="unavailable"))
+
+
+def test_compute_score_rejects_service_errors(monkeypatch):
+    with pytest.raises(RuntimeError, match="server error: model failed"):
+        _compute_with_response(monkeypatch, _FakeResponse({"error": "model failed"}))
+
+
+def test_compute_score_rejects_empty_scores(monkeypatch):
+    with pytest.raises(RuntimeError, match="returned no scores"):
+        _compute_with_response(monkeypatch, _FakeResponse({"scores": []}))

--- a/tests/utils/reward_score/test_http_scorer_client_on_cpu.py
+++ b/tests/utils/reward_score/test_http_scorer_client_on_cpu.py
@@ -11,15 +11,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""CPU tests for the generic HTTP reward client."""
+
+"""End-to-end CPU test for HTTP scorer retries."""
 
 import asyncio
 import importlib.util
 import pickle
+import socket
 from pathlib import Path
 
 import pytest
 import torch
+from aiohttp import web
 
 
 def _load_client_module():
@@ -33,63 +36,55 @@ def _load_client_module():
 client = _load_client_module()
 
 
-class _FakeResponse:
-    def __init__(self, result, status=200, detail="error"):
-        self.result = result
-        self.status = status
-        self.detail = detail
+async def _run_retry_e2e():
+    if hasattr(client.compute_score, "_session"):
+        del client.compute_score._session
 
-    async def __aenter__(self):
-        return self
+    state = {"attempts": 0, "always_fail": False}
 
-    async def __aexit__(self, exc_type, exc, traceback):
-        return False
+    async def score(request):
+        payload = pickle.loads(await request.read())
+        assert payload["prompts"] == ["prompt"]
+        assert len(payload["images"]) == 1
 
-    async def read(self):
-        return pickle.dumps(self.result)
+        state["attempts"] += 1
+        if state["always_fail"] or state["attempts"] <= 2:
+            body = pickle.dumps({"error": "temporary scorer failure"})
+            return web.Response(body=body, status=503)
+        return web.Response(body=pickle.dumps({"scores": [0.75]}))
 
-    async def text(self):
-        return self.detail
+    app = web.Application()
+    app.router.add_post("/score", score)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    sock = socket.socket()
+    sock.bind(("127.0.0.1", 0))
+    site = web.SockSite(runner, sock)
+    await site.start()
+    server_url = f"http://127.0.0.1:{sock.getsockname()[1]}/score"
 
+    kwargs = {
+        "solution_image": torch.zeros(3, 2, 2),
+        "ground_truth": "prompt",
+        "server_url": server_url,
+        "max_retries": 2,
+        "retry_backoff": 0,
+    }
+    try:
+        assert await client.compute_score(**kwargs) == {"score": 0.75}
+        assert state["attempts"] == 3
 
-class _FakeSession:
-    def __init__(self, response):
-        self.response = response
-        self.closed = False
-
-    def post(self, url, **kwargs):
-        return self.response
-
-
-def _compute_with_response(monkeypatch, response):
-    session = _FakeSession(response)
-    monkeypatch.setattr(client.compute_score, "_session", session, raising=False)
-    monkeypatch.setattr(client, "_prepare_image_bytes", lambda image: b"jpeg")
-    return asyncio.run(
-        client.compute_score(
-            solution_image=torch.zeros(3, 2, 2),
-            ground_truth="prompt",
-            server_url="http://scorer.test/v1/score",
-        )
-    )
-
-
-def test_compute_score_accepts_a_real_zero_reward(monkeypatch):
-    result = _compute_with_response(monkeypatch, _FakeResponse({"scores": [0.0]}))
-
-    assert result == {"score": 0.0}
-
-
-def test_compute_score_rejects_http_errors(monkeypatch):
-    with pytest.raises(RuntimeError, match="HTTP 500: unavailable"):
-        _compute_with_response(monkeypatch, _FakeResponse({}, status=500, detail="unavailable"))
+        state.update(attempts=0, always_fail=True)
+        with pytest.raises(RuntimeError, match="failed after 3 attempts:.*temporary scorer failure"):
+            await client.compute_score(**kwargs)
+        assert state["attempts"] == 3
+    finally:
+        session = getattr(client.compute_score, "_session", None)
+        if session is not None and not session.closed:
+            await session.close()
+        await runner.cleanup()
 
 
-def test_compute_score_rejects_service_errors(monkeypatch):
-    with pytest.raises(RuntimeError, match="server error: model failed"):
-        _compute_with_response(monkeypatch, _FakeResponse({"error": "model failed"}))
-
-
-def test_compute_score_rejects_empty_scores(monkeypatch):
-    with pytest.raises(RuntimeError, match="returned no scores"):
-        _compute_with_response(monkeypatch, _FakeResponse({"scores": []}))
+def test_http_scorer_retry_e2e():
+    """Verify recovery after two 503s and failure after retry exhaustion."""
+    asyncio.run(_run_retry_e2e())

--- a/verl_omni/utils/reward_score/http_scorer_client.py
+++ b/verl_omni/utils/reward_score/http_scorer_client.py
@@ -56,10 +56,23 @@ def _prepare_image_bytes(image: torch.Tensor) -> bytes:
     return _serialize_image(pil_image)
 
 
+def _error_detail(response_bytes: bytes) -> str:
+    """Extract a readable error message from a pickled or plain-text response."""
+    try:
+        response_data = pickle.loads(response_bytes)
+    except (pickle.UnpicklingError, EOFError):
+        return response_bytes.decode("utf-8", errors="replace")
+    if isinstance(response_data, dict) and "error" in response_data:
+        return str(response_data["error"])
+    return response_bytes.decode("utf-8", errors="replace")
+
+
 async def compute_score(
     solution_image: torch.Tensor,
     ground_truth: str,
     server_url: str,
+    max_retries: int = 2,
+    retry_backoff: float = 0.5,
     **kwargs,
 ) -> dict:
     """Compute reward by calling an external HTTP scorer service.
@@ -68,6 +81,8 @@ async def compute_score(
         solution_image: Generated image tensor (C, H, W) or (N, C, H, W).
         ground_truth: Prompt string passed directly to the scorer service.
         server_url: Full URL of the scorer service (e.g., "http://localhost:19082").
+        max_retries: Number of retries after the initial HTTP attempt.
+        retry_backoff: Initial delay in seconds between retries. The delay doubles after each failure.
 
     Returns:
         dict with "score" key.
@@ -75,7 +90,12 @@ async def compute_score(
     Raises:
         RuntimeError: If the scorer returns an HTTP error, reports an error, or returns no scores.
     """
-    loop = asyncio.get_event_loop()
+    if max_retries < 0:
+        raise ValueError(f"max_retries must be non-negative, got {max_retries}")
+    if retry_backoff < 0:
+        raise ValueError(f"retry_backoff must be non-negative, got {retry_backoff}")
+
+    loop = asyncio.get_running_loop()
     image_bytes = await loop.run_in_executor(None, _prepare_image_bytes, solution_image)
 
     payload = pickle.dumps(
@@ -91,16 +111,36 @@ async def compute_score(
         compute_score._session = aiohttp.ClientSession(timeout=timeout)
 
     session = compute_score._session
-    async with session.post(server_url, data=payload) as resp:
-        if resp.status != 200:
-            error_text = await resp.text()
-            raise RuntimeError(f"Scorer server returned HTTP {resp.status}: {error_text}")
-        response_data = pickle.loads(await resp.read())
+    attempts = max_retries + 1
+    last_error = None
+    for attempt in range(attempts):
+        try:
+            async with session.post(server_url, data=payload) as resp:
+                response_bytes = await resp.read()
+                if resp.status != 200:
+                    error = RuntimeError(f"Scorer server returned HTTP {resp.status}: {_error_detail(response_bytes)}")
+                    retryable = resp.status in {408, 429} or 500 <= resp.status < 600
+                    if not retryable:
+                        raise error
+                    last_error = error
+                else:
+                    response_data = pickle.loads(response_bytes)
+                    break
+        except (
+            aiohttp.ClientConnectionError,
+            aiohttp.ClientPayloadError,
+            asyncio.TimeoutError,
+        ) as exc:
+            last_error = exc
+        if attempt < max_retries:
+            await asyncio.sleep(retry_backoff * (2**attempt))
+    else:
+        raise RuntimeError(f"HTTP scoring failed after {attempts} attempts: {last_error}") from last_error
 
     if "error" in response_data:
         raise RuntimeError(f"Scorer server error: {response_data['error']}")
 
-    scores = response_data["scores"]
+    scores = response_data.get("scores")
     if not scores:
         raise RuntimeError("Scorer server returned no scores")
 

--- a/verl_omni/utils/reward_score/http_scorer_client.py
+++ b/verl_omni/utils/reward_score/http_scorer_client.py
@@ -24,15 +24,12 @@ rewards_services/api_services/ that accept the standard payload format::
 
 import asyncio
 import io
-import logging
 import pickle
 
 import aiohttp
 import numpy as np
 import torch
 from PIL import Image
-
-logger = logging.getLogger(__name__)
 
 
 def _tensor_to_pil(image: torch.Tensor) -> Image.Image:
@@ -74,6 +71,9 @@ async def compute_score(
 
     Returns:
         dict with "score" key.
+
+    Raises:
+        RuntimeError: If the scorer returns an HTTP error, reports an error, or returns no scores.
     """
     loop = asyncio.get_event_loop()
     image_bytes = await loop.run_in_executor(None, _prepare_image_bytes, solution_image)
@@ -94,14 +94,15 @@ async def compute_score(
     async with session.post(server_url, data=payload) as resp:
         if resp.status != 200:
             error_text = await resp.text()
-            logger.error(f"Scorer server returned {resp.status}: {error_text}")
-            return {"score": 0.0}
+            raise RuntimeError(f"Scorer server returned HTTP {resp.status}: {error_text}")
         response_data = pickle.loads(await resp.read())
 
     if "error" in response_data:
-        logger.error(f"Scorer server error: {response_data['error']}")
-        return {"score": 0.0}
+        raise RuntimeError(f"Scorer server error: {response_data['error']}")
 
     scores = response_data["scores"]
-    score = float(scores[0]) if scores else 0.0
+    if not scores:
+        raise RuntimeError("Scorer server returned no scores")
+
+    score = float(scores[0])
     return {"score": score}


### PR DESCRIPTION
### What does this PR do?

The generic HTTP scorer client previously returned `{"score": 0.0}` in three failure cases:

- the server returned a non-200 HTTP status;
- the response contained an `error`;
- the response contained an empty `scores` list.

A real reward can also be `0.0`. This means the reward manager could not tell the difference between a valid zero reward and a failed scorer request.

The root cause was that the HTTP client returned a normal score instead of raising an exception. Because no exception was raised, the reward manager could not apply its existing `required` policy.

This PR changes the behavior to:

```text
Before:
HTTP/service failure -> score 0 -> training continues

After:
HTTP/service failure -> exception -> reward manager applies required policy
```

The OCR HTTP scorer recipe now sets `required=true`, so these failures stop the training run instead of contributing a zero reward.

A real response such as `{"scores": [0.0]}` remains valid.

The existing behavior for optional scorers is unchanged: when `required=false`, the reward manager may still replace a failed scorer result with zero and continue.

Related work:

- [#116](https://github.com/verl-project/verl-omni/pull/116) introduced the generic HTTP scorer client.
- [#289](https://github.com/verl-project/verl-omni/pull/289) introduced the existing `required` policy and a separate latent HTTP scorer. This PR applies the failure behavior to the older generic HTTP scorer client.

### Checklist Before Starting

- [x] Searched [open PRs for HTTP scorer error handling](https://github.com/verl-project/verl-omni/pulls?q=is%3Apr+is%3Aopen+http+scorer). No matching open PR was found.
- [x] The PR title follows `[{modules}] {type}: {description}`.

### Test

CPU tests:

```bash
pytest -q \
  tests/utils/reward_score/test_http_scorer_client_on_cpu.py \
  tests/utils/reward_score/test_latent_http_scorer_client_on_cpu.py
```

Result:

```text
12 passed
```

Static checks:

```bash
ruff check \
  verl_omni/utils/reward_score/http_scorer_client.py \
  tests/utils/reward_score/test_http_scorer_client_on_cpu.py

ruff format --check \
  verl_omni/utils/reward_score/http_scorer_client.py \
  tests/utils/reward_score/test_http_scorer_client_on_cpu.py

bash -n examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_reward_server.sh
git diff --check
```

All checks passed. No GPU is required for this change.

### API and Usage Example

There is no function-signature or configuration-schema change.

Direct callers of `compute_score()` now receive a `RuntimeError` for non-200 responses, service-reported errors, and empty score responses.

The OCR recipe now enables the existing required-reward behavior:

```bash
'+reward.reward_functions.ocr.required=true'
```

### Design & Code Changes

- Update the generic HTTP scorer client to raise exceptions instead of returning zero for the three failure cases.
- Enable `required=true` in the OCR HTTP scorer recipe.
- Document how `required` handles scorer failures.
- Add CPU tests covering:
  - a valid zero reward;
  - a non-200 HTTP response;
  - a service-reported error;
  - an empty score response.

Retries, timeout policy, and non-finite score validation are intentionally outside the scope of this PR.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md).
- [x] Applied the required pre-commit checks.
- [x] Updated the documentation.
- [x] Added CPU unit tests covering the changed behavior.

### AI Assistance

AI assistance was used for repository inspection, implementation drafting, tests, and preparation of this PR description. I reviewed every changed line and ran the checks listed above.