### PR TITLE
[recipe, doc] chore: update Qwen3-Omni offline DPO recipe and performance report

### DIFF
--- a/examples/dpo_trainer/README.md
+++ b/examples/dpo_trainer/README.md
@@ -1,6 +1,6 @@
 # DPO Training
 
-Last updated: 06/30/2026
+Last updated: 08/14/2026
 
 This directory contains examples for **direct-preference** training (DPO and
 related losses). Three workflows are supported:
@@ -126,11 +126,12 @@ Common overrides:
 
 ```bash
 CUDA_VISIBLE_DEVICES=0,1,2,3 \
-TOTAL_TRAINING_STEPS=100 \
+TOTAL_TRAINING_STEPS=200 \
 TRAIN_BATCH_SIZE=32 \
 VAL_BATCH_SIZE=32 \
 bash examples/dpo_trainer/qwen3_omni/qwen3_omni/run_qwen3_omni_omni_preference_lora.sh
 ```
+
 
 Key settings:
 
@@ -144,8 +145,9 @@ Key settings:
   modalities, `96` means `32` per modality.
 - `ModalityGroupedBatchSampler`: keeps batches single-modality, which is required
   by the offline MLLM DPO collator.
-- `actor_rollout_ref.model.lora_rank`, `lora_alpha`, `target_modules`: LoRA
-  configuration for the trainable thinker modules.
+- `actor_rollout_ref.model.lora_rank`, `lora_alpha`, `target_modules`,
+  `target_parameters`: LoRA on thinker attention (`q/k/v/o_proj`) and MoE
+  (`gate_up_proj`, `down_proj`) modules. Rank defaults to 32, alpha to 64.
 - `actor_rollout_ref.model.exclude_modules`: freezes talker, code2wav, visual,
   and audio tower modules in the example.
 - `actor_rollout_ref.actor.omni_loss.*`: DPO loss options such as `beta`,
@@ -158,9 +160,9 @@ Key settings:
 > Measured on 4× NVIDIA H800 GPUs. Offline DPO reads preference pairs directly,
 > so no reward model is used during training.
 
-| Script | Model | Algorithm | # Cards | Reward Model | Training Samples per Step | `ppo_micro_batch_size_per_gpu` | Throughput (Samples / Card / Seconds) | Time per Step (Seconds) |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| `examples/dpo_trainer/qwen3_omni/qwen3_omni/run_qwen3_omni_omni_preference_lora.sh` | Qwen3-Omni-30B-A3B-Instruct | Offline DPO + LoRA | 4 | None | 32×2=64 | 2 | 0.1533 | 106.95 |
+| Script | Model | Algorithm | # Cards | Reward Model | Training Samples per Step | `ppo_micro_batch_size_per_gpu` | Throughput (Samples / Card / Seconds) | Time per Step (Seconds) | Val Accuracy | Val Reward Margin | W&B Report |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `examples/dpo_trainer/qwen3_omni/qwen3_omni/run_qwen3_omni_omni_preference_lora.sh` | Qwen3-Omni-30B-A3B-Instruct | Offline DPO + LoRA | 4 | None | 32×2=64 | 2 | 1.35 | 14.07 | 0.90742 | 0.843 | [W&B report](https://api.wandb.ai/links/didan/iumxl2zr) |
 
 ### Validation
 
@@ -218,7 +220,7 @@ MODEL_PATH=/path/to/Qwen3-Omni-30B-A3B-Instruct/
 OUT_DIR=outputs/qwen3_omni_judge_eval
 MAX_SAMPLES=60
 CUDA_DEVICES=1
-STEPS=(25 50 75 100)
+STEPS=(50 100 150 200)
 MODALITIES=(image video audio)
 
 mkdir -p "${OUT_DIR}"

--- a/examples/dpo_trainer/qwen3_omni/eval_vlm_as_judge.sh
+++ b/examples/dpo_trainer/qwen3_omni/eval_vlm_as_judge.sh
@@ -5,7 +5,7 @@ OUT_DIR=${OUT_DIR:-outputs/qwen3_omni_judge_eval}
 MAX_SAMPLES=60
 
 CUDA_DEVICES=${CUDA_DEVICES:-0}
-STEPS=(25 50 75 100)
+STEPS=(50 100 150 200)
 MODALITIES=(image video audio)
 
 mkdir -p "${OUT_DIR}"

--- a/examples/dpo_trainer/qwen3_omni/qwen3_omni/run_qwen3_omni_omni_preference_lora.sh
+++ b/examples/dpo_trainer/qwen3_omni/qwen3_omni/run_qwen3_omni_omni_preference_lora.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Qwen3-Omni offline DPO + LoRA training on Omni-Preference.
 #
-# Defaults are set for a short real-data run (~100 optimizer steps). Override
+# Defaults are set for a short real-data run (~200 optimizer steps). Override
 # paths and batch sizes with environment variables, or append Hydra overrides.
 set -xeuo pipefail
 
@@ -22,7 +22,7 @@ export PYTHONPATH="${REPO_ROOT}${PYTHONPATH:+:${PYTHONPATH}}"
 
 MODEL_PATH=${MODEL_PATH:-Qwen/Qwen3-Omni-30B-A3B-Instruct}
 DATA_DIR=${DATA_DIR:-data/omni-preference/parquet_dpo}
-TOTAL_TRAINING_STEPS=${TOTAL_TRAINING_STEPS:-100}
+TOTAL_TRAINING_STEPS=${TOTAL_TRAINING_STEPS:-200}
 NUM_GPUS=${NUM_GPUS:-4}
 
 TRAIN_BATCH_SIZE=${TRAIN_BATCH_SIZE:-32}
@@ -37,8 +37,8 @@ LORA_TARGET_MODULES=${LORA_TARGET_MODULES:-'["q_proj","k_proj","v_proj","o_proj"
 LORA_TARGET_PARAMS=${LORA_TARGET_PARAMS:-'["gate_up_proj","down_proj"]'}
 ATTN_IMPLEMENTATION=${ATTN_IMPLEMENTATION:-sdpa}
 LR=${LR:-1.0e-6}
-SAVE_FREQ=${SAVE_FREQ:-25}
-TEST_FREQ=${TEST_FREQ:-25}
+SAVE_FREQ=${SAVE_FREQ:-50}
+TEST_FREQ=${TEST_FREQ:-50}
 VAL_MAX_SAMPLES=${VAL_MAX_SAMPLES:-96}
 
 IMAGE_RATIO=${IMAGE_RATIO:-1.0}


### PR DESCRIPTION
### What does this PR do?

Refresh the Qwen3-Omni offline DPO LoRA recipe so the example script, judge eval steps, and `examples/dpo_trainer/README.md` match a 200-step run, and record measured H800 performance plus a W&B report.

This is a follow-up to the original Qwen3-Omni multimodal DPO recipe in #269. It only updates example defaults and docs; it does not change trainer code.


### Test

Validated with a real Omni-Preference offline DPO LoRA run on **4× NVIDIA H800**, using `examples/dpo_trainer/qwen3_omni/qwen3_omni/run_qwen3_omni_omni_preference_lora.sh`.

| Metric | Value |
| --- | --- |
| Time per step | 14.07 s |
| Throughput | 1.35 samples / card / s |
| Validation accuracy | 0.90742 |
| Validation reward margin | 0.843 |

W&B report: https://api.wandb.ai/links/didan/iumxl2zr

No GPU CI coverage for this recipe change. Docs/script defaults were checked against the launcher (`TOTAL_TRAINING_STEPS=200`, `SAVE_FREQ=50`, `TEST_FREQ=50`) and the judge eval checkpoint list (`STEPS=(50 100 150 200)`).

### API and Usage Example

No API change. Usage is unchanged except for the new defaults:

```bash
DATA_DIR=/path/to/Omni-Preference/parquet_dpo \
MODEL_PATH=/path/to/Qwen3-Omni-30B-A3B-Instruct \
bash examples/dpo_trainer/qwen3_omni/qwen3_omni/run_qwen3_omni_omni_preference_lora.sh