### PR TITLE
[vllm_omni, rollout, diffusion, tests] fix: restore CuMem tags after sleep

### DIFF
--- a/tests/workers/rollout/rollout_vllm/test_vllm_omni_generate.py
+++ b/tests/workers/rollout/rollout_vllm/test_vllm_omni_generate.py
@@ -174,7 +174,7 @@ def _assert_training_step_execution_contract(
     assert output.extra_fields["prompt_embeds"].shape[:-1] == output.extra_fields["prompt_embeds_mask"].shape
 
 
-def _build_rollout_cfg(*, step_execution: bool = False) -> Any:
+def _build_rollout_cfg(*, step_execution: bool = False, enable_sleep_mode: bool = False) -> Any:
     from tests.utils.smoke_attention import resolve_smoke_attention_backends
 
     _, rollout_attn_backend = resolve_smoke_attention_backends()
@@ -196,7 +196,7 @@ def _build_rollout_cfg(*, step_execution: bool = False) -> Any:
         "enforce_eager": True,
         "enable_chunked_prefill": False,
         "enable_prefix_caching": False,
-        "enable_sleep_mode": False,
+        "enable_sleep_mode": enable_sleep_mode,
         "free_cache_engine": True,
         "disable_log_stats": True,
         "n": 1,
@@ -235,7 +235,13 @@ def _build_model_cfg(*, attn_backend: str | None = None, algorithm: str = "flow_
     )
 
 
-def _launch_server(*, step_execution: bool = False, algorithm: str = "flow_grpo"):
+def _launch_server(
+    *,
+    step_execution: bool = False,
+    algorithm: str = "flow_grpo",
+    enable_sleep_mode: bool = False,
+    rollout_mode: RolloutMode = RolloutMode.STANDALONE,
+):
     ray.init(
         runtime_env={
             "env_vars": {
@@ -257,9 +263,9 @@ def _launch_server(*, step_execution: bool = False, algorithm: str = "flow_grpo"
         },
         max_concurrency=16,
     ).remote(
-        config=_build_rollout_cfg(step_execution=step_execution),
+        config=_build_rollout_cfg(step_execution=step_execution, enable_sleep_mode=enable_sleep_mode),
         model_config=_build_model_cfg(algorithm=algorithm),
-        rollout_mode=RolloutMode.STANDALONE,
+        rollout_mode=rollout_mode,
         workers=[],
         replica_rank=0,
         node_rank=0,
@@ -290,6 +296,18 @@ def init_server():
 def init_step_execution_server():
     """Function-scoped step-execution server (cannot share with request-level)."""
     server = _launch_server(step_execution=True)
+    yield server
+    _shutdown_server()
+
+
+@pytest.fixture
+def init_sleep_server():
+    """Function-scoped server with CuMem sleep mode enabled."""
+    server = _launch_server(
+        step_execution=False,
+        enable_sleep_mode=True,
+        rollout_mode=RolloutMode.HYBRID,
+    )
     yield server
     _shutdown_server()
 
@@ -371,6 +389,22 @@ def test_generate_request_level_batch(init_server):
         _assert_valid_diffusion_output(output, index=i, expect_logprobs=True)
 
     print(f"All {len(_PROMPTS)} request-level-batched generates returned valid DiffusionOutput")
+
+
+def test_generate_after_repeated_sleep_wakeup(init_sleep_server):
+    """A level-1 sleep/wake must restore every allocation needed by the next forward."""
+    prompt = _PROMPTS[0]
+
+    for cycle in range(3):
+        output = _generate_concurrent(
+            init_sleep_server,
+            [prompt],
+            logprobs_first_only=False,
+        )[0]
+        _assert_valid_diffusion_output(output, index=cycle, expect_logprobs=True)
+
+        ray.get(init_sleep_server.sleep.remote(), timeout=600)
+        ray.get(init_sleep_server.wake_up.remote(), timeout=600)
 
 
 def test_flow_grpo_step_execution_contract(init_step_execution_server):

--- a/tests/workers/rollout/rollout_vllm/test_vllm_omni_wake_up_on_cpu.py
+++ b/tests/workers/rollout/rollout_vllm/test_vllm_omni_wake_up_on_cpu.py
@@ -1,0 +1,53 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from verl_omni.workers.rollout.vllm_rollout.vllm_omni_async_server import vLLMOmniHttpServer
+
+
+@pytest.mark.asyncio
+async def test_wake_up_restores_every_sleep_tag():
+    server = object.__new__(vLLMOmniHttpServer)
+    server.node_rank = 0
+    server.engine = Mock()
+    server.engine.collective_rpc = AsyncMock()
+    server._invalidate_lora_request_cache = Mock()
+
+    await server.wake_up()
+
+    server.engine.collective_rpc.assert_awaited_once_with(
+        "wake_up",
+        kwargs={"tags": ["kv_cache", "weights"]},
+    )
+    server._invalidate_lora_request_cache.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_wake_up_preserves_explicit_tags():
+    server = object.__new__(vLLMOmniHttpServer)
+    server.node_rank = 0
+    server.engine = Mock()
+    server.engine.collective_rpc = AsyncMock()
+    server._invalidate_lora_request_cache = Mock()
+
+    await server.wake_up(tags=["weights"])
+
+    server.engine.collective_rpc.assert_awaited_once_with(
+        "wake_up",
+        kwargs={"tags": ["weights"]},
+    )
+

--- a/verl_omni/workers/rollout/vllm_rollout/vllm_omni_async_server.py
+++ b/verl_omni/workers/rollout/vllm_rollout/vllm_omni_async_server.py
@@ -302,11 +302,12 @@ class vLLMOmniHttpServer(vLLMHttpServer):
         raise NotImplementedError("vLLM-Omni headless mode is not implemented yet.")
 
     # -----------------------------------------------------------------------
-    # wake_up hook: Omni does not restore KV cache on wake-up
+    # wake_up hook: restore every tag released by level-1 sleep
     # -----------------------------------------------------------------------
 
     def _get_wake_up_tags(self) -> list[str]:
-        return ["weights"]
+        """Return all CuMem tags that vLLM-Omni marks asleep."""
+        return ["kv_cache", "weights"]
 
     async def wake_up(self, tags: list[str] | None = None):
         """Override parent to use collective_rpc instead of engine.wake_up().


### PR DESCRIPTION
### What does this PR do?

This draft fixes a reproducible CUDA illegal-memory-access failure after a level-1 vLLM-Omni sleep/wake cycle.

The current `vLLMOmniHttpServer._get_wake_up_tags()` returns only `["weights"]`, while level-1 sleep tracks both `kv_cache` and `weights`. The change restores both tags by default, preserves explicitly supplied tag lists, and adds CPU plus three-cycle GPU lifecycle regression coverage.

Related work:

- #377 identifies this wake-tag divergence as an unresolved item in a broader server refactor. This PR is the narrow bug fix and regression coverage for that item.
- vllm-project/vllm#44395 reports the same class of partial-wake illegal-memory-access failure.
- The duplicate search found no focused open PR implementing this fix.

### Checklist Before Starting

- [x] Searched similar work: https://github.com/verl-project/verl-omni/pulls?q=is%3Apr+is%3Aopen+sleep+wake+CuMemAllocator
- [x] Title follows `[{modules}] {type}: {description}`.

### Test

Passed locally:

```text
uv run --isolated --no-project --with ruff ruff check <three changed files>
All checks passed!

PR_TITLE='[vllm_omni, rollout, diffusion, tests] fix: restore CuMem tags after sleep'   python3 tests/special_sanity/check_pr_title.py
PR title is valid

git diff --check
```

Reproduction evidence from the unfixed MiniMax-H3 PR #383 environment on 2 x H200 NVL:

- `free_cache_engine=false`: one-step train plus final validation passed and exited cleanly.
- `free_cache_engine=true`: training rollout passed, then final validation failed after wake with CUDA illegal memory access.
- The failing run used less peak and failure-time VRAM than the passing run, with no OOM, ECC, driver Xid, or competing GPU process.

Still pending before marking ready for review:

- [ ] Run the CPU pytest in a clean main-branch dependency environment. The available PR #383 environment could not collect current main because its installed vLLM-Omni lacks `pipeline_ltx2_3`.
- [ ] Run the new three-cycle generate -> sleep -> wake -> generate GPU regression on the fix.
- [ ] Run the full changed-file pre-commit suite.

### API and Usage Example

No public API or configuration change. Existing jobs with `actor_rollout_ref.rollout.free_cache_engine=true` keep the same interface.

### Design & Code Changes

- Restore `["kv_cache", "weights"]` when `wake_up()` receives no explicit tags.
- Preserve caller-supplied partial tags.
- Add a CPU unit test for the `collective_rpc("wake_up", ...)` payload.
- Add a repeated sleep/wake/generate GPU lifecycle test.

### Checklist Before Submitting

- [ ] Human submitter has reviewed every changed line and can explain the change.
- [ ] Read the contribution guide.
- [ ] Run full pre-commit checks.
- [x] Added unit and end-to-end regression coverage.
- [x] No documentation update is needed because there is no user-facing API/config change.

AI assistance was used to isolate the failure, implement the patch, add tests, and draft this description. The human submitter will review the changes and rerun the pending tests before moving this PR out of draft.
