### PR TITLE
[trainer] fix: Optimize host/device memory usage with aggressive_empty_cache (avoiding OOM)

### DIFF
--- a/examples/dancegrpo_trainer/wan22/run_wan22_5b_t2v_hpsv3_auto.sh
+++ b/examples/dancegrpo_trainer/wan22/run_wan22_5b_t2v_hpsv3_auto.sh
@@ -11,6 +11,7 @@
 #
 set -x
 
+export MIMALLOC_PURGE_DELAY=0
 if npu-smi info &>/dev/null; then
     DEVICE="npu"
 elif nvidia-smi &>/dev/null; then

--- a/examples/dancegrpo_trainer/wan22/run_wan22_5b_t2v_hpsv3_auto.sh
+++ b/examples/dancegrpo_trainer/wan22/run_wan22_5b_t2v_hpsv3_auto.sh
@@ -115,3 +115,4 @@ python3 -m verl_omni.trainer.main_diffusion \
     trainer.test_freq=30 \
     trainer.total_epochs=15 \
     trainer.total_training_steps=120 "$@" \
+    2>&1 | tee run_wan22_5b_t2v_hpsv3_${DEVICE}.log

--- a/examples/dancegrpo_trainer/wan22/run_wan22_5b_t2v_hpsv3_auto.sh
+++ b/examples/dancegrpo_trainer/wan22/run_wan22_5b_t2v_hpsv3_auto.sh
@@ -115,4 +115,3 @@ python3 -m verl_omni.trainer.main_diffusion \
     trainer.test_freq=30 \
     trainer.total_epochs=15 \
     trainer.total_training_steps=120 "$@" \
-    2>&1 | tee run_wan22_5b_t2v_hpsv3_${DEVICE}.log

--- a/examples/dancegrpo_trainer/wan22/run_wan22_5b_t2v_hpsv3_auto.sh
+++ b/examples/dancegrpo_trainer/wan22/run_wan22_5b_t2v_hpsv3_auto.sh
@@ -11,7 +11,6 @@
 #
 set -x
 
-export MIMALLOC_PURGE_DELAY=0
 if npu-smi info &>/dev/null; then
     DEVICE="npu"
 elif nvidia-smi &>/dev/null; then

--- a/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
+++ b/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
@@ -48,6 +48,7 @@ from verl.utils.checkpoint.checkpoint_manager import find_latest_ckpt_path, shou
 from verl.utils.config import omega_conf_to_dataclass
 from verl.utils.debug import marked_timer
 from verl.utils.import_utils import load_class_from_fqn
+from verl.utils.memory_utils import aggressive_empty_cache
 from verl.utils.metric import reduce_metrics
 from verl.utils.py_functional import rename_dict
 from verl.utils.tracking import ValidationGenerationsLogger
@@ -79,7 +80,7 @@ from verl_omni.trainer.diffusion.rollout_correction import (
 )
 from verl_omni.utils.tracking import _export_video, batch_items, log_wandb_media, wrap_val_samples_for_wandb
 from verl_omni.workers.utils.padding import embeds_padding_2_no_padding
-from verl.utils.memory_utils import aggressive_empty_cache
+
 
 sys_logger = logging.getLogger(__name__)
 

--- a/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
+++ b/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
@@ -81,7 +81,6 @@ from verl_omni.trainer.diffusion.rollout_correction import (
 from verl_omni.utils.tracking import _export_video, batch_items, log_wandb_media, wrap_val_samples_for_wandb
 from verl_omni.workers.utils.padding import embeds_padding_2_no_padding
 
-
 sys_logger = logging.getLogger(__name__)
 
 

--- a/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
+++ b/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
@@ -79,6 +79,7 @@ from verl_omni.trainer.diffusion.rollout_correction import (
 )
 from verl_omni.utils.tracking import _export_video, batch_items, log_wandb_media, wrap_val_samples_for_wandb
 from verl_omni.workers.utils.padding import embeds_padding_2_no_padding
+from verl.utils.memory_utils import aggressive_empty_cache
 
 sys_logger = logging.getLogger(__name__)
 
@@ -1338,6 +1339,7 @@ class PolicyGradientRayTrainer(BaseRayDiffusionTrainer):
                 if hasattr(self.train_dataset, "on_batch_end"):
                     # The dataset may be changed after each training batch
                     self.train_dataset.on_batch_end(batch=batch)
+                aggressive_empty_cache()
 
 
 class DirectPreferenceRayTrainer(BaseRayDiffusionTrainer):


### PR DESCRIPTION
Added aggressive_empty_cache function call to optimize memory usage after batch processing.

### What does this PR do?

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `vllm_omni`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `diffusion`, `omni`, `tests`, `docker`
  - If this PR involves multiple modules, separate them with `,` like `[diffusion, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][diffusion, fsdp] feat: new rollout scheduler`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update the documentation.
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl-omni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
