### PR TITLE
[ci, tests] fix: stabilize L3 qwen-image FlowGRPO nightly determinism and artifact upload

### DIFF
--- a/.github/workflows/l3_nightly.yml
+++ b/.github/workflows/l3_nightly.yml
@@ -143,6 +143,7 @@ jobs:
       HF_HUB_ENABLE_HF_TRANSFER: "0"
       NIGHTLY_PIN_KERNELS: "0.14.1"
       NIGHTLY_PIN_FA3_FWD: "0.0.3"
+      NIGHTLY_PIN_FLASH_ATTN: "2.8.3"
       NIGHTLY_PIN_TRANSFORMERS: "5.14.1"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -157,6 +158,7 @@ jobs:
           pip3 install ".[gpu,dev,audio]"
           pip3 install "kernels==${NIGHTLY_PIN_KERNELS}"
           pip3 install "fa3-fwd==${NIGHTLY_PIN_FA3_FWD}"
+          pip3 install "flash-attn==${NIGHTLY_PIN_FLASH_ATTN}"
           pip3 install "vllm-omni @ git+https://github.com/vllm-project/vllm-omni.git@$(cat .github/vllm_omni_pin.txt)"
           pip3 install --no-deps --force-reinstall "verl @ git+https://github.com/verl-project/verl.git@$(cat .github/verl_pin.txt)"
           pip3 install --no-deps -e .
@@ -166,7 +168,7 @@ jobs:
           pip3 install veomni==0.1.11 --no-deps
           pip3 install torchcodec librosa soundfile av audioread
           pip3 install "transformers[mistral-common]==${NIGHTLY_PIN_TRANSFORMERS}"
-          python3 -c "import importlib.metadata as m; print('[NIGHTLY] pinned deps:', 'transformers='+m.version('transformers'), 'kernels='+m.version('kernels'), 'fa3-fwd='+m.version('fa3-fwd'))"
+          python3 -c "import importlib.metadata as m; print('[NIGHTLY] pinned deps:', 'transformers='+m.version('transformers'), 'kernels='+m.version('kernels'), 'fa3-fwd='+m.version('fa3-fwd'), 'flash-attn='+m.version('flash-attn'))"
 
       - name: Download L3 baseline from setup job
         if: env.RUN_MODE == 'nightly'

--- a/.github/workflows/l3_nightly.yml
+++ b/.github/workflows/l3_nightly.yml
@@ -141,6 +141,9 @@ jobs:
       NO_PROXY: "localhost,127.0.0.1,hf-mirror.com,github.com,api.github.com,codeload.github.com,.github.com,.actions.githubusercontent.com,.blob.core.windows.net"
       HF_ENDPOINT: "https://hf-mirror.com"
       HF_HUB_ENABLE_HF_TRANSFER: "0"
+      NIGHTLY_PIN_KERNELS: "0.14.1"
+      NIGHTLY_PIN_FA3_FWD: "0.0.3"
+      NIGHTLY_PIN_TRANSFORMERS: "5.14.1"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -152,6 +155,8 @@ jobs:
         run: |
           # vllm023.dev1 image PyPI mirror may lag pypi.org (e.g. kernels, fa3-fwd).
           pip3 install ".[gpu,dev,audio]"
+          pip3 install "kernels==${NIGHTLY_PIN_KERNELS}"
+          pip3 install "fa3-fwd==${NIGHTLY_PIN_FA3_FWD}"
           pip3 install "vllm-omni @ git+https://github.com/vllm-project/vllm-omni.git@$(cat .github/vllm_omni_pin.txt)"
           pip3 install --no-deps --force-reinstall "verl @ git+https://github.com/verl-project/verl.git@$(cat .github/verl_pin.txt)"
           pip3 install --no-deps -e .
@@ -160,7 +165,8 @@ jobs:
           # TODO: rm --no-deps when VeOmni supports torch2.11.
           pip3 install veomni==0.1.11 --no-deps
           pip3 install torchcodec librosa soundfile av audioread
-          pip3 install "transformers[mistral-common]"
+          pip3 install "transformers[mistral-common]==${NIGHTLY_PIN_TRANSFORMERS}"
+          python3 -c "import importlib.metadata as m; print('[NIGHTLY] pinned deps:', 'transformers='+m.version('transformers'), 'kernels='+m.version('kernels'), 'fa3-fwd='+m.version('fa3-fwd'))"
 
       - name: Download L3 baseline from setup job
         if: env.RUN_MODE == 'nightly'

--- a/.github/workflows/l3_nightly.yml
+++ b/.github/workflows/l3_nightly.yml
@@ -138,7 +138,7 @@ jobs:
     timeout-minutes: 180
     env:
       HTTPS_PROXY: ${{ secrets.PROXY_HTTPS }}
-      NO_PROXY: "localhost,127.0.0.1,hf-mirror.com"
+      NO_PROXY: "localhost,127.0.0.1,hf-mirror.com,github.com,api.github.com,codeload.github.com,.github.com,.actions.githubusercontent.com,.blob.core.windows.net"
       HF_ENDPOINT: "https://hf-mirror.com"
       HF_HUB_ENABLE_HF_TRANSFER: "0"
     steps:

--- a/tests/nightly/qwen_image_flowgrpo/env_metadata.py
+++ b/tests/nightly/qwen_image_flowgrpo/env_metadata.py
@@ -1,0 +1,162 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Collect dependency and runtime metadata for nightly regression artifacts."""
+
+from __future__ import annotations
+
+import importlib.metadata
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_GIT_PIN_FILES = {
+    "vllm_omni_git": _REPO_ROOT / ".github" / "vllm_omni_pin.txt",
+    "verl_git": _REPO_ROOT / ".github" / "verl_pin.txt",
+}
+_ENV_PIN_KEYS = {
+    "kernels_pip": "NIGHTLY_PIN_KERNELS",
+    "fa3_fwd_pip": "NIGHTLY_PIN_FA3_FWD",
+    "transformers_pip": "NIGHTLY_PIN_TRANSFORMERS",
+}
+
+
+def _read_pin(path: Path) -> str | None:
+    if not path.is_file():
+        return None
+    text = path.read_text(encoding="utf-8").strip()
+    return text or None
+
+
+def _distribution_version(name: str) -> str | None:
+    try:
+        return importlib.metadata.version(name)
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+
+def _module_version(module_name: str, attr: str = "__version__") -> str | None:
+    if importlib.util.find_spec(module_name) is None:
+        return None
+    try:
+        module = importlib.import_module(module_name)
+    except Exception:
+        return "import_failed"
+    value = getattr(module, attr, None)
+    return str(value) if value is not None else None
+
+
+def _read_git_pins() -> dict[str, str | None]:
+    return {key: _read_pin(path) for key, path in _GIT_PIN_FILES.items()}
+
+
+def _read_env_pins() -> dict[str, str | None]:
+    return {key: os.environ.get(env_key) for key, env_key in _ENV_PIN_KEYS.items()}
+
+
+def _git_head() -> str | None:
+    try:
+        completed = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=_REPO_ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    return completed.stdout.strip() or None
+
+
+def collect_env_metadata(*, attn_backend: str | None = None, rollout_attn_backend: str | None = None) -> dict[str, Any]:
+    """Return pinned and installed versions plus FA3 availability flags."""
+    try:
+        from verl_omni.utils import diffusion_attention as da
+
+        fa3_flags = {
+            "fa3_available": da.fa3_available(),
+            "actor_fa3_available": da.actor_fa3_available(),
+            "rollout_fa3_available": da.rollout_fa3_available(),
+        }
+    except Exception as exc:
+        fa3_flags = {"fa3_check_error": str(exc)}
+
+    metadata: dict[str, Any] = {
+        "python": sys.version.split()[0],
+        "git_head": _git_head(),
+        "pins": {**_read_git_pins(), **_read_env_pins()},
+        "installed": {
+            "torch": _module_version("torch"),
+            "transformers": _distribution_version("transformers"),
+            "vllm": _distribution_version("vllm"),
+            "vllm_omni": _distribution_version("vllm-omni"),
+            "verl": _distribution_version("verl"),
+            "verl_omni": _distribution_version("verl-omni"),
+            "kernels": _distribution_version("kernels"),
+            "fa3_fwd": _distribution_version("fa3-fwd"),
+            "flash_attn": _distribution_version("flash-attn"),
+            "ray": _distribution_version("ray"),
+            "diffusers": _distribution_version("diffusers"),
+            "peft": _distribution_version("peft"),
+            "accelerate": _distribution_version("accelerate"),
+        },
+        "attention": {
+            "attn_backend": attn_backend or os.environ.get("NIGHTLY_ATTN_BACKEND"),
+            "rollout_attn_backend": rollout_attn_backend or os.environ.get("NIGHTLY_ROLLOUT_ATTN_BACKEND"),
+            **fa3_flags,
+        },
+        "nightly": {
+            "deterministic_seed": os.environ.get("NIGHTLY_DETERMINISTIC_SEED"),
+            "require_fa3": os.environ.get("NIGHTLY_REQUIRE_FA3"),
+        },
+    }
+    return metadata
+
+
+def write_env_metadata(output: Path, **kwargs: Any) -> dict[str, Any]:
+    payload = collect_env_metadata(**kwargs)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with output.open("w", encoding="utf-8") as file:
+        json.dump(payload, file, indent=2, sort_keys=True)
+    return payload
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Write nightly environment metadata JSON")
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--attn-backend", default=None)
+    parser.add_argument("--rollout-attn-backend", default=None)
+    args = parser.parse_args()
+    payload = write_env_metadata(
+        args.output.expanduser().resolve(),
+        attn_backend=args.attn_backend,
+        rollout_attn_backend=args.rollout_attn_backend,
+    )
+    print(f"[NIGHTLY] env metadata: {args.output}")
+    print(
+        "[NIGHTLY] attention:",
+        payload.get("attention", {}),
+        "transformers=",
+        payload.get("installed", {}).get("transformers"),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/nightly/qwen_image_flowgrpo/env_metadata.py
+++ b/tests/nightly/qwen_image_flowgrpo/env_metadata.py
@@ -32,6 +32,7 @@ _GIT_PIN_FILES = {
 _ENV_PIN_KEYS = {
     "kernels_pip": "NIGHTLY_PIN_KERNELS",
     "fa3_fwd_pip": "NIGHTLY_PIN_FA3_FWD",
+    "flash_attn_pip": "NIGHTLY_PIN_FLASH_ATTN",
     "transformers_pip": "NIGHTLY_PIN_TRANSFORMERS",
 }
 

--- a/tests/nightly/qwen_image_flowgrpo/run.py
+++ b/tests/nightly/qwen_image_flowgrpo/run.py
@@ -34,6 +34,9 @@ _FORWARDED_ENV_NAMES = {
     "CUBLAS_WORKSPACE_CONFIG",
     "DEBUG_METRICS_JSONL",
     "NIGHTLY_DETERMINISTIC_SEED",
+    "NIGHTLY_REQUIRE_FA3",
+    "NIGHTLY_ATTN_BACKEND",
+    "NIGHTLY_ROLLOUT_ATTN_BACKEND",
     "PYTHONHASHSEED",
     "TOKENIZERS_PARALLELISM",
 }
@@ -70,8 +73,36 @@ def _patch_ray_init() -> None:
     ray.init = ray_init_with_debug_hooks
 
 
+def _patch_require_fa3() -> None:
+    """Disable FA3→SDPA fallback for nightly runs that require deterministic FA3."""
+    if os.environ.get("NIGHTLY_REQUIRE_FA3", "0") != "1":
+        return
+
+    import verl_omni.utils.diffusion_attention as diffusion_attention
+
+    if getattr(diffusion_attention.fallback_fa3_if_unavailable, "__nightly_require_fa3__", False):
+        return
+
+    def fallback_fa3_if_unavailable_or_raise(config) -> None:
+        attn_backend = config.actor_rollout_ref.model.get("attn_backend", diffusion_attention.ACTOR_FA3_BACKEND)
+        if attn_backend != diffusion_attention.ACTOR_FA3_BACKEND:
+            return
+        if diffusion_attention.fa3_available():
+            return
+        raise RuntimeError(
+            "FA3 is required for nightly but unavailable: "
+            f"actor_kernels={diffusion_attention.actor_fa3_available()}, "
+            f"rollout_fa={diffusion_attention.rollout_fa3_available()}. "
+            "Install pinned kernels and fa3-fwd, and use a supported GPU (SM 8.x)."
+        )
+
+    fallback_fa3_if_unavailable_or_raise.__nightly_require_fa3__ = True
+    diffusion_attention.fallback_fa3_if_unavailable = fallback_fa3_if_unavailable_or_raise
+
+
 def main() -> None:
     install_debug_hooks.install_debug_hooks()
+    _patch_require_fa3()
     _patch_ray_init()
     runpy.run_module("verl_omni.trainer.main_diffusion", run_name="__main__", alter_sys=True)
 

--- a/tests/nightly/qwen_image_flowgrpo/run_qwen_image_flowgrpo.sh
+++ b/tests/nightly/qwen_image_flowgrpo/run_qwen_image_flowgrpo.sh
@@ -37,6 +37,7 @@ DEBUG_METRICS_JSONL=${DEBUG_METRICS_JSONL:-${CURRENT_DUMP_DIR}/metrics.jsonl}
 CURRENT_METRICS_JSON=${CURRENT_METRICS_JSON:-${CURRENT_DUMP_DIR}/metrics.json}
 BASELINE_METRICS_JSON=${BASELINE_METRICS_JSON:-${BASELINE_DUMP_DIR}/metrics.json}
 DUMP_COMPARE_JSON=${DUMP_COMPARE_JSON:-${CURRENT_DUMP_DIR}/dump_compare.json}
+ENV_METADATA_JSON=${ENV_METADATA_JSON:-${LOG_DIR}/env_metadata.json}
 
 ENGINE=vllm_omni
 REWARD_ENGINE=vllm
@@ -49,10 +50,16 @@ TRAIN_BATCH_SIZE=$((MINI_BSZ * N_RESP_PER_PROMPT))
 
 ATTN_BACKEND=_flash_3_varlen_hub
 ROLLOUT_ATTN_BACKEND=FLASH_ATTN
-if ! python3 -c 'from verl_omni.utils.diffusion_attention import fa3_available; raise SystemExit(0 if fa3_available() else 1)' >/dev/null 2>&1; then
-    ATTN_BACKEND=native
-    ROLLOUT_ATTN_BACKEND=TORCH_SDPA
+export NIGHTLY_REQUIRE_FA3=1
+export NIGHTLY_ATTN_BACKEND=${ATTN_BACKEND}
+export NIGHTLY_ROLLOUT_ATTN_BACKEND=${ROLLOUT_ATTN_BACKEND}
+
+if ! python3 -c 'from verl_omni.utils.diffusion_attention import fa3_available, actor_fa3_available, rollout_fa3_available; import sys; sys.exit(0 if fa3_available() else 1)'; then
+    python3 -c 'from verl_omni.utils.diffusion_attention import actor_fa3_available, rollout_fa3_available; print(f"[NIGHTLY] FA3 check failed: actor_kernels={actor_fa3_available()} rollout_fa={rollout_fa3_available()}")'
+    echo "[NIGHTLY] FA3 is required for this regression (kernels + fa3-fwd/flash-attn rollout). Aborting."
+    exit 1
 fi
+echo "[NIGHTLY] diffusion attention: ATTN_BACKEND=${ATTN_BACKEND} ROLLOUT_ATTN_BACKEND=${ROLLOUT_ATTN_BACKEND} fa3_available=1"
 
 export NIGHTLY_DETERMINISTIC_SEED
 export PYTHONHASHSEED=${PYTHONHASHSEED:-${NIGHTLY_DETERMINISTIC_SEED}}
@@ -65,6 +72,11 @@ export GENRM_OCR_SEED=${GENRM_OCR_SEED:-${NIGHTLY_DETERMINISTIC_SEED}}
 
 rm -rf "${CURRENT_DUMP_DIR}"
 mkdir -p "${CURRENT_DUMP_DIR}" "${BASELINE_DUMP_DIR}" "${LOG_DIR}"
+
+python3 "${SCRIPT_DIR}/env_metadata.py" \
+    --output "${ENV_METADATA_JSON}" \
+    --attn-backend "${ATTN_BACKEND}" \
+    --rollout-attn-backend "${ROLLOUT_ATTN_BACKEND}"
 
 python3 "${SCRIPT_DIR}/create_single_sample_data.py" \
     --local_save_dir "${DATA_DIR}" \
@@ -118,7 +130,7 @@ python3 "${SCRIPT_DIR}/run.py" \
     actor_rollout_ref.rollout.n=${N_RESP_PER_PROMPT} \
     actor_rollout_ref.rollout.agent.num_workers=1 \
     actor_rollout_ref.rollout.load_format=safetensors \
-    actor_rollout_ref.rollout.layered_summon=True \
+    actor_rollout_ref.rollout.layered_summon=False \
     actor_rollout_ref.rollout.enforce_eager=True \
     actor_rollout_ref.rollout.seed=42 \
     actor_rollout_ref.rollout.pipeline.num_inference_steps=4 \
@@ -126,7 +138,7 @@ python3 "${SCRIPT_DIR}/run.py" \
     actor_rollout_ref.rollout.pipeline.width=256 \
     actor_rollout_ref.rollout.pipeline.true_cfg_scale=1.0 \
     actor_rollout_ref.rollout.pipeline.max_sequence_length=${MAX_PROMPT_LENGTH} \
-    actor_rollout_ref.rollout.algo.noise_level=1.0 \
+    actor_rollout_ref.rollout.algo.noise_level=0.0 \
     actor_rollout_ref.rollout.algo.sde_type=sde \
     actor_rollout_ref.rollout.algo.sde_window_size=2 \
     actor_rollout_ref.rollout.algo.sde_window_range="[0,2]" \


### PR DESCRIPTION
## Summary

- Extend `NO_PROXY` in `l3_nightly.yml` so GitHub / Actions artifact endpoints bypass `HTTPS_PROXY`, fixing intermittent `Failed to CreateArtifact: ECONNRESET` on Volcengine GPU runners.
- Pin nightly dependency versions inline in the workflow (`kernels==0.14.1`, `fa3-fwd==0.0.3`, `transformers[mistral-common]==5.14.1`) to reduce run-to-run drift from unpinned PyPI packages.
- Require FA3 for the Qwen-Image FlowGRPO regression: abort if FA3 is unavailable instead of silently falling back to SDPA (`run_qwen_image_flowgrpo.sh` + `run.py` patch to block `fallback_fa3_if_unavailable`).
- Reduce rollout non-determinism in the nightly script: `noise_level=0.0`, `layered_summon=False`.
- Add `env_metadata.py` to record git/pip pins, installed package versions, FA3 flags, and attention backend selection once per run; write to `logs/**/env_metadata.json` and upload via the report artifact only.

## Test plan

- [ ] Trigger `l3_nightly` via `workflow_dispatch` with `mode=baseline` on a GPU runner; confirm artifact upload succeeds and `logs/qwen_image_flowgrpo/env_metadata.json` is present in the report artifact.
- [ ] Re-run with `mode=nightly` against the refreshed baseline; confirm dump compare and perf metrics pass.
- [ ] Verify FA3 failure path: on a runner without FA3, the job fails fast with a clear `[NIGHTLY] FA3 check failed` message (no SDPA fallback).

## Post-merge

After merging, **refresh the L3 baseline** (`workflow_dispatch` → `mode=baseline`) before expecting strict nightly comparisons to pass — rollout settings (`noise_level`, `layered_summon`) and pinned deps change tensor outputs.

