### PR TITLE
[misc] fix: upgrade kernels client to 0.16.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ audio = [
 # CUDA rollout backend (vllm) + actor FA3 (kernels) + liger-kernel. Install in step 1 on GPU.
 gpu = [
     "vllm==0.27.0",
-    "kernels==0.14.1",
+    "kernels==0.16.0",
     "liger-kernel",
 ]
 # Training stack (install in step 2).


### PR DESCRIPTION
### What does this PR do?

Upgrade the `kernels` client from 0.14.1 to 0.16.0 so the PyTorch 2.13 / CUDA 13.0 environment can load the compatible FA3 Hub kernel used by the current vLLM-Omni dependency set.

The Hub already provides a compatible `torch-stable-abi29-cu130` build. The failure is in client-side variant selection: `kernels==0.14.1` looks for an exact PyTorch build for PyTorch 2.13, while the available exact-version CUDA 13.0 builds stop at `torch212-cxx11-cu130`. This results in `Cannot find a build variant` instead of selecting the compatible stable-ABI build.

`kernels==0.16.0` recognizes and selects the stable-ABI variant. It also supports the current `get_kernel(..., version=...)` loading API used by vLLM-Omni 0.27.

AI assistance was used to prepare this change and PR description.

- [x] The human submitter has reviewed every changed line and can explain and defend the change end-to-end.

### Checklist Before Starting

- [x] Search for similar PRs. No matching open PR was found on 2026-08-20:
  - [`kernels 0.16.0`](https://github.com/verl-project/verl-omni/pulls?q=is%3Apr+is%3Aopen+kernels+0.16.0)
  - [`FA3 stable ABI`](https://github.com/verl-project/verl-omni/pulls?q=is%3Apr+is%3Aopen+FA3+stable+ABI)
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `vllm_omni`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `diffusion`, `omni`, `tests`, `docker`
  - If this PR involves multiple modules, separate them with `,` like `[diffusion, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][diffusion, fsdp] feat: new rollout scheduler`

### Test

Ran the public Qwen-Image OCR FSDP2 FlowGRPO Nsight Systems benchmark on an 8-GPU environment:

```bash
bash examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_fsdp2_benchmark_nsys.sh
```

The script is part of the public repository: [`run_qwen_image_ocr_fsdp2_benchmark_nsys.sh`](https://github.com/verl-project/verl-omni/blob/main/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_fsdp2_benchmark_nsys.sh).

Validated environment:

```text
kernels==0.16.0
torch==2.13.0
CUDA 13.0
```

Before this change, `kernels==0.14.1` failed to resolve the FA3 Hub kernel during model initialization:

```text
Cannot find a build variant for this system in kernels-community/flash-attn3
```

The failure output listed `torch-stable-abi29-cu130-x86_64-linux` as available, alongside exact-version CUDA 13.0 builds up to `torch212-cxx11-cu130-x86_64-linux`. It reported 17 variant-resolution errors and fell back to native attention on all 8 actor workers.

With `kernels==0.16.0`, the same benchmark kept the configured `_flash_3_varlen_hub` backend, loaded all actor checkpoint shards, and completed successfully. A repeated run produced the same result:

```text
                              Variant errors    Native fallbacks
Before, kernels 0.14.1              17                 8
After,  kernels 0.16.0               0                 0
Second run with kernels 0.16.0        0                 0
```

The runtime cache contained the selected stable-ABI build and its imported Python bytecode:

```text
kernels--kernels-community--flash-attn3/
  snapshots/43f0bd269777115d94ff826e0d113ce9c1c9087b/
    build/torch-stable-abi29-cu130-x86_64-linux/
      _flash_attn3_cuda_8a730d9.abi3.so
      __init__.py
      _ops.py
      flash_attn_interface.py
      __pycache__/
        __init__.cpython-312.pyc
        _ops.cpython-312.pyc
        flash_attn_interface.cpython-312.pyc
```

This verifies that the compatible stable-ABI package was selected, downloaded, imported, and exercised by the full FlowGRPO workload.

Repository checks:

```bash
pre-commit run --all-files --show-diff-on-failure --color=always
```

All hooks passed.

### API and Usage Example

No user-facing API change. This is a dependency compatibility update for the existing FA3 kernel loading path.

### Design & Code Changes

- Change the `gpu` optional dependency in `pyproject.toml` from `kernels==0.14.1` to `kernels==0.16.0`.
- No other source, dependency, or environment changes are included.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update the documentation. Not applicable: the dependency declaration is the complete user-facing change, and there is no documentation to update.
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl-omni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: there is no test to add for this dependency-only variant-selection fix. It requires the matching PyTorch 2.13 / CUDA 13.0 GPU environment and Hub artifact, and the existing public Qwen-Image FlowGRPO benchmark completed successfully as recorded above.
