### PR TITLE
[doc] fix: require accurate coding assistant attribution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,16 @@ Co-authored-by: GitHub Copilot
 Signed-off-by: Your Name <your.email@example.com>
 ```
 
+Other examples:
+
+```text
+Co-authored-by: Cursor <cursoragent@cursor.com>
+Co-authored-by: OpenAI Codex <noreply@openai.com>
+Co-authored-by: Claude Code
+```
+
+Use the identity of the tool that actually contributed.
+
 ### Resolving agent reviews
 
 Review comments from agent bots (e.g., gemini-code-assist) can be outdated or wrong. Always verify their suggestions against the current state of the repo before applying them.


### PR DESCRIPTION
### What does this PR do?

Clarify the coding-assistant attribution guidance in `AGENTS.md` so contributors use the identity of the tool that actually participated in a change.

The existing commit example names only GitHub Copilot. When that example is followed mechanically by another coding assistant, it can incorrectly attribute the contribution to Copilot. This PR keeps the existing Copilot example, adds common identities for Cursor, OpenAI Codex, and Claude Code, and explicitly requires accurate tool attribution. The exact names and email forms in these examples were selected from frequently used forms found in the project's commit history.

This is a project-wide commit convention, so it belongs in `AGENTS.md`. The updated file has 105 lines and remains below its 200-line budget.

AI assistance was used to prepare this change and PR description.

- [x] The human submitter has reviewed every changed line and can explain and defend the change end-to-end.

### Checklist Before Starting

- [x] Search for similar PRs. No matching open PR was found on 2026-08-20:
  - [`coding assistant attribution`](https://github.com/verl-project/verl-omni/pulls?q=is%3Apr+is%3Aopen+coding+assistant+attribution)
  - [`Co-authored-by Copilot`](https://github.com/verl-project/verl-omni/pulls?q=is%3Apr+is%3Aopen+Co-authored-by+Copilot)
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `vllm_omni`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `diffusion`, `omni`, `tests`, `docker`
  - If this PR involves multiple modules, separate them with `,` like `[diffusion, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][diffusion, fsdp] feat: new rollout scheduler`

### Test

Documentation-only change. Ran the repository checks:

```bash
pre-commit run --all-files --show-diff-on-failure --color=always
```

All hooks passed.

### API and Usage Example

No API change.

The updated commit-trailer examples are:

```text
Co-authored-by: GitHub Copilot
Co-authored-by: Cursor <cursoragent@cursor.com>
Co-authored-by: OpenAI Codex <noreply@openai.com>
Co-authored-by: Claude Code
```

Contributors should include the identity only for the tool that actually contributed.

### Design & Code Changes

- Preserve the existing GitHub Copilot commit-trailer example.
- Add examples for Cursor, OpenAI Codex, and Claude Code using the exact names and email forms frequently found in the project's commit history.
- State the governing rule directly: use the identity of the tool that actually contributed.
- Keep the change scoped to `AGENTS.md`; no runtime behavior is affected.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update the documentation. This PR updates `AGENTS.md`.
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl-omni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: there is no unit or end-to-end test to add for this documentation-only change because it has no executable behavior.
