### PR TITLE
[ci] fix: override kernels client for GPU smoke

### DIFF
--- a/.github/actions/gpu-smoke-prepare/action.yml
+++ b/.github/actions/gpu-smoke-prepare/action.yml
@@ -31,6 +31,8 @@ runs:
         uv pip install --system --break-system-packages veomni==0.1.11 --no-deps
         uv pip install --system --break-system-packages torchcodec librosa soundfile av audioread
         uv pip install --system --break-system-packages "transformers[mistral-common]"
+        # GPU-smoke-only override; the project GPU extra remains on kernels==0.16.0.
+        uv pip install --system --break-system-packages "kernels==0.14.1"
         # NCCL checkpoint engine (diffusion v1 separate_async weight sync).
         uv pip install --system --break-system-packages pyzmq
         uv pip install --system --break-system-packages cupy-cuda12x || uv pip install --system --break-system-packages cupy-cuda13x


### PR DESCRIPTION
## Summary

Install `kernels==0.14.1` only in the GPU smoke preparation action, after the
shared dependencies are installed. The project `gpu` extra remains pinned to
`kernels==0.16.0`; this change tests the CI-only compatibility path for the
GPU smoke regression that began after #417.

## Duplicate-work check

Before opening this PR, I ran:

```bash
gh issue view 417 --repo verl-project/verl-omni --comments
gh pr list --repo verl-project/verl-omni --state open --search "417 in:body"
gh pr list --repo verl-project/verl-omni --state open --search "gpu smoke kernels in:title,body"
```

The two open-PR searches returned no results. #417 changed the project-wide
GPU extra to `kernels==0.16.0`; this PR does not revert it and instead adds a
GPU-smoke-only override to investigate the CI regression.

## Tests

- YAML parse and command-order assertion for
  `.github/actions/gpu-smoke-prepare/action.yml`: passed.
- `SKIP=autogen-trainer-cfg pre-commit run --files .github/actions/gpu-smoke-prepare/action.yml`:
  all applicable hooks passed. The skipped hook regenerates trainer configs,
  which this CI-only change does not affect.
- The unskipped full pre-commit invocation exceeded five minutes in the
  unrelated `autogen-trainer-cfg` hook.

The GPU smoke workflow is the required validation for this runner-specific
dependency override.

## Accountability

The human submitter reviewed every changed line and accepts responsibility for
this PR. AI assistance (Pi Coding Agent) was used for this change.
