### PR TITLE
[worker, trainer, cfg, tests, doc] feat: multi-teacher routing and standalone teacher pool for diffusion OPD

### DIFF
--- a/docs/algo/diffusion_opd.md
+++ b/docs/algo/diffusion_opd.md
@@ -1,6 +1,6 @@
 # Diffusion On-Policy Distillation
 
-Last updated: 08/09/2026.
+Last updated: 08/23/2026.
 
 ## Background
 
@@ -38,12 +38,67 @@ so distillation can be combined with a KL penalty toward the initial policy.
 ### `distillation.enabled` (bool)
 
 Whether on-policy distillation is enabled. Default: `false`. When `true`, the
-actor worker builds the frozen teacher and the trainer scores every rollout
-batch with it before the actor update.
+frozen teachers are built (in the actor worker, or on their own resource pool)
+and the trainer scores every rollout batch with them before the actor update.
 
-### `distillation.teacher_models.teacher_model.model_path` (str)
+### `distillation.n_gpus_per_node` (int)
 
-Local path to the frozen teacher checkpoint. **Required** when enabled.
+Number of GPUs per node in the teacher resource pool. Default: `0`. Only read
+when `nnodes > 0`.
+
+### `distillation.nnodes` (int)
+
+Number of nodes in the teacher resource pool. Default: `0`, which colocates
+the teachers with the actor on the actor's GPUs. Set to `≥ 1` to give the
+teachers their own `teacher_pool` of `n_gpus_per_node × nnodes` GPUs.
+
+**Constraint:** with `nnodes > 0`, the pool size must exactly equal the sum of
+`world_size` across all configured teachers, or
+`DiffusionDistillationConfig.__post_init__` raises.
+
+### `distillation.teacher_key` (str)
+
+Column of the batch's non-tensor data used to route each sample to the right
+teacher in multi-teacher setups. Default: `"data_source"`.
+
+- **Single-teacher**: ignored (everything goes to the sole teacher).
+- **Multi-teacher**: the value of `sample[teacher_key]` must match the `key`
+  of one of the configured teachers, or `DiffusionTeacherManager` raises.
+
+### `distillation.teacher_models` (dict)
+
+Map of teacher entries. Each value is a
+`DiffusionDistillationTeacherModelConfig`.
+
+The single-teacher entry is named `teacher_model` by convention. **Pitfall:**
+when adding more named teachers, the `teacher_model` entry is silently popped
+— so do **not** keep `teacher_model` as one entry alongside other named
+teachers. Either rely on it alone, or rename it (e.g. `teacher_model1`) and
+add the others.
+
+```bash
+# WRONG: teacher_model is popped, only teacher_model2 is used
+distillation.teacher_models.teacher_model.key=ocr
+distillation.teacher_models.teacher_model.model_path=/ckpt/ocr_teacher
++distillation.teacher_models.teacher_model2.key=aesthetic
++distillation.teacher_models.teacher_model2.model_path=/ckpt/aesthetic_teacher
+
+# RIGHT: rename the first teacher
++distillation.teacher_models.teacher_model1.key=ocr
++distillation.teacher_models.teacher_model1.model_path=/ckpt/ocr_teacher
++distillation.teacher_models.teacher_model2.key=aesthetic
++distillation.teacher_models.teacher_model2.model_path=/ckpt/aesthetic_teacher
+```
+
+### `distillation.teacher_models.<name>.key` (str)
+
+Identifier used to route samples to this teacher in multi-teacher mode. Must
+match the value of `sample[distillation.teacher_key]`. Default: `null`
+(required for multi-teacher; auto-set to `"default"` for single-teacher).
+
+### `distillation.teacher_models.<name>.model_path` (str)
+
+Local path to the frozen teacher checkpoint. **Required.**
 
 The teacher must be a full pipeline checkpoint from the same pipeline family
 as the student (e.g. a fine-tuned Stable Diffusion 3.5 teacher for a Stable
@@ -52,7 +107,13 @@ the teacher replays the student's trajectories on the student's noise grid,
 and worker init raises if the resolved scheduler configs differ. LoRA
 checkpoints must be merged before use; the teacher never loads adapters.
 
-Only the single `teacher_model` entry is supported.
+### `distillation.teacher_models.<name>.world_size` (int)
+
+Number of GPUs this teacher occupies in the teacher resource pool. Default:
+`0`. Only read when `nnodes > 0`; a single teacher auto-fills the whole pool,
+multiple teachers must set it explicitly so the sum matches the pool size.
+Each teacher's sub-pool is its own worker group, so teachers are scored
+concurrently.
 
 ### Loss-side switches
 
@@ -78,8 +139,8 @@ The teacher reuses the reference model's scoring configuration:
 
 ## Usage
 
-Supported scope: the policy-gradient trainer with online sampling, FSDP/FSDP2
-engines, and a single teacher. Unsupported combinations raise at startup.
+Supported scope: the policy-gradient trainer with online sampling and
+FSDP/FSDP2 engines. Unsupported combinations raise at startup.
 
 A complete working recipe is
 [`examples/diffusionopd_trainer/sd35/run_sd35_medium_ocr_distill.sh`](../examples/diffusionopd_trainer.md):
@@ -122,6 +183,61 @@ actor_rollout_ref:
     distill_loss_coef: 1.0
     use_kl_loss: true
     kl_loss_coef: 0.04
+```
+
+### Multi-teacher
+
+Several task-specialised teachers can distil into one student: every sample is
+routed by its `data_source` (or whichever column `teacher_key` names) to the
+teacher whose `key` matches, scored there, and the per-sample
+`teacher_prev_sample_mean` is scattered back into the batch. Each teacher holds
+a full copy of its weights, so the memory cost grows with the number of
+teachers; with colocated teachers that memory comes out of the actor's GPUs.
+
+```yaml
+distillation:
+  enabled: true
+  teacher_key: data_source
+  teacher_models:
+    ocr:
+      key: ocr
+      model_path: /ckpt/sd35m-ocr-teacher
+    aesthetic:
+      key: aesthetic
+      model_path: /ckpt/sd35m-aesthetic-teacher
+actor_rollout_ref:
+  actor:
+    diffusion_loss:
+      loss_mode: distill_kl
+    use_kl_loss: false
+```
+
+### Standalone teacher pool
+
+Teachers can run on their own GPUs instead of the actor's: `nnodes > 0`
+allocates a `teacher_pool`, split into one sub-pool per teacher according to
+`world_size`. The actor's GPUs are set by `trainer.n_gpus_per_node`, the
+teachers' by `distillation.n_gpus_per_node`. Teacher scoring stays a serial
+stage of the training step, so a standalone pool does not make it faster than
+the same GPUs colocated; it isolates teacher memory from the actor and the
+rollout engine's sleep/wake cycle.
+
+```yaml
+trainer:
+  n_gpus_per_node: 4
+distillation:
+  enabled: true
+  n_gpus_per_node: 2
+  nnodes: 1
+  teacher_models:
+    ocr:
+      key: ocr
+      model_path: /ckpt/sd35m-ocr-teacher
+      world_size: 1
+    aesthetic:
+      key: aesthetic
+      model_path: /ckpt/sd35m-aesthetic-teacher
+      world_size: 1
 ```
 
 ## Metrics

--- a/docs/algo/diffusion_opd.md
+++ b/docs/algo/diffusion_opd.md
@@ -1,6 +1,6 @@
 # Diffusion On-Policy Distillation
 
-Last updated: 08/23/2026.
+Last updated: 08/26/2026.
 
 ## Background
 
@@ -32,6 +32,30 @@ The teacher is fused into the actor worker the same way the reference model
 is: a third frozen, forward-only engine that replays the student's
 trajectories with a different checkpoint. Teacher and reference can coexist,
 so distillation can be combined with a KL penalty toward the initial policy.
+
+## Teacher Runtime
+
+`DiffusionTeacherManager` runs teacher scoring as one stage of the training
+step, after rewards and before the actor update. Each teacher is a worker
+group of frozen, forward-only engines; a batch passes through four moves:
+
+1. **Route.** The batch column named by `teacher_key` maps every sample to a
+   teacher. A single-teacher setup skips the column; a missing column or an
+   unmatched key raises instead of mis-routing.
+2. **Split and pad.** The batch is split into one sub-batch per teacher, and
+   each sub-batch is padded by repeating its own rows up to a multiple of the
+   teacher's `world_size ×` scoring micro-batch size — so every data-parallel
+   rank gets a non-empty shard that divides evenly into forward micro-batches,
+   whatever the step's task mix is.
+3. **Score.** All sub-batches are dispatched before any result is awaited, so
+   teachers score concurrently. Each teacher replays the stored student states
+   through its own transformer and returns its per-step transition means.
+4. **Reassemble.** Outputs are unpadded, concatenated, and restored to the
+   input row order, then merged into the batch as `teacher_prev_sample_mean`.
+
+Routing and padding happen on the driver, before dispatch, so teacher
+placement is purely a resource decision: colocated teachers and a standalone
+pool see identical inputs and produce identical outputs.
 
 ## Configuration Parameters
 

--- a/docs/examples/config.md
+++ b/docs/examples/config.md
@@ -164,7 +164,7 @@ actor_rollout_ref:
 - `actor_rollout_ref.actor.use_distill_loss`: Enable teacher-anchored online policy distillation.
 - `actor_rollout_ref.actor.distill_loss_mode`: `distill_kl` or `distill_fm_mse`.
 - `actor_rollout_ref.actor.distill_loss_coef`: Distillation loss coefficient.
-- `distillation.enabled` / `distillation.teacher_models.teacher_model.model_path`: Frozen teacher that produces the `teacher_*` batch keys the distillation losses consume — see [Diffusion On-Policy Distillation](../algo/diffusion_opd.md).
+- `distillation.enabled` / `distillation.teacher_models.<name>.{key,model_path,world_size}` / `distillation.teacher_key` / `distillation.{n_gpus_per_node,nnodes}`: Frozen teachers (routed per sample, colocated or on their own pool) that produce the `teacher_*` batch keys the distillation losses consume — see [Diffusion On-Policy Distillation](../algo/diffusion_opd.md).
 - `actor_rollout_ref.actor.rollout_correction.*`: Per-actor mirror of `algorithm.rollout_correction` (used when `bypass_mode=True` for per-step RS inside `diffusion_loss`).
 
 Shared PPO / FSDP / optim fields (`ppo_mini_batch_size`, `ppo_epochs`, `optim.lr`, `fsdp_config`, …) follow upstream verl — see the [verl Config Explanation](https://verl.readthedocs.io/en/latest/examples/config.html).

--- a/examples/diffusionopd_trainer/sd35/mixed_task_reward.py
+++ b/examples/diffusionopd_trainer/sd35/mixed_task_reward.py
@@ -1,0 +1,40 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Per-task reward dispatch for the mixed OCR + PickScore distillation recipe.
+
+OCR rows go to the GenRM OCR scorer through the reward router; PickScore rows
+are scored locally with PickScore_v1 on ``PICKSCORE_DEVICE``. Both branches
+return the same key set: the reward loop merges per-sample dicts into one
+table and requires identical keys on every row.
+"""
+
+import os
+
+from verl.utils.device import get_device_name
+
+from verl_omni.utils.reward_score.genrm_ocr import compute_score_ocr
+from verl_omni.utils.reward_score.pickscore_reward import compute_score_pickscore
+
+_PICKSCORE_DEVICE = os.environ.get("PICKSCORE_DEVICE", get_device_name())
+
+
+async def compute_score_mixed(data_source, solution_image, ground_truth, extra_info, **kwargs):
+    """Route one sample to the scorer of its task, keyed on ``data_source``."""
+    if "pickscore" in data_source:
+        result = await compute_score_pickscore(
+            data_source, solution_image, ground_truth, extra_info, device=_PICKSCORE_DEVICE
+        )
+        return {"score": result["score"], "pickscore_raw": result["pickscore_raw"], "genrm_response": ""}
+    result = await compute_score_ocr(data_source, solution_image, ground_truth, extra_info, **kwargs)
+    return {"score": result["score"], "pickscore_raw": float("nan"), "genrm_response": result.get("genrm_response", "")}

--- a/examples/diffusionopd_trainer/sd35/run_sd35_medium_mopd_distill.sh
+++ b/examples/diffusionopd_trainer/sd35/run_sd35_medium_mopd_distill.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# SD3.5-Medium multi-teacher on-policy distillation on mixed OCR + PickScore data.
+#
+# Batches mix two tasks and each row is routed to its task's frozen teacher by
+# the `data_source` column (the default `distillation.teacher_key`). The student
+# minimizes distill_kl toward the routed teacher's transition means; per-task
+# rewards (GenRM OCR, PickScore) are monitored only and never enter the loss.
+#
+# Teachers: merge the task LoRAs of quanhaol/DiffusionOPD (AesTeacher/lora,
+# OCRTeacher/lora) into stabilityai/stable-diffusion-3.5-medium with peft
+# (`PeftModel.from_pretrained` + `merge_and_unload`), save the merged
+# transformer, and reuse the base model's other components.
+#
+# Data: examples/flowgrpo_trainer/data_process/sd3_ocr.py and
+# sd3_pickscore_sfw.py produce the two parquet pairs used below.
+set -x
+
+WORKSPACE=${OCR_WORKSPACE:-${WORKSPACE:-$HOME}}
+
+ocr_train_path=$WORKSPACE/data/ocr/sd3/train.parquet
+ocr_test_path=$WORKSPACE/data/ocr/sd3/test.parquet
+pickscore_train_path=$WORKSPACE/data/pickscore_sfw/sd3/train.parquet
+pickscore_test_path=$WORKSPACE/data/pickscore_sfw/sd3/test.parquet
+
+model_name=stabilityai/stable-diffusion-3.5-medium
+ocr_teacher_path=${OCR_TEACHER_PATH:?set OCR_TEACHER_PATH to the merged OCR teacher checkpoint}
+aes_teacher_path=${AES_TEACHER_PATH:?set AES_TEACHER_PATH to the merged Aes teacher checkpoint}
+reward_model_name=Qwen/Qwen2.5-VL-3B-Instruct
+reward_function_path=examples/diffusionopd_trainer/sd35/mixed_task_reward.py
+custom_chat_template='{% for message in messages %}{% if message['\''role'\''] == '\''user'\'' %}{{ message['\''content'\''] }}{% endif %}{% endfor %}'
+
+NUM_GPUS_ACTOR_ROLLOUT=2
+NUM_GPUS_REWARD=1
+ROLLOUT_TP=1
+REWARD_TP=1
+IMAGE_RESOLUTION=384
+TOTAL_TRAINING_STEPS=100
+ATTN_BACKEND=native
+
+MAX_NUM_SEQS=${MAX_NUM_SEQS:-256}
+REQUEST_BATCH_MAX_WAIT_MS=${REQUEST_BATCH_MAX_WAIT_MS:-10}
+ROLLOUT_ATTN_BACKEND=TORCH_SDPA
+
+if [ "${FA3:-0}" = "1" ]; then
+    ATTN_BACKEND="_flash_3_varlen_hub"
+    ROLLOUT_ATTN_BACKEND=FLASH_ATTN_3_HUB
+fi
+
+ENGINE=vllm_omni
+REWARD_ENGINE=vllm
+
+python3 -m verl_omni.trainer.main_diffusion \
+    data.train_files="[\"$ocr_train_path\",\"$pickscore_train_path\"]" \
+    data.val_files="[\"$ocr_test_path\",\"$pickscore_test_path\"]" \
+    data.train_batch_size=8 \
+    data.val_max_samples=64 \
+    data.max_prompt_length=512 \
+    data.truncation=error \
+    data.seed=42 \
+    actor_rollout_ref.model.algorithm=flow_grpo \
+    actor_rollout_ref.model.path=$model_name \
+    actor_rollout_ref.model.custom_chat_template="\"$custom_chat_template\"" \
+    'actor_rollout_ref.model.extra_tokenizers={clip: {path: tokenizer, max_length: 77}, t5: {path: tokenizer_3, max_length: 256}}' \
+    actor_rollout_ref.model.attn_backend=$ATTN_BACKEND \
+    actor_rollout_ref.model.lora_rank=32 \
+    actor_rollout_ref.model.lora_alpha=64 \
+    actor_rollout_ref.model.target_modules="['to_q','to_k','to_v','to_out.0','add_q_proj','add_k_proj','add_v_proj','to_add_out']" \
+    distillation.enabled=True \
+    +distillation.teacher_models.ocr_teacher.key=flow_grpo/ocr \
+    +distillation.teacher_models.ocr_teacher.model_path=$ocr_teacher_path \
+    +distillation.teacher_models.pickscore_teacher.key=flow_grpo/pickscore_sfw \
+    +distillation.teacher_models.pickscore_teacher.model_path=$aes_teacher_path \
+    actor_rollout_ref.actor.diffusion_loss.loss_mode=distill_kl \
+    actor_rollout_ref.actor.diffusion_loss.clip_ratio=1e-5 \
+    actor_rollout_ref.actor.use_kl_loss=False \
+    actor_rollout_ref.actor.kl_loss_coef=0.0 \
+    actor_rollout_ref.actor.optim.lr=1e-4 \
+    actor_rollout_ref.actor.optim.weight_decay=0.0001 \
+    actor_rollout_ref.actor.ppo_mini_batch_size=4 \
+    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=8 \
+    actor_rollout_ref.actor.strategy=fsdp2 \
+    actor_rollout_ref.actor.fsdp_config.param_offload=False \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=False \
+    actor_rollout_ref.actor.fsdp_config.model_dtype=bfloat16 \
+    actor_rollout_ref.actor.fsdp_config.ulysses_sequence_parallel_size=1 \
+    actor_rollout_ref.rollout.rollout_attn_backend=$ROLLOUT_ATTN_BACKEND \
+    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=8 \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=$ROLLOUT_TP \
+    actor_rollout_ref.rollout.name=$ENGINE \
+    actor_rollout_ref.rollout.n=8 \
+    actor_rollout_ref.rollout.seed=42 \
+    actor_rollout_ref.rollout.agent.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT / ROLLOUT_TP)) \
+    actor_rollout_ref.rollout.load_format=safetensors \
+    actor_rollout_ref.rollout.pipeline.height=$IMAGE_RESOLUTION \
+    actor_rollout_ref.rollout.pipeline.width=$IMAGE_RESOLUTION \
+    actor_rollout_ref.rollout.pipeline.num_inference_steps=10 \
+    actor_rollout_ref.rollout.pipeline.guidance_scale=1.0 \
+    actor_rollout_ref.rollout.pipeline.max_sequence_length=256 \
+    actor_rollout_ref.rollout.max_prompt_embed_length=333 \
+    actor_rollout_ref.rollout.algo.noise_level=0.8 \
+    actor_rollout_ref.rollout.algo.sde_type="cps" \
+    actor_rollout_ref.rollout.algo.sde_window_size=3 \
+    actor_rollout_ref.rollout.algo.sde_window_range="[0,5]" \
+    ++actor_rollout_ref.rollout.engine_kwargs.vllm_omni.max_num_seqs=${MAX_NUM_SEQS} \
+    ++actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
+    actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=28 \
+    actor_rollout_ref.rollout.val_kwargs.algo.noise_level=0.0 \
+    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=8 \
+    reward.num_workers=$((NUM_GPUS_REWARD / REWARD_TP)) \
+    reward.reward_model.enable=True \
+    reward.reward_model.model_path=$reward_model_name \
+    reward.reward_model.rollout.name=$REWARD_ENGINE \
+    reward.reward_model.enable_resource_pool=True \
+    reward.reward_model.nnodes=1 \
+    reward.reward_model.n_gpus_per_node=$NUM_GPUS_REWARD \
+    reward.reward_model.rollout.gpu_memory_utilization=0.9 \
+    reward.reward_model.rollout.free_cache_engine=False \
+    reward.reward_model.rollout.tensor_model_parallel_size=$REWARD_TP \
+    reward.reward_model.rollout.enforce_eager=False \
+    reward.custom_reward_function.path=$reward_function_path \
+    reward.custom_reward_function.name=compute_score_mixed \
+    trainer.logger='["console", "wandb"]' \
+    trainer.project_name=diffusion_opd \
+    trainer.experiment_name=sd35_medium_mopd_distill \
+    trainer.log_val_generations=8 \
+    trainer.val_before_train=True \
+    trainer.n_gpus_per_node=$NUM_GPUS_ACTOR_ROLLOUT \
+    trainer.nnodes=1 \
+    trainer.save_freq=100 \
+    trainer.test_freq=20 \
+    trainer.total_epochs=15 \
+    trainer.total_training_steps=$TOTAL_TRAINING_STEPS \
+    "$@"

--- a/tests/gpu_smoke/run_gpu_smoke_diffusion_e2e.sh
+++ b/tests/gpu_smoke/run_gpu_smoke_diffusion_e2e.sh
@@ -48,4 +48,12 @@ run_test 6 "Bagel PickScore LoRA FlowGRPO e2e" \
     env CUDA_VISIBLE_DEVICES="${CUDA_DEVICE_LIST}" NUM_GPUS="${NUM_GPUS}" \
     bash tests/special_e2e/run_flowgrpo_bagel_pickscore.sh "${diffusion_trainer_args[@]}"
 
+run_test 7 "Diffusion OPD two colocated teachers e2e" \
+    env CUDA_VISIBLE_DEVICES="${CUDA_DEVICE_LIST}" NUM_GPUS="${NUM_GPUS}" SMOKE=mopd \
+    bash tests/special_e2e/run_diffusion_teacher_smoke.sh
+
+run_test 8 "Diffusion OPD standalone teacher pool e2e" \
+    env CUDA_VISIBLE_DEVICES="${CUDA_DEVICE_LIST}" NUM_GPUS="${NUM_GPUS}" SMOKE=standalone \
+    bash tests/special_e2e/run_diffusion_teacher_smoke.sh
+
 gpu_smoke_summary

--- a/tests/special_e2e/create_dummy_diffusion_data.py
+++ b/tests/special_e2e/create_dummy_diffusion_data.py
@@ -41,13 +41,13 @@ USER_PROMPTS = [
 ]
 
 
-def build_rows(split: str, n: int):
+def build_rows(split: str, n: int, data_sources: list[str]):
     rows = []
     for i in range(n):
         prompt_text = USER_PROMPTS[i % len(USER_PROMPTS)]
         rows.append(
             {
-                "data_source": "jpeg_compressibility",
+                "data_source": data_sources[i % len(data_sources)],
                 "prompt": [
                     {"role": "system", "content": SYSTEM_PROMPT},
                     {"role": "user", "content": prompt_text},
@@ -72,12 +72,18 @@ def main():
     )
     parser.add_argument("--train_size", type=int, default=32, help="Number of training samples")
     parser.add_argument("--val_size", type=int, default=8, help="Number of validation samples")
+    parser.add_argument(
+        "--data_sources",
+        default="jpeg_compressibility",
+        help="Comma-separated data_source values assigned to rows in round-robin order",
+    )
     args = parser.parse_args()
+    data_sources = args.data_sources.split(",")
 
     os.makedirs(args.local_save_dir, exist_ok=True)
 
-    train_df = pd.DataFrame(build_rows("train", args.train_size))
-    val_df = pd.DataFrame(build_rows("test", args.val_size))
+    train_df = pd.DataFrame(build_rows("train", args.train_size, data_sources))
+    val_df = pd.DataFrame(build_rows("test", args.val_size, data_sources))
 
     train_path = os.path.join(args.local_save_dir, "train.parquet")
     val_path = os.path.join(args.local_save_dir, "test.parquet")

--- a/tests/special_e2e/run_diffusion_teacher_smoke.sh
+++ b/tests/special_e2e/run_diffusion_teacher_smoke.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Diffusion OPD teacher-runtime e2e smoke.
 #
-# Two runs over one SD3 checkpoint pair:
+# Four runs over tiny SD3 checkpoints:
 #   SMOKE=distill      pure distillation -- teacher is a *distinct* checkpoint and
 #                      `diffusion_loss.loss_mode=distill_kl` is the only objective.
 #   SMOKE=coexistence  actor + reference + teacher live at once: flow_grpo plus the
@@ -9,6 +9,10 @@
 #                      lora_rank/lora_adapter_path are pinned empty on purpose: either
 #                      one set makes main_diffusion fold the ref into the actor, and the
 #                      run would pass while holding only two model states.
+#   SMOKE=mopd         pure distillation with two teachers colocated with the actor; rows
+#                      alternate `data_source` between the two routing keys.
+#   SMOKE=standalone   same two teachers, each on its own GPU in the distillation
+#                      resource pool (needs NUM_GPUS=3: one actor GPU + two teacher GPUs).
 #
 # Reward is the pure-CPU jpeg compressibility score, so no reward-model server is
 # needed -- this smoke is about the teacher runtime, not about reward quality.
@@ -17,12 +21,13 @@
 # so the step-1 KL is positive) and needs no downloads; set MODEL_PATH and
 # TEACHER_PATH to run against real checkpoints instead.
 #
-# Override via env: NUM_GPUS, MODEL_PATH, TEACHER_PATH, DATA_DIR, TOTAL_TRAIN_STEPS, SMOKE
+# Override via env: NUM_GPUS, MODEL_PATH, TEACHER_PATH, TEACHER2_PATH, DATA_DIR, TOTAL_TRAIN_STEPS, SMOKE
 set -euo pipefail
 
 NUM_GPUS=${NUM_GPUS:-1}
 MODEL_PATH=${MODEL_PATH:-${HOME}/models/tiny-random/sd3-teacher-smoke-student}
 TEACHER_PATH=${TEACHER_PATH:-${HOME}/models/tiny-random/sd3-teacher-smoke-teacher}
+TEACHER2_PATH=${TEACHER2_PATH:-${HOME}/models/tiny-random/sd3-teacher-smoke-teacher2}
 DATA_DIR=${DATA_DIR:-${HOME}/data/dummy_diffusion_teacher}
 TOTAL_TRAIN_STEPS=${TOTAL_TRAIN_STEPS:-1}
 SMOKE=${SMOKE:-distill}
@@ -33,6 +38,9 @@ fi
 if [[ ! -f "${TEACHER_PATH}/model_index.json" ]]; then
     python3 tests/special_e2e/build_sd3_tiny_random.py --output-dir "${TEACHER_PATH}" --seed 1
 fi
+if [[ "${SMOKE}" == "mopd" || "${SMOKE}" == "standalone" ]] && [[ ! -f "${TEACHER2_PATH}/model_index.json" ]]; then
+    python3 tests/special_e2e/build_sd3_tiny_random.py --output-dir "${TEACHER2_PATH}" --seed 2
+fi
 
 ENGINE=vllm_omni
 max_prompt_length=128
@@ -41,29 +49,59 @@ max_prompt_length=128
 ATTN_BACKEND=native
 ROLLOUT_ATTN_BACKEND=TORCH_SDPA
 
+# Standalone teachers take two GPUs of their own; the actor keeps the rest.
+if [[ "${SMOKE}" == "standalone" ]]; then
+    actor_gpus=$((NUM_GPUS - 2))
+else
+    actor_gpus=${NUM_GPUS}
+fi
+
 n_resp_per_prompt=2
 micro_bsz_per_gpu=1
-mini_bsz=$((micro_bsz_per_gpu * NUM_GPUS))
+mini_bsz=$((micro_bsz_per_gpu * actor_gpus))
 train_batch_size=$((mini_bsz * n_resp_per_prompt))
+
+# Two-teacher smokes alternate rows between the two routing keys.
+if [[ "${SMOKE}" == "mopd" || "${SMOKE}" == "standalone" ]]; then
+    data_sources=teacher_a,teacher_b
+else
+    data_sources=jpeg_compressibility
+fi
 
 python3 tests/special_e2e/create_dummy_diffusion_data.py \
     --local_save_dir "${DATA_DIR}" \
     --train_size "${train_batch_size}" \
-    --val_size 2
+    --val_size 2 \
+    --data_sources "${data_sources}"
 
 # SD3's CLIP tokenizer ships no chat template, and the diffusion agent loop applies
 # one to every prompt; pass through the raw user content.
 custom_chat_template='{% for message in messages %}{% if message['\''role'\''] == '\''user'\'' %}{{ message['\''content'\''] }}{% endif %}{% endfor %}'
 
-# Objective differs per smoke; the teacher runtime config does not.
+single_teacher=(
+    distillation.teacher_models.teacher_model.model_path="${TEACHER_PATH}"
+)
+two_teachers=(
+    +distillation.teacher_models.a.key=teacher_a
+    +distillation.teacher_models.a.model_path="${TEACHER_PATH}"
+    +distillation.teacher_models.a.world_size=1
+    +distillation.teacher_models.b.key=teacher_b
+    +distillation.teacher_models.b.model_path="${TEACHER2_PATH}"
+    +distillation.teacher_models.b.world_size=1
+)
+pure_distill=(
+    actor_rollout_ref.actor.diffusion_loss.loss_mode=distill_kl
+    actor_rollout_ref.actor.use_kl_loss=False
+)
+
+# Objective and teacher placement differ per smoke.
 case "${SMOKE}" in
     distill)
-        objective=(
-            actor_rollout_ref.actor.diffusion_loss.loss_mode=distill_kl
-            actor_rollout_ref.actor.use_kl_loss=False
-        )
+        teacher=("${single_teacher[@]}")
+        objective=("${pure_distill[@]}")
         ;;
     coexistence)
+        teacher=("${single_teacher[@]}")
         objective=(
             actor_rollout_ref.actor.diffusion_loss.loss_mode=flow_grpo
             actor_rollout_ref.actor.use_distill_loss=True
@@ -72,8 +110,22 @@ case "${SMOKE}" in
             actor_rollout_ref.actor.kl_loss_coef=0.04
         )
         ;;
+    mopd)
+        teacher=("${two_teachers[@]}")
+        objective=("${pure_distill[@]}")
+        ;;
+    standalone)
+        teacher=(
+            "${two_teachers[@]}"
+            distillation.n_gpus_per_node=2
+            distillation.nnodes=1
+            # The default fixed port range hands every worker group the same rendezvous port.
+            trainer.ray_master_port_range=null
+        )
+        objective=("${pure_distill[@]}")
+        ;;
     *)
-        echo "Unknown SMOKE=${SMOKE}; expected 'distill' or 'coexistence'." >&2
+        echo "Unknown SMOKE=${SMOKE}; expected 'distill', 'coexistence', 'mopd' or 'standalone'." >&2
         exit 1
         ;;
 esac
@@ -91,7 +143,7 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.model.custom_chat_template="\"${custom_chat_template}\"" \
     "actor_rollout_ref.model.extra_tokenizers={clip: {path: tokenizer, max_length: 77}, t5: {path: tokenizer_3, max_length: ${max_prompt_length}}}" \
     distillation.enabled=True \
-    distillation.teacher_models.teacher_model.model_path="${TEACHER_PATH}" \
+    "${teacher[@]}" \
     "${objective[@]}" \
     actor_rollout_ref.actor.optim.lr=1e-4 \
     actor_rollout_ref.actor.ppo_mini_batch_size=${mini_bsz} \
@@ -131,7 +183,7 @@ python3 -m verl_omni.trainer.main_diffusion \
     trainer.project_name=verl-test \
     trainer.experiment_name=diffusion-teacher-${SMOKE} \
     trainer.log_val_generations=0 \
-    trainer.n_gpus_per_node=${NUM_GPUS} \
+    trainer.n_gpus_per_node=${actor_gpus} \
     trainer.nnodes=1 \
     trainer.val_before_train=False \
     trainer.test_freq=-1 \

--- a/tests/trainer/diffusion/test_controller_nsys_profiler_on_cpu.py
+++ b/tests/trainer/diffusion/test_controller_nsys_profiler_on_cpu.py
@@ -59,6 +59,7 @@ def _make_trainer(events, *, controller_enabled=True, use_reference_policy=True)
     trainer.ref_policy_wg = _RecordingWorkerGroup(events, "ref")
     trainer.use_reference_policy = use_reference_policy
     trainer.ref_in_actor = False
+    trainer.use_teacher_policy = False
     trainer._controller_nsys_profile_enabled = controller_enabled
     trainer._controller_nsys_profile_active = False
     return trainer

--- a/tests/trainer/diffusion/test_diffusion_teacher_manager_on_cpu.py
+++ b/tests/trainer/diffusion/test_diffusion_teacher_manager_on_cpu.py
@@ -78,9 +78,11 @@ def make_batch(data_source):
     return batch
 
 
-def make_manager(overrides, teacher_wg):
+def make_manager(overrides, teacher_wg, **kwargs):
     cfg = compose_cfg(overrides)
-    return DiffusionTeacherManager(omega_conf_to_dataclass(cfg.distillation), cfg.actor_rollout_ref.model, teacher_wg)
+    return DiffusionTeacherManager(
+        omega_conf_to_dataclass(cfg.distillation), cfg.actor_rollout_ref.model, teacher_wg, **kwargs
+    )
 
 
 class TestDiffusionTeacherManagerInit:
@@ -131,6 +133,32 @@ class TestComputePrevSampleMean:
         assert wg["ocr"].calls == [("ocr", 4)]
         assert wg["aes"].calls == [("aes", 2)]
         assert [kind for kind, _ in log] == ["infer", "infer", "get", "get"]
+
+    def test_odd_sub_batch_padded_to_micro_batch_divisor(self):
+        log = []
+        wg = {"ocr": FakeTeacherWorkerGroup(1.0, 2, log), "aes": FakeTeacherWorkerGroup(2.0, 2, log)}
+        manager = make_manager(MULTI, wg, infer_micro_batch_size_per_gpu=8)
+        data_source = ["ocr"] * 3 + ["aes"] * 5
+
+        out = manager.compute_prev_sample_mean(make_batch(data_source))
+
+        # 3 and 5 rows are both padded to world_size * micro so every rank's shard splits into micro-batches
+        assert wg["ocr"].calls == [("ocr", 16)]
+        assert wg["aes"].calls == [("aes", 16)]
+        prev = out.batch["teacher_prev_sample_mean"]
+        assert prev.shape == (8, 4, 8, 3)
+        expected = torch.tensor([1.0] * 3 + [2.0] * 5).view(8, 1, 1, 1).expand(8, 4, 8, 3)
+        torch.testing.assert_close(prev, expected)
+
+    def test_without_micro_batch_size_pads_to_world_size_only(self):
+        log = []
+        wg = {"ocr": FakeTeacherWorkerGroup(1.0, 2, log), "aes": FakeTeacherWorkerGroup(2.0, 1, log)}
+        manager = make_manager(MULTI, wg)
+
+        manager.compute_prev_sample_mean(make_batch(["ocr", "ocr", "ocr", "aes"]))
+
+        assert wg["ocr"].calls == [("ocr", 4)]
+        assert wg["aes"].calls == [("aes", 1)]
 
     def test_single_teacher_dispatches_whole_batch_once(self):
         log = []

--- a/tests/trainer/diffusion/test_diffusion_teacher_manager_on_cpu.py
+++ b/tests/trainer/diffusion/test_diffusion_teacher_manager_on_cpu.py
@@ -1,0 +1,143 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU tests for routing rollout batches to frozen diffusion teachers."""
+
+import os
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+from hydra import compose, initialize_config_dir
+from verl import DataProto
+from verl.utils import tensordict_utils as tu
+from verl.utils.config import omega_conf_to_dataclass
+
+import verl_omni
+from verl_omni.trainer.diffusion.teacher_manager import DiffusionTeacherManager
+
+CONFIG_DIR = os.path.join(os.path.dirname(os.path.abspath(verl_omni.__file__)), "trainer", "config")
+
+SINGLE = [
+    "distillation.enabled=true",
+    "distillation.teacher_models.teacher_model.model_path=/ckpt/teacher",
+]
+MULTI = [
+    "distillation.enabled=true",
+    "+distillation.teacher_models.a.key=ocr",
+    "+distillation.teacher_models.a.model_path=/ckpt/a",
+    "+distillation.teacher_models.b.key=aes",
+    "+distillation.teacher_models.b.model_path=/ckpt/b",
+]
+
+
+def compose_cfg(overrides):
+    with initialize_config_dir(config_dir=CONFIG_DIR, version_base=None):
+        return compose(config_name="diffusion_trainer", overrides=overrides)
+
+
+class FakeTeacherWorkerGroup:
+    """Records dispatch order and returns a key-specific constant as a future."""
+
+    def __init__(self, value, world_size, log):
+        self.value = value
+        self.world_size = world_size
+        self.log = log
+        self.calls = []
+
+    def infer_teacher_batch(self, td):
+        teacher_key = tu.get(td, "teacher_key")
+        self.calls.append((teacher_key, td.batch_size[0]))
+        self.log.append(("infer", teacher_key))
+        prev = torch.full((td.batch_size[0], 4, 8, 3), self.value, dtype=torch.bfloat16)
+
+        def get():
+            self.log.append(("get", teacher_key))
+            return tu.get_tensordict({"prev_sample_mean": prev})
+
+        return SimpleNamespace(get=get)
+
+
+def make_batch(data_source):
+    n = len(data_source)
+    batch = DataProto.from_tensordict(
+        tu.get_tensordict({"all_latents": torch.randn(n, 5, 8, 3), "all_timesteps": torch.zeros(n, 4)})
+    )
+    batch.non_tensor_batch["data_source"] = np.array(data_source, dtype=object)
+    return batch
+
+
+def make_manager(overrides, teacher_wg):
+    cfg = compose_cfg(overrides)
+    return DiffusionTeacherManager(omega_conf_to_dataclass(cfg.distillation), cfg.actor_rollout_ref.model, teacher_wg)
+
+
+class TestDiffusionTeacherManagerInit:
+    def test_rejects_mismatched_worker_group_keys(self):
+        with pytest.raises(ValueError, match="do not match teacher routing keys"):
+            make_manager(MULTI, {"ocr": SimpleNamespace(), "other": SimpleNamespace()})
+
+
+class TestResolveTeacherKeys:
+    def test_single_teacher_ignores_routing_column(self):
+        manager = make_manager(SINGLE, {"default": SimpleNamespace()})
+        keys = manager._resolve_teacher_keys(make_batch(["x", "y"]))
+        assert list(keys) == ["default", "default"]
+
+    def test_multi_teacher_requires_routing_column(self):
+        manager = make_manager(MULTI, {"ocr": SimpleNamespace(), "aes": SimpleNamespace()})
+        batch = make_batch(["ocr"])
+        del batch.non_tensor_batch["data_source"]
+        with pytest.raises(ValueError, match="Routing key is required for multi-teacher distillation"):
+            manager._resolve_teacher_keys(batch)
+
+    def test_multi_teacher_rejects_unknown_key(self):
+        manager = make_manager(MULTI, {"ocr": SimpleNamespace(), "aes": SimpleNamespace()})
+        with pytest.raises(ValueError, match="No teacher configured for routing key"):
+            manager._resolve_teacher_keys(make_batch(["ocr", "bogus"]))
+
+    def test_multi_teacher_returns_column(self):
+        manager = make_manager(MULTI, {"ocr": SimpleNamespace(), "aes": SimpleNamespace()})
+        keys = manager._resolve_teacher_keys(make_batch(["aes", "ocr"]))
+        assert list(keys) == ["aes", "ocr"]
+
+
+class TestComputePrevSampleMean:
+    def test_multi_teacher_routes_groups_and_restores_order(self):
+        log = []
+        wg = {"ocr": FakeTeacherWorkerGroup(1.0, 2, log), "aes": FakeTeacherWorkerGroup(2.0, 1, log)}
+        manager = make_manager(MULTI, wg)
+        data_source = ["ocr", "aes", "ocr", "aes", "ocr"]
+
+        out = manager.compute_prev_sample_mean(make_batch(data_source))
+
+        assert set(out.batch.keys()) == {"teacher_prev_sample_mean"}
+        prev = out.batch["teacher_prev_sample_mean"]
+        assert prev.dtype == torch.float32
+        assert prev.shape == (5, 4, 8, 3)
+        expected = torch.tensor([1.0, 2.0, 1.0, 2.0, 1.0]).view(5, 1, 1, 1).expand(5, 4, 8, 3)
+        torch.testing.assert_close(prev, expected)
+        assert wg["ocr"].calls == [("ocr", 4)]
+        assert wg["aes"].calls == [("aes", 2)]
+        assert [kind for kind, _ in log] == ["infer", "infer", "get", "get"]
+
+    def test_single_teacher_dispatches_whole_batch_once(self):
+        log = []
+        wg = {"default": FakeTeacherWorkerGroup(3.0, 2, log)}
+        manager = make_manager(SINGLE, wg)
+
+        out = manager.compute_prev_sample_mean(make_batch(["x", "y", "z"]))
+
+        assert wg["default"].calls == [("default", 3)]
+        torch.testing.assert_close(out.batch["teacher_prev_sample_mean"], torch.full((3, 4, 8, 3), 3.0))

--- a/tests/trainer/diffusion/test_distillation_config_on_cpu.py
+++ b/tests/trainer/diffusion/test_distillation_config_on_cpu.py
@@ -40,22 +40,83 @@ class TestDiffusionDistillationConfig:
                 teacher_models={"teacher_model": DiffusionDistillationTeacherModelConfig()},
             )
 
-    def test_enabled_requires_single_teacher_model_entry(self):
-        with pytest.raises(NotImplementedError, match="teacher_model"):
-            DiffusionDistillationConfig(
-                enabled=True,
-                teacher_models={
-                    "teacher_model": DiffusionDistillationTeacherModelConfig(model_path="/ckpt/a"),
-                    "second": DiffusionDistillationTeacherModelConfig(model_path="/ckpt/b"),
-                },
-            )
-
-    def test_enabled_with_model_path_passes(self):
+    def test_single_teacher_is_keyed_default(self):
         config = DiffusionDistillationConfig(
             enabled=True,
             teacher_models={"teacher_model": DiffusionDistillationTeacherModelConfig(model_path="/ckpt/teacher")},
         )
-        assert config.teacher_models["teacher_model"].model_path == "/ckpt/teacher"
+        assert set(config.teacher_models) == {"default"}
+        assert config.teacher_models["default"].key == "default"
+        assert config.teacher_models["default"].model_path == "/ckpt/teacher"
+        assert config.teacher_models["default"].world_size == 0
+
+    def test_single_teacher_fills_standalone_pool(self):
+        config = DiffusionDistillationConfig(
+            enabled=True,
+            n_gpus_per_node=2,
+            nnodes=2,
+            teacher_models={"teacher_model": DiffusionDistillationTeacherModelConfig(model_path="/ckpt/teacher")},
+        )
+        assert config.teacher_models["default"].world_size == 4
+
+    def test_multi_teacher_pops_default_entry_and_indexes_by_key(self):
+        config = DiffusionDistillationConfig(
+            enabled=True,
+            teacher_models={
+                "teacher_model": DiffusionDistillationTeacherModelConfig(),
+                "a": DiffusionDistillationTeacherModelConfig(key="ocr", model_path="/ckpt/a"),
+                "b": DiffusionDistillationTeacherModelConfig(key="aes", model_path="/ckpt/b"),
+            },
+        )
+        assert set(config.teacher_models) == {"ocr", "aes"}
+        assert config.teacher_models["ocr"].model_path == "/ckpt/a"
+        assert config.teacher_models["aes"].model_path == "/ckpt/b"
+
+    def test_multi_teacher_requires_key(self):
+        with pytest.raises(ValueError, match="key must be specified"):
+            DiffusionDistillationConfig(
+                enabled=True,
+                teacher_models={
+                    "teacher_model": DiffusionDistillationTeacherModelConfig(),
+                    "a": DiffusionDistillationTeacherModelConfig(model_path="/ckpt/a"),
+                    "b": DiffusionDistillationTeacherModelConfig(key="aes", model_path="/ckpt/b"),
+                },
+            )
+
+    def test_multi_teacher_rejects_duplicate_key(self):
+        with pytest.raises(ValueError, match="Duplicate teacher key"):
+            DiffusionDistillationConfig(
+                enabled=True,
+                teacher_models={
+                    "teacher_model": DiffusionDistillationTeacherModelConfig(),
+                    "a": DiffusionDistillationTeacherModelConfig(key="ocr", model_path="/ckpt/a"),
+                    "b": DiffusionDistillationTeacherModelConfig(key="ocr", model_path="/ckpt/b"),
+                },
+            )
+
+    def test_standalone_pool_requires_matching_world_size_sum(self):
+        with pytest.raises(ValueError, match="must match the distillation resource pool size"):
+            DiffusionDistillationConfig(
+                enabled=True,
+                n_gpus_per_node=4,
+                nnodes=1,
+                teacher_models={
+                    "teacher_model": DiffusionDistillationTeacherModelConfig(),
+                    "a": DiffusionDistillationTeacherModelConfig(key="ocr", model_path="/ckpt/a", world_size=1),
+                    "b": DiffusionDistillationTeacherModelConfig(key="aes", model_path="/ckpt/b", world_size=1),
+                },
+            )
+
+    def test_colocated_ignores_world_size(self):
+        config = DiffusionDistillationConfig(
+            enabled=True,
+            teacher_models={
+                "teacher_model": DiffusionDistillationTeacherModelConfig(),
+                "a": DiffusionDistillationTeacherModelConfig(key="ocr", model_path="/ckpt/a"),
+                "b": DiffusionDistillationTeacherModelConfig(key="aes", model_path="/ckpt/b"),
+            },
+        )
+        assert set(config.teacher_models) == {"ocr", "aes"}
 
 
 class TestDistillationConfigComposition:
@@ -81,4 +142,28 @@ class TestDistillationConfigComposition:
             ]
         )
         config = omega_conf_to_dataclass(cfg.distillation)
-        assert config.teacher_models["teacher_model"].model_path == "/ckpt/teacher"
+        assert config.teacher_models["default"].model_path == "/ckpt/teacher"
+        assert config.teacher_key == "data_source"
+        assert config.n_gpus_per_node == 0
+        assert config.nnodes == 0
+
+    def test_cli_multi_teacher_entries(self):
+        from verl.utils.config import omega_conf_to_dataclass
+
+        cfg = self._compose(
+            [
+                "distillation.enabled=true",
+                "+distillation.teacher_models.a.key=ocr",
+                "+distillation.teacher_models.a.model_path=/ckpt/a",
+                "+distillation.teacher_models.a.world_size=1",
+                "+distillation.teacher_models.b.key=aes",
+                "+distillation.teacher_models.b.model_path=/ckpt/b",
+                "+distillation.teacher_models.b.world_size=1",
+                "distillation.n_gpus_per_node=2",
+                "distillation.nnodes=1",
+            ]
+        )
+        config = omega_conf_to_dataclass(cfg.distillation)
+        assert set(config.teacher_models) == {"ocr", "aes"}
+        assert all(isinstance(t, DiffusionDistillationTeacherModelConfig) for t in config.teacher_models.values())
+        assert config.teacher_models["aes"].world_size == 1

--- a/tests/trainer/diffusion/test_distillation_trainer_wiring_on_cpu.py
+++ b/tests/trainer/diffusion/test_distillation_trainer_wiring_on_cpu.py
@@ -14,10 +14,8 @@
 """CPU tests for the diffusion distillation trainer wiring."""
 
 import os
-from types import SimpleNamespace
 
 import pytest
-import torch
 from hydra import compose, initialize_config_dir
 
 import verl_omni
@@ -79,23 +77,3 @@ class TestValidateDistillationConfig:
                     ]
                 )
             )
-
-
-class TestComputeTeacherPrevSampleMean:
-    def test_returns_float32_teacher_key(self):
-        from verl import DataProto
-        from verl.utils import tensordict_utils as tu
-
-        from verl_omni.trainer.diffusion.ray_diffusion_trainer import PolicyGradientRayTrainer
-
-        prev = torch.randn(2, 4, 8, 3, dtype=torch.bfloat16)
-        fake_wg = SimpleNamespace(infer_teacher_batch=lambda td: tu.get_tensordict({"prev_sample_mean": prev}))
-        cfg = compose_cfg(ENABLE + ["actor_rollout_ref.actor.diffusion_loss.loss_mode=distill_kl"])
-        fake_self = SimpleNamespace(config=cfg, actor_rollout_wg=fake_wg)
-        batch = DataProto.from_tensordict(
-            tu.get_tensordict({"all_latents": torch.randn(2, 5, 8, 3), "all_timesteps": torch.zeros(2, 4)})
-        )
-        out = PolicyGradientRayTrainer._compute_teacher_prev_sample_mean(fake_self, batch)
-        assert set(out.batch.keys()) == {"teacher_prev_sample_mean"}
-        assert out.batch["teacher_prev_sample_mean"].dtype == torch.float32
-        torch.testing.assert_close(out.batch["teacher_prev_sample_mean"], prev.float())

--- a/tests/trainer/diffusion/test_distillation_trainer_wiring_on_cpu.py
+++ b/tests/trainer/diffusion/test_distillation_trainer_wiring_on_cpu.py
@@ -77,3 +77,37 @@ class TestValidateDistillationConfig:
                     ]
                 )
             )
+
+
+class TestTeacherPoolRegistration:
+    def _runner(self, overrides):
+        from verl_omni.trainer.main_diffusion import TaskRunner
+
+        cfg = compose_cfg(ENABLE + ["actor_rollout_ref.actor.diffusion_loss.loss_mode=distill_kl"] + overrides)
+        runner = TaskRunner()
+        actor_rollout_cls, _ = runner.add_actor_rollout_worker(cfg)
+        runner.add_teacher_model_worker(cfg, actor_rollout_cls)
+        return cfg, runner
+
+    def test_standalone_registers_teacher_pool(self):
+        from verl.trainer.ppo.utils import Role
+
+        cfg, runner = self._runner(["distillation.n_gpus_per_node=2", "distillation.nnodes=1"])
+        manager = runner.init_resource_pool_mgr(cfg)
+        assert manager.resource_pool_spec["teacher_pool"] == [2]
+        assert runner.mapping[Role.TeacherModel] == "teacher_pool"
+        assert Role.TeacherModel in runner.role_worker_mapping
+
+    def test_colocated_registers_nothing(self):
+        from verl.trainer.ppo.utils import Role
+
+        cfg, runner = self._runner([])
+        manager = runner.init_resource_pool_mgr(cfg)
+        assert "teacher_pool" not in manager.resource_pool_spec
+        assert Role.TeacherModel not in runner.mapping
+        assert Role.TeacherModel not in runner.role_worker_mapping
+
+    def test_standalone_requires_gpus_per_node(self):
+        cfg, runner = self._runner(["distillation.n_gpus_per_node=0", "distillation.nnodes=1"])
+        with pytest.raises(ValueError, match="config.distillation.n_gpus_per_node must be greater than 0"):
+            runner.init_resource_pool_mgr(cfg)

--- a/tests/trainer/diffusion/test_worker_batch_projection_on_cpu.py
+++ b/tests/trainer/diffusion/test_worker_batch_projection_on_cpu.py
@@ -28,6 +28,7 @@ from verl_omni.trainer.diffusion.ray_diffusion_trainer import (
     PolicyGradientRayTrainer,
     _to_diffusion_worker_tensordict,
 )
+from verl_omni.trainer.diffusion.teacher_manager import DiffusionTeacherManager
 from verl_omni.trainer.diffusion.v1.trainer_base import PolicyGradientDiffusionTrainerV1
 
 
@@ -114,12 +115,6 @@ def test_worker_projection_preserves_driver_batch_and_shared_tensor_storage(incl
     [
         (PolicyGradientRayTrainer, "_compute_old_log_prob", "actor_rollout_wg", "infer_actor_batch"),
         (PolicyGradientRayTrainer, "_compute_ref_log_prob", "ref_policy_wg", "infer_ref_batch"),
-        (
-            PolicyGradientRayTrainer,
-            "_compute_teacher_prev_sample_mean",
-            "actor_rollout_wg",
-            "infer_teacher_batch",
-        ),
         (PolicyGradientRayTrainer, "_update_actor", "actor_rollout_wg", "update_actor"),
         (DirectPreferenceRayTrainer, "_compute_ref_noise_pred", "ref_policy_wg", "infer_ref_batch"),
         (DirectPreferenceRayTrainer, "_update_actor", "actor_rollout_wg", "update_actor"),
@@ -136,6 +131,19 @@ def test_v0_diffusion_worker_hops_exclude_responses(trainer_cls, method_name, wo
 
     worker = getattr(trainer, worker_attr)
     sent_batch = getattr(worker, remote_method).call_args.args[0]
+    _assert_worker_projection(sent_batch, driver_batch)
+
+
+def test_teacher_manager_hop_excludes_responses():
+    actor, _ = _make_worker_groups()
+    manager = DiffusionTeacherManager.__new__(DiffusionTeacherManager)
+    manager.model_config = _make_config().actor_rollout_ref.model
+    manager.teacher_wg = {"default": actor}
+    driver_batch = _make_batch()
+
+    manager._infer(driver_batch, "default")
+
+    sent_batch = actor.infer_teacher_batch.call_args.args[0]
     _assert_worker_projection(sent_batch, driver_batch)
 
 

--- a/tests/workers/test_distillation_teacher_config_on_cpu.py
+++ b/tests/workers/test_distillation_teacher_config_on_cpu.py
@@ -62,3 +62,35 @@ def test_teacher_training_config_derivation(actor_rollout_ref_config, tmp_path):
     assert teacher_training_config.engine_config.forward_only is True
     # ref gives no scoring micro-batch by default, so the actor training micro-batch applies
     assert teacher_training_config.engine_config.infer_micro_batch_size_per_gpu == 8
+
+
+def test_infer_teacher_batch_routes_by_teacher_key():
+    from types import SimpleNamespace
+
+    import torch
+    from tensordict import TensorDict
+    from verl.utils import tensordict_utils as tu
+
+    from verl_omni.workers.engine_workers import ActorRolloutRefWorker
+
+    class FakeTeacher:
+        def __init__(self, value):
+            self.value = value
+            self.seen = None
+
+        def infer_batch(self, data):
+            self.seen = data
+            return TensorDict(
+                {"prev_sample_mean": torch.full((data.batch_size[0], 1), self.value)}, batch_size=data.batch_size
+            )
+
+    teachers = {"ocr": FakeTeacher(1.0), "aes": FakeTeacher(2.0)}
+    worker = SimpleNamespace(teachers=teachers, enable_routing_replay=False, profiler=None)
+    data = TensorDict({"x": torch.zeros(3, 1)}, batch_size=[3])
+    data = tu.assign_non_tensor(data, teacher_key="aes")
+
+    output = ActorRolloutRefWorker.infer_teacher_batch.__wrapped__(worker, data)
+
+    assert torch.equal(output["prev_sample_mean"], torch.full((3, 1), 2.0))
+    assert teachers["ocr"].seen is None
+    assert "teacher_key" not in teachers["aes"].seen.keys()

--- a/verl_omni/trainer/config/_generated_diffusion_trainer.yaml
+++ b/verl_omni/trainer/config/_generated_diffusion_trainer.yaml
@@ -481,10 +481,15 @@ reward:
 distillation:
   _target_: verl_omni.workers.config.diffusion.DiffusionDistillationConfig
   enabled: false
+  n_gpus_per_node: 0
+  nnodes: 0
   teacher_models:
     teacher_model:
       _target_: verl_omni.workers.config.diffusion.DiffusionDistillationTeacherModelConfig
+      key: null
       model_path: null
+      world_size: 0
+  teacher_key: data_source
 algorithm:
   _target_: verl_omni.trainer.config.DiffusionAlgoConfig
   trainer_type: policy_gradient

--- a/verl_omni/trainer/config/_generated_diffusion_veomni_trainer.yaml
+++ b/verl_omni/trainer/config/_generated_diffusion_veomni_trainer.yaml
@@ -522,10 +522,15 @@ reward:
 distillation:
   _target_: verl_omni.workers.config.diffusion.DiffusionDistillationConfig
   enabled: false
+  n_gpus_per_node: 0
+  nnodes: 0
   teacher_models:
     teacher_model:
       _target_: verl_omni.workers.config.diffusion.DiffusionDistillationTeacherModelConfig
+      key: null
       model_path: null
+      world_size: 0
+  teacher_key: data_source
 algorithm:
   _target_: verl_omni.trainer.config.DiffusionAlgoConfig
   trainer_type: policy_gradient

--- a/verl_omni/trainer/config/diffusion/distillation/diffusion_distillation.yaml
+++ b/verl_omni/trainer/config/diffusion/distillation/diffusion_distillation.yaml
@@ -4,14 +4,43 @@ _target_: verl_omni.workers.config.diffusion.DiffusionDistillationConfig
 # Whether on-policy distillation is enabled.
 enabled: false
 
-# Teacher entries. Single-teacher setups configure the `teacher_model` entry.
+# Number of GPUs per node in the distillation teacher resource pool
+n_gpus_per_node: 0
+
+# Number of nodes in the distillation teacher resource pool. 0 colocates the teachers with the actor.
+nnodes: 0
+
+# multi-teacher configs
 teacher_models:
 
-  # The single supported teacher.
+  # Single-teacher config. This entry is popped when other teacher entries are added, so
+  # using `teacher_model` as one of several keys silently drops it. For
+  # example, the following CLI overrides result in ONLY `teacher_model2` being used:
+  #
+  # distillation.teacher_models.teacher_model.key=ocr
+  # distillation.teacher_models.teacher_model.model_path=/ckpt/ocr_teacher
+  # +distillation.teacher_models.teacher_model2.key=aesthetic
+  # +distillation.teacher_models.teacher_model2.model_path=/ckpt/aesthetic_teacher
+  #
+  # Instead, give the first teacher a different name:
+  #
+  # +distillation.teacher_models.teacher_model1.key=ocr
+  # +distillation.teacher_models.teacher_model1.model_path=/ckpt/ocr_teacher
+  # +distillation.teacher_models.teacher_model2.key=aesthetic
+  # +distillation.teacher_models.teacher_model2.model_path=/ckpt/aesthetic_teacher
   teacher_model:
 
     # Target class for this configuration
     _target_: verl_omni.workers.config.diffusion.DiffusionDistillationTeacherModelConfig
 
+    # Identifier to route examples to this teacher in multi-teacher setups. Auto-set to `default` for a single teacher.
+    key: null
+
     # Local path to the frozen teacher checkpoint (same pipeline family as the student).
     model_path: null
+
+    # Number of GPUs this teacher occupies in the distillation teacher resource pool. A single teacher fills the pool.
+    world_size: 0
+
+# Key to route examples to the appropriate teacher model in multi-teacher setups. Should correspond to a field in the data proto, e.g., data_source.
+teacher_key: data_source

--- a/verl_omni/trainer/diffusion/diffusion_trainer_utils.py
+++ b/verl_omni/trainer/diffusion/diffusion_trainer_utils.py
@@ -15,7 +15,16 @@
 
 from typing import Any
 
+from verl import DataProto
 from verl.trainer.distillation import is_distillation_enabled
+
+
+def _to_diffusion_worker_tensordict(batch: DataProto):
+    """Project a driver batch for actor/ref workers without copying tensor storage."""
+    worker_batch = batch.to_tensordict()
+    worker_batch.pop("responses", None)
+    return worker_batch
+
 
 OLD_POLICY_DECAY_SCHEDULES = {
     "copy": (0, 0.0, 0.0),

--- a/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
+++ b/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
@@ -39,7 +39,7 @@ from verl.checkpoint_engine import CheckpointEngineManager
 from verl.plugin.platform import get_platform
 from verl.protocol import pad_dataproto_to_divisor, unpad_dataproto
 from verl.single_controller.ray import RayClassWithInitArgs, RayWorkerGroup, ResourcePoolManager
-from verl.single_controller.ray.base import create_colocated_worker_cls
+from verl.single_controller.ray.base import create_colocated_worker_cls, split_resource_pool
 from verl.trainer.distillation import is_distillation_enabled
 from verl.trainer.ppo.metric_utils import compute_variance_proxy_metrics, process_validation_metrics
 from verl.trainer.ppo.reward import extract_reward
@@ -714,6 +714,10 @@ class BaseRayDiffusionTrainer(ABC):
             return
         self._init_online_rollout_stack(actor_rollout_resource_pool)
 
+    @staticmethod
+    def _teacher_wg_name(key: str) -> str:
+        return f"teacher_{key.replace('/', '_')}"
+
     def _init_colocated_workers(self):
         """Create Ray pools and colocated actor/ref worker groups (online and offline)."""
         self.resource_pool_manager.create_resource_pool()
@@ -748,6 +752,22 @@ class BaseRayDiffusionTrainer(ABC):
                 role=str(Role.RefPolicy),
             )
             self.resource_pool_to_cls[resource_pool][str(Role.RefPolicy)] = ref_policy_cls
+
+        # create standalone teachers if needed, one sub-pool per teacher
+        if self.use_teacher_policy and Role.TeacherModel in self.role_worker_mapping:
+            teacher_pool = self.resource_pool_manager.get_resource_pool(Role.TeacherModel)
+            teacher_models = self.distillation_config.teacher_models
+            split_pools = split_resource_pool(teacher_pool, split_size=[t.world_size for t in teacher_models.values()])
+            for key, pool in zip(teacher_models, split_pools, strict=True):
+                self.resource_pool_to_cls[pool] = {
+                    self._teacher_wg_name(key): RayClassWithInitArgs(
+                        self.role_worker_mapping[Role.TeacherModel],
+                        config=self.config.actor_rollout_ref,
+                        distillation_config=self.config.get("distillation"),
+                        role=str(Role.TeacherModel),
+                        teacher_key=key,
+                    )
+                }
 
         # initialize WorkerGroup
         # NOTE: if you want to use a different resource pool for each role, which can support different parallel size,
@@ -804,7 +824,14 @@ class BaseRayDiffusionTrainer(ABC):
             self.ref_policy_wg = self.actor_rollout_wg
 
         if self.use_teacher_policy:
-            teacher_wg = {key: self.actor_rollout_wg for key in self.distillation_config.teacher_models}
+            if Role.TeacherModel in self.role_worker_mapping:
+                teacher_wg = {
+                    key: all_wg[self._teacher_wg_name(key)] for key in self.distillation_config.teacher_models
+                }
+                for wg in teacher_wg.values():
+                    wg.init_model()
+            else:
+                teacher_wg = {key: self.actor_rollout_wg for key in self.distillation_config.teacher_models}
             self.teacher_model_manager = DiffusionTeacherManager(
                 self.distillation_config, self.config.actor_rollout_ref.model, teacher_wg
             )
@@ -1024,6 +1051,9 @@ class BaseRayDiffusionTrainer(ABC):
             self.actor_rollout_wg.start_profile(role="e2e", profile_step=self.global_steps)
             if self.use_reference_policy and not self.ref_in_actor:
                 self.ref_policy_wg.start_profile(profile_step=self.global_steps)
+            if self.use_teacher_policy and Role.TeacherModel in self.role_worker_mapping:
+                for wg in self.teacher_model_manager.teacher_wg.values():
+                    wg.start_profile(profile_step=self.global_steps)
         except Exception:
             if controller_profile_started:
                 try:
@@ -1041,6 +1071,9 @@ class BaseRayDiffusionTrainer(ABC):
             self.actor_rollout_wg.stop_profile()
             if self.use_reference_policy and not self.ref_in_actor:
                 self.ref_policy_wg.stop_profile()
+            if self.use_teacher_policy and Role.TeacherModel in self.role_worker_mapping:
+                for wg in self.teacher_model_manager.teacher_wg.values():
+                    wg.stop_profile()
         finally:
             if self._controller_nsys_profile_active:
                 try:

--- a/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
+++ b/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
@@ -69,6 +69,7 @@ from verl_omni.trainer.diffusion.diffusion_metric_utils import (
 )
 from verl_omni.trainer.diffusion.diffusion_trainer_utils import (
     NoOpCheckpointManager,
+    _to_diffusion_worker_tensordict,
     old_policy_decay,
     validate_distillation_config,
 )
@@ -78,17 +79,11 @@ from verl_omni.trainer.diffusion.rollout_correction import (
     compute_rollout_corr_metrics_from_batch,
     rollout_correction_enabled,
 )
+from verl_omni.trainer.diffusion.teacher_manager import DiffusionTeacherManager
 from verl_omni.utils.tracking import _export_video, batch_items, log_wandb_media, wrap_val_samples_for_wandb
 from verl_omni.workers.utils.padding import embeds_padding_2_no_padding
 
 sys_logger = logging.getLogger(__name__)
-
-
-def _to_diffusion_worker_tensordict(batch: DataProto):
-    """Project a driver batch for actor/ref workers without copying tensor storage."""
-    worker_batch = batch.to_tensordict()
-    worker_batch.pop("responses", None)
-    return worker_batch
 
 
 def compute_advantage(
@@ -213,6 +208,7 @@ class BaseRayDiffusionTrainer(ABC):
         self.ref_in_actor = lora_rank > 0 or config.actor_rollout_ref.model.get("lora_adapter_path") is not None
 
         self.use_teacher_policy = is_distillation_enabled(config.get("distillation"))
+        self.distillation_config = omega_conf_to_dataclass(config.distillation) if self.use_teacher_policy else None
         validate_distillation_config(config)
 
         self._create_dataloader(train_dataset, val_dataset, collate_fn, train_sampler)
@@ -807,6 +803,12 @@ class BaseRayDiffusionTrainer(ABC):
         if self.ref_in_actor:
             self.ref_policy_wg = self.actor_rollout_wg
 
+        if self.use_teacher_policy:
+            teacher_wg = {key: self.actor_rollout_wg for key in self.distillation_config.teacher_models}
+            self.teacher_model_manager = DiffusionTeacherManager(
+                self.distillation_config, self.config.actor_rollout_ref.model, teacher_wg
+            )
+
         return actor_rollout_resource_pool
 
     def _init_online_rollout_stack(self, actor_rollout_resource_pool):
@@ -1079,21 +1081,6 @@ class PolicyGradientRayTrainer(BaseRayDiffusionTrainer):
         )
         return DataProto.from_tensordict(ref_log_prob)
 
-    def _compute_teacher_prev_sample_mean(self, batch: DataProto) -> DataProto:
-        batch_td = _to_diffusion_worker_tensordict(batch)
-        batch_td = embeds_padding_2_no_padding(batch_td)
-        tu.assign_non_tensor(
-            batch_td,
-            compute_loss=False,
-            height=self.config.actor_rollout_ref.model.pipeline.height,
-            width=self.config.actor_rollout_ref.model.pipeline.width,
-            vae_scale_factor=self.config.actor_rollout_ref.model.get("vae_scale_factor", 8),
-        )
-        output = self.actor_rollout_wg.infer_teacher_batch(batch_td)
-        prev_sample_mean = tu.get(output, "prev_sample_mean")
-        teacher_output = tu.get_tensordict({"teacher_prev_sample_mean": prev_sample_mean.float()})
-        return DataProto.from_tensordict(teacher_output)
-
     def _compute_old_log_prob(self, batch: DataProto) -> tuple[DataProto, Optional[float]]:
         batch_td = _to_diffusion_worker_tensordict(batch)
         batch_td = embeds_padding_2_no_padding(batch_td)
@@ -1280,7 +1267,7 @@ class PolicyGradientRayTrainer(BaseRayDiffusionTrainer):
                     if self.use_teacher_policy:
                         # score the rollout trajectories with the frozen teacher
                         with marked_timer("teacher", timing_raw, color="olive"):
-                            batch = batch.union(self._compute_teacher_prev_sample_mean(batch))
+                            batch = batch.union(self.teacher_model_manager.compute_prev_sample_mean(batch))
 
                     with marked_timer("adv", timing_raw, color="brown"):
                         # we combine with rule-based rm

--- a/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
+++ b/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
@@ -832,8 +832,13 @@ class BaseRayDiffusionTrainer(ABC):
                     wg.init_model()
             else:
                 teacher_wg = {key: self.actor_rollout_wg for key in self.distillation_config.teacher_models}
+            from verl_omni.workers.engine_workers import resolve_teacher_infer_micro_batch_size
+
             self.teacher_model_manager = DiffusionTeacherManager(
-                self.distillation_config, self.config.actor_rollout_ref.model, teacher_wg
+                self.distillation_config,
+                self.config.actor_rollout_ref.model,
+                teacher_wg,
+                infer_micro_batch_size_per_gpu=resolve_teacher_infer_micro_batch_size(self.config.actor_rollout_ref),
             )
 
         return actor_rollout_resource_pool

--- a/verl_omni/trainer/diffusion/teacher_manager.py
+++ b/verl_omni/trainer/diffusion/teacher_manager.py
@@ -1,0 +1,105 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import torch
+from omegaconf import DictConfig
+from verl import DataProto
+from verl.protocol import pad_dataproto_to_divisor, unpad_dataproto
+from verl.single_controller.base import WorkerGroup
+from verl.utils import tensordict_utils as tu
+
+from verl_omni.trainer.diffusion.diffusion_trainer_utils import _to_diffusion_worker_tensordict
+from verl_omni.workers.config.diffusion import DiffusionDistillationConfig, DiffusionDistillationTeacherModelConfig
+from verl_omni.workers.utils.padding import embeds_padding_2_no_padding
+
+
+class DiffusionTeacherManager:
+    """Routes rollout batches to frozen diffusion teachers and scores them."""
+
+    def __init__(
+        self,
+        distillation_config: DiffusionDistillationConfig,
+        model_config: DictConfig,
+        teacher_wg: dict[str, WorkerGroup],
+    ):
+        self.distillation_config = distillation_config
+        self.teacher_key: str = distillation_config.teacher_key
+        self.teacher_model_configs: dict[str, DiffusionDistillationTeacherModelConfig] = (
+            distillation_config.teacher_models
+        )
+        expected = set(self.teacher_model_configs)
+        if set(teacher_wg.keys()) != expected:
+            raise ValueError(
+                f"teacher worker group keys {sorted(teacher_wg.keys())} "
+                f"do not match teacher routing keys {sorted(expected)}."
+            )
+        self.teacher_wg = teacher_wg
+        self.model_config = model_config
+
+    def _resolve_teacher_keys(self, batch: DataProto) -> np.ndarray:
+        if len(self.teacher_model_configs) == 1:
+            # Single-teacher path: route everything to the one teacher regardless of the sample's key.
+            return np.full(len(batch), next(iter(self.teacher_model_configs)), dtype=object)
+        if self.teacher_key not in batch.non_tensor_batch:
+            raise ValueError(
+                f"Routing key is required for multi-teacher distillation "
+                f"(configured via distillation.teacher_key={self.teacher_key!r})."
+            )
+        routing_keys = batch.non_tensor_batch[self.teacher_key]
+        unknown = sorted(set(routing_keys) - set(self.teacher_model_configs))
+        if unknown:
+            raise ValueError(
+                f"No teacher configured for routing key {unknown}. "
+                f"Configured teachers: {sorted(self.teacher_model_configs)}."
+            )
+        return routing_keys
+
+    def _infer(self, batch: DataProto, teacher_key: str):
+        batch_td = _to_diffusion_worker_tensordict(batch)
+        batch_td = embeds_padding_2_no_padding(batch_td)
+        tu.assign_non_tensor(
+            batch_td,
+            compute_loss=False,
+            height=self.model_config.pipeline.height,
+            width=self.model_config.pipeline.width,
+            vae_scale_factor=self.model_config.get("vae_scale_factor", 8),
+            teacher_key=teacher_key,
+        )
+        return self.teacher_wg[teacher_key].infer_teacher_batch(batch_td)
+
+    @staticmethod
+    def _to_dataproto(output) -> DataProto:
+        prev_sample_mean = tu.get(output, "prev_sample_mean")
+        teacher_output = tu.get_tensordict({"teacher_prev_sample_mean": prev_sample_mean.float()})
+        return DataProto.from_tensordict(teacher_output)
+
+    def compute_prev_sample_mean(self, batch: DataProto) -> DataProto:
+        """Score ``batch`` with its teachers, returning ``teacher_prev_sample_mean`` in the input row order."""
+        routing_keys = self._resolve_teacher_keys(batch)
+        if len(self.teacher_model_configs) == 1:
+            return self._to_dataproto(self._infer(batch, routing_keys[0]).get())
+        # dispatch per teacher from the driver so every DP rank of a teacher sees a non-empty shard
+        order, pending = [], []
+        for teacher_key, wg in self.teacher_wg.items():
+            idxs = np.flatnonzero(routing_keys == teacher_key)
+            if len(idxs) == 0:
+                continue
+            padded, pad_size = pad_dataproto_to_divisor(batch.select_idxs(idxs), wg.world_size)
+            pending.append((self._infer(padded, teacher_key), pad_size))
+            order.append(idxs)
+        outputs = [unpad_dataproto(self._to_dataproto(future.get()), pad_size) for future, pad_size in pending]
+        teacher_output = DataProto.concat(outputs)
+        teacher_output.reorder(torch.from_numpy(np.argsort(np.concatenate(order))))
+        return teacher_output

--- a/verl_omni/trainer/diffusion/teacher_manager.py
+++ b/verl_omni/trainer/diffusion/teacher_manager.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Optional
+
 import numpy as np
 import torch
 from omegaconf import DictConfig
@@ -33,8 +35,10 @@ class DiffusionTeacherManager:
         distillation_config: DiffusionDistillationConfig,
         model_config: DictConfig,
         teacher_wg: dict[str, WorkerGroup],
+        infer_micro_batch_size_per_gpu: Optional[int] = None,
     ):
         self.distillation_config = distillation_config
+        self.infer_micro_batch_size_per_gpu = infer_micro_batch_size_per_gpu
         self.teacher_key: str = distillation_config.teacher_key
         self.teacher_model_configs: dict[str, DiffusionDistillationTeacherModelConfig] = (
             distillation_config.teacher_models
@@ -91,12 +95,14 @@ class DiffusionTeacherManager:
         if len(self.teacher_model_configs) == 1:
             return self._to_dataproto(self._infer(batch, routing_keys[0]).get())
         # dispatch per teacher from the driver so every DP rank of a teacher sees a non-empty shard
+        # that splits evenly into forward micro-batches
         order, pending = [], []
         for teacher_key, wg in self.teacher_wg.items():
             idxs = np.flatnonzero(routing_keys == teacher_key)
             if len(idxs) == 0:
                 continue
-            padded, pad_size = pad_dataproto_to_divisor(batch.select_idxs(idxs), wg.world_size)
+            size_divisor = wg.world_size * (self.infer_micro_batch_size_per_gpu or 1)
+            padded, pad_size = pad_dataproto_to_divisor(batch.select_idxs(idxs), size_divisor)
             pending.append((self._infer(padded, teacher_key), pad_size))
             order.append(idxs)
         outputs = [unpad_dataproto(self._to_dataproto(future.get()), pad_size) for future, pad_size in pending]

--- a/verl_omni/trainer/main_diffusion.py
+++ b/verl_omni/trainer/main_diffusion.py
@@ -21,6 +21,7 @@ import hydra
 import ray
 from omegaconf import OmegaConf
 from verl.trainer.constants_ppo import get_ppo_ray_runtime_env
+from verl.trainer.distillation import is_distillation_enabled
 from verl.trainer.ppo.utils import need_reference_policy
 from verl.utils.device import auto_set_device, is_cuda_available
 
@@ -194,6 +195,14 @@ class TaskRunner:
             config.reward.reward_model.nnodes = config.trainer.nnodes
             config.reward.reward_model.n_gpus_per_node = config.trainer.n_gpus_per_node
 
+        distillation_config = config.get("distillation")
+        if is_distillation_enabled(distillation_config) and distillation_config.nnodes > 0:
+            if distillation_config.n_gpus_per_node <= 0:
+                raise ValueError("config.distillation.n_gpus_per_node must be greater than 0")
+
+            teacher_pool = [distillation_config.n_gpus_per_node] * distillation_config.nnodes
+            resource_pool_spec["teacher_pool"] = teacher_pool
+
         from verl.trainer.ppo.ray_trainer import ResourcePoolManager
 
         resource_pool_manager = ResourcePoolManager(resource_pool_spec=resource_pool_spec, mapping=self.mapping)
@@ -213,6 +222,15 @@ class TaskRunner:
                     self.mapping[Role.RewardModel] = "global_pool"
         elif config.algorithm.sample_source == "offline":
             return
+
+    def add_teacher_model_worker(self, config, teacher_model_cls):
+        """Add standalone teacher model workers when distillation runs on its own resource pool."""
+        from verl.trainer.ppo.ray_trainer import Role
+
+        distillation_config = config.get("distillation")
+        if is_distillation_enabled(distillation_config) and distillation_config.nnodes > 0:
+            self.role_worker_mapping[Role.TeacherModel] = ray.remote(teacher_model_cls)
+            self.mapping[Role.TeacherModel] = "teacher_pool"
 
     def add_ref_policy_worker(self, config, ref_policy_cls):
         """Add reference policy worker if KL loss or KL reward is used."""
@@ -241,6 +259,8 @@ class TaskRunner:
         actor_rollout_cls, ray_worker_group_cls = self.add_actor_rollout_worker(config)
 
         self.add_reward_model_resource_pool(config)
+
+        self.add_teacher_model_worker(config, actor_rollout_cls)
 
         # Add a reference policy worker if KL loss is used.
         self.add_ref_policy_worker(config, actor_rollout_cls)

--- a/verl_omni/workers/config/diffusion/distillation.py
+++ b/verl_omni/workers/config/diffusion/distillation.py
@@ -22,38 +22,111 @@ __all__ = ["DiffusionDistillationTeacherModelConfig", "DiffusionDistillationConf
 
 @dataclass
 class DiffusionDistillationTeacherModelConfig(BaseConfig):
-    """Frozen diffusion distillation teacher."""
+    """Frozen diffusion distillation teacher.
 
-    # Local path to the teacher checkpoint, a full pipeline checkpoint from the
-    # same pipeline family as the student.
+    key (str, optional):
+        Identifier to route examples to the teacher model in multi-teacher setting.
+    model_path (str, optional):
+        Local path to the teacher checkpoint, a full pipeline checkpoint from the
+        same pipeline family as the student.
+    world_size (int):
+        Number of GPUs this teacher occupies in the distillation resource pool.
+    """
+
+    _mutable_fields = BaseConfig._mutable_fields | {"key", "world_size"}
+
+    key: Optional[str] = None
     model_path: Optional[str] = None
+    world_size: int = 0
+
+    def check_configured(self):
+        if self.model_path is None:
+            raise ValueError("model_path must be specified for distillation teacher model config.")
+        if self.key is None:
+            raise ValueError("key must be specified for distillation teacher model config.")
 
 
 @dataclass
 class DiffusionDistillationConfig(BaseConfig):
-    """Diffusion on-policy distillation."""
+    """Diffusion on-policy distillation.
+
+    enabled (bool):
+        Whether on-policy distillation is enabled.
+    n_gpus_per_node (int):
+        Number of GPUs per node in the teacher resource pool.
+    nnodes (int):
+        Number of nodes in the teacher resource pool. 0 colocates the teachers with the actor.
+    teacher_models (dict[str, DiffusionDistillationTeacherModelConfig]):
+        Configurations for teacher models used for multi-teacher distillation.
+    teacher_key (str):
+        Key to route examples to the appropriate teacher model in multi-teacher setups. Should correspond to a field in
+        the data proto, e.g., data_source.
+
+    NOTE: The `teacher_model` entry is in the `teacher_models` dict by default.
+    Since it is popped when other teacher entries are added, using `teacher_model` as
+    one of several keys silently drops it. For example, the following CLI overrides result
+    in ONLY `teacher_model2` being used:
+
+    ```bash
+    distillation.teacher_models.teacher_model.key=ocr
+    distillation.teacher_models.teacher_model.model_path=/ckpt/ocr_teacher
+    +distillation.teacher_models.teacher_model2.key=aesthetic
+    +distillation.teacher_models.teacher_model2.model_path=/ckpt/aesthetic_teacher
+    ```
+    Instead, give the first teacher a different name:
+
+    ```bash
+    +distillation.teacher_models.teacher_model1.key=ocr
+    +distillation.teacher_models.teacher_model1.model_path=/ckpt/ocr_teacher
+    +distillation.teacher_models.teacher_model2.key=aesthetic
+    +distillation.teacher_models.teacher_model2.model_path=/ckpt/aesthetic_teacher
+    ```
+    """
 
     _mutable_fields = BaseConfig._mutable_fields | {"teacher_models"}
 
-    # Whether on-policy distillation is enabled.
     enabled: bool = False
-
-    # Teacher entries. Only the single `teacher_model` entry is supported.
+    n_gpus_per_node: int = 0
+    nnodes: int = 0
     teacher_models: dict[str, DiffusionDistillationTeacherModelConfig] = field(default_factory=dict)
+    teacher_key: str = "data_source"
 
     def __post_init__(self):
         if not self.enabled:
             return
-        if set(self.teacher_models) != {"teacher_model"}:
-            raise NotImplementedError(
-                f"Diffusion distillation supports a single teacher configured under "
-                f"distillation.teacher_models.teacher_model, but got entries {sorted(self.teacher_models)}."
-            )
+
+        self.teacher_models = self._resolve_teacher_models()
+        if self.nnodes > 0:
+            teacher_world_size_sum = sum(teacher_model.world_size for teacher_model in self.teacher_models.values())
+            total_pool_size = self.n_gpus_per_node * self.nnodes
+            if teacher_world_size_sum != total_pool_size:
+                raise ValueError(
+                    f"Sum of teacher world_size ({teacher_world_size_sum}) must match "
+                    f"the distillation resource pool size "
+                    f"({self.n_gpus_per_node=} * {self.nnodes=} = {total_pool_size})."
+                )
+
+    def _resolve_teacher_models(self) -> dict[str, DiffusionDistillationTeacherModelConfig]:
         from verl.utils.config import omega_conf_to_dataclass
 
-        teacher_model = omega_conf_to_dataclass(
-            self.teacher_models["teacher_model"], dataclass_type=DiffusionDistillationTeacherModelConfig
-        )
-        if teacher_model.model_path is None:
-            raise ValueError("model_path must be specified for the distillation teacher model.")
-        self.teacher_models["teacher_model"] = teacher_model
+        assert "teacher_model" in self.teacher_models
+        if len(self.teacher_models) == 1:
+            # Single teacher occupies the entire teacher resource pool.
+            teacher_model = self.teacher_models["teacher_model"]
+            teacher_model.world_size = self.n_gpus_per_node * self.nnodes
+            teacher_model.key = "default"
+        else:
+            # Multiple teachers: remove default single teacher config
+            self.teacher_models.pop("teacher_model")
+
+        # Teacher models dict is keyed by teacher_key instead of YAML entry name
+        teacher_models = {}
+        for teacher_config in self.teacher_models.values():
+            teacher_config = omega_conf_to_dataclass(
+                teacher_config, dataclass_type=DiffusionDistillationTeacherModelConfig
+            )
+            teacher_config.check_configured()
+            if teacher_config.key in teacher_models:
+                raise ValueError(f"Duplicate teacher key {teacher_config.key} found in teacher models.")
+            teacher_models[teacher_config.key] = teacher_config
+        return teacher_models

--- a/verl_omni/workers/engine_workers.py
+++ b/verl_omni/workers/engine_workers.py
@@ -513,6 +513,16 @@ class TrainingWorker(Worker, DistProfilerExtension):
         return self.engine.load_checkpoint(local_path, hdfs_path, del_local_after_load)
 
 
+def resolve_teacher_infer_micro_batch_size(config: DictConfig) -> Optional[int]:
+    """Micro batch size the teacher engine splits its forward-only scoring into."""
+    infer_micro_bsz = config.ref.get("log_prob_micro_batch_size_per_gpu", None)
+    if infer_micro_bsz is None:
+        infer_micro_bsz = config.ref.get("ppo_micro_batch_size_per_gpu", None)
+    if infer_micro_bsz is None:
+        infer_micro_bsz = config.actor.ppo_micro_batch_size_per_gpu
+    return infer_micro_bsz
+
+
 def build_teacher_training_config(
     config: DictConfig,
     model_config: DiffusionModelConfig,
@@ -537,12 +547,9 @@ def build_teacher_training_config(
         optimizer_config=teacher_config.optim,
         checkpoint_config=teacher_config.checkpoint,
     )
-    infer_micro_bsz = config.ref.get("log_prob_micro_batch_size_per_gpu", None)
-    if infer_micro_bsz is None:
-        infer_micro_bsz = config.ref.get("ppo_micro_batch_size_per_gpu", None)
-    if infer_micro_bsz is None:
-        infer_micro_bsz = config.actor.ppo_micro_batch_size_per_gpu
-    teacher_training_config.engine_config.infer_micro_batch_size_per_gpu = infer_micro_bsz
+    teacher_training_config.engine_config.infer_micro_batch_size_per_gpu = resolve_teacher_infer_micro_batch_size(
+        config
+    )
     return teacher_training_config
 
 

--- a/verl_omni/workers/engine_workers.py
+++ b/verl_omni/workers/engine_workers.py
@@ -56,6 +56,7 @@ from verl.workers.rollout.base import BaseRollout, get_rollout_class
 from verl.workers.rollout.vllm_rollout.bucketed_weight_transfer import BucketedWeightSender
 from verl.workers.utils.losses import ppo_loss
 
+from verl_omni.pipelines.utils import build_scheduler
 from verl_omni.utils.mfu import (
     DiffusionFlopsCounter,
     allgather_diffusion_flops_meta,
@@ -553,18 +554,24 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
     """
 
     def __init__(
-        self, config: DictConfig, role: str, distillation_config: Optional[DistillationConfig] = None, **kwargs
+        self,
+        config: DictConfig,
+        role: str,
+        distillation_config: Optional[DistillationConfig] = None,
+        teacher_key: Optional[str] = None,
+        **kwargs,
     ):
         Worker.__init__(self)
         self.config = config
         self.distillation_config = distillation_config
         self.distillation_enabled = is_distillation_enabled(distillation_config)
+        self.teacher_key = teacher_key
         self.role = role
         self.actor: TrainingWorker = None
         self.ref: TrainingWorker = None
-        self.teacher: TrainingWorker = None
+        self.teachers: dict[str, TrainingWorker] = {}
         self.rollout: BaseRollout = None
-        assert self.role in ["actor", "rollout", "ref", "actor_rollout", "actor_rollout_ref"]
+        assert self.role in ["actor", "rollout", "ref", "teacher", "actor_rollout", "actor_rollout_ref"]
         self._is_actor = self.role in ["actor", "actor_rollout", "actor_rollout_ref"]
         self._is_rollout = self.role in ["rollout", "actor_rollout", "actor_rollout_ref"]
         self._is_ref = self.role in ["ref", "actor_rollout_ref"]
@@ -743,26 +750,37 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
             self.actor.set_loss_fn(self.loss_fn)
             self.set_dispatch_collect(mesh_name="actor", **self.actor.get_dispatch_collect())
 
-        # 2.5 build frozen teacher for diffusion on-policy distillation
-        if self.distillation_enabled and is_diffusion and "actor" in self.role:
-            if self.config.actor.strategy not in ("fsdp", "fsdp2"):
-                raise NotImplementedError(
-                    f"The diffusion distillation teacher supports fsdp/fsdp2, got {self.config.actor.strategy!r}."
-                )
+        # 2.5 build frozen teachers for diffusion on-policy distillation
+        if self.distillation_enabled and is_diffusion:
             distillation_config = omega_conf_to_dataclass(self.distillation_config)
-            teacher_training_config = build_teacher_training_config(
-                config=self.config,
-                model_config=model_config,
-                teacher_model_config=distillation_config.teacher_models["default"],
-            )
-            self.teacher = TrainingWorker(config=teacher_training_config)
-            self.teacher.reset()
-            if self.teacher.engine.scheduler.config != self.actor.engine.scheduler.config:
-                raise ValueError(
-                    "Teacher and student resolved different scheduler configs; the teacher must replay "
-                    "the student's trajectories on the same noise schedule."
+            teacher_in_actor = distillation_config.nnodes == 0
+            if "teacher" in self.role or ("actor" in self.role and teacher_in_actor):
+                if self.config.actor.strategy not in ("fsdp", "fsdp2"):
+                    raise NotImplementedError(
+                        f"The diffusion distillation teacher supports fsdp/fsdp2, got {self.config.actor.strategy!r}."
+                    )
+                student_scheduler_config = build_scheduler(model_config).config
+                teacher_models = distillation_config.teacher_models
+                if self.teacher_key is not None:
+                    teacher_models = {self.teacher_key: teacher_models[self.teacher_key]}
+                for key, teacher_model_config in teacher_models.items():
+                    teacher_training_config = build_teacher_training_config(
+                        config=self.config,
+                        model_config=model_config,
+                        teacher_model_config=teacher_model_config,
+                    )
+                    teacher = TrainingWorker(config=teacher_training_config)
+                    teacher.reset()
+                    if teacher.engine.scheduler.config != student_scheduler_config:
+                        raise ValueError(
+                            "Teacher and student resolved different scheduler configs; the teacher must replay "
+                            "the student's trajectories on the same noise schedule."
+                        )
+                    self.teachers[key] = teacher
+                # all teachers share the worker's DP layout, so one mesh serves every teacher
+                self.set_dispatch_collect(
+                    mesh_name="teacher", **next(iter(self.teachers.values())).get_dispatch_collect()
                 )
-            self.set_dispatch_collect(mesh_name="teacher", **self.teacher.get_dispatch_collect())
 
         # 3. build rollout engine
         if "rollout" in self.role:
@@ -816,11 +834,12 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
         output = self.ref.infer_batch(data=data)
         return output.cpu() if output is not None else None
 
-    @register(dispatch_mode=make_nd_compute_dataproto_dispatch_fn(mesh_name="teacher"))
+    @register(dispatch_mode=make_nd_compute_dataproto_dispatch_fn(mesh_name="teacher"), blocking=False)
     @DistProfiler.annotate(color="olive", role="infer_teacher_batch")
     @_with_routing_replay_flag(enabled=False)
     def infer_teacher_batch(self, data: TensorDict) -> TensorDict:
-        output = self.teacher.infer_batch(data=data)
+        teacher_key = tu.pop(data, key="teacher_key")
+        output = self.teachers[teacher_key].infer_batch(data=data)
         return output.cpu() if output is not None else None
 
     @register(dispatch_mode=make_nd_compute_dataproto_dispatch_fn(mesh_name="actor"))

--- a/verl_omni/workers/engine_workers.py
+++ b/verl_omni/workers/engine_workers.py
@@ -753,7 +753,7 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
             teacher_training_config = build_teacher_training_config(
                 config=self.config,
                 model_config=model_config,
-                teacher_model_config=distillation_config.teacher_models["teacher_model"],
+                teacher_model_config=distillation_config.teacher_models["default"],
             )
             self.teacher = TrainingWorker(config=teacher_training_config)
             self.teacher.reset()


### PR DESCRIPTION
### What does this PR do?

Brings verl's multi-teacher on-policy distillation design (`DistillationConfig`, `AsyncTeacherLLMServerManager`, `teacher_pool`) to the diffusion OPD runtime merged in #300 and #325.

- **Config.** `distillation.teacher_models` accepts several named entries, each with a routing `key` and, for a standalone pool, a `world_size`. A single-teacher config is unchanged and resolves to the key `default`. `distillation.teacher_key` (default `data_source`) names the batch column used for routing. `distillation.n_gpus_per_node` and `nnodes` define an optional `teacher_pool`; `nnodes: 0` (the default) keeps the teachers colocated with the actor, exactly as before.
- **Worker.** `ActorRolloutRefWorker` builds one frozen `TrainingWorker` per routing key (`self.teachers`), accepts `role="teacher"` for standalone groups, and `infer_teacher_batch` picks the teacher from a `teacher_key` carried in the TensorDict metadata. The call is `blocking=False`.
- **Trainer.** The new `DiffusionTeacherManager` is the diffusion counterpart of verl's `AsyncTeacherLLMServerManager`. It resolves routing keys with verl's exact error messages, sends each key's rows to its teacher group (padded to the group's DP size × its infer micro batch size so every rank's shard splits into micro-batches, all groups in flight before the first `.get()`), and scatters `teacher_prev_sample_mean` back in the original row order. The loss side is untouched.
- **Placement.** With `nnodes > 0`, `main_diffusion` registers `teacher_pool` / `Role.TeacherModel`, and the trainer splits the pool into one sub-pool per teacher (`split_resource_pool`, by `world_size`), each with its own worker group, so the teachers score concurrently. Teacher scoring remains a serial stage of the step, so a standalone pool buys memory isolation and distance from the rollout engine's sleep/wake cycle, not speed. Note: the default `trainer.ray_master_port_range` hands every spawned worker group the same rendezvous port, so multi-worker-group runs currently need `trainer.ray_master_port_range=null` (the standalone smoke sets it); the port-range fix, split out of this PR per review, makes the default work by slicing the range per group.

Not in scope, left for follow-ups: per-teacher `lora_adapter_path` / `guidance_scale`, a pure-distillation fast path, and the v1 trainer.

### Checklist Before Starting

- [x] Duplicate check: [`teacher`](https://github.com/verl-project/verl-omni/pulls?q=is%3Apr+is%3Aopen+teacher) and [`distillation`](https://github.com/verl-project/verl-omni/pulls?q=is%3Apr+is%3Aopen+distillation) return only #304 and #355.
  - #304 (mine, draft): this PR combined the 1st and 3rd of the split discussed there, which implements verl-style teacher registry and routing + standalone teacher-pool.
  - #355: routes by the `task_id` of its multi-task dataset to frozen LoRA teachers on the actor backbone. This PR is the config, registry, routing, and placement layer in verl's shape for separate-weight teachers. The two compose: #355's `teacher_name` column can serve directly as `teacher_key`.
- [x] PR title format: `[worker, trainer, cfg, tests, doc] feat: ...`

### API and Usage Example

Default-off; a single-teacher config needs no change. Two colocated teachers routed by `data_source`:

```yaml
distillation:
  enabled: true
  teacher_key: data_source
  teacher_models:
    ocr:
      key: ocr
      model_path: /ckpt/sd35m-ocr-teacher
    aesthetic:
      key: aesthetic
      model_path: /ckpt/sd35m-aesthetic-teacher
actor_rollout_ref:
  actor:
    diffusion_loss:
      loss_mode: distill_kl
```

The same teachers on their own GPUs (the actor keeps `trainer.n_gpus_per_node`):

```yaml
distillation:
  n_gpus_per_node: 2
  nnodes: 1
  teacher_models:
    ocr: {key: ocr, model_path: /ckpt/sd35m-ocr-teacher, world_size: 1}
    aesthetic: {key: aesthetic, model_path: /ckpt/sd35m-aesthetic-teacher, world_size: 1}
```

Full reference, including the `teacher_model`-is-popped pitfall inherited from verl: `docs/algo/diffusion_opd.md`.

### Test

**CPU** (`python -m pytest … -q`, verl 0.10.0.dev @ c4b389a, vllm-omni 0.27.0rc1):

```
tests/trainer/diffusion/test_distillation_config_on_cpu.py
tests/trainer/diffusion/test_distillation_trainer_wiring_on_cpu.py
tests/trainer/diffusion/test_diffusion_teacher_manager_on_cpu.py   (new)
tests/workers/test_distillation_teacher_config_on_cpu.py
tests/special_sanity/test_config_docs.py
→ 34 passed; tests/trainer/diffusion + tests/workers -k on_cpu → 290 passed, 1 skipped
pre-commit run --files <all changed> → all hooks pass
```

**GPU** (4× RTX PRO 6000, vllm-omni 0.27.0rc1, tiny random SD3 checkpoints unless noted; `tests/special_e2e/run_diffusion_teacher_smoke.sh`). With `rollout.seed=0` the rollout engine is close to, but not bit-exact across runs: four same-code runs of the same smoke span 2e-5 relative in `distill_kl_loss`, and their `all_latents` differ by up to 1.7e-2. That floor is the yardstick for every scalar below; the placement question is settled on tensors instead.

| smoke | GPUs | result |
|---|---|---|
| `SMOKE=distill` / `coexistence` (regression) | 1 | pass; step-1 `distill_kl_loss` 0.12816689 vs. pre-PR code 0.12816426 (rel 2e-5, at the floor) |
| `SMOKE=mopd` (two colocated teachers, `data_source` alternating) | 1 | pass |
| mopd with both entries pointing at the *same* checkpoint | 1 | `distill_kl_loss` 0.12816554 vs. single-teacher 0.12816689: every row is scored and scattered back in order |
| `SMOKE=standalone` (actor 1 + `teacher_pool` 2, one sub-pool per teacher) | 3 | pass; teacher groups run concurrently, `timing_s/teacher` 0.58 s vs. 1.10 s with a sequential `.get()` |
| mopd with unknown `key` / missing `key` / missing column | 1 | startup `ValueError` with verl's messages |
| **tensor equivalence** on a dumped step-1 batch (4 rows, 2 per key): colocated vs. standalone `world_size` 1+1, and vs. standalone 2+1 (FSDP DP=2 teacher; also the 1-row-per-key subset, which pads 1→2) | 1 / 3 / 4 | `teacher_prev_sample_mean` is `torch.equal` in all four comparisons (max\|Δ\| = 0) |
| real SD3.5-Medium student + OCR teacher, 10 steps: colocated (teacher DP=2 on the actor GPUs) vs. standalone `world_size=2` | 2 / 4 | `distill_kl_loss` 3.20e-3 → 1.50e-3 vs. 3.21e-3 → 1.49e-3 (rel gap 0.2% at step 1, ≤ 2.9% over 10 steps, within the floor); `timing_s/teacher` 2.11 s vs. 2.12 s, `timing_s/step` 13.1 s vs. 13.5 s |
| real SD3.5-M, mixed two-task data, two routed teachers, odd per-task row counts against `infer_micro_batch_size=8` (sub-batch padding path) | 4 | pass — 6-step targeted run (`distill_kl_loss` 7.8e-4 → 4.8e-4) plus the 300-step reward-curve run below on the same path |

All smokes, the unknown-key negative, and the real-checkpoint run were repeated after rebasing onto current main (verl pin `c4b389a`, vllm-omni 0.27.0rc1): step-1 `distill_kl_loss` 0.12816553 (single-teacher) and 0.11859834 (standalone) are bit-identical to the pre-rebase values, mopd 0.11859706 sits at the rollout floor; the negative still fails at startup with verl's message; the real SD3.5-M colocated 3-step run gives 3.18e-3 → 2.05e-3 → 2.06e-3 vs. 3.21e-3 → 2.06e-3 → 2.05e-3 pre-rebase (within the floor), `timing_s/teacher` 2.01 s vs. 2.07 s.

`tests/gpu_smoke/run_gpu_smoke_diffusion_e2e.sh` gains the `mopd` (test 7) and `standalone` (test 8) cases.

**Reward Curves**

<img width="1875" height="720" alt="prc_mopd_reward_curves" src="https://github.com/user-attachments/assets/fe128a9d-da57-49d3-86d6-50ce9ef54e74" />

Setup: the DiffusionOPD paper's Stage-2 scenario — SD3.5-M LoRA student on **mixed two-task data** (flow-GRPO OCR prompts + PickScore-SFW prompts, `data_source` column as the routing key), distilling from the paper's two task teachers (`quanhaol/DiffusionOPD` OCR / Aes LoRAs merged into full SD3.5-M checkpoints). Loss is `distill_kl` only; rewards (GenRM-OCR for ocr rows, PickScore for pickscore rows — the same scorer the reference implementation uses for the Aes task) are monitored, never in the loss. 300 steps, val every 5 steps on a fixed 64-prompt set (32/task), colocated placement (standalone equivalence is settled bit-exactly above).

Four runs, one sentence each:

- **Teacher bands** (val-only): OCR-Teacher scores ocr 0.719 / pickscore 0.736; Aes-Teacher scores ocr 0.405 / pickscore **0.826** — orthogonal specialties.
- **Routed two teachers** (this PR's `teacher_models` + default `teacher_key=data_source`): OCR reward climbs 0.20 → the 0.719 teacher band by step ~25 and oscillates around it; PickScore climbs 0.755 → 0.819 (holding 0.818–0.822 over the last 60 steps, peak 0.826 at step 280 — the Aes band) — **each task converges toward its own teacher**.
- **Single-teacher control** (OCR teacher only, the unchanged auto-key `default` path): OCR also reaches its band, but PickScore *drops* from 0.755 and stays pinned at 0.732–0.739 for all 300 steps — exactly the OCR-Teacher's own PickScore level; without routing, the off-task reward is dragged to the single teacher's level and longer training does not recover it.

On the `distill_kl` wobble of the routed run (left panel): each logged point is the mean over one 8-pr
ompt step whose task mix is a fresh random draw, and the two teachers' KL magnitudes differ, so the ag
gregate swings with the mix. One LoRA also cannot sit tightly on two teachers at once, so the two runs
' loss levels are not comparable. The per-task reward curves are the primary evidence.

Command (the new example script in this PR; the control run uses the same mixed data with a single `teacher_model` entry, i.e. the unchanged auto-key `default` path):

```bash
OCR_TEACHER_PATH=$MODELS/sd35-ocr-teacher AES_TEACHER_PATH=$MODELS/sd35-aes-teacher \
bash examples/diffusionopd_trainer/sd35/run_sd35_medium_mopd_distill.sh \
    trainer.total_training_steps=300 trainer.test_freq=5
```

### Design & Code Changes

- `verl_omni/workers/config/diffusion/distillation.py`: `DiffusionDistillationTeacherModelConfig` (`key`, `model_path`, `world_size`), `_resolve_teacher_models` line for line from verl, pool-size check when `nnodes > 0`.
- `verl_omni/workers/engine_workers.py`: `self.teachers: dict[str, TrainingWorker]`, `role="teacher"`, `infer_teacher_batch` routes on `teacher_key`.
- `verl_omni/trainer/diffusion/teacher_manager.py` (new): `DiffusionTeacherManager`; routed sub-batches pad to `world_size * infer_micro_batch_size_per_gpu`. `_to_diffusion_worker_tensordict` (the #430 responses-stripping projection) moves to `diffusion_trainer_utils.py` so the manager applies it to teacher RPCs too.
- `examples/diffusionopd_trainer/sd35/run_sd35_medium_mopd_distill.sh` + `mixed_task_reward.py` (new): the mixed OCR + PickScore recipe behind the reward curves.
- `verl_omni/trainer/diffusion/ray_diffusion_trainer.py`, `main_diffusion.py`: `teacher_pool` registration, per-teacher sub-pools and worker groups, the manager in the fit loop, profiler start/stop for standalone groups.
- Tests, smokes, and docs as listed above; `docs/examples/config.md` synced.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md#code-linting-and-formatting).
- [x] Add / Update the documentation: `docs/algo/diffusion_opd.md`, `docs/examples/config.md`.
- [x] Add unit or end-to-end test(s) to the CI workflow: CPU tests above; `ci-e2e-diffusion` tests 7 and 8.

### Note on AI assistance

AI assistance (Claude) was used for this change. I reviewed every changed line, ran the CPU suites and the GPU runs above myself on the hardware listed, and can defend the design end to end.

