### PR TITLE
[ckpt, data, fsdp, omni] fix: reject silent fallbacks

### DIFF
--- a/docs/examples/config.md
+++ b/docs/examples/config.md
@@ -1,6 +1,6 @@
 # Config Explanation
 
-Last updated: 07/30/2026
+Last updated: 08/23/2026
 
 VeRL-Omni builds on [verl](https://github.com/verl-project/verl) and reuses the
 same Hydra config surface for shared RL trainer fields (`data`, FSDP actor /
@@ -336,7 +336,7 @@ actor_rollout_ref:
 - `actor_rollout_ref.model.override_config`: Dict merged into HF config load (e.g. `attn_implementation`).
 - `actor_rollout_ref.model.enable_activation_offload` / `use_remove_padding`: Memory / packing flags for the FSDP actor.
 - `actor_rollout_ref.model.lora_*` / `target_modules` / `policy_state_adapters` / `fsdp_layer_prefixes`: Same LoRA roles as diffusion (defaults differ slightly, e.g. `lora_alpha: 16`).
-- `actor_rollout_ref.model.use_liger` / `use_fused_kernels` / `fused_kernel_options` / `tiled_mlp`: Optional kernel / memory optimizations.
+- `actor_rollout_ref.model.use_liger` / `use_fused_kernels`: Unsupported by omni FSDP/FSDP2 and must remain `false`; enabling either fails before model loading. The adjacent `fused_kernel_options` / `tiled_mlp` fields are backend-specific.
 - `actor_rollout_ref.model.max_image_tokens` / `max_audio_tokens` / `max_video_tokens`: Multimodal token budgets (`null` = unset).
 - `actor_rollout_ref.model.lora` / `mtp`: Megatron-style LoRA block and multi-token prediction (speculative decoding) configs; see the YAML comments in `omni/model/omni_model.yaml`.
 

--- a/tests/utils/dataset/test_offline_dpo_dataset_on_cpu.py
+++ b/tests/utils/dataset/test_offline_dpo_dataset_on_cpu.py
@@ -124,6 +124,29 @@ def test_dataset_rejects_inverted_pair_scores(tmp_path):
         dataset[0]
 
 
+@pytest.mark.parametrize("score_key", ["win_score", "lose_score"])
+def test_dataset_rejects_missing_score_columns(tmp_path, score_key):
+    row = _row()
+    del row[score_key]
+    data_file = tmp_path / "pairs.json"
+    data_file.write_text(json.dumps([row]))
+
+    with pytest.raises(ValueError, match=score_key):
+        OfflineDPODataset(str(data_file), tokenizer=DummyTokenizer(), config=_config())
+
+
+@pytest.mark.parametrize("score_key", ["win_score", "lose_score"])
+def test_dataset_rejects_missing_score_values(tmp_path, score_key):
+    rows = [_row(uid="pair-0"), _row(uid="pair-1")]
+    del rows[1][score_key]
+    data_file = tmp_path / "pairs.json"
+    data_file.write_text(json.dumps(rows))
+    dataset = OfflineDPODataset(str(data_file), tokenizer=DummyTokenizer(), config=_config())
+
+    with pytest.raises(ValueError, match=rf"row 1 column '{score_key}'.*finite number"):
+        dataset[1]
+
+
 def test_expand_offline_dpo_features_preserves_pair_order():
     feature = {
         OFFLINE_DPO_PAIR_MARKER: True,

--- a/tests/workers/test_checkpoint_engine_on_cpu.py
+++ b/tests/workers/test_checkpoint_engine_on_cpu.py
@@ -1,0 +1,52 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from verl_omni.workers.checkpoint_engine import OmniCheckpointEngineManager
+
+
+def _manager_with_actor(actor_wg):
+    manager = object.__new__(OmniCheckpointEngineManager)
+    manager.actor_wg = actor_wg
+    return manager
+
+
+def test_lora_probe_allows_backend_without_capability():
+    manager = _manager_with_actor(object())
+
+    assert manager._fetch_actor_lora_peft_config() is None
+
+
+def test_lora_probe_returns_first_configured_actor_result():
+    expected = {"r": 8, "lora_alpha": 16}
+
+    class ActorWorkerGroup:
+        def get_lora_peft_config(self):
+            return [None, expected]
+
+    manager = _manager_with_actor(ActorWorkerGroup())
+
+    assert manager._fetch_actor_lora_peft_config() is expected
+
+
+def test_lora_probe_propagates_genuine_actor_failure():
+    class ActorWorkerGroup:
+        def get_lora_peft_config(self):
+            raise RuntimeError("actor RPC failed")
+
+    manager = _manager_with_actor(ActorWorkerGroup())
+
+    with pytest.raises(RuntimeError, match="actor RPC failed"):
+        manager._fetch_actor_lora_peft_config()

--- a/tests/workers/test_omni_fsdp_engine_on_cpu.py
+++ b/tests/workers/test_omni_fsdp_engine_on_cpu.py
@@ -382,6 +382,19 @@ def test_build_module_calls_adapter_configure_model(architecture):
         assert result is fake_configured_module
 
 
+@pytest.mark.parametrize("option", ["use_liger", "use_fused_kernels"])
+def test_build_module_rejects_unsupported_optimizations_before_model_load(option):
+    omni_impl = _get_omni_impl_module()
+    engine = object.__new__(omni_impl.OmniFSDPEngine)
+    engine.model_config = _make_mock_model_config(**{option: True})
+
+    with patch.object(omni_impl.AutoModelForMultimodalLM, "from_pretrained") as mock_from_pretrained:
+        with pytest.raises(ValueError, match=rf"{option}=True"):
+            engine._build_module()
+
+    mock_from_pretrained.assert_not_called()
+
+
 # ---------------------------------------------------------------------------
 # ``_build_lora_module`` dtype handling
 # ---------------------------------------------------------------------------

--- a/verl_omni/trainer/config/omni/model/omni_model.yaml
+++ b/verl_omni/trainer/config/omni/model/omni_model.yaml
@@ -82,10 +82,10 @@ policy_state_adapters: ["default"]
 # FSDP layer name prefixes for LoRA parameter layered summon.
 fsdp_layer_prefixes: []
 
-# whether to use liger
+# Unsupported by omni FSDP/FSDP2; enabling fails before model loading.
 use_liger: False
 
-# whether to use fused kernels
+# Unsupported by omni FSDP/FSDP2; enabling fails before model loading.
 use_fused_kernels: False
 
 # fused kernel options

--- a/verl_omni/utils/dataset/offline_dpo_dataset.py
+++ b/verl_omni/utils/dataset/offline_dpo_dataset.py
@@ -167,6 +167,17 @@ def _tensor_from_column(value: Any, *, dtype: torch.dtype) -> torch.Tensor:
     return torch.tensor(_to_nested(value), dtype=dtype)
 
 
+def _score_from_column(row: dict[str, Any], key: str, item: int) -> float:
+    value = row[key]
+    try:
+        score = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"Offline DPO row {item} column {key!r} must be a finite number; got {value!r}.") from exc
+    if not np.isfinite(score):
+        raise ValueError(f"Offline DPO row {item} column {key!r} must be a finite number; got {value!r}.")
+    return score
+
+
 class OfflineDPODataset(Dataset):
     """Dataset for rows containing offline DPO pairs plus precomputed SD3 tensors."""
 
@@ -193,6 +204,8 @@ class OfflineDPODataset(Dataset):
             self.prompt_key,
             self.win_key,
             self.lose_key,
+            self.win_score_key,
+            self.lose_score_key,
             "img_win_latents",
             "img_lose_latents",
             "prompt_embeds",
@@ -213,8 +226,8 @@ class OfflineDPODataset(Dataset):
         data_file = self.data_files[0] if len(self.data_files) == 1 else None
         pair_uid = str(row.get("uid") or uuid.uuid4())
 
-        win_score = float(row.get(self.win_score_key, 1.0))
-        lose_score = float(row.get(self.lose_score_key, 0.0))
+        win_score = _score_from_column(row, self.win_score_key, item)
+        lose_score = _score_from_column(row, self.lose_score_key, item)
         if win_score < lose_score:
             raise ValueError(f"Offline DPO row {item} has win_score < lose_score: {win_score} < {lose_score}")
 

--- a/verl_omni/workers/checkpoint_engine.py
+++ b/verl_omni/workers/checkpoint_engine.py
@@ -11,15 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import logging
-import os
-
 import ray
 from verl.checkpoint_engine import CheckpointEngineManager
 from verl.utils.ray_utils import auto_await
-
-logger = logging.getLogger(__name__)
-logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
 
 class OmniCheckpointEngineManager(CheckpointEngineManager):
@@ -57,11 +51,9 @@ class OmniCheckpointEngineManager(CheckpointEngineManager):
 
     def _fetch_actor_lora_peft_config(self):
         """Return the actor's LoRA ``peft_config`` dict, or ``None``."""
-        try:
-            results = self.actor_wg.get_lora_peft_config()
-        except Exception as e:  # noqa: BLE001 - tolerate backend/registration differences
-            logger.warning("get_lora_peft_config failed (%s); assuming non-LoRA run", e)
+        if not hasattr(self.actor_wg, "get_lora_peft_config"):
             return None
+        results = self.actor_wg.get_lora_peft_config()
         for result in results or []:
             if result is not None:
                 return result

--- a/verl_omni/workers/engine/fsdp/omni_impl.py
+++ b/verl_omni/workers/engine/fsdp/omni_impl.py
@@ -143,6 +143,16 @@ class OmniFSDPEngine(FSDPEngineWithLMHead):
             log_gpu_memory_usage("After offload_fsdp_model_to_cpu", logger=logger)
 
     def _build_module(self):
+        unsupported_options = [
+            option for option in ("use_liger", "use_fused_kernels") if getattr(self.model_config, option, False)
+        ]
+        if unsupported_options:
+            enabled_options = ", ".join(f"{option}=True" for option in unsupported_options)
+            raise ValueError(
+                f"Omni models do not support these enabled optimizations: {enabled_options}. "
+                "Set them to false before starting the worker."
+            )
+
         from verl.utils.torch_dtypes import PrecisionType
 
         from verl_omni.pipelines.model_base import OmniModelBase
@@ -169,11 +179,6 @@ class OmniFSDPEngine(FSDPEngineWithLMHead):
 
         with init_context(), warnings.catch_warnings():
             warnings.simplefilter("ignore")
-
-            if getattr(self.model_config, "use_liger", False):
-                logger.warning("use_liger is set but not applied for omni models; this is a no-op.")
-            if getattr(self.model_config, "use_fused_kernels", False):
-                logger.warning("use_fused_kernels is set but not applied for omni models; this is a no-op.")
 
             module = AutoModelForMultimodalLM.from_pretrained(
                 pretrained_model_name_or_path=self.model_config.local_path,


### PR DESCRIPTION
### What does this PR do?

Implements A5, A8, and A9 from #388 so invalid offline DPO data, unsupported omni FSDP optimizations, and genuine LoRA checkpoint probe failures fail fast instead of silently changing training behavior.

- Require the configured offline DPO win/lose score columns at dataset construction, reject missing or non-finite per-row scores with row/column context, and remove fabricated `1.0` / `0.0` defaults.
- Reject `use_liger=True` or `use_fused_kernels=True` for omni FSDP/FSDP2 before model loading.
- Treat a worker group without `get_lora_peft_config` as a supported non-LoRA backend, while propagating genuine RPC/backend failures from an available method.
- Add focused CPU regressions and document the FSDP/FSDP2 restriction.

This is not duplicating an existing PR. The required searches found no open PR referencing #388 and no open PR matching the affected data, FSDP, or checkpoint areas: [issue search](https://github.com/verl-project/verl-omni/pulls?q=is%3Apr+is%3Aopen+388+in%3Abody), [area-keyword search](https://github.com/verl-project/verl-omni/pulls?q=is%3Apr+is%3Aopen+offline_dpo_dataset+get_lora_peft_config+use_fused_kernels).

AI assistance was used. The human submitter reviewed every changed line and approved publication.

### Checklist Before Starting

- [x] Search for similar PRs. See the query and result summary above.
- [x] Format the PR title as `[{modules}] {type}: {description}`.

### Test

Focused CPU tests:

```bash
.venv/bin/python -c 'import pathlib, sys, types, pytest; root = types.ModuleType("verl_omni"); root.__path__ = [str(pathlib.Path.cwd() / "verl_omni")]; sys.modules["verl_omni"] = root; raise SystemExit(pytest.main(["-q", "tests/utils/dataset/test_offline_dpo_dataset_on_cpu.py", "tests/workers/test_omni_fsdp_engine_on_cpu.py", "tests/workers/test_checkpoint_engine_on_cpu.py"]))'
```

Result: `34 passed, 2 warnings`.

The minimal package-root injection bypasses only package-wide GPU rollout auto-registration because the local macOS environment cannot install the Linux/CUDA vLLM and vLLM-Omni stack. The three target test modules and their production imports execute normally.

Repository quality gates:

```bash
pre-commit run --all-files --show-diff-on-failure --color=never
```

Result: all 12 hooks passed, including Ruff, Ruff format, mypy, generated-config verification, documentation checks, structure checks, and compileall.

PR title validation:

```bash
PR_TITLE='[ckpt, data, fsdp, omni] fix: reject silent fallbacks' python tests/special_sanity/check_pr_title.py
```

Result: passed.

An independent read-only review of the final A5/A8/A9 diff returned `safe` with no blocking findings.

### API and Usage Example

No API or config keys are added. Previously accepted invalid inputs now raise actionable errors:

- Missing configured score columns fail during `OfflineDPODataset` construction.
- Missing, malformed, or non-finite row scores fail during sample access.
- Unsupported omni FSDP/FSDP2 kernel flags fail before model loading.
- An available `get_lora_peft_config` method now propagates genuine backend/RPC failures; worker groups without that capability still return `None`.

### Design & Code Changes

- Dataset-level schema validation owns required-column checks.
- Row decoding owns finite numeric score validation before scores can reach collation.
- `OmniFSDPEngine._build_module` rejects unsupported enabled optimizations before allocating/loading the model.
- The checkpoint manager uses capability detection for optional LoRA support instead of a broad exception fallback.
- Public config documentation and YAML comments match the runtime restriction.

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] Apply `pre-commit run --all-files --show-diff-on-failure --color=always` equivalent checks.
- [x] Update the documentation.
- [x] Add CPU unit tests covered by the existing `tests/**/*_on_cpu.py` workflow.
