### PR TITLE
[diffusion, trainer, tests] feat: strip responses from worker batches

### DIFF
--- a/tests/trainer/diffusion/test_worker_batch_projection_on_cpu.py
+++ b/tests/trainer/diffusion/test_worker_batch_projection_on_cpu.py
@@ -1,0 +1,165 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU contracts for excluding driver-only pixels from diffusion worker RPCs."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+import torch
+from omegaconf import OmegaConf
+from verl import DataProto
+from verl.utils import tensordict_utils as tu
+
+from verl_omni.trainer.diffusion.ray_diffusion_trainer import (
+    DirectPreferenceRayTrainer,
+    PolicyGradientRayTrainer,
+    _to_diffusion_worker_tensordict,
+)
+from verl_omni.trainer.diffusion.v1.trainer_base import PolicyGradientDiffusionTrainerV1
+
+
+def _make_config():
+    return OmegaConf.create(
+        {
+            "algorithm": {"paired_preference": False},
+            "actor_rollout_ref": {
+                "model": {
+                    "pipeline": {"height": 64, "width": 64},
+                    "vae_scale_factor": 8,
+                },
+                "actor": {
+                    "ppo_mini_batch_size": 2,
+                    "ppo_epochs": 1,
+                    "data_loader_seed": 0,
+                    "shuffle": False,
+                },
+                "rollout": {"n": 1, "multi_turn": {"enable": False}},
+            },
+        }
+    )
+
+
+def _make_batch(*, include_responses: bool = True):
+    latents = torch.arange(16, dtype=torch.float32).reshape(2, 2, 2, 2)
+    tensors = {"latents": latents}
+    if include_responses:
+        tensors["responses"] = torch.randint(256, (2, 3, 4, 4), dtype=torch.uint8)
+    return DataProto.from_dict(
+        tensors=tensors,
+        non_tensors={"sample_id": np.array(["sample-0", "sample-1"], dtype=object)},
+        meta_info={"driver_tag": "keep-me"},
+    )
+
+
+def _make_infer_output():
+    shape = (2, 1)
+    return tu.get_tensordict(
+        {
+            "log_probs": torch.zeros(shape),
+            "prev_sample_mean": torch.zeros(shape),
+            "noise_pred": torch.zeros(shape),
+            "noise": torch.zeros(shape),
+            "timesteps": torch.zeros(shape),
+        },
+        non_tensor_dict={"metrics": {}},
+    )
+
+
+def _make_worker_groups():
+    actor = MagicMock()
+    ref = MagicMock()
+    actor.infer_actor_batch.return_value = _make_infer_output()
+    actor.infer_teacher_batch.return_value = _make_infer_output()
+    actor.update_actor.return_value = tu.get_tensordict({}, non_tensor_dict={"metrics": {}})
+    ref.infer_ref_batch.return_value = _make_infer_output()
+    return actor, ref
+
+
+def _assert_worker_projection(sent_batch, driver_batch):
+    assert "responses" not in sent_batch
+    assert "responses" in driver_batch.batch
+    assert sent_batch["latents"].data_ptr() == driver_batch.batch["latents"].data_ptr()
+
+
+@pytest.mark.parametrize("include_responses", [True, False])
+def test_worker_projection_preserves_driver_batch_and_shared_tensor_storage(include_responses):
+    driver_batch = _make_batch(include_responses=include_responses)
+    responses = driver_batch.batch.get("responses")
+
+    worker_batch = _to_diffusion_worker_tensordict(driver_batch)
+
+    assert "responses" not in worker_batch
+    assert ("responses" in driver_batch.batch) is include_responses
+    assert driver_batch.batch.get("responses") is responses
+    assert worker_batch["latents"].data_ptr() == driver_batch.batch["latents"].data_ptr()
+    assert tu.get(worker_batch, "sample_id") == ["sample-0", "sample-1"]
+    assert tu.get(worker_batch, "driver_tag") == "keep-me"
+
+
+@pytest.mark.parametrize(
+    ("trainer_cls", "method_name", "worker_attr", "remote_method"),
+    [
+        (PolicyGradientRayTrainer, "_compute_old_log_prob", "actor_rollout_wg", "infer_actor_batch"),
+        (PolicyGradientRayTrainer, "_compute_ref_log_prob", "ref_policy_wg", "infer_ref_batch"),
+        (
+            PolicyGradientRayTrainer,
+            "_compute_teacher_prev_sample_mean",
+            "actor_rollout_wg",
+            "infer_teacher_batch",
+        ),
+        (PolicyGradientRayTrainer, "_update_actor", "actor_rollout_wg", "update_actor"),
+        (DirectPreferenceRayTrainer, "_compute_ref_noise_pred", "ref_policy_wg", "infer_ref_batch"),
+        (DirectPreferenceRayTrainer, "_update_actor", "actor_rollout_wg", "update_actor"),
+    ],
+)
+def test_v0_diffusion_worker_hops_exclude_responses(trainer_cls, method_name, worker_attr, remote_method):
+    trainer = trainer_cls.__new__(trainer_cls)
+    trainer.config = _make_config()
+    trainer.ref_in_actor = False
+    trainer.actor_rollout_wg, trainer.ref_policy_wg = _make_worker_groups()
+    driver_batch = _make_batch()
+
+    getattr(trainer, method_name)(driver_batch)
+
+    worker = getattr(trainer, worker_attr)
+    sent_batch = getattr(worker, remote_method).call_args.args[0]
+    _assert_worker_projection(sent_batch, driver_batch)
+
+
+@pytest.mark.parametrize(
+    ("method_name", "worker_attr", "remote_method"),
+    [
+        ("_compute_old_log_prob", "actor_rollout_wg", "infer_actor_batch"),
+        ("_compute_ref_log_prob", "ref_policy_wg", "infer_ref_batch"),
+        ("_update_actor", "actor_rollout_wg", "update_actor"),
+    ],
+)
+def test_v1_diffusion_worker_hops_exclude_responses(method_name, worker_attr, remote_method):
+    actor, ref = _make_worker_groups()
+    trainer = SimpleNamespace(
+        config=_make_config(),
+        ref_in_actor=False,
+        actor_rollout_wg=actor,
+        ref_policy_wg=ref,
+    )
+    driver_batch = _make_batch()
+
+    method = getattr(PolicyGradientDiffusionTrainerV1, method_name)
+    method(trainer, driver_batch)
+
+    worker = getattr(trainer, worker_attr)
+    sent_batch = getattr(worker, remote_method).call_args.args[0]
+    _assert_worker_projection(sent_batch, driver_batch)

--- a/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
+++ b/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
@@ -83,6 +83,13 @@ from verl_omni.workers.utils.padding import embeds_padding_2_no_padding
 sys_logger = logging.getLogger(__name__)
 
 
+def _to_diffusion_worker_tensordict(batch: DataProto):
+    """Project a driver batch for actor/ref workers without copying tensor storage."""
+    worker_batch = batch.to_tensordict()
+    worker_batch.pop("responses", None)
+    return worker_batch
+
+
 def compute_advantage(
     data: DataProto,
     adv_estimator: str,
@@ -928,7 +935,7 @@ class BaseRayDiffusionTrainer(ABC):
         rollout_config = self.config.actor_rollout_ref.rollout
         batch.meta_info["multi_turn"] = rollout_config.multi_turn.enable
         # update actor
-        batch_td = batch.to_tensordict()
+        batch_td = _to_diffusion_worker_tensordict(batch)
         # step 2: convert from padding to no-padding
         batch_td = embeds_padding_2_no_padding(batch_td)
         ppo_mini_batch_size = self.config.actor_rollout_ref.actor.ppo_mini_batch_size
@@ -1006,7 +1013,7 @@ class PolicyGradientRayTrainer(BaseRayDiffusionTrainer):
     """Policy-gradient diffusion trainer for FlowGRPO, MixGRPO, DanceGRPO, GRPO-Guard, etc."""
 
     def _compute_ref_log_prob(self, batch: DataProto) -> DataProto:
-        batch_td = batch.to_tensordict()
+        batch_td = _to_diffusion_worker_tensordict(batch)
         batch_td = embeds_padding_2_no_padding(batch_td)
         metadata = {
             "compute_loss": False,
@@ -1030,7 +1037,7 @@ class PolicyGradientRayTrainer(BaseRayDiffusionTrainer):
         return DataProto.from_tensordict(ref_log_prob)
 
     def _compute_teacher_prev_sample_mean(self, batch: DataProto) -> DataProto:
-        batch_td = batch.to_tensordict()
+        batch_td = _to_diffusion_worker_tensordict(batch)
         batch_td = embeds_padding_2_no_padding(batch_td)
         tu.assign_non_tensor(
             batch_td,
@@ -1045,7 +1052,7 @@ class PolicyGradientRayTrainer(BaseRayDiffusionTrainer):
         return DataProto.from_tensordict(teacher_output)
 
     def _compute_old_log_prob(self, batch: DataProto) -> tuple[DataProto, Optional[float]]:
-        batch_td = batch.to_tensordict()
+        batch_td = _to_diffusion_worker_tensordict(batch)
         batch_td = embeds_padding_2_no_padding(batch_td)
         tu.assign_non_tensor(
             batch_td,
@@ -1412,7 +1419,7 @@ class DirectPreferenceRayTrainer(BaseRayDiffusionTrainer):
     def _update_actor(self, batch: DataProto) -> DataProto:
         rollout_config = self.config.actor_rollout_ref.rollout
         batch.meta_info["multi_turn"] = rollout_config.multi_turn.enable
-        batch_td = batch.to_tensordict()
+        batch_td = _to_diffusion_worker_tensordict(batch)
         batch_td = embeds_padding_2_no_padding(batch_td)
         ppo_mini_batch_size = self.config.actor_rollout_ref.actor.ppo_mini_batch_size
         paired = self.config.algorithm.get("paired_preference", False)
@@ -1451,7 +1458,7 @@ class DirectPreferenceRayTrainer(BaseRayDiffusionTrainer):
 
     def _compute_ref_noise_pred(self, batch: DataProto) -> Optional[DataProto]:
         """Reference transformer output and shared flow tensors."""
-        batch_td = batch.to_tensordict()
+        batch_td = _to_diffusion_worker_tensordict(batch)
         batch_td = embeds_padding_2_no_padding(batch_td)
         metadata = {
             "compute_loss": False,

--- a/verl_omni/trainer/diffusion/v1/trainer_base.py
+++ b/verl_omni/trainer/diffusion/v1/trainer_base.py
@@ -61,7 +61,7 @@ from verl_omni.trainer.diffusion.diffusion_metric_utils import (
     compute_throughput_metrics_diffusion,
     compute_timing_metrics_diffusion,
 )
-from verl_omni.trainer.diffusion.ray_diffusion_trainer import compute_advantage
+from verl_omni.trainer.diffusion.ray_diffusion_trainer import _to_diffusion_worker_tensordict, compute_advantage
 from verl_omni.trainer.diffusion.rollout_correction import (
     apply_bypass_mode_to_diffusion_batch,
     apply_rollout_correction_to_diffusion_batch,
@@ -819,7 +819,7 @@ class PolicyGradientDiffusionTrainerV1(ABC):
 
     def _compute_old_log_prob(self, data: DataProto) -> DataProto:
         """Recompute old log-probs over diffusion latents with the actor engine."""
-        batch_td = data.to_tensordict()
+        batch_td = _to_diffusion_worker_tensordict(data)
         batch_td = embeds_padding_2_no_padding(batch_td)
         tu.assign_non_tensor(
             batch_td,
@@ -838,7 +838,7 @@ class PolicyGradientDiffusionTrainerV1(ABC):
 
     def _compute_ref_log_prob(self, data: DataProto) -> DataProto:
         """Compute reference log-probs over diffusion latents."""
-        batch_td = data.to_tensordict()
+        batch_td = _to_diffusion_worker_tensordict(data)
         batch_td = embeds_padding_2_no_padding(batch_td)
         metadata = {
             "compute_loss": False,
@@ -884,7 +884,7 @@ class PolicyGradientDiffusionTrainerV1(ABC):
         """Update the diffusion actor network."""
         rollout_config = self.config.actor_rollout_ref.rollout
         data.meta_info["multi_turn"] = rollout_config.multi_turn.enable
-        batch_td = data.to_tensordict()
+        batch_td = _to_diffusion_worker_tensordict(data)
         batch_td = embeds_padding_2_no_padding(batch_td)
         ppo_mini_batch_size = self.config.actor_rollout_ref.actor.ppo_mini_batch_size
         ppo_mini_batch_size = ppo_mini_batch_size * self.config.actor_rollout_ref.rollout.n


### PR DESCRIPTION
### What does this PR do?

Implements Phase 1 of #386 by excluding driver-only `responses` pixels from diffusion actor, reference, teacher, and old-log-prob worker payloads while retaining the original `DataProto` for reward scoring, evaluation, and logging.

- Adds one shallow `DataProto` → `TensorDict` projection that removes only `responses` without copying tensor storage.
- Applies the projection to the v0 policy-gradient/direct-preference paths and the equivalent v1 trainer paths.
- Adds CPU contracts for field removal, driver ownership, shared tensor storage, metadata preservation, and every affected production entry point.

This complements #373, which implemented the separate uint8 response representation phase. AI assistance was used for this change, and the final diff received human review before publication.

### Checklist Before Starting

- [x] Searched for similar PRs: [open PRs referencing #386](https://github.com/verl-project/verl-omni/pulls?q=is%3Apr+is%3Aopen+386) and exact head `WenZheWang:wenzhe/strip-unused-responses`; no duplicate found.
- [x] Formatted the PR title as `[{modules}] {type}: {description}` and validated it with `tests/special_sanity/check_pr_title.py`.

### Test

```text
pytest -q tests/trainer/diffusion
175 passed, 4 warnings

pre-commit run --files \
  verl_omni/trainer/diffusion/ray_diffusion_trainer.py \
  verl_omni/trainer/diffusion/v1/trainer_base.py \
  tests/trainer/diffusion/test_worker_batch_projection_on_cpu.py
all hooks passed
```

The CPU suite ran on macOS with an import-only stub for the optional vLLM rollout package because vLLM is unavailable on macOS; the production trainer modules and methods were exercised.

Hardware validation on exact head `ba3918cfb4e2a2bca9120ded699b2e52ddf9ba50`:

- CPU Ray transport benchmark (`torch 2.6.0+cu124`, Ray 2.53.0): batch 8, 192 frames, 512×512 RGB uint8 responses, 2 warmups and 8 measured repetitions per arm. Tensor payload fell from 1,224,737,280 to 16,777,728 bytes (98.63% reduction); median end-to-end transfer time fell from 1.64636 s to 0.03249 s (98.03% reduction). The driver retained `responses`, the projected worker payload excluded it, and all predeclared gates passed.
- One-A800 deterministic GPU smoke (`NVIDIA A800 80GB PCIe`, CUDA 12.4, `torch 2.6.0+cu124`, Ray 2.53.0): seed 42, six optimizer steps per arm. Tensor payload fell from 402,784,288 to 131,104 bytes (99.967% reduction); baseline and projected loss sequences were identical, maximum absolute loss and parameter differences were both 0.0, and final parameter SHA256 values matched. All eight predeclared correctness gates passed.

The hardware evidence is intentionally scoped to response-payload transport and deterministic optimizer equivalence. It does not claim end-to-end diffusion quality, full-model production throughput, or multi-GPU semantics.

### API and Usage Example

No public API, configuration, or user workflow changes. Diffusion trainer call sites automatically omit `responses` only when preparing actor/ref worker payloads.

### Design & Code Changes

1. `DataProto.to_tensordict()` creates the worker-side container while preserving references to existing tensor storage.
2. The projection removes `responses` from that container only; the driver-side `DataProto` remains unchanged.
3. All v0/v1 actor update, reference/teacher inference, and old-log-prob entry points reuse the same projection before RPC dispatch.
4. Tests assert the worker payload excludes pixels while all other tensor, non-tensor, and metadata contracts remain intact.

### Checklist Before Submitting

- [x] Read the Contribute Guide and repository agent instructions.
- [x] Applied pre-commit checks; all hooks passed for the changed files.
- [x] Documentation is unchanged because this is an internal transport optimization with no API, configuration, or usage change.
- [x] Added `test_worker_batch_projection_on_cpu.py`; existing CPU workflow discovery covers `tests/trainer/diffusion/*_on_cpu.py`, so no workflow edit is required.
