### PR TITLE
[diffusion, rollout, tests, recipe] feat: add MiniMax H3 FL2VA FlowGRPO

### DIFF
--- a/examples/flowgrpo_trainer/minimax_h3/README.md
+++ b/examples/flowgrpo_trainer/minimax_h3/README.md
@@ -1,14 +1,16 @@
-# MiniMax H3 T2VA FlowGRPO
+# MiniMax H3 T2VA and FL2VA FlowGRPO
 
-Last updated: 08/23/2026
+Last updated: 08/28/2026
 
-This recipe trains `MiniMaxAI/MiniMax-H3` LoRA adapters with FlowGRPO for
-text-to-audio-video (T2VA) generation. The provided launchers configure a
-Diffusers H3 Actor and vLLM-Omni rollout for joint video and audio generation,
-with CLAP and ImageBind as the default alignment rewards.
+These recipes train `MiniMaxAI/MiniMax-H3` LoRA adapters with FlowGRPO for
+text-to-audio-video (T2VA) and first-frame image-to-audio-video (FL2VA)
+generation. The launchers configure a Diffusers H3 Actor and vLLM-Omni rollout
+for joint video and audio generation, with CLAP and ImageBind as the default
+alignment rewards.
 
-The launchers support NVIDIA GPUs and Ascend NPUs. FL2VA and Ref2VA training
-are not yet supported by the FlowGRPO adapters.
+The T2VA launchers support NVIDIA GPUs and Ascend NPUs; the FL2VA launcher
+targets NVIDIA GPUs. Ref2VA training is not yet supported by the FlowGRPO
+adapters.
 
 ## Install
 
@@ -96,6 +98,24 @@ This writes `$DATA_DIR/train.parquet` and `$DATA_DIR/test.parquet`, the paths
 consumed by both launchers. Use `--train_size` or `--val_size` to create a
 smaller debugging dataset.
 
+FL2VA conditions each clip on a first frame. Reuse the DiffusionNFT FL2VA
+converter (symlinked here as `prepare_fl2va_data.py`), which emits one
+`<image>` token and `frame_indices=[0]`:
+
+```bash
+export RAW_FL2VA_DIR=/path/to/raw_fl2va
+export FL2VA_DATA_DIR="$HOME/data/fl2va/verl_omni"
+
+python3 examples/flowgrpo_trainer/minimax_h3/prepare_fl2va_data.py \
+  --input_dir "$RAW_FL2VA_DIR" \
+  --output_dir "$FL2VA_DATA_DIR" \
+  --frame_mode first
+```
+
+Each `train.jsonl` / `test.jsonl` row carries a prompt and a first-frame image
+path relative to the input directory; see the DiffusionNFT FL2VA recipe for the
+exact schema.
+
 ## Install reward dependencies
 
 The provided launchers enable both CLAP and ImageBind rewards. Install their
@@ -143,6 +163,19 @@ bash examples/flowgrpo_trainer/minimax_h3/run_minimax_h3_t2va_lora.sh \
   actor_rollout_ref.model.attn_backend=native \
   actor_rollout_ref.rollout.rollout_attn_backend=TORCH_SDPA
 ```
+
+### NVIDIA GPU (FL2VA)
+
+```bash
+MODEL_PATH="$MODEL_ROOT/FL2VA" \
+DATA_DIR="$HOME/data/fl2va/verl_omni" \
+IMAGEBIND_MODEL_PATH=/path/to/imagebind_huge.pth \
+bash examples/flowgrpo_trainer/minimax_h3/run_minimax_h3_fl2va_lora.sh
+```
+
+FL2VA reuses the same CPS FlowGRPO configuration as T2VA. The first-frame
+condition rows are held fixed across the reverse-SDE window and re-injected
+after every transition, so only the target video/audio rows are scored.
 
 ### Ascend NPU
 
@@ -220,6 +253,6 @@ Extra Hydra overrides may be appended to either launcher command.
 
 ## Current limitations
 
-- Only T2VA rollout and training are supported. FL2VA and Ref2VA are TODOs.
+- T2VA and FL2VA rollout and training are supported. Ref2VA is a TODO.
 - CLAP and ImageBind are required by the provided launchers; change the reward
   configuration explicitly if either reward is unavailable.

--- a/examples/flowgrpo_trainer/minimax_h3/prepare_fl2va_data.py
+++ b/examples/flowgrpo_trainer/minimax_h3/prepare_fl2va_data.py
@@ -1,0 +1,1 @@
+../../diffusionnft_trainer/minimax_h3/prepare_fl2va_data.py

--- a/examples/flowgrpo_trainer/minimax_h3/run_minimax_h3_fl2va_lora.sh
+++ b/examples/flowgrpo_trainer/minimax_h3/run_minimax_h3_fl2va_lora.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# MiniMax H3 FL2VA (first-frame conditioned) LoRA FlowGRPO with CLAP and ImageBind rewards.
+set -x
+
+export WANDB_MODE=${WANDB_MODE:-online}
+
+WORKSPACE=${WORKSPACE:-$HOME}
+MODEL_PATH=${MODEL_PATH:-$WORKSPACE/models/MiniMax-H3/FL2VA}
+DATA_DIR=${DATA_DIR:-$WORKSPACE/data/fl2va/verl_omni}
+CLAP_MODEL_PATH=${CLAP_MODEL_PATH:-laion/larger_clap_general}
+IMAGEBIND_MODEL_PATH=${IMAGEBIND_MODEL_PATH:-.checkpoints/imagebind_huge.pth}
+ACTOR_CONFIG_PATH=${ACTOR_CONFIG_PATH:-$(dirname "$MODEL_PATH")/transformer}
+NUM_GPUS=${NUM_GPUS:-8}
+ROLLOUT_TP=${ROLLOUT_TP:-2}
+TEXT_ENCODER_TP=${TEXT_ENCODER_TP:-$ROLLOUT_TP}
+REWARD_DEVICE=${REWARD_DEVICE:-cuda}
+REWARD_NUM_WORKERS=${REWARD_NUM_WORKERS:-1}
+TOTAL_TRAINING_STEPS=${TOTAL_TRAINING_STEPS:-100}
+ASPECT_RATIO=${ASPECT_RATIO:-16:9}
+HEIGHT=${HEIGHT:-256}
+WIDTH=${WIDTH:-384}
+NUM_FRAMES=${NUM_FRAMES:-121}
+INFER_STEPS=${INFER_STEPS:-10}
+VAL_HEIGHT=${VAL_HEIGHT:-512}
+VAL_WIDTH=${VAL_WIDTH:-768}
+
+train_path=$DATA_DIR/train.parquet
+test_path=$DATA_DIR/test.parquet
+
+script_path=$(readlink -f "$0")
+script_name=$(basename "$script_path" .sh)
+repo_root=$(dirname "$script_path")
+while [[ "$repo_root" != "/" && ! -f "$repo_root/LICENSE" ]]; do
+    repo_root=$(dirname "$repo_root")
+done
+if [[ ! -f "$repo_root/LICENSE" ]]; then
+    echo "Unable to locate repo root from $script_path: no LICENSE found" >&2
+    exit 1
+fi
+
+output_dir=${OUTPUT_DIR:-$repo_root/outputs/$script_name}
+checkpoint_dir=$output_dir/checkpoints
+run_timestamp=$(date +"%Y%m%d_%H%M")
+log_file=$output_dir/logs/$run_timestamp/${NODE_RANK:-0}.log
+mkdir -p "$checkpoint_dir" "$(dirname "$log_file")"
+exec > >(tee -a "$log_file") 2>&1
+
+h3_lora_targets="['to_q','to_k','to_v','to_out.0','ff.net.0.proj','ff.net.2']"
+
+python3 -m verl_omni.trainer.main_diffusion \
+    data.train_files=$train_path \
+    data.val_files=$test_path \
+    data.train_batch_size=32 \
+    data.val_max_samples=128 \
+    data.max_prompt_length=1024 \
+    data.truncation=error \
+    data.seed=42 \
+    algorithm.adv_estimator=flow_grpo \
+    algorithm.global_std=True \
+    actor_rollout_ref.model.path=$MODEL_PATH \
+    actor_rollout_ref.model.config_path=$ACTOR_CONFIG_PATH \
+    actor_rollout_ref.model.algorithm=flow_grpo \
+    actor_rollout_ref.model.transformer_subfolder=transformer \
+    actor_rollout_ref.model.attn_backend=_flash_3_varlen_hub \
+    actor_rollout_ref.model.enable_gradient_checkpointing=True \
+    actor_rollout_ref.model.lora_rank=64 \
+    actor_rollout_ref.model.lora_alpha=128 \
+    actor_rollout_ref.model.target_modules="$h3_lora_targets" \
+    actor_rollout_ref.model.fsdp_layer_prefixes="['transformer_blocks.','token_refiner.refiner_blocks.']" \
+    '+actor_rollout_ref.actor.fsdp_config.wrap_policy.transformer_layer_cls_to_wrap=[MiniMaxH3TransformerBlock,MiniMaxH3TokenRefinerBlock]' \
+    actor_rollout_ref.actor.strategy=fsdp2 \
+    actor_rollout_ref.actor.optim.lr=3e-4 \
+    actor_rollout_ref.actor.optim.weight_decay=0.0001 \
+    actor_rollout_ref.actor.ppo_mini_batch_size=16 \
+    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=1 \
+    actor_rollout_ref.actor.use_kl_loss=False \
+    actor_rollout_ref.actor.fsdp_config.model_dtype=bfloat16 \
+    actor_rollout_ref.actor.fsdp_config.ulysses_sequence_parallel_size=1 \
+    actor_rollout_ref.rollout.name=vllm_omni \
+    actor_rollout_ref.rollout.rollout_attn_backend=FLASH_ATTN_3_HUB \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=$ROLLOUT_TP \
+    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.text_encoder_tp_size=$TEXT_ENCODER_TP \
+    actor_rollout_ref.rollout.n=8 \
+    actor_rollout_ref.rollout.seed=42 \
+    actor_rollout_ref.rollout.agent.num_workers=$((NUM_GPUS / ROLLOUT_TP)) \
+    actor_rollout_ref.rollout.agent.default_agent_loop=minimax_h3_diffusion_single_turn_agent \
+    actor_rollout_ref.rollout.max_prompt_embed_length=1024 \
+    actor_rollout_ref.rollout.load_format=safetensors \
+    actor_rollout_ref.rollout.calculate_log_probs=True \
+    actor_rollout_ref.rollout.pipeline.height=$HEIGHT \
+    actor_rollout_ref.rollout.pipeline.width=$WIDTH \
+    actor_rollout_ref.rollout.pipeline.aspect_ratio=${ASPECT_RATIO} \
+    actor_rollout_ref.rollout.pipeline.num_frames=$NUM_FRAMES \
+    actor_rollout_ref.rollout.pipeline.frame_rate=24 \
+    actor_rollout_ref.rollout.pipeline.num_inference_steps=$INFER_STEPS \
+    actor_rollout_ref.rollout.pipeline.true_cfg_scale=1.0 \
+    actor_rollout_ref.rollout.pipeline.max_sequence_length=1024 \
+    +actor_rollout_ref.rollout.pipeline.output_type=np \
+    actor_rollout_ref.rollout.val_kwargs.pipeline.height=$VAL_HEIGHT \
+    actor_rollout_ref.rollout.val_kwargs.pipeline.width=$VAL_WIDTH \
+    actor_rollout_ref.rollout.val_kwargs.pipeline.num_frames=$NUM_FRAMES \
+    actor_rollout_ref.rollout.val_kwargs.pipeline.frame_rate=24.0 \
+    actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=40 \
+    actor_rollout_ref.rollout.val_kwargs.pipeline.true_cfg_scale=1.0 \
+    +actor_rollout_ref.rollout.val_kwargs.pipeline.output_type=pt \
+    actor_rollout_ref.rollout.algo.noise_level=0.8 \
+    actor_rollout_ref.rollout.algo.sde_type=cps \
+    actor_rollout_ref.rollout.algo.sde_window_range='[0,8]' \
+    actor_rollout_ref.rollout.algo.sde_window_size=3 \
+    actor_rollout_ref.rollout.algo.sde_contiguous=True \
+    actor_rollout_ref.rollout.algo.sde_window_seed=42 \
+    reward.num_workers=$REWARD_NUM_WORKERS \
+    reward.reward_model.enable=False \
+    reward.custom_reward_function.path=pkg://verl_omni.reward_loop.reward_manager.multi \
+    reward.custom_reward_function.name=_multi_reward_placeholder \
+    reward.reward_manager.name=MultiVisualRewardManager \
+    reward.reward_manager.module.path=pkg://verl_omni.reward_loop.reward_manager \
+    "+reward.reward_functions.clap.path=$repo_root/verl_omni/utils/reward_score/clap.py" \
+    '+reward.reward_functions.clap.name=compute_score' \
+    '+reward.reward_functions.clap.weight=1.0' \
+    '+reward.reward_functions.clap.required=true' \
+    "+reward.reward_functions.clap.device=$REWARD_DEVICE:0" \
+    "+reward.reward_functions.clap.model_name_or_path=$CLAP_MODEL_PATH" \
+    "+reward.reward_functions.imagebind.path=$repo_root/verl_omni/utils/reward_score/imagebind.py" \
+    '+reward.reward_functions.imagebind.name=compute_score' \
+    '+reward.reward_functions.imagebind.weight=1.0' \
+    '+reward.reward_functions.imagebind.required=true' \
+    "+reward.reward_functions.imagebind.device=$REWARD_DEVICE:1" \
+    "+reward.reward_functions.imagebind.model_name_or_path=$IMAGEBIND_MODEL_PATH" \
+    '+reward.reward_functions.imagebind.mode=audio_video' \
+    reward.aggregation=weighted_sum \
+    trainer.logger='["console","wandb"]' \
+    trainer.project_name=flow_grpo \
+    trainer.experiment_name=minimax_h3_fl2va_lora_gpu \
+    trainer.default_local_dir=$checkpoint_dir \
+    trainer.validation_data_dir=$output_dir/validation_data \
+    trainer.rollout_data_dir=$output_dir/rollout_data \
+    trainer.rollout_data_save_freq=10 \
+    trainer.log_val_generations=8 \
+    trainer.video_fps=24 \
+    trainer.val_before_train=True \
+    trainer.n_gpus_per_node=$NUM_GPUS \
+    trainer.nnodes=1 \
+    trainer.save_freq=10 \
+    trainer.max_actor_ckpt_to_keep=1 \
+    trainer.test_freq=10 \
+    trainer.total_epochs=15 \
+    trainer.total_training_steps=$TOTAL_TRAINING_STEPS "$@"

--- a/tests/pipelines/test_minimax_h3_flow_grpo_on_cpu.py
+++ b/tests/pipelines/test_minimax_h3_flow_grpo_on_cpu.py
@@ -63,6 +63,7 @@ def _trajectory() -> dict[str, torch.Tensor]:
         "h3_video_indices": torch.tensor([[0, 1]]),
         "h3_audio_indices": torch.tensor([[2, 3, 4]]),
         "h3_text_indices": torch.tensor([[5, 6]]),
+        "h3_video_update_mask": torch.ones(1, video.shape[1], dtype=torch.bool),
     }
 
 
@@ -309,6 +310,10 @@ class _FakeH3Branch:
 
     def __init__(self, *, packed, text_embeddings, token_tags, device):
         del packed, text_embeddings, token_tags, device
+        self.img_pos = torch.arange(2)
+        self.audio_pos = torch.arange(2, 5)
+        self.update_mask_dev = torch.ones(2, dtype=torch.bool)
+        self.audio_update_mask = torch.ones(3, dtype=torch.bool)
 
     def forward_kwargs(self, *, video_rows, audio_rows, **kwargs):
         del kwargs
@@ -447,6 +452,112 @@ def test_rollout_denoise_window_records_replayable_aligned_trajectory(monkeypatc
     pipeline.record_denoise_step.assert_any_call(1, normalized_timestep=0.8)
     pipeline.record_denoise_step.assert_any_call(2, normalized_timestep=0.6)
     pipeline.record_denoise_step.assert_called_with(None)
+
+
+def test_fl2va_denoise_keeps_condition_rows_fixed_and_scores_only_targets(monkeypatch) -> None:
+    """FL2VA builds full video rows (one keyframe condition row + two targets), steps only
+    the target rows through the SDE, re-injects the fixed condition row every transition,
+    and stores the full-row trajectory for Actor replay."""
+
+    class _FakeFL2VABranch:
+        def __init__(self, *, packed, text_embeddings, token_tags, device):
+            del packed, text_embeddings, token_tags, device
+            self.img_pos = torch.arange(3)
+            self.audio_pos = torch.arange(3, 6)
+            self.update_mask_dev = torch.tensor([False, True, True])
+            self.audio_update_mask = torch.ones(3, dtype=torch.bool)
+
+        def forward_kwargs(self, *, video_rows, audio_rows, **kwargs):
+            del kwargs
+            return {"hidden_states": video_rows, "audio_hidden_states": audio_rows}
+
+    pipeline = object.__new__(MiniMaxH3PipelineWithLogProb)
+    pipeline.device = torch.device("cpu")
+    pipeline._flow_grpo_noise_level = 0.8
+    pipeline._flow_grpo_sde_type = "cps"
+    pipeline._flow_grpo_window_size = 2
+    pipeline._flow_grpo_window_range = [1, 3]
+    pipeline._flow_grpo_sde_contiguous = True
+    pipeline._flow_grpo_seed = 123
+    pipeline._h3_max_text_len = 2
+    pipeline._initial_noise = MagicMock(return_value=(torch.zeros(2, H3_VIDEO_WIDTH), torch.zeros(3, H3_AUDIO_WIDTH)))
+    pipeline.record_denoise_step = MagicMock()
+    pipeline.progress_bar = lambda total: nullcontext(SimpleNamespace(update=MagicMock()))
+    pipeline._resident_dit_layers_on_device = lambda enabled: nullcontext()
+    pipeline._layout_outputs = MagicMock(return_value=_layout_metadata())
+
+    def transformer(**model_inputs):
+        return (
+            torch.zeros_like(model_inputs["hidden_states"]),
+            torch.zeros_like(model_inputs["audio_hidden_states"]),
+        )
+
+    pipeline.transformer = transformer
+    pipeline._transformer_for_task = MagicMock(return_value=transformer)
+
+    video_sigmas = [1.0, 0.8, 0.6, 0.4, 0.2, 0.0]
+    audio_sigmas = [1.0, 0.7, 0.5, 0.3, 0.1, 0.0]
+    video_sample_rows = []
+
+    def fake_transition(_scheduler, sample, _velocity, step, **kwargs):
+        is_video = sample.shape[-1] == H3_VIDEO_WIDTH
+        if is_video:
+            video_sample_rows.append(sample.shape[1])
+        log_prob = torch.tensor([0.2 if is_video else 0.6]) if kwargs["return_log_prob"] else None
+        return sample + float(step + 1), log_prob, sample, torch.tensor(0.1), torch.tensor(0.2)
+
+    unpatchify_rows = []
+
+    def fake_unpatchify(video_rows, **kwargs):
+        del kwargs
+        unpatchify_rows.append(int(video_rows.shape[0]))
+        return torch.tensor([11.0])
+
+    packed = {"token_tags": torch.zeros(7, dtype=torch.long), "text_pos": torch.tensor([5, 6])}
+    module = "verl_omni.pipelines.minimax_h3_flow_grpo.vllm_omni_rollout_adapter"
+    monkeypatch.setattr(f"{module}.minimax_h3_packed_sequence", lambda **kwargs: packed)
+    monkeypatch.setattr(f"{module}.MiniMaxH3DenoiseBranch", _FakeFL2VABranch)
+    monkeypatch.setattr(f"{module}.h3_sigma_schedules", lambda *args: (video_sigmas, audio_sigmas))
+    monkeypatch.setattr(f"{module}.configure_flow_scheduler", lambda *args: None)
+    monkeypatch.setattr(f"{module}.sample_h3_transition", fake_transition)
+    monkeypatch.setattr(
+        f"{module}.minimax_h3_imgvid_cond_noise_aug_rows",
+        lambda *args, **kwargs: torch.full((1, H3_VIDEO_WIDTH), 5.0),
+    )
+    monkeypatch.setattr(f"{module}.minimax_h3_unpatchify_video_tokens", fake_unpatchify)
+    monkeypatch.setattr(f"{module}.minimax_h3_unpack_audio_tokens", lambda *args, **kwargs: torch.tensor([22.0]))
+
+    pipeline.diffuse(
+        task="fl2va",
+        text_embeddings=torch.randn(2, 8),
+        text_tags=torch.ones(2, dtype=torch.long),
+        seed=7,
+        latent_t=1,
+        latent_h=4,
+        latent_w=4,
+        audio_t=3,
+        num_frames=1,
+        num_steps=6,
+        video_shift=12.0,
+        audio_shift=3.0,
+        visual_condition=torch.randn(1, 3, 8, 8),
+        visual_condition_shape=(1, 8, 8),
+        audio_condition=None,
+        ref_audio_t=None,
+        visual_condition_shapes=[(1, 8, 8)],
+        keyframe_frame_indices=[0],
+    )
+
+    trajectory = pipeline._flow_grpo_trajectory
+    # Every video transition steps only the two target rows, never the keyframe row.
+    assert video_sample_rows == [2, 2, 2, 2, 2]
+    # The final VAE decode consumes only the two target rows, not the condition row.
+    assert unpatchify_rows == [2]
+    # The stored trajectory keeps the full three-row video layout (cond + targets).
+    assert trajectory["all_latents"].shape == (1, 2, 1, 3 * H3_VIDEO_WIDTH + 3 * H3_AUDIO_WIDTH)
+    assert trajectory["all_next_latents"].shape == trajectory["all_latents"].shape
+    assert trajectory["all_log_probs"].shape == (1, 2)
+    assert trajectory["h3_step_indices"].tolist() == [[1, 2]]
 
 
 def _batched_actor_payload(batch_size: int = 2) -> dict[str, torch.Tensor]:

--- a/verl_omni/pipelines/minimax_h3_flow_grpo/diffusers_training_adapter.py
+++ b/verl_omni/pipelines/minimax_h3_flow_grpo/diffusers_training_adapter.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Diffusers Actor adapter for MiniMax H3 T2VA FlowGRPO."""
+"""Diffusers Actor adapter for MiniMax H3 T2VA and FL2VA FlowGRPO."""
 
 from __future__ import annotations
 
@@ -130,6 +130,7 @@ class MiniMaxH3FlowGRPO(DiffusionModelBase):
             "h3_video_indices",
             "h3_audio_indices",
             "h3_text_indices",
+            "h3_video_update_mask",
         }
         missing = sorted(required - set(micro_batch.keys()))
         if missing:
@@ -151,6 +152,7 @@ class MiniMaxH3FlowGRPO(DiffusionModelBase):
         video_indices = _shared_layout(micro_batch["h3_video_indices"], video_rows, "video indices").long()
         audio_indices = _shared_layout(micro_batch["h3_audio_indices"], audio_rows, "audio indices").long()
         text_indices = _shared_layout(micro_batch["h3_text_indices"], prompt_embeds.shape[1], "text indices").long()
+        video_update_mask = _shared_layout(micro_batch["h3_video_update_mask"], video_rows, "video update mask").bool()
 
         original_step = _shared_int(micro_batch["h3_step_indices"][:, step], "scheduler step")
         step_timesteps = torch.stack((timesteps[:, step], micro_batch["h3_audio_timesteps"][:, step]), dim=-1)
@@ -175,6 +177,7 @@ class MiniMaxH3FlowGRPO(DiffusionModelBase):
                 "text_indices": text_indices.to(current_video.device),
                 "return_dict": False,
                 "_h3_scheduler_step": original_step,
+                "_h3_video_update_mask": video_update_mask.to(current_video.device),
             },
             None,
         )
@@ -195,6 +198,7 @@ class MiniMaxH3FlowGRPO(DiffusionModelBase):
             raise ValueError("MiniMax H3 replay requires rollout scheduler inputs.")
         model_inputs = dict(model_inputs)
         original_step = int(model_inputs.pop("_h3_scheduler_step"))
+        update_mask = model_inputs.pop("_h3_video_update_mask")
         video_velocity, audio_velocity = module(**model_inputs)
         video = model_inputs["hidden_states"].float()
         audio = model_inputs["audio_hidden_states"].float()
@@ -203,15 +207,21 @@ class MiniMaxH3FlowGRPO(DiffusionModelBase):
             video.shape[1],
             audio.shape[1],
         )
+        # Only the update-mask (target) rows carry a stochastic transition; keyframe
+        # condition rows are fixed, so the replay scores the same target rows the rollout
+        # did (a no-op slice for T2VA's all-True mask).
+        video_target = video[:, update_mask]
+        video_velocity_target = video_velocity.float()[:, update_mask]
+        next_video_target = next_video[:, update_mask]
         video_scheduler, audio_scheduler = scheduler
         video_out = sample_h3_transition(
             video_scheduler,
-            video,
-            video_velocity.float(),
+            video_target,
+            video_velocity_target,
             original_step,
             noise_level=model_config.algo.noise_level,
             sde_type=model_config.algo.sde_type,
-            prev_sample=next_video,
+            prev_sample=next_video_target,
         )
         audio_out = sample_h3_transition(
             audio_scheduler,
@@ -227,7 +237,7 @@ class MiniMaxH3FlowGRPO(DiffusionModelBase):
         if video_log_prob is None or audio_log_prob is None:
             raise RuntimeError("MiniMax H3 replay did not compute log probabilities.")
 
-        video_weight = video[0].numel()
+        video_weight = video_target[0].numel()
         audio_weight = audio[0].numel()
         total_weight = video_weight + audio_weight
         log_prob = combine_log_probs(video_log_prob, audio_log_prob)

--- a/verl_omni/pipelines/minimax_h3_flow_grpo/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/minimax_h3_flow_grpo/vllm_omni_rollout_adapter.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""vLLM-Omni rollout adapter for MiniMax H3 T2VA FlowGRPO."""
+"""vLLM-Omni rollout adapter for MiniMax H3 T2VA and FL2VA FlowGRPO."""
 
 from __future__ import annotations
 
@@ -24,7 +24,12 @@ import torch
 import torch.nn.functional as F
 from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.models.minimax_h3 import MiniMaxH3Pipeline
-from vllm_omni.diffusion.models.minimax_h3.denoise_loop import MiniMaxH3DenoiseBranch
+from vllm_omni.diffusion.models.minimax_h3.condition_noise import minimax_h3_imgvid_cond_noise_aug_rows
+from vllm_omni.diffusion.models.minimax_h3.denoise_loop import (
+    MINIMAX_H3_AUDIO_REF_COND_TIMESTEP,
+    MINIMAX_H3_IMGVID_COND_TIMESTEP,
+    MiniMaxH3DenoiseBranch,
+)
 from vllm_omni.diffusion.models.minimax_h3.packed_sequence import minimax_h3_packed_sequence
 from vllm_omni.diffusion.models.minimax_h3.packed_tokens import (
     minimax_h3_unpack_audio_tokens,
@@ -59,7 +64,7 @@ def _pad_first_dim(value: torch.Tensor, target: int) -> torch.Tensor:
 
 @VllmOmniPipelineBase.register("MiniMaxH3Pipeline", algorithm="flow_grpo")
 class MiniMaxH3PipelineWithLogProb(MiniMaxH3WeightSyncMixin, MiniMaxH3Pipeline):
-    """Adapt ``MiniMaxH3Pipeline`` for single-request T2VA FlowGRPO rollout.
+    """Adapt ``MiniMaxH3Pipeline`` for single-request T2VA / FL2VA FlowGRPO rollout.
 
     Overrides:
         - ``__init__`` adds request-scoped FlowGRPO and CPS state.
@@ -153,6 +158,7 @@ class MiniMaxH3PipelineWithLogProb(MiniMaxH3WeightSyncMixin, MiniMaxH3Pipeline):
             "h3_video_indices": branch.img_pos.unsqueeze(0),
             "h3_audio_indices": branch.audio_pos.unsqueeze(0),
             "h3_text_indices": text_indices,
+            "h3_video_update_mask": branch.update_mask_dev.unsqueeze(0),
         }
 
     def diffuse(
@@ -180,19 +186,26 @@ class MiniMaxH3PipelineWithLogProb(MiniMaxH3WeightSyncMixin, MiniMaxH3Pipeline):
         keyframe_frame_indices: list[int] | None = None,
         base_schedule: Sequence[float] | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        video_rows, audio_rows = self._initial_noise(
+        target_video_rows, audio_rows = self._initial_noise(
             seed=seed,
             latent_t=latent_t,
             latent_h=latent_h,
             latent_w=latent_w,
             audio_t=audio_t,
         )
-        video_rows = video_rows.to(self.device)
+        target_video_rows = target_video_rows.to(self.device)
         audio_rows = audio_rows.to(self.device)
 
         if task == "ref2va":
             # TODO: Build the Ref2VA packed blocks and preserve their anchors during Actor replay.
             raise NotImplementedError("MiniMax H3 FlowGRPO does not support Ref2VA yet.")
+        if audio_condition is not None:
+            # TODO: Add Ref2VA audio anchors to CPS transitions and Actor replay.
+            raise NotImplementedError("MiniMax H3 FlowGRPO does not support audio conditions yet.")
+        if task not in {"t2va", "fl2va"}:
+            raise NotImplementedError(f"MiniMax H3 FlowGRPO supports t2va and fl2va, got {task!r}.")
+
+        keyframe_indices = list(keyframe_frame_indices or [])
         packed = minimax_h3_packed_sequence(
             text_len=int(text_embeddings.shape[0]),
             latent_t=latent_t,
@@ -200,32 +213,10 @@ class MiniMaxH3PipelineWithLogProb(MiniMaxH3WeightSyncMixin, MiniMaxH3Pipeline):
             latent_w=latent_w,
             audio_t=audio_t,
             include_keyframe_cond=task == "fl2va",
+            keyframe_frame_indices=keyframe_indices if task == "fl2va" else None,
+            frame_count=num_frames if task == "fl2va" else None,
         )
-
-        visual_anchor = visual_condition
-        if visual_anchor is not None:
-            # TODO: Add FL2VA/Ref2VA visual anchors to CPS transitions and Actor replay.
-            raise NotImplementedError("MiniMax H3 FlowGRPO does not support visual conditions yet.")
-
-        audio_anchor = audio_condition
-        if audio_anchor is not None:
-            # TODO: Add Ref2VA audio anchors to CPS transitions and Actor replay.
-            raise NotImplementedError("MiniMax H3 FlowGRPO does not support audio conditions yet.")
-
-        if task == "fl2va":
-            # A valid FL2VA request should carry a visual condition. Keep a
-            # clear boundary in case upstream request validation changes.
-            raise NotImplementedError("MiniMax H3 FlowGRPO does not support FL2VA yet.")
-        del (
-            base_schedule,
-            num_frames,
-            visual_condition_shape,
-            ref_audio_t,
-            ref_blocks,
-            visual_condition_shapes,
-            audio_condition_lengths,
-            keyframe_frame_indices,
-        )
+        del base_schedule, ref_audio_t, ref_blocks, audio_condition_lengths
         if not math.isclose(video_shift, H3_VIDEO_SHIFT, rel_tol=0.0, abs_tol=1e-6) or not math.isclose(
             audio_shift, H3_AUDIO_SHIFT, rel_tol=0.0, abs_tol=1e-6
         ):
@@ -242,6 +233,36 @@ class MiniMaxH3PipelineWithLogProb(MiniMaxH3WeightSyncMixin, MiniMaxH3Pipeline):
             token_tags=tags,
             device=self.device,
         )
+        if not bool(branch.audio_update_mask.all()):
+            raise NotImplementedError("MiniMax H3 FlowGRPO does not support audio-reference condition rows.")
+
+        # FL2VA keyframe rows are fixed conditioning: build them once, place them at the
+        # non-update positions, and re-inject after every transition so the SDE never
+        # perturbs the anchor. T2VA keeps the mask all-True and the condition set empty,
+        # so the loop below is identical to the text-only path.
+        update_mask = branch.update_mask_dev
+        condition_rows = target_video_rows.new_zeros((0, target_video_rows.shape[-1]))
+        if task == "fl2va":
+            condition_shapes = visual_condition_shapes
+            if condition_shapes is None and visual_condition_shape is not None:
+                condition_shapes = [visual_condition_shape]
+            if visual_condition is None or not condition_shapes or not keyframe_indices:
+                raise ValueError("MiniMax H3 FL2VA rollout did not provide complete visual condition metadata.")
+            condition_rows = minimax_h3_imgvid_cond_noise_aug_rows(
+                visual_condition,
+                condition_shapes=condition_shapes,
+                target_latent_t=latent_t,
+                imgvid_cond_num_frames=len(condition_shapes),
+                seed=seed,
+                noise_aug=MINIMAX_H3_IMGVID_COND_TIMESTEP,
+            ).to(device=self.device, dtype=target_video_rows.dtype)
+
+        video_rows = target_video_rows.new_zeros((branch.img_pos.shape[0], target_video_rows.shape[-1]))
+        video_rows[update_mask] = target_video_rows
+        if condition_rows.shape[0] != int((~update_mask).sum().item()):
+            raise ValueError("MiniMax H3 FL2VA condition row count does not match the official packed layout.")
+        if condition_rows.numel():
+            video_rows[~update_mask] = condition_rows
 
         video_sigmas, audio_sigmas = h3_sigma_schedules(num_steps, video_shift, audio_shift)
         video_scheduler = FlowMatchSDEDiscreteScheduler()
@@ -289,15 +310,20 @@ class MiniMaxH3PipelineWithLogProb(MiniMaxH3WeightSyncMixin, MiniMaxH3Pipeline):
                         audio_rows=audio_rows,
                         t_video=video_t,
                         t_audio=audio_timestep,
-                        imgvid_cond_timestep=video_t,
-                        audio_ref_cond_timestep=audio_timestep,
+                        imgvid_cond_timestep=max(video_t, MINIMAX_H3_IMGVID_COND_TIMESTEP),
+                        audio_ref_cond_timestep=max(audio_timestep, MINIMAX_H3_AUDIO_REF_COND_TIMESTEP),
                     )
                     video_velocity, audio_velocity = transformer(**model_inputs)
                     is_selected = step in selected
+                    # The DiT emits one velocity per packed row; only the update-mask (target)
+                    # rows carry a stochastic transition and log-prob. Keyframe condition rows
+                    # stay fixed and are re-injected below (a no-op for T2VA's all-True mask).
+                    target_rows = video_rows[update_mask]
+                    target_velocity = video_velocity[update_mask]
                     video_transition = sample_h3_transition(
                         video_scheduler,
-                        video_rows.unsqueeze(0),
-                        video_velocity.unsqueeze(0),
+                        target_rows.unsqueeze(0),
+                        target_velocity.unsqueeze(0),
                         step,
                         noise_level=self._flow_grpo_noise_level if is_selected else 0.0,
                         sde_type=self._flow_grpo_sde_type,
@@ -314,13 +340,20 @@ class MiniMaxH3PipelineWithLogProb(MiniMaxH3WeightSyncMixin, MiniMaxH3Pipeline):
                         generator=generator,
                         return_log_prob=is_selected,
                     )
+                    next_video_rows = video_rows.clone()
+                    next_video_rows[update_mask] = video_transition[0][0]
+                    if condition_rows.numel():
+                        next_video_rows[~update_mask] = condition_rows
+                    next_audio_rows = audio_transition[0][0]
                     if is_selected:
                         video_log_prob = video_transition[1]
                         audio_log_prob = audio_transition[1]
                         if video_log_prob is None or audio_log_prob is None:
                             raise RuntimeError("MiniMax H3 rollout did not compute log probabilities.")
                         current_latents.append(flatten_joint_latents(video_rows.unsqueeze(0), audio_rows.unsqueeze(0)))
-                        next_latents.append(flatten_joint_latents(video_transition[0], audio_transition[0]))
+                        next_latents.append(
+                            flatten_joint_latents(next_video_rows.unsqueeze(0), next_audio_rows.unsqueeze(0))
+                        )
                         log_probs.append(
                             combine_log_probs(
                                 video_log_prob,
@@ -330,8 +363,8 @@ class MiniMaxH3PipelineWithLogProb(MiniMaxH3WeightSyncMixin, MiniMaxH3Pipeline):
                         step_indices.append(step)
                         selected_video_sigmas.append(video_sigma)
                         selected_audio_sigmas.append(audio_sigma)
-                    video_rows = video_transition[0][0]
-                    audio_rows = audio_transition[0][0]
+                    video_rows = next_video_rows
+                    audio_rows = next_audio_rows
                     progress.update()
         self.record_denoise_step(None)
 
@@ -348,7 +381,7 @@ class MiniMaxH3PipelineWithLogProb(MiniMaxH3WeightSyncMixin, MiniMaxH3Pipeline):
         }
 
         video_latent = minimax_h3_unpatchify_video_tokens(
-            video_rows,
+            video_rows[update_mask],
             latent_shape=(latent_t, latent_h // 2, latent_w // 2, 24),
             patch_size=(1, 2, 2),
         )
@@ -379,6 +412,7 @@ class MiniMaxH3PipelineWithLogProb(MiniMaxH3WeightSyncMixin, MiniMaxH3Pipeline):
             "h3_video_indices",
             "h3_audio_indices",
             "h3_text_indices",
+            "h3_video_update_mask",
         )
         return with_rollout_data(
             output,


### PR DESCRIPTION
### What does this PR do?

Implement MiniMax H3 **FL2VA (first-frame-conditioned) FlowGRPO** on top of the
now-merged **T2VA FlowGRPO** foundation (#368): CPS joint video/audio sampling,
per-modality video/audio sigma schedules, and the shared `common.py` /
`weight_sync.py` helpers — not a separate dual-SDE implementation. #368 shipped
T2VA and left FL2VA/Ref2VA as `NotImplementedError` stubs; this PR fills in the
FL2VA path.

Rollout adapter (`vllm_omni_rollout_adapter.diffuse`):
- Replace the FL2VA / visual-condition `NotImplementedError` stubs with the real
  path: build keyframe condition rows via `minimax_h3_imgvid_cond_noise_aug_rows`,
  place them at the non-update packed positions, step **only** the update-mask
  (target) rows through the CPS transition, and re-inject the fixed condition
  rows after every step. T2VA (all-True mask, empty condition set) is unchanged.
- Carry the video update mask (`h3_video_update_mask`) in the replayable layout.

Training adapter (`diffusers_training_adapter.py`):
- Reconstruct the full packed video rows for the DiT forward, then score only
  the update-mask target rows so rollout and Actor log-probs stay aligned.

Recipe / docs / tests:
- Add `run_minimax_h3_fl2va_lora.sh` (first-frame, `frame_indices=[0]`,
  CLAP + ImageBind rewards, CPS window), symlink `prepare_fl2va_data.py` to the
  DiffusionNFT data converter, and extend the README for FL2VA.
- Add an FL2VA denoise CPU test and update the shared fixtures for the new mask.

**Reverse-SDE terminal safety.** The recipe inherits `sde_type=cps` from the
T2VA recipe. `cps` scales its stochastic term by the *next* sigma (0 at the
terminal transition), so no undenoised noise leaks into the final latent — it is
terminal-safe by construction, matching the upstream T2VA (#368) and LTX2 recipes.

### Not a duplicate

- #368 (mengchengTang) added **T2VA** FlowGRPO and has merged; it left
  FL2VA/Ref2VA as `NotImplementedError` stubs. This PR implements the **FL2VA**
  (first-frame) path on that merged foundation. Ref2VA remains a TODO.
- Checked open PRs by head branch and by `FL2VA FlowGRPO` / `minimax h3 fl2va`:
  no other open PR targets FL2VA FlowGRPO.

### Test

CPU (project `.venv`, `vllm_omni` 0.27):

```
pytest --asyncio-mode=auto \
  tests/pipelines/test_minimax_h3_flow_grpo_on_cpu.py \
  tests/pipelines/test_minimax_h3_rollout_contract_on_cpu.py \
  tests/utils/test_tracking_on_cpu.py
=> 27 passed
```

Covers adapter import + registration, the raw-text agent loop, t2va/fl2va
`diffuse` (fl2va: condition rows held fixed, only target rows stepped through the
CPS transition), and the joint-transition replay through `prepare_model_inputs` /
`forward_and_sample_previous_step`.

- `ruff check` + `ruff format --check` + `git diff --check` on changed files: clean.
- GPU generation quality validated separately (curves below).

### Training Reward
<img width="1857" height="629" alt="image" src="https://github.com/user-attachments/assets/cf884524-9c01-4457-b719-5f37f63412d9" />
<img width="1860" height="628" alt="image" src="https://github.com/user-attachments/assets/adee0721-107f-478f-bd2b-54d960f63da8" />
### Val Reward
<img width="1855" height="629" alt="image" src="https://github.com/user-attachments/assets/5a2e6687-eb07-490d-a0bd-e1bda94d5a5a" />

### AI assistance

AI assistance (pi coding agent) was used for this change. A human submitter has
reviewed every changed line and is responsible for the PR end to end.

