### PR TITLE
[trainer, tests] fix: support the W&B 0.29 Image API

### DIFF
--- a/tests/utils/test_tracking_on_cpu.py
+++ b/tests/utils/test_tracking_on_cpu.py
@@ -121,7 +121,7 @@ def test_image_samples_become_wandb_image_and_no_temp_dir(monkeypatch):
     assert media_to_log == {}
     assert len(wrapped) == 1 and wrapped[0][0] == "prompt"
     assert captured[0][0].dtype == torch.uint8
-    assert captured[0][1]["normalize"] is False
+    assert captured[0][1] == {"file_type": "jpg"}
 
 
 def test_image_samples_reject_non_uint8_input(monkeypatch):

--- a/verl_omni/trainer/diffusion/v1/trainer_base.py
+++ b/verl_omni/trainer/diffusion/v1/trainer_base.py
@@ -1032,7 +1032,7 @@ class PolicyGradientDiffusionTrainerV1(ABC):
                     raise ValueError(f"Expected a uint8 image tensor, got {getattr(image, 'dtype', type(image))}.")
             import wandb
 
-            outputs = [wandb.Image(image, file_type="jpg", normalize=False) for image in outputs]
+            outputs = [wandb.Image(image, file_type="jpg") for image in outputs]
         samples = list(zip(inputs, outputs, scores, strict=True))
         samples.sort(key=lambda x: x[0])
         rng = np.random.RandomState(42)

--- a/verl_omni/utils/tracking.py
+++ b/verl_omni/utils/tracking.py
@@ -193,7 +193,7 @@ def wrap_val_samples_for_wandb(samples, fps=24, output_dir=None):
         else:
             if not isinstance(out, torch.Tensor) or out.dtype != torch.uint8:
                 raise ValueError(f"Expected a uint8 image tensor, got {getattr(out, 'dtype', type(out))}.")
-            media = wandb.Image(out, file_type="jpg", normalize=False)
+            media = wandb.Image(out, file_type="jpg")
         wrapped.append((inp, media, score))
     return wrapped, video_tmp_dir, media_to_log
 


### PR DESCRIPTION
### What does this PR do?

Fix validation-image logging for W&B 0.29. The current W&B `Image` constructor
removed the `normalize` parameter, so the CPU workflow failed when the
unconstrained dependency resolver selected W&B 0.29.

This PR removes the unsupported argument from both W&B image-log call sites:

- the shared validation media wrapper; and
- the diffusion trainer's validation-generation logger.

Both call sites already require `torch.uint8` images, so omitting the removed
argument preserves the existing uint8 image contract while using W&B's current
API. No W&B version cap is added.

### Checklist Before Starting

- [x] Search for similar PRs. Queries: [wandb](https://github.com/verl-project/verl-omni/pulls?q=is%3Apr+is%3Aopen+wandb) and [normalize](https://github.com/verl-project/verl-omni/pulls?q=is%3Apr+is%3Aopen+normalize). #442 changes video-export resilience; it does not update the removed W&B image argument.
- [x] Format the PR title as `[{modules}] {type}: {description}`.

### Test

```bash
TORCH_COMPILE_DISABLE=1 TORCHINDUCTOR_DISABLE=1 \
  python -m pytest -q -s --asyncio-mode=auto \
  tests/utils/test_tracking_on_cpu.py
# 5 passed
```

The same test also passed with an isolated `wandb==0.29.0` installation ahead
of the project environment on `PYTHONPATH`:

```bash
PYTHONPATH="<isolated-wandb-0.29>:$PWD" \
  python -m pytest -q -s --asyncio-mode=auto \
  tests/utils/test_tracking_on_cpu.py
# 5 passed
```

```bash
SKIP=autogen-trainer-cfg pre-commit run --files \
  verl_omni/utils/tracking.py \
  verl_omni/trainer/diffusion/v1/trainer_base.py \
  tests/utils/test_tracking_on_cpu.py
# all applicable hooks passed

git diff --check
# passed
```

### API and Usage Example

No public API, configuration, or launch-command changes. The existing
validation logging paths now work with the current W&B image API.

### Design & Code Changes

1. Keep the existing uint8 input validation at both call sites.
2. Pass only `file_type="jpg"`, which is supported by both W&B 0.28 and 0.29.
3. Update the mock assertion to check the supported W&B arguments.
4. Exercise the existing real offline W&B image-encoding test under W&B 0.29.

### Checklist Before Submitting

- [x] Read the Contribute Guide and testing guide.
- [x] Run applicable pre-commit checks.
- [x] Documentation is not required because there is no user-facing API change.
- [x] Update existing CPU coverage for the changed W&B call contract.

### AI assistance and human accountability

AI assistance (pi) was used for investigation, implementation, and validation.
The human submitter reviewed every changed line and is responsible for this
contribution.
