### PR TITLE
[rollout] fix: avoid vLLM-Omni sleep(level=2) during weight sync

### DIFF
--- a/verl_omni/workers/rollout/vllm_rollout/vllm_omni_async_server.py
+++ b/verl_omni/workers/rollout/vllm_rollout/vllm_omni_async_server.py
@@ -34,7 +34,7 @@ from verl.utils.import_utils import import_external_libs
 from verl.utils.net_utils import get_free_port
 from verl.utils.tokenizer import normalize_token_ids
 from verl.workers.config import RolloutConfig
-from verl.workers.rollout.replica import TokenOutput
+from verl.workers.rollout.replica import RolloutMode, TokenOutput
 from verl.workers.rollout.utils import run_uvicorn
 from verl.workers.rollout.vllm_rollout.utils import (
     VLLM_LORA_INT_ID,
@@ -390,6 +390,20 @@ class vLLMOmniHttpServer(vLLMHttpServer):
     def _get_wake_up_tags(self) -> list[str]:
         return ["weights"]
 
+    def _resolve_sleep_level(self) -> int:
+        """vLLM-Omni cannot restore after ``sleep(level=2)``.
+
+        AsyncOmni discards GPU weights on level 2 and has not implemented
+        reload-from-disk, so ``wake_up()`` raises ``NotImplementedError``.
+        Level 1 offloads weights to CPU RAM and supports DMA restore. It also
+        preserves non-actor pipeline components (text encoder, VAE) that actor
+        weight sync does not reload.
+
+        # TODO (andy): use sleep_level=2 when vllm-omni implements wake_up
+        after level-2 sleep AND the trainer syncs the full pipeline.
+        """
+        return 1
+
     async def wake_up(self, tags: list[str] | None = None):
         """Override parent to use collective_rpc instead of engine.wake_up().
 
@@ -422,11 +436,34 @@ class vLLMOmniHttpServer(vLLMHttpServer):
         weight syncs. Use level-1 sleep so those weights are offloaded and can
         be restored on wake-up instead of discarded by level-2 sleep.
         """
-        # TODO (andy): use `sleep_level=2` in the future when the
-        #  trainer side incorporates the whole components of the model.
         self._invalidate_lora_request_cache()
-        await self.engine.collective_rpc("sleep", kwargs={"level": 1})
+        await self.engine.collective_rpc("sleep", kwargs={"level": self._resolve_sleep_level()})
         await self.engine.reset_encoder_cache()
+
+    async def release_kv_cache(self):
+        """Free cache around a weight sync without discarding Omni weights.
+
+        Upstream ``vLLMHttpServer.release_kv_cache`` (verl ``fefb080``+) does
+        ``engine.sleep(level=_resolve_sleep_level())`` then
+        ``engine.wake_up(tags=["weights"])``. For full-weight GPU rollouts that
+        sleep level is 2, which AsyncOmni cannot wake from. Route through
+        ``collective_rpc`` at level 1, matching ``wake_up`` / ``_sleep_hybrid``.
+        """
+        if self.node_rank != 0 or not self.config.free_cache_engine:
+            return
+        if self.rollout_mode == RolloutMode.COLOCATED:
+            return
+        self._invalidate_lora_request_cache()
+        await self.engine.collective_rpc("sleep", kwargs={"level": self._resolve_sleep_level()})
+        await self.engine.collective_rpc("wake_up", kwargs={"tags": ["weights"]})
+
+    async def resume_kv_cache(self):
+        """Restore after a weight sync. Route through collective_rpc like wake_up."""
+        if self.node_rank != 0 or not self.config.free_cache_engine:
+            return
+        if self.rollout_mode == RolloutMode.COLOCATED:
+            return
+        await self.engine.collective_rpc("wake_up", kwargs={"tags": ["kv_cache"]})
 
     async def resume_generation(self):
         if self.node_rank == 0:

--- a/verl_omni/workers/rollout/vllm_rollout/vllm_omni_async_server.py
+++ b/verl_omni/workers/rollout/vllm_rollout/vllm_omni_async_server.py
@@ -434,8 +434,7 @@ class vLLMOmniHttpServer(vLLMHttpServer):
         await self.engine.reset_encoder_cache()
 
     async def release_kv_cache(self):
-        """Free cache around a weight sync without discarding Omni weights.
-        """
+        """Free cache around a weight sync without discarding Omni weights."""
         if self.node_rank != 0 or not self.config.free_cache_engine:
             return
         if self.rollout_mode == RolloutMode.COLOCATED:

--- a/verl_omni/workers/rollout/vllm_rollout/vllm_omni_async_server.py
+++ b/verl_omni/workers/rollout/vllm_rollout/vllm_omni_async_server.py
@@ -391,14 +391,7 @@ class vLLMOmniHttpServer(vLLMHttpServer):
         return ["weights"]
 
     def _resolve_sleep_level(self) -> int:
-        """vLLM-Omni cannot restore after ``sleep(level=2)``.
-
-        AsyncOmni discards GPU weights on level 2 and has not implemented
-        reload-from-disk, so ``wake_up()`` raises ``NotImplementedError``.
-        Level 1 offloads weights to CPU RAM and supports DMA restore. It also
-        preserves non-actor pipeline components (text encoder, VAE) that actor
-        weight sync does not reload.
-
+        """
         # TODO (andy): use sleep_level=2 when vllm-omni implements wake_up
         after level-2 sleep AND the trainer syncs the full pipeline.
         """
@@ -442,12 +435,6 @@ class vLLMOmniHttpServer(vLLMHttpServer):
 
     async def release_kv_cache(self):
         """Free cache around a weight sync without discarding Omni weights.
-
-        Upstream ``vLLMHttpServer.release_kv_cache`` (verl ``fefb080``+) does
-        ``engine.sleep(level=_resolve_sleep_level())`` then
-        ``engine.wake_up(tags=["weights"])``. For full-weight GPU rollouts that
-        sleep level is 2, which AsyncOmni cannot wake from. Route through
-        ``collective_rpc`` at level 1, matching ``wake_up`` / ``_sleep_hybrid``.
         """
         if self.node_rank != 0 or not self.config.free_cache_engine:
             return


### PR DESCRIPTION
Upstream release_kv_cache sleeps at level 2 then wakes weights, which AsyncOmni cannot restore. Keep Omni on level-1 sleep so separate FlowGRPO e2e can update weights.

AI assistance (Cursor) was used for this change.

### What does this PR do?

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `vllm_omni`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `diffusion`, `omni`, `tests`, `docker`
  - If this PR involves multiple modules, separate them with `,` like `[diffusion, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][diffusion, fsdp] feat: new rollout scheduler`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update the documentation.
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl-omni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
