### PR TITLE
[env, recipe] fix: enable NumPy serialization for NPU recipes

### DIFF
--- a/examples/dancegrpo_trainer/wan22/run_wan22_5b_t2v_hpsv3_auto.sh
+++ b/examples/dancegrpo_trainer/wan22/run_wan22_5b_t2v_hpsv3_auto.sh
@@ -22,6 +22,7 @@ fi
 echo "Detected device: $DEVICE"
 
 if [ "$DEVICE" = "npu" ]; then
+    export VERL_DATAPROTO_SERIALIZATION_METHOD=numpy
     ASCEND_HOME_PATH=${ASCEND_HOME_PATH:-/usr/local/Ascend/cann-9.0.0}
     source $ASCEND_HOME_PATH/set_env.sh
     source $ASCEND_HOME_PATH/../nnal/atb/set_env.sh

--- a/examples/dpo_trainer/sd35/run_sd35_medium_offline_dpo_lora_npu.sh
+++ b/examples/dpo_trainer/sd35/run_sd35_medium_offline_dpo_lora_npu.sh
@@ -2,6 +2,7 @@
 set -x
 
 export TORCH_COMPILE_DISABLE=1
+export VERL_DATAPROTO_SERIALIZATION_METHOD=numpy
 
 # Set WORKSPACE to any writable directory; defaults to $HOME.
 WORKSPACE=${WORKSPACE:-$HOME}

--- a/examples/dpo_trainer/sd35/run_sd35_medium_offline_dpo_lora_npu.sh
+++ b/examples/dpo_trainer/sd35/run_sd35_medium_offline_dpo_lora_npu.sh
@@ -45,3 +45,4 @@ python3 -m verl_omni.trainer.main_diffusion --config-name=offline_dpo_trainer \
     trainer.save_freq=30 \
     trainer.total_epochs=300 \
     trainer.total_training_steps=1000 "$@"
+

--- a/examples/flowgrpo_trainer/bagel/run_bagel_ocr_lora_npu.sh
+++ b/examples/flowgrpo_trainer/bagel/run_bagel_ocr_lora_npu.sh
@@ -6,6 +6,7 @@
 #       --input_dir ~/data/ocr \
 #       --output_dir ~/data/ocr/bagel
 set -x
+export VERL_DATAPROTO_SERIALIZATION_METHOD=numpy
 ASCEND_HOME_PATH=${ASCEND_HOME_PATH:-/usr/local/Ascend/cann-9.0.0}
 source $ASCEND_HOME_PATH/set_env.sh
 source $ASCEND_HOME_PATH/../nnal/atb/set_env.sh

--- a/examples/flowgrpo_trainer/ltx2/run_ltx2_3_t2av_lora_npu.sh
+++ b/examples/flowgrpo_trainer/ltx2/run_ltx2_3_t2av_lora_npu.sh
@@ -3,6 +3,7 @@
 set -x
 
 export WANDB_MODE=${WANDB_MODE:-offline}
+export VERL_DATAPROTO_SERIALIZATION_METHOD=numpy
 ASCEND_HOME_PATH=${ASCEND_HOME_PATH:-/usr/local/Ascend/ascend-toolkit}
 
 source $ASCEND_HOME_PATH/set_env.sh

--- a/examples/gspo_trainer/qwen3_omni/run_qwen3_omni_thinker_gspo_npu.sh
+++ b/examples/gspo_trainer/qwen3_omni/run_qwen3_omni_thinker_gspo_npu.sh
@@ -15,6 +15,7 @@ set -x
 
 export CPATH=/usr/include${CPATH:+:$CPATH}
 export VLLM_ASCEND_ENABLE_NZ=0
+export VERL_DATAPROTO_SERIALIZATION_METHOD=numpy
 export VERL_USE_EXTERNAL_MODULES=verl_omni,verl_omni.models.transformers.qwen3_omni_thinker
 
 MODEL_PATH=${MODEL_PATH:-"Qwen/Qwen3-Omni-30B-A3B-Instruct"}


### PR DESCRIPTION
### What does this PR do?

Set the following environment variable in the remaining non-V1 NPU training scripts to fix the CPU memory leak on NPU:

```bash
export VERL_DATAPROTO_SERIALIZATION_METHOD=numpy
```

Related: [[PR #259], [[Issue #402]].

### Checklist Before Starting

- [x] Search for similar PRs: [[search result](https://github.com/verl-project/verl-omni/pulls?q=is%3Apr+VERL_DATAPROTO_SERIALIZATION_METHOD)](https://github.com/verl-project/verl-omni/pulls?q=is%3Apr+VERL_DATAPROTO_SERIALIZATION_METHOD)
- [x] Format the PR title as `[{modules}] {type}: {description}`.

### Test

```text
bash -n: passed
git diff --check: passed
```

NPU end-to-end testing was not performed.

### API and Usage Example

No API changes.

### Design & Code Changes

Set `VERL_DATAPROTO_SERIALIZATION_METHOD=numpy` in the remaining non-V1 NPU training scripts.
