### PR TITLE
[diffusion, tests, doc] feat: add FLOPs/MFU estimators for SD3 and Wan

### DIFF
--- a/docs/perf/diffusion_mfu.md
+++ b/docs/perf/diffusion_mfu.md
@@ -1,7 +1,7 @@
 (diffusion_mfu)=
 # Diffusion FLOPs / MFU
 
-Last updated: 06/02/2026
+Last updated: 08/29/2026
 
 VeRL-Omni reports **Model FLOPs Utilization (MFU)** for diffusion RL
 training using the same actor keys upstream
@@ -45,6 +45,22 @@ vs optimisation) on the same setup, not as cross-cluster benchmarks.
 > therefore an over-estimate of the *achieved* compute (its backward
 > skips `∂L/∂w` for frozen weights), but it lets you compare relative
 > throughput across runs on one metric.
+
+## Supported architectures
+
+The registry (`verl_omni.utils.mfu._REGISTRY`) currently ships estimators for:
+
+| Architecture | Registry key(s) | Attention topology |
+|---|---|---|
+| Qwen-Image | `QwenImagePipeline`, `QwenImagePipelineWithLogProb` | dual-stream joint full attention |
+| Stable Diffusion 3 / 3.5 (no `dual_attention_layers`) | `StableDiffusion3Pipeline`, `StableDiffusion3PipelineWithLogProb` | dual-stream joint full attention, `context_pre_only` last block |
+| Wan2.1 / Wan2.2 | `WanPipeline` | single-stream self-attention + cross-attention to text |
+
+Any other architecture (Bagel, Boogu-Image, LTX2, MiniMax-H3, SD3.5's
+`dual_attention_layers` variant, Qwen-Image-Edit, Qwen3-Omni, ...) is not
+yet registered; `DiffusionFlopsCounter` degrades to `MFU=0` with a
+`RuntimeWarning` for those until an estimator is added. See [Adding a new
+architecture](#adding-a-new-architecture).
 
 ## How FLOPs are computed
 
@@ -297,13 +313,19 @@ Two facts matter for the estimator:
 
 ### Step 3 — Write the architecture class
 
-```python
-# verl_omni/utils/mfu/qwen_image.py
+`WanFlops` ships in `verl_omni/utils/mfu/wan.py` and is registered under
+`WanPipeline` (see [Supported architectures](#supported-architectures)).
+The snippet below is a simplified version of it for illustration; the
+shipped class additionally accounts for `patch_embedding` /
+`proj_out` / `text_embedder` (which scale with token count, not batch
+size) and overrides `get_latent_seqlens` to divide by the 3D patch
+volume, since Wan's raw `(B, C, T, H, W)` latents are patchified
+*inside* the transformer rather than pre-packed by the pipeline.
 
-@register_diffusion_architecture(
-    "WanPipeline",
-    "WanPipelineWithLogProb",   # alias, if you ship a custom rollout class
-)
+```python
+# verl_omni/utils/mfu/wan.py
+
+@register_diffusion_architecture("WanPipeline")
 class WanFlops(DiffusionModelFlops):
     """Wan2.2 DiT FLOPs estimator (self-attn + cross-attn topology)."""
 

--- a/docs/perf/diffusion_mfu.md
+++ b/docs/perf/diffusion_mfu.md
@@ -48,7 +48,7 @@ vs optimisation) on the same setup, not as cross-cluster benchmarks.
 
 ## Supported architectures
 
-The registry (`verl_omni.utils.mfu._REGISTRY`) currently ships estimators for:
+The registry (`verl_omni.utils.mfu.diffusion_flops_counter._REGISTRY`) currently ships estimators for:
 
 | Architecture | Registry key(s) | Attention topology |
 |---|---|---|

--- a/tests/utils/test_stable_diffusion_3_flops_on_cpu.py
+++ b/tests/utils/test_stable_diffusion_3_flops_on_cpu.py
@@ -1,0 +1,231 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU-only unit tests for ``StableDiffusion3Flops``."""
+
+import math
+import warnings
+
+import pytest
+
+from verl_omni.utils.mfu import DiffusionFlopsCounter, StableDiffusion3Flops
+from verl_omni.utils.mfu.diffusion_flops_counter import _REGISTRY
+
+# Mirrors a real SD3-medium transformer/config.json (no dual_attention_layers).
+SD3_CONFIG: dict = {
+    "_class_name": "SD3Transformer2DModel",
+    "sample_size": 128,
+    "patch_size": 2,
+    "in_channels": 16,
+    "num_layers": 24,
+    "attention_head_dim": 64,
+    "num_attention_heads": 24,
+    "joint_attention_dim": 4096,
+    "caption_projection_dim": 1536,
+    "pooled_projection_dim": 2048,
+    "out_channels": 16,
+    "dual_attention_layers": (),
+}
+
+
+def _counter() -> DiffusionFlopsCounter:
+    return DiffusionFlopsCounter("StableDiffusion3Pipeline", SD3_CONFIG)
+
+
+def _reference_sd3_flops(
+    config: dict,
+    latent_seqlens: list[int],
+    prompt_seqlens: list[int],
+    delta_time: float,
+    *,
+    num_timesteps: int,
+    num_forward_passes: int,
+) -> float:
+    """Independent reference re-derived from ``JointTransformerBlock`` source."""
+    num_heads = int(config["num_attention_heads"])
+    head_dim = int(config["attention_head_dim"])
+    num_layers = int(config["num_layers"])
+    in_channels = int(config["in_channels"])
+    joint_attention_dim = int(config["joint_attention_dim"])
+    caption_projection_dim = int(config["caption_projection_dim"])
+    patch_size = int(config.get("patch_size", 2))
+    out_channels = int(config.get("out_channels") or in_channels)
+
+    dim = num_heads * head_dim
+    batch_size = max(len(latent_seqlens), len(prompt_seqlens))
+    img_tot = sum(latent_seqlens)
+    txt_tot = sum(prompt_seqlens)
+
+    flops_fwd = 0.0
+    for layer in range(num_layers):
+        is_last = layer == num_layers - 1
+        # Image stream: attn (QKV+out, 4*dim^2) + ff (dim->4dim->dim, 8*dim^2).
+        flops_fwd += 2 * (12 * dim * dim) * img_tot
+        # Text stream: same as image, except the last (context_pre_only)
+        # layer drops to_add_out and ff_context, keeping only add_q/k/v_proj.
+        txt_n = 12 * dim * dim if not is_last else 3 * dim * dim
+        flops_fwd += 2 * txt_n * txt_tot
+        # AdaLN modulation, batch-scaled (one temb per sample).
+        img_mod_n = 6 * dim * dim
+        txt_mod_n = 6 * dim * dim if not is_last else 2 * dim * dim
+        flops_fwd += 2 * (img_mod_n + txt_mod_n) * batch_size
+
+        # Joint full attention over the concatenated (img, txt) sequence.
+        for img_s, txt_s in zip(latent_seqlens, prompt_seqlens, strict=False):
+            joint_s = img_s + txt_s
+            flops_fwd += 2 * 2 * (joint_s**2) * head_dim * num_heads
+
+    flops_fwd += 2 * (in_channels * patch_size * patch_size * dim) * img_tot  # pos_embed
+    flops_fwd += 2 * (joint_attention_dim * caption_projection_dim) * txt_tot  # context_embedder
+    flops_fwd += 2 * (patch_size * patch_size * out_channels * dim) * img_tot  # proj_out
+
+    flops_fwd_bwd = 3 * flops_fwd
+    flops_all_steps = flops_fwd_bwd * num_timesteps * num_forward_passes
+    return flops_all_steps / delta_time / 1e12
+
+
+class TestStableDiffusion3FlopsRegistry:
+    def test_registered(self):
+        assert _REGISTRY["StableDiffusion3Pipeline"] is StableDiffusion3Flops
+        assert _REGISTRY["StableDiffusion3PipelineWithLogProb"] is StableDiffusion3Flops
+
+
+class TestStableDiffusion3FlopsLatentSeqlens:
+    def test_divides_by_patch_area(self):
+        # 512x512 raw latent, patch_size=2 -> 64x64 = 4096 tokens.
+        from tests.utils.test_diffusion_flops_counter_on_cpu import _Tensor
+
+        data = {"image_latents": _Tensor((2, 16, 64, 64))}
+        seqs = StableDiffusion3Flops(SD3_CONFIG).get_latent_seqlens(data)
+        assert seqs == [32 * 32] * 2
+
+
+class TestStableDiffusion3FlopsScaling:
+    def _kwargs(self, **overrides):
+        defaults = dict(
+            latent_seqlens=[1024, 1024],
+            prompt_seqlens=[256, 192],
+            delta_time=2.0,
+            num_timesteps=10,
+            num_forward_passes=2,
+        )
+        defaults.update(overrides)
+        return defaults
+
+    def test_linear_in_num_timesteps(self):
+        counter = _counter()
+        est_a, _ = counter.estimate_flops(**self._kwargs(num_timesteps=10))
+        est_b, _ = counter.estimate_flops(**self._kwargs(num_timesteps=30))
+        assert math.isclose(est_b / est_a, 3.0, rel_tol=1e-9)
+
+    def test_linear_in_num_forward_passes(self):
+        counter = _counter()
+        est_a, _ = counter.estimate_flops(**self._kwargs(num_forward_passes=1))
+        est_b, _ = counter.estimate_flops(**self._kwargs(num_forward_passes=2))
+        assert math.isclose(est_b / est_a, 2.0, rel_tol=1e-9)
+
+    def test_matches_hand_rolled_reference(self):
+        counter = _counter()
+        kwargs = self._kwargs()
+        est, _ = counter.estimate_flops(**kwargs)
+        ref = _reference_sd3_flops(SD3_CONFIG, **kwargs)
+        assert math.isclose(est, ref, rel_tol=1e-9), (est, ref)
+
+    def test_matches_reference_across_shapes(self):
+        counter = _counter()
+        scenarios = [
+            dict(latent_seqlens=[256], prompt_seqlens=[64], delta_time=0.5, num_timesteps=1, num_forward_passes=1),
+            dict(
+                latent_seqlens=[1024, 4096],
+                prompt_seqlens=[128, 512],
+                delta_time=8.0,
+                num_timesteps=50,
+                num_forward_passes=2,
+            ),
+            dict(latent_seqlens=[1], prompt_seqlens=[1], delta_time=1.0, num_timesteps=1, num_forward_passes=1),
+        ]
+        for kwargs in scenarios:
+            est, _ = counter.estimate_flops(**kwargs)
+            ref = _reference_sd3_flops(SD3_CONFIG, **kwargs)
+            assert math.isclose(est, ref, rel_tol=1e-9), (kwargs, est, ref)
+
+    def test_attention_is_quadratic_in_joint_seqlen(self):
+        counter = _counter()
+        est_small, _ = counter.estimate_flops(
+            latent_seqlens=[512], prompt_seqlens=[256], delta_time=1.0, num_timesteps=1, num_forward_passes=1
+        )
+        est_large, _ = counter.estimate_flops(
+            latent_seqlens=[1024], prompt_seqlens=[512], delta_time=1.0, num_timesteps=1, num_forward_passes=1
+        )
+        ratio = est_large / est_small
+        assert 2.0 < ratio < 4.0, ratio
+
+    def test_dual_attention_layers_warns(self):
+        cfg = dict(SD3_CONFIG, dual_attention_layers=(0, 1, 2))
+        counter = DiffusionFlopsCounter("StableDiffusion3Pipeline", cfg)
+        with warnings.catch_warnings(record=True) as warned:
+            warnings.simplefilter("always")
+            counter.estimate_flops(
+                latent_seqlens=[256], prompt_seqlens=[64], delta_time=1.0, num_timesteps=1, num_forward_passes=1
+            )
+        assert any("dual_attention_layers" in str(w.message) for w in warned)
+
+
+class TestStableDiffusion3FlopsParamCount:
+    """Ground-truth check against an instantiated ``SD3Transformer2DModel``."""
+
+    @pytest.fixture(scope="class")
+    def tiny_sd3(self):
+        from diffusers import SD3Transformer2DModel
+
+        return SD3Transformer2DModel(
+            sample_size=32,
+            patch_size=2,
+            in_channels=8,
+            num_layers=3,
+            attention_head_dim=16,
+            num_attention_heads=4,
+            joint_attention_dim=48,
+            caption_projection_dim=64,
+            pooled_projection_dim=32,
+            out_channels=8,
+            dual_attention_layers=(),
+        )
+
+    def test_per_layer_weight_count_matches_module_numel(self, tiny_sd3):
+        dim = tiny_sd3.config.num_attention_heads * tiny_sd3.config.attention_head_dim
+
+        non_last_block = tiny_sd3.transformer_blocks[0]
+        last_block = tiny_sd3.transformer_blocks[-1]
+
+        def stream_weights(block, img: bool) -> int:
+            attn = block.attn
+            if img:
+                linears = [attn.to_q, attn.to_k, attn.to_v, attn.to_out[0]]
+                ff = block.ff
+            else:
+                linears = [attn.add_q_proj, attn.add_k_proj, attn.add_v_proj]
+                if attn.to_add_out is not None:
+                    linears.append(attn.to_add_out)
+                ff = block.ff_context
+            total = sum(m.weight.numel() for m in linears)
+            if ff is not None:
+                total += sum(p.numel() for p in ff.parameters() if p.dim() == 2)
+            return total
+
+        assert stream_weights(non_last_block, img=True) == 12 * dim * dim
+        assert stream_weights(non_last_block, img=False) == 12 * dim * dim
+        assert stream_weights(last_block, img=True) == 12 * dim * dim
+        assert stream_weights(last_block, img=False) == 3 * dim * dim
+        assert last_block.context_pre_only is True
+        assert non_last_block.context_pre_only is False

--- a/tests/utils/test_wan_flops_on_cpu.py
+++ b/tests/utils/test_wan_flops_on_cpu.py
@@ -1,0 +1,210 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU-only unit tests for ``WanFlops``."""
+
+import math
+
+import pytest
+
+from verl_omni.utils.mfu import DiffusionFlopsCounter, WanFlops
+from verl_omni.utils.mfu.diffusion_flops_counter import _REGISTRY
+
+# Mirrors a real Wan2.1/2.2 14B transformer/config.json.
+WAN_CONFIG: dict = {
+    "_class_name": "WanTransformer3DModel",
+    "patch_size": (1, 2, 2),
+    "num_attention_heads": 40,
+    "attention_head_dim": 128,
+    "in_channels": 16,
+    "out_channels": 16,
+    "text_dim": 4096,
+    "ffn_dim": 13824,
+    "num_layers": 40,
+    "added_kv_proj_dim": None,
+}
+
+
+def _counter(cfg: dict | None = None) -> DiffusionFlopsCounter:
+    return DiffusionFlopsCounter("WanPipeline", cfg or WAN_CONFIG)
+
+
+def _reference_wan_flops(
+    config: dict,
+    latent_seqlens: list[int],
+    prompt_seqlens: list[int],
+    delta_time: float,
+    *,
+    num_timesteps: int,
+    num_forward_passes: int,
+) -> float:
+    """Independent reference re-derived from ``WanTransformerBlock`` source."""
+    num_heads = int(config["num_attention_heads"])
+    head_dim = int(config["attention_head_dim"])
+    num_layers = int(config["num_layers"])
+    ffn_dim = int(config["ffn_dim"])
+    in_channels = int(config["in_channels"])
+    out_channels = int(config.get("out_channels") or in_channels)
+    text_dim = int(config.get("text_dim", 0))
+    patch_size = config.get("patch_size", (1, 2, 2))
+    patch_prod = 1
+    for p in patch_size:
+        patch_prod *= int(p)
+
+    dim = num_heads * head_dim
+    added_kv = int(config.get("added_kv_proj_dim") or dim)
+    batch_size = max(len(latent_seqlens), len(prompt_seqlens))
+    img_tot = sum(latent_seqlens)
+    txt_tot = sum(prompt_seqlens)
+
+    flops_fwd = 0.0
+    for _layer in range(num_layers):
+        # attn1 (self, QKV+out on latents): 4*dim^2.
+        flops_fwd += 2 * (4 * dim * dim) * img_tot
+        # attn2 (cross): Q + out on latents (2*dim^2), K/V from text (2*dim*added_kv).
+        flops_fwd += 2 * (2 * dim * dim) * img_tot
+        flops_fwd += 2 * (2 * dim * added_kv) * txt_tot
+        # ffn: dim -> ffn_dim -> dim.
+        flops_fwd += 2 * (2 * dim * ffn_dim) * img_tot
+
+    flops_fwd += 2 * (in_channels * patch_prod * dim) * img_tot  # patch_embedding
+    flops_fwd += 2 * (patch_prod * out_channels * dim) * img_tot  # proj_out
+    flops_fwd += 2 * (text_dim * dim + dim * dim) * txt_tot  # text_embedder (2-layer)
+    flops_fwd += 2 * (6 * dim * dim) * batch_size  # condition_embedder.time_proj
+
+    for latent_s, prompt_s in zip(latent_seqlens, prompt_seqlens, strict=False):
+        flops_fwd += num_layers * 2 * 2 * (latent_s**2) * head_dim * num_heads  # self-attn
+        flops_fwd += num_layers * 2 * 2 * (latent_s * prompt_s) * head_dim * num_heads  # cross-attn
+
+    flops_fwd_bwd = 3 * flops_fwd
+    flops_all_steps = flops_fwd_bwd * num_timesteps * num_forward_passes
+    return flops_all_steps / delta_time / 1e12
+
+
+class TestWanFlopsRegistry:
+    def test_registered(self):
+        assert _REGISTRY["WanPipeline"] is WanFlops
+
+
+class TestWanFlopsLatentSeqlens:
+    def test_divides_by_patch_volume(self):
+        from tests.utils.test_diffusion_flops_counter_on_cpu import _Tensor
+
+        # (B=1, C=16, T=21, H=60, W=104) raw latent, patch=(1,2,2) -> 21*30*52.
+        data = {"image_latents": _Tensor((1, 16, 21, 60, 104))}
+        seqs = WanFlops(WAN_CONFIG).get_latent_seqlens(data)
+        assert seqs == [21 * 30 * 52]
+
+
+class TestWanFlopsScaling:
+    def _kwargs(self, **overrides):
+        defaults = dict(
+            latent_seqlens=[512, 512],
+            prompt_seqlens=[64, 96],
+            delta_time=2.0,
+            num_timesteps=10,
+            num_forward_passes=2,
+        )
+        defaults.update(overrides)
+        return defaults
+
+    def test_linear_in_num_timesteps(self):
+        counter = _counter()
+        est_a, _ = counter.estimate_flops(**self._kwargs(num_timesteps=10))
+        est_b, _ = counter.estimate_flops(**self._kwargs(num_timesteps=30))
+        assert math.isclose(est_b / est_a, 3.0, rel_tol=1e-9)
+
+    def test_superlinear_in_latent_seqlen(self):
+        # Wan's huge ffn_dim (13824) makes the dense (linear) term dominate
+        # at moderate seqlens, unlike Qwen/SD3 where attention dominates
+        # quickly; the quadratic self-attn term only overtakes it at scale.
+        # A 16x input growth should still yield a strictly-superlinear
+        # (>16x) output growth once the self-attn term is large enough.
+        counter = _counter()
+        kw = dict(prompt_seqlens=[64], delta_time=1.0, num_timesteps=1, num_forward_passes=1)
+        small, _ = counter.estimate_flops(latent_seqlens=[4096], **kw)
+        large, _ = counter.estimate_flops(latent_seqlens=[65536], **kw)
+        assert large / small > 16.0
+
+    def test_matches_hand_rolled_reference(self):
+        counter = _counter()
+        kwargs = self._kwargs()
+        est, _ = counter.estimate_flops(**kwargs)
+        ref = _reference_wan_flops(WAN_CONFIG, **kwargs)
+        assert math.isclose(est, ref, rel_tol=1e-9), (est, ref)
+
+    def test_matches_reference_across_shapes_and_added_kv(self):
+        cfg = dict(WAN_CONFIG, added_kv_proj_dim=2048)
+        counter = _counter(cfg)
+        scenarios = [
+            dict(latent_seqlens=[256], prompt_seqlens=[64], delta_time=0.5, num_timesteps=1, num_forward_passes=1),
+            dict(
+                latent_seqlens=[1024, 4096],
+                prompt_seqlens=[128, 512],
+                delta_time=8.0,
+                num_timesteps=50,
+                num_forward_passes=2,
+            ),
+        ]
+        for kwargs in scenarios:
+            est, _ = counter.estimate_flops(**kwargs)
+            ref = _reference_wan_flops(cfg, **kwargs)
+            assert math.isclose(est, ref, rel_tol=1e-9), (kwargs, est, ref)
+
+    def test_mismatched_seqlen_lengths_raises(self):
+        counter = _counter()
+        with pytest.raises(ValueError, match="same length"):
+            counter.estimate_flops(
+                latent_seqlens=[1024, 1024],
+                prompt_seqlens=[256],
+                delta_time=1.0,
+                num_timesteps=1,
+                num_forward_passes=1,
+            )
+
+
+class TestWanFlopsParamCount:
+    """Ground-truth check against an instantiated ``WanTransformer3DModel``."""
+
+    @pytest.fixture(scope="class")
+    def tiny_wan(self):
+        from diffusers.models.transformers.transformer_wan import WanTransformer3DModel
+
+        return WanTransformer3DModel(
+            patch_size=(1, 2, 2),
+            num_attention_heads=4,
+            attention_head_dim=16,
+            in_channels=8,
+            out_channels=8,
+            text_dim=32,
+            freq_dim=32,
+            ffn_dim=128,
+            num_layers=2,
+            added_kv_proj_dim=None,
+        )
+
+    def test_per_layer_weight_count_matches_module_numel(self, tiny_wan):
+        dim = tiny_wan.config.num_attention_heads * tiny_wan.config.attention_head_dim
+        block = tiny_wan.blocks[0]
+
+        self_attn_weights = sum(
+            m.weight.numel() for m in (block.attn1.to_q, block.attn1.to_k, block.attn1.to_v, block.attn1.to_out[0])
+        )
+        cross_q_out_weights = sum(m.weight.numel() for m in (block.attn2.to_q, block.attn2.to_out[0]))
+        cross_kv_weights = sum(m.weight.numel() for m in (block.attn2.to_k, block.attn2.to_v))
+        ffn_weights = sum(p.numel() for p in block.ffn.parameters() if p.dim() == 2)
+
+        assert self_attn_weights == 4 * dim * dim
+        assert cross_q_out_weights == 2 * dim * dim
+        assert cross_kv_weights == 2 * dim * dim  # added_kv_proj_dim=None -> falls back to dim
+        assert ffn_weights == 2 * dim * tiny_wan.config.ffn_dim

--- a/verl_omni/utils/mfu/__init__.py
+++ b/verl_omni/utils/mfu/__init__.py
@@ -14,7 +14,7 @@
 
 """Diffusion Model FLOPs Utilization (MFU) utilities."""
 
-from verl_omni.utils.mfu import qwen_image  # noqa: F401 — register built-in architectures
+from verl_omni.utils.mfu import qwen_image, stable_diffusion_3, wan  # noqa: F401 — register built-in architectures
 from verl_omni.utils.mfu.diffusion_flops_counter import (
     DiffusionFlopsCounter,
     DiffusionModelFlops,
@@ -25,11 +25,15 @@ from verl_omni.utils.mfu.diffusion_flops_counter import (
     register_diffusion_architecture,
 )
 from verl_omni.utils.mfu.qwen_image import QwenImageFlops
+from verl_omni.utils.mfu.stable_diffusion_3 import StableDiffusion3Flops
+from verl_omni.utils.mfu.wan import WanFlops
 
 __all__ = [
     "DiffusionModelFlops",
     "DiffusionFlopsCounter",
     "QwenImageFlops",
+    "StableDiffusion3Flops",
+    "WanFlops",
     "register_diffusion_architecture",
     "get_forward_passes_per_step",
     "get_device_peak_tflops",

--- a/verl_omni/utils/mfu/stable_diffusion_3.py
+++ b/verl_omni/utils/mfu/stable_diffusion_3.py
@@ -1,0 +1,126 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""FLOPs estimator for Stable Diffusion 3 (SD3 / SD3.5) and aliases."""
+
+from __future__ import annotations
+
+import warnings
+from typing import Any, Sequence
+
+from verl_omni.utils.mfu.diffusion_flops_counter import (
+    DiffusionModelFlops,
+    register_diffusion_architecture,
+    sum_seqlens,
+)
+
+__all__ = ["StableDiffusion3Flops"]
+
+
+@register_diffusion_architecture(
+    "StableDiffusion3Pipeline",
+    "StableDiffusion3PipelineWithLogProb",
+)
+class StableDiffusion3Flops(DiffusionModelFlops):
+    """FLOPs estimator for ``SD3Transformer2DModel``.
+
+    SD3 is a dual-stream MM-DiT: image and text tokens each go through their
+    own per-block linears (``JointTransformerBlock``) and meet only in joint
+    full attention, same topology as Qwen-Image. Two differences from
+    Qwen-Image matter for the formula:
+
+    - The last block is ``context_pre_only``: the text stream drops its
+      output projection (``to_add_out``) and its FFN (``ff_context``),
+      keeping only the ``add_q/k/v_proj`` needed to feed joint attention.
+    - The transformer consumes raw ``(B, C, H, W)`` latents and patchifies
+      internally (``PatchEmbed``), so the default latent-seqlens extractor
+      overcounts by ``patch_size**2``.
+
+    ``dual_attention_layers`` (SD3.5's extra image-only ``attn2``) is not
+    modeled; a warning fires if the config declares any, since the formula
+    below would undercount those layers.
+    """
+
+    def get_latent_seqlens(self, data: Any) -> list[int]:
+        raw = super().get_latent_seqlens(data)
+        patch_size = int(self.config.get("patch_size", 2))
+        divisor = patch_size * patch_size
+        return [s // divisor for s in raw]
+
+    def estimate_flops(
+        self,
+        latent_seqlens: Sequence[int],
+        prompt_seqlens: Sequence[int],
+        delta_time: float,
+        *,
+        num_timesteps: int,
+        num_forward_passes: int,
+    ) -> float:
+        cfg = self.config
+        dim = self.dim
+        num_layers = int(cfg["num_layers"])
+        in_channels = int(cfg["in_channels"])
+        joint_attention_dim = int(cfg["joint_attention_dim"])
+        caption_projection_dim = int(cfg.get("caption_projection_dim") or dim)
+        patch_size = int(cfg.get("patch_size", 2))
+        out_channels = int(cfg.get("out_channels") or in_channels)
+
+        dual_attention_layers = cfg.get("dual_attention_layers") or ()
+        if len(dual_attention_layers) > 0:
+            warnings.warn(
+                "StableDiffusion3Flops does not model SD3.5's dual_attention_layers "
+                f"(got {dual_attention_layers!r}); the estimate undercounts those layers' "
+                "extra image-only attn2 block.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+
+        # Attn (QKV + out, 4*dim^2) + FFN (dim->4dim->dim, gelu-approximate, 8*dim^2).
+        block_n_per_stream = 12 * dim * dim
+        # Last block is context_pre_only: text stream keeps only add_q/k/v_proj (3*dim^2),
+        # dropping to_add_out (1*dim^2) and ff_context (8*dim^2).
+        txt_last_block_n = 3 * dim * dim
+
+        img_in_n = in_channels * patch_size * patch_size * dim
+        txt_in_n = joint_attention_dim * caption_projection_dim
+        proj_out_n = patch_size * patch_size * out_channels * dim
+
+        img_tot = sum_seqlens(latent_seqlens)
+        txt_tot = sum_seqlens(prompt_seqlens)
+        batch_size = max(
+            len(latent_seqlens) if latent_seqlens else 0,
+            len(prompt_seqlens) if prompt_seqlens else 0,
+        )
+
+        img_dense_flops = self.compute_dense_flops(num_layers * block_n_per_stream + img_in_n + proj_out_n, img_tot)
+        txt_dense_n = max(num_layers - 1, 0) * block_n_per_stream + (txt_last_block_n if num_layers > 0 else 0)
+        txt_dense_flops = self.compute_dense_flops(txt_dense_n + txt_in_n, txt_tot)
+
+        # Modulation (AdaLN) linears are batch-scaled, not token-scaled: one
+        # timestep embedding per sample, not per token. Image stream uses
+        # AdaLayerNormZero (dim -> 6*dim) every layer; text stream uses the
+        # same for all but the last layer, which uses AdaLayerNormContinuous
+        # (dim -> 2*dim, no gate) since it is context_pre_only.
+        img_mod_n = num_layers * 6 * dim * dim
+        txt_mod_n = max(num_layers - 1, 0) * 6 * dim * dim + (2 * dim * dim if num_layers > 0 else 0)
+        mod_flops = self.compute_dense_flops(img_mod_n + txt_mod_n, batch_size)
+
+        # SD3 attention is joint full attention over the concatenated
+        # (img, txt) sequence, same topology as Qwen-Image.
+        attn_flops = self.compute_attention_flops(latent_seqlens, prompt_seqlens)
+
+        flops_all_steps = (
+            (img_dense_flops + txt_dense_flops + mod_flops + attn_flops) * num_timesteps * num_forward_passes
+        )
+        return flops_all_steps / delta_time / 1e12

--- a/verl_omni/utils/mfu/wan.py
+++ b/verl_omni/utils/mfu/wan.py
@@ -1,0 +1,125 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""FLOPs estimator for Wan2.1/2.2 (``WanTransformer3DModel``) and aliases."""
+
+from __future__ import annotations
+
+from typing import Any, Sequence
+
+from verl_omni.utils.mfu.diffusion_flops_counter import (
+    DiffusionModelFlops,
+    register_diffusion_architecture,
+    sum_seqlens,
+)
+
+__all__ = ["WanFlops"]
+
+
+@register_diffusion_architecture("WanPipeline")
+class WanFlops(DiffusionModelFlops):
+    """FLOPs estimator for ``WanTransformer3DModel``.
+
+    Wan is a single-stream video DiT: video-latent tokens self-attend
+    (``attn1``, cost proportional to ``latent_s**2``), then cross-attend to
+    the text encoder stream (``attn2``, cost proportional to
+    ``latent_s * prompt_s``). This is unlike Qwen-Image/SD3's joint full
+    attention over the concatenated sequence.
+
+    Latents arrive as raw ``(B, C, T, H, W)`` (or FlowGRPO-stacked
+    ``(B, T_steps, C, T, H, W)``); the base extractor's spatial-product
+    default already returns the post-patchify token count only if the
+    tensor were pre-patched, which Wan's pipeline does not do before this
+    point, so ``get_latent_seqlens`` divides by the 3D patch volume.
+    """
+
+    def get_latent_seqlens(self, data: Any) -> list[int]:
+        raw = super().get_latent_seqlens(data)
+        patch_size = self.config.get("patch_size", (1, 2, 2))
+        divisor = 1
+        for p in patch_size:
+            divisor *= int(p)
+        return [s // divisor for s in raw]
+
+    def estimate_flops(
+        self,
+        latent_seqlens: Sequence[int],
+        prompt_seqlens: Sequence[int],
+        delta_time: float,
+        *,
+        num_timesteps: int,
+        num_forward_passes: int,
+    ) -> float:
+        cfg = self.config
+        dim = self.dim
+        num_heads = int(cfg.get("num_attention_heads", 0))
+        head_dim = int(cfg.get("attention_head_dim", 0))
+        num_layers = int(cfg["num_layers"])
+        ffn_dim = int(cfg["ffn_dim"])
+        added_kv = int(cfg.get("added_kv_proj_dim") or dim)
+        in_channels = int(cfg["in_channels"])
+        out_channels = int(cfg.get("out_channels") or in_channels)
+        text_dim = int(cfg.get("text_dim", dim))
+        patch_size = cfg.get("patch_size", (1, 2, 2))
+        patch_prod = 1
+        for p in patch_size:
+            patch_prod *= int(p)
+
+        # Self-attn (QKV + out, 4*dim^2) + cross-attn Q/out on the latent
+        # side (2*dim^2) + FFN (dim->ffn_dim->dim, explicit ffn_dim, not a
+        # 4x-dim assumption).
+        img_block_n = 4 * dim * dim + 2 * dim * dim + 2 * dim * ffn_dim
+        # Cross-attn K/V projected from the text stream.
+        txt_block_n = 2 * dim * added_kv
+
+        img_in_n = in_channels * patch_prod * dim  # patch_embedding (Conv3d)
+        proj_out_n = patch_prod * out_channels * dim
+        txt_in_n = text_dim * dim + dim * dim  # PixArtAlphaTextProjection (2-layer MLP)
+
+        img_tot = sum_seqlens(latent_seqlens)
+        txt_tot = sum_seqlens(prompt_seqlens)
+        batch_size = max(
+            len(latent_seqlens) if latent_seqlens else 0,
+            len(prompt_seqlens) if prompt_seqlens else 0,
+        )
+
+        img_dense_flops = self.compute_dense_flops(num_layers * img_block_n + img_in_n + proj_out_n, img_tot)
+        txt_dense_flops = self.compute_dense_flops(num_layers * txt_block_n + txt_in_n, txt_tot)
+
+        # condition_embedder.time_proj: a single dim -> 6*dim linear shared
+        # across all layers (not one per layer); modulation itself is an
+        # additive `scale_shift_table` parameter, not a matmul.
+        time_proj_flops = self.compute_dense_flops(6 * dim * dim, batch_size)
+
+        if latent_seqlens and prompt_seqlens and len(latent_seqlens) != len(prompt_seqlens):
+            raise ValueError(
+                f"latent_seqlens and prompt_seqlens must have the same length, "
+                f"got {len(latent_seqlens)} and {len(prompt_seqlens)}."
+            )
+
+        # Self-attention over the latent stream only.
+        self_attn_flops = self.compute_attention_flops(latent_seqlens, [])
+        # Cross-attention: latent queries against text keys/values, cost
+        # proportional to latent_s * prompt_s (not the joint (a+b)^2 term).
+        cross_seqlen_sum = sum(
+            int(latent) * int(prompt) for latent, prompt in zip(latent_seqlens, prompt_seqlens, strict=True)
+        )
+        cross_attn_flops = 12 * num_layers * num_heads * head_dim * cross_seqlen_sum
+
+        flops_all_steps = (
+            (img_dense_flops + txt_dense_flops + time_proj_flops + self_attn_flops + cross_attn_flops)
+            * num_timesteps
+            * num_forward_passes
+        )
+        return flops_all_steps / delta_time / 1e12


### PR DESCRIPTION
## Summary

Pivoted from an earlier SRPO draft on this branch to a different roadmap
item: **FlopsCounter for diffusion models** (verl-project/verl#5755).

verl-omni already ships a full, generic diffusion FLOPs/MFU framework
(`verl_omni/utils/mfu/diffusion_flops_counter.py`: `DiffusionModelFlops`,
`@register_diffusion_architecture`, `DiffusionFlopsCounter`), documented in
`docs/perf/diffusion_mfu.md`. However only **one** architecture was actually
registered — `QwenImageFlops` for `QwenImagePipeline`. Every other
already-supported pipeline (`sd3_dpo`, `sd3_flow_grpo`, `wan22_dance_grpo`,
`bagel_flow_grpo`, `boogu_image_flow_grpo`, `ltx2_flow_grpo`,
`minimax_h3_*`, `qwen_image_*` variants beyond the base pipeline) has no
registered FLOPs estimator, so `DiffusionFlopsCounter` degrades to
`MFU=0` with a `RuntimeWarning` for all of them.

This PR extends the registry to two more architectures:

### What's new

- `StableDiffusion3Flops` (`verl_omni/utils/mfu/stable_diffusion_3.py`),
  registered for `StableDiffusion3Pipeline` /
  `StableDiffusion3PipelineWithLogProb` (covers `sd3_dpo`,
  `sd3_flow_grpo`). Models SD3's dual-stream joint attention
  (`JointTransformerBlock`), including the `context_pre_only` last block
  where the text stream drops `to_add_out` and `ff_context`. Overrides
  `get_latent_seqlens` to divide by `patch_size**2` since SD3 patchifies
  raw `(B, C, H, W)` latents internally rather than the pipeline
  pre-packing them. `dual_attention_layers` (SD3.5's extra image-only
  `attn2`) is not modeled and triggers an explicit `RuntimeWarning`
  rather than a silent undercount.
- `WanFlops` (`verl_omni/utils/mfu/wan.py`), registered for `WanPipeline`
  (covers `wan22_dance_grpo`). Models Wan's different topology:
  self-attention over the video-latent stream only, plus cross-attention
  from latents to the text stream (not joint attention over a
  concatenated sequence, and not Qwen-Image's `4*dim` FFN assumption —
  Wan uses an explicit `ffn_dim`). Overrides `get_latent_seqlens` to
  divide by the 3D patch volume for the same reason as SD3.
- `docs/perf/diffusion_mfu.md`: added a "Supported architectures" table
  and pointed the Wan tutorial snippet at the real, more complete
  implementation (it also accounts for `patch_embedding` / `proj_out` /
  `text_embedder`, which the original teaching snippet omitted).
- CPU unit tests: `tests/utils/test_stable_diffusion_3_flops_on_cpu.py`,
  `tests/utils/test_wan_flops_on_cpu.py`. Each includes an independent
  hand-rolled reference re-derived from the diffusers block source
  (not from the production formula), scaling checks (linear in
  timesteps/forward-passes, quadratic/superlinear in seqlen), and a
  ground-truth check against an instantiated tiny
  `SD3Transformer2DModel` / `WanTransformer3DModel`'s actual
  `.numel()`.

### What's explicitly NOT covered (skipped, not guessed)

Bagel, Boogu-Image, LTX2, MiniMax-H3, and SD3.5's `dual_attention_layers`
variant are **not** registered here. Bagel in particular is a custom
mixed causal/full-attention transformer defined in this repo
(`verl_omni/pipelines/bagel_flow_grpo/bagel_model.py`), not a
well-documented diffusers class — deriving a correct per-block formula
for it needs more careful review than fit in this pass, and per the
honesty bar this repo holds AI-assisted PRs to, a wrong FLOPs formula is
worse than the existing `MFU=0` warning it would silently replace. They
remain unregistered and continue to warn + report `MFU=0`.

## Duplicate-work check

- `gh issue view 5755 --repo verl-project/verl --comments` — the FlopsCounter
  line item has no assignee and no prior comments claiming it.
- `gh pr list --repo verl-project/verl-omni --state open --search "5755 in:body"` —
  no other open PR references this issue for FlopsCounter work.
- `gh pr list --repo verl-project/verl-omni --state open --search "flops"` — no
  other open PR touches `verl_omni/utils/mfu/`.

## Test plan

CPU unit tests (all passing). Note: this reviewer's local macOS environment
cannot install `vllm_omni` (GPU-only dependency) or an unrelated
`pyarrow`/`datasets` pin used by upstream `verl`'s dataset utils, so
`verl_omni`'s package `__init__` (which eagerly imports the pipeline
registry and trainer) cannot be imported as-is locally. Confirmed this
is a pre-existing environment limitation, not caused by this change, by
reproducing it on `main` before this diff. Worked around it locally the
same way this branch's prior CPU smoke test did — pre-registering an
empty `verl_omni` package (pointed at the real source tree via
`__path__`) in `sys.modules` before import, which skips only the heavy
`__init__`-time imports and exercises the real, unmodified
`verl_omni.utils.mfu` module:

```
$ python -c "
import sys, types, pytest, os
root = os.path.abspath('verl_omni')
pkg = types.ModuleType('verl_omni'); pkg.__path__ = [root]
sys.modules['verl_omni'] = pkg
sys.exit(pytest.main(['-q',
    'tests/utils/test_diffusion_flops_counter_on_cpu.py',
    'tests/utils/test_stable_diffusion_3_flops_on_cpu.py',
    'tests/utils/test_wan_flops_on_cpu.py']))
"
...
61 passed, 3 warnings in 1.72s
```

**Update: also verified via a genuine full-package install (no stub) on
Modal, both CPU-only and on a real GPU.**

CPU, Linux x86_64 container (Modal, Ubuntu 22.04, Python 3.12.1), real
`pip install -e .[dev]` per `docker/Dockerfile.cuda`'s recipe (vllm==0.27.0,
kernels==0.14.1, liger-kernel, then `vllm-omni@444485650` /
`verl@fefb080` per `.github/*_pin.txt`, then `-e .[dev]`) with an
unmodified `import verl_omni` (no `sys.modules` stub):

```
torch 2.13.0+cpu, transformers 5.14.1, diffusers 0.38.0, vllm 0.27.0
tests/utils/test_stable_diffusion_3_flops_on_cpu.py ... (9 tests) PASSED
tests/utils/test_wan_flops_on_cpu.py ... (7 tests) PASSED
tests/utils/test_diffusion_flops_counter_on_cpu.py ... (45 tests) PASSED
======================= 61 passed, 23 warnings in 34.83s =======================
```

GPU, same install recipe on `nvidia/cuda:13.0.2-cudnn-devel-ubuntu22.04`
(torch 2.13.0+cu130, matching CUDA 13 that `vllm==0.27.0`'s compiled
extension requires — a CUDA 12.x base fails eager `import vllm_omni` with
`ImportError: libcudart.so.13: cannot open shared object file`), on a
Modal A100-40GB: `import verl_omni` succeeds through the real,
un-stubbed package/pipeline registry, and a genuine forward+backward pass
through a tiny-random `SD3Transformer2DModel` (diffusers, random
weights, 4 layers/hidden_size=64, built the same way as
`tests/special_e2e/build_sd3_tiny_random.py`) drove
`DiffusionFlopsCounter("StableDiffusion3Pipeline", ...)` end to end with
a real device-peak lookup (`get_device_peak_tflops()` → 312 TFLOPS for
A100, from `verl.utils.flops_counter.get_device_flops`):

```
GPU: NVIDIA A100-SXM4-40GB
Before (unregistered architecture name): est_tflops_per_sec=0.0, warned=True  (matches pre-PR MFU=0 behavior)
After  (StableDiffusion3Pipeline, registered): estimated_tflops_per_sec=0.0010025024830039146
                                                promised_device_peak_tflops=312.0
                                                mfu=3.21e-06 (non-zero)
```

Also re-ran the identical smoke test on a Modal L40S (cheaper than A100,
and present in `verl`'s device-peak-TFLOPS table), same image/install
recipe, same tiny-random `SD3Transformer2DModel` construction:

```
GPU: NVIDIA L40S
Before (unregistered architecture name): est_tflops_per_sec=0.0, promised_tflops=362.05, warned=True  (matches pre-PR MFU=0 behavior)
After  (StableDiffusion3Pipeline, registered): estimated_tflops_per_sec=0.0019476260475777827
                                                promised_device_peak_tflops=362.05
                                                mfu=5.379439435375729e-06 (0.0005%, non-zero)
```

The MFU is tiny in absolute terms because this is a toy-scale
forward+backward smoke test (4-layer, hidden_size=64 transformer,
wall-clock dominated by one-off CUDA/kernel-launch overhead, not a real
training step) — the point is confirming the new estimator now returns a
real, non-zero, non-warning FLOPs/MFU value on real GPU hardware where
it previously returned exactly `0.0` with a `RuntimeWarning`. This holds
across both GPUs tested (A100 and L40S); L40S is the cheaper option to
use for future reruns of this smoke test.

Not run: no full RL training loop, no real (non-tiny-random) SD3/Wan
checkpoint, no end-to-end MFU number from an actual training log.

## API usage example

```python
from verl_omni.utils.mfu import DiffusionFlopsCounter

counter = DiffusionFlopsCounter("StableDiffusion3Pipeline", transformer_config)
est_tflops, promised_tflops = counter.estimate_flops(
    latent_seqlens=[1024] * batch_size,
    prompt_seqlens=[77] * batch_size,
    delta_time=step_wall_time,
    num_timesteps=num_denoise_steps,
    num_forward_passes=2,  # true CFG
)
mfu = est_tflops / promised_tflops / dp_size
```

- [x] AI assistance (Claude Code) was used for this change.
- [x] A human submitter (onepunchmonk) has reviewed every changed line.

Related to verl-project/verl#5755


