### PR TITLE
[diffusion, tests] fix: track fused MiniMax H3 weights

### DIFF
--- a/tests/pipelines/test_minimax_h3_flow_grpo_on_cpu.py
+++ b/tests/pipelines/test_minimax_h3_flow_grpo_on_cpu.py
@@ -272,11 +272,11 @@ class _SyncPipeline(MiniMaxH3WeightSyncMixin, _RecordingBase):
         )
 
 
-def test_full_weight_sync_uses_fused_loaders_and_renames_plain_weights() -> None:
+def test_full_weight_sync_uses_fused_loaders_and_returns_model_parameter_names() -> None:
     pipeline = _SyncPipeline()
     q = torch.randn(8, 8)
     geglu = torch.arange(32, dtype=torch.float32).reshape(8, 4)
-    pipeline.load_weights(
+    loaded = pipeline.load_weights(
         [
             ("transformer.transformer_blocks.0.attn.to_q.weight", q),
             ("transformer.transformer_blocks.0.ff.net.0.proj.weight", geglu),
@@ -289,6 +289,11 @@ def test_full_weight_sync_uses_fused_loaders_and_renames_plain_weights() -> None
     torch.testing.assert_close(pipeline.fc1.weight_loader.call_args_list[0].args[1], geglu[4:])
     torch.testing.assert_close(pipeline.fc1.weight_loader.call_args_list[1].args[1], geglu[:4])
     assert pipeline.forwarded[0][0] == "transformer.audio_patch_proj.weight"
+    assert loaded == {
+        "transformer.audio_patch_proj.weight",
+        "transformer.blocks.0.attn.qkv_proj.weight",
+        "transformer.blocks.0.mlp.fc1.weight",
+    }
 
 
 def test_lora_weight_sync_splits_geglu_and_rewrites_targets() -> None:

--- a/verl_omni/pipelines/minimax_h3_flow_grpo/weight_sync.py
+++ b/verl_omni/pipelines/minimax_h3_flow_grpo/weight_sync.py
@@ -104,7 +104,7 @@ class MiniMaxH3WeightSyncMixin:
                 # Keep Q/K/V separate. The fused parameter's native loader packs
                 # the requested shard and applies the correct TP partition.
                 param.weight_loader(param, tensor, projection[0])
-                loaded.add(name)
+                loaded.add(f"{component}.{target_name}")
                 continue
 
             if inner.endswith(".ff.net.0.proj.weight"):
@@ -119,7 +119,7 @@ class MiniMaxH3WeightSyncMixin:
                 up, gate = tensor.chunk(2, dim=0)
                 param.weight_loader(param, gate, 0)
                 param.weight_loader(param, up, 1)
-                loaded.add(name)
+                loaded.add(f"{component}.{target_name}")
                 continue
 
             translated.append((f"{component}.{_diffusers_to_vllm_name(inner)}", tensor))


### PR DESCRIPTION
## Summary

Fix MiniMax H3 FlowGRPO's full-weight loader bookkeeping for Diffusers QKV and
GEGLU projections. These projections are loaded through vLLM-Omni's fused,
TP-aware parameter loaders, but the adapter reported their original Diffusers
source names as loaded. vLLM-Omni's strict post-load check expects canonical
fused H3 parameter names and incorrectly rejected the initialized weights.

The loader now reports the canonical `qkv_proj` and `fc1` names. The new CPU
assertion covers the full returned set as well as the existing fused-loader and
GEGLU-order checks.

## Duplicate-work check

- Reviewed #368, which introduced the T2VA FlowGRPO adapter; this fixes its
  strict full-weight-load bookkeeping regression.
- Checked open PRs citing #368 and searched for MiniMax H3 FlowGRPO
  weight-loading work. #448 implements FL2VA trajectory support and does not
  modify `weight_sync.py`; no open PR addresses this loader failure.

## Tests

Passed:

```console
TORCH_COMPILE_DISABLE=1 TORCHINDUCTOR_DISABLE=1 \
  python -m pytest -q -s --asyncio-mode=auto \
  tests/pipelines/test_minimax_h3_flow_grpo_on_cpu.py
# 12 passed

pre-commit run --files \
  verl_omni/pipelines/minimax_h3_flow_grpo/weight_sync.py \
  tests/pipelines/test_minimax_h3_flow_grpo_on_cpu.py
# all applicable hooks passed

PR_TITLE='[diffusion, tests] fix: track fused MiniMax H3 weights' \
  python tests/special_sanity/check_pr_title.py
# passed
```

Integration validation against the pending tiny-random T2VA FlowGRPO smoke:

```console
CUDA_VISIBLE_DEVICES=4,5,6,7 NUM_GPUS=4 ROLLOUT_TP=2 \
TOTAL_TRAINING_STEPS=1 \
python tests/special_e2e/run_flowgrpo_minimax_h3_tiny.py
# Training Progress 1/1 in 118.61 seconds
# 16 rollout MP4s and 16 JSONL records written
```

## AI assistance and review

AI assistance (pi coding agent) was used for this change. The human submitter
reviewed every changed line and is responsible for this contribution.
