### PR TITLE
[2/N][diffusion, rollout, tests] refactor: declare diffusion media outputs

### DIFF
--- a/tests/pipelines/test_diffusion_io_spec_on_cpu.py
+++ b/tests/pipelines/test_diffusion_io_spec_on_cpu.py
@@ -1,0 +1,95 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Every registered diffusion pipeline must declare its rollout media outputs.
+
+The diffusion rollout strategy and (later) the reward/trainer consumers read
+the produced modality from the adapter-declared ``DiffusionIOSpec`` instead of
+inferring it from tensor rank, so a missing declaration is a bug.
+"""
+
+import pytest
+
+pytest.importorskip("verl_omni.pipelines.model_base")
+from verl_omni.pipelines.model_base import VllmOmniPipelineBase
+
+# (adapter module, architecture, algorithm, primary modality)
+_PRIMARY_MODALITY = [
+    (
+        "verl_omni.pipelines.bagel_flow_grpo.vllm_omni_rollout_adapter",
+        "OmniBagelForConditionalGeneration",
+        "flow_grpo",
+        "image",
+    ),
+    ("verl_omni.pipelines.boogu_image_flow_grpo.vllm_omni_rollout_adapter", "BooguImagePipeline", "flow_grpo", "image"),
+    ("verl_omni.pipelines.qwen_image_flow_grpo.vllm_omni_rollout_adapter", "QwenImagePipeline", "flow_grpo", "image"),
+    (
+        "verl_omni.pipelines.qwen_image_diffusion_nft.vllm_omni_rollout_adapter",
+        "QwenImagePipeline",
+        "diffusion_nft",
+        "image",
+    ),
+    ("verl_omni.pipelines.qwen_image_dpo.vllm_omni_rollout_adapter", "QwenImagePipeline", "dpo", "image"),
+    # dual_grpo / mix_grpo subclass QwenImagePipelineWithLogProb and inherit the spec.
+    ("verl_omni.pipelines.qwen_image_dual_grpo.vllm_omni_rollout_adapter", "QwenImagePipeline", "dual_grpo", "image"),
+    ("verl_omni.pipelines.qwen_image_mix_grpo.vllm_omni_rollout_adapter", "QwenImagePipeline", "mix_grpo", "image"),
+    (
+        "verl_omni.pipelines.qwen_image_edit_flow_grpo.vllm_omni_rollout_adapter",
+        "QwenImageEditPlusPipeline",
+        "flow_grpo",
+        "image",
+    ),
+    ("verl_omni.pipelines.sd3_flow_grpo.vllm_omni_rollout_adapter", "StableDiffusion3Pipeline", "flow_grpo", "image"),
+    ("verl_omni.pipelines.wan22_dance_grpo.vllm_omni_rollout_adapter", "WanPipeline", "dance_grpo", "video"),
+    ("verl_omni.pipelines.ltx2_flow_grpo.vllm_omni_rollout_adapter", "LTX2Pipeline", "flow_grpo", "video"),
+    ("verl_omni.pipelines.minimax_h3_flow_grpo.vllm_omni_rollout_adapter", "MiniMaxH3Pipeline", "flow_grpo", "video"),
+    (
+        "verl_omni.pipelines.minimax_h3_diffusion_nft.vllm_omni_rollout_adapter",
+        "MiniMaxH3Pipeline",
+        "diffusion_nft",
+        "video",
+    ),
+]
+
+# (architecture, algorithm, declared audio sample rate) for joint video/audio pipelines.
+_JOINT_AUDIO_SAMPLE_RATE = [
+    ("verl_omni.pipelines.minimax_h3_flow_grpo.vllm_omni_rollout_adapter", "MiniMaxH3Pipeline", "flow_grpo", 32000),
+    (
+        "verl_omni.pipelines.minimax_h3_diffusion_nft.vllm_omni_rollout_adapter",
+        "MiniMaxH3Pipeline",
+        "diffusion_nft",
+        32000,
+    ),
+    ("verl_omni.pipelines.ltx2_flow_grpo.vllm_omni_rollout_adapter", "LTX2Pipeline", "flow_grpo", 24000),
+]
+
+
+@pytest.mark.parametrize(("module", "architecture", "algorithm", "modality"), _PRIMARY_MODALITY)
+def test_registered_pipeline_declares_primary_modality(module, architecture, algorithm, modality):
+    pytest.importorskip(module)
+    cls = VllmOmniPipelineBase.get_class(architecture, algorithm)
+    assert cls is not None, f"{architecture}/{algorithm} is not registered"
+    spec = getattr(cls, "diffusion_io_spec", None)
+    assert spec is not None, f"{architecture}/{algorithm} must declare diffusion_io_spec"
+    assert spec.primary.modality == modality
+
+
+@pytest.mark.parametrize(("module", "architecture", "algorithm", "sample_rate"), _JOINT_AUDIO_SAMPLE_RATE)
+def test_joint_pipeline_declares_audio_stream(module, architecture, algorithm, sample_rate):
+    pytest.importorskip(module)
+    cls = VllmOmniPipelineBase.get_class(architecture, algorithm)
+    spec = getattr(cls, "diffusion_io_spec", None)
+    assert spec is not None
+    audio = next((stream for stream in spec.auxiliary if stream.modality == "audio"), None)
+    assert audio is not None, f"{architecture}/{algorithm} must declare an auxiliary audio stream"
+    assert audio.sample_rate == sample_rate

--- a/tests/pipelines/test_minimax_h3_flow_grpo_on_cpu.py
+++ b/tests/pipelines/test_minimax_h3_flow_grpo_on_cpu.py
@@ -185,6 +185,9 @@ def test_rollout_output_reaches_actor_and_replays_joint_transition(monkeypatch) 
     )
     server = object.__new__(vLLMOmniHttpServer)
     server.global_steps = 1
+    # The strategy resolves the audio sample rate from the adapter-declared
+    # DiffusionIOSpec, which is keyed by (architecture, algorithm).
+    server.model_config = SimpleNamespace(architecture="MiniMaxH3Pipeline", algorithm="flow_grpo")
     processed = DiffusionStrategy(server).process_output(final_res, None, {"output_type": "pt", "logprobs": True})
 
     for key in ("all_latents", "all_next_latents", "h3_step_indices", "h3_audio_timesteps"):

--- a/tests/pipelines/test_minimax_h3_rollout_contract_on_cpu.py
+++ b/tests/pipelines/test_minimax_h3_rollout_contract_on_cpu.py
@@ -25,6 +25,9 @@ import torch
 
 server_module = pytest.importorskip("verl_omni.workers.rollout.vllm_rollout.vllm_omni_async_server")
 tracking_module = pytest.importorskip("verl_omni.utils.tracking")
+# The strategy resolves H3's audio sample rate from the adapter-declared
+# DiffusionIOSpec, so the pipeline adapter must be imported/registered.
+pytest.importorskip("verl_omni.pipelines.minimax_h3_flow_grpo.vllm_omni_rollout_adapter")
 
 _VIDEO_T, _VIDEO_C, _VIDEO_H, _VIDEO_W = 107, 3, 384, 640
 _AUDIO_SR = 32000
@@ -61,6 +64,8 @@ def _make_h3_final_res(batch_size: int = 1):
 def _server():
     server = object.__new__(server_module.vLLMOmniHttpServer)
     server.global_steps = 3
+    # Keys the adapter-declared DiffusionIOSpec (audio sample rate 32000).
+    server.model_config = SimpleNamespace(architecture="MiniMaxH3Pipeline", algorithm="flow_grpo")
     server._to_tensor = __import__("torchvision").transforms.PILToTensor()
     return server
 

--- a/tests/workers/rollout/rollout_vllm/test_vllm_omni_strategy_on_cpu.py
+++ b/tests/workers/rollout/rollout_vllm/test_vllm_omni_strategy_on_cpu.py
@@ -19,6 +19,7 @@ from unittest.mock import AsyncMock
 import pytest
 import torch
 
+from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
 from verl_omni.workers.rollout.vllm_rollout import vllm_omni_ar_strategy as ar_strategy_module
 from verl_omni.workers.rollout.vllm_rollout import vllm_omni_async_server as server_module
 from verl_omni.workers.rollout.vllm_rollout import vllm_omni_diffusion_strategy as diffusion_strategy_module
@@ -281,6 +282,67 @@ def test_diffusion_strategy_preserves_multistage_prompt_shape():
     assert prompt["extra_args"] == {"multi_modal_data": {"image": ["image"]}}
     assert params[0] == "ar-stage"
     assert params[-1].extra_args == {"pipeline_private_arg": 7}
+
+
+def _joint_video_audio_final_res():
+    video = torch.zeros(1, 3, 2, 8, 8, dtype=torch.uint8)
+    audio = torch.zeros(1, 16)
+    final_res = SimpleNamespace(
+        images=[(video, audio)],
+        trajectory_latents=None,
+        trajectory_timesteps=None,
+        trajectory_log_probs=None,
+        multimodal_output=None,
+        request_output=None,
+    )
+    return final_res, audio
+
+
+def test_diffusion_strategy_uses_declared_audio_sample_rate(monkeypatch):
+    pipeline_cls = SimpleNamespace(
+        diffusion_io_spec=DiffusionIOSpec(
+            primary=MediaSpec("video"),
+            auxiliary=(MediaSpec("audio", sample_rate=48000),),
+        )
+    )
+    monkeypatch.setattr(
+        diffusion_strategy_module.VllmOmniPipelineBase,
+        "get_class",
+        staticmethod(lambda **kwargs: pipeline_cls),
+    )
+    server = SimpleNamespace(
+        global_steps=1,
+        model_config=SimpleNamespace(architecture="Architecture", algorithm="Algorithm"),
+    )
+    final_res, audio = _joint_video_audio_final_res()
+
+    processed = DiffusionStrategy(server).process_output(final_res, None, {"output_type": "pt", "logprobs": False})
+
+    # The audio sample rate comes from the adapter-declared DiffusionIOSpec,
+    # not the strategy's legacy 32 kHz fallback.
+    assert processed.extra_fields["audio_sample_rate"] == 48000
+    # process_output unbatches the leading dimension of auxiliary media.
+    torch.testing.assert_close(processed.extra_fields["audio"], audio[0])
+
+
+def test_diffusion_strategy_omits_audio_sample_rate_without_declared_spec(monkeypatch):
+    # Without an adapter-declared DiffusionIOSpec the strategy still surfaces the
+    # auxiliary audio stream but attaches no model-specific sample-rate default.
+    monkeypatch.setattr(
+        diffusion_strategy_module.VllmOmniPipelineBase,
+        "get_class",
+        staticmethod(lambda **kwargs: SimpleNamespace()),
+    )
+    server = SimpleNamespace(
+        global_steps=1,
+        model_config=SimpleNamespace(architecture="Architecture", algorithm="Algorithm"),
+    )
+    final_res, audio = _joint_video_audio_final_res()
+
+    processed = DiffusionStrategy(server).process_output(final_res, None, {"output_type": "pt", "logprobs": False})
+
+    torch.testing.assert_close(processed.extra_fields["audio"], audio[0])
+    assert "audio_sample_rate" not in processed.extra_fields
 
 
 @pytest.mark.parametrize(

--- a/verl_omni/pipelines/bagel_flow_grpo/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/bagel_flow_grpo/vllm_omni_rollout_adapter.py
@@ -39,6 +39,7 @@ from verl_omni.pipelines.bagel_flow_grpo.common import (
 )
 from verl_omni.pipelines.diffusion_rollout_output import rollout_output
 from verl_omni.pipelines.model_base import VllmOmniPipelineBase
+from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
 from verl_omni.pipelines.schedulers import FlowMatchSDEDiscreteScheduler
 
 logger = logging.getLogger(__name__)
@@ -241,6 +242,10 @@ def _pick_sde_window(
 @VllmOmniPipelineBase.register("OmniBagelForConditionalGeneration", algorithm="flow_grpo")
 class BagelPipelineWithLogProb(BagelPipeline):
     """BAGEL pipeline variant for RL rollouts with verl-omni."""
+
+    #: Declares the primary rollout media stream so downstream consumers read
+    #: the modality from the adapter instead of inferring it from tensor rank.
+    diffusion_io_spec = DiffusionIOSpec(primary=MediaSpec("image"))
 
     def __init__(self, *, od_config: OmniDiffusionConfig, prefix: str = ""):
         super().__init__(od_config=od_config, prefix=prefix)

--- a/verl_omni/pipelines/boogu_image_flow_grpo/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/boogu_image_flow_grpo/vllm_omni_rollout_adapter.py
@@ -42,6 +42,7 @@ from verl_omni.pipelines.request_batch import (
 from verl_omni.pipelines.request_batch import (
     split_diffusion_output_by_request as _split_diffusion_output_by_request,
 )
+from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
 from verl_omni.pipelines.schedulers import FlowMatchSDEDiscreteScheduler
 from verl_omni.pipelines.utils import ImageGenerationRequest
 
@@ -89,6 +90,10 @@ class BooguImagePipelineWithLogProb(QwenImageTokenIdPromptMixin, BooguImagePipel
     """
 
     supports_request_batch = True
+
+    #: Declares the primary rollout media stream so downstream consumers read
+    #: the modality from the adapter instead of inferring it from tensor rank.
+    diffusion_io_spec = DiffusionIOSpec(primary=MediaSpec("image"))
 
     def __init__(self, *, od_config: OmniDiffusionConfig, prefix: str = "") -> None:
         super().__init__(od_config=od_config, prefix=prefix)

--- a/verl_omni/pipelines/ltx2_flow_grpo/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/ltx2_flow_grpo/vllm_omni_rollout_adapter.py
@@ -50,6 +50,7 @@ from verl_omni.pipelines.diffusion_rollout_output import (
     wrap_rollout_postprocessor,
 )
 from verl_omni.pipelines.model_base import VllmOmniPipelineBase
+from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
 from verl_omni.pipelines.schedulers import FlowMatchSDEDiscreteScheduler
 
 from .common import calculate_shift, normalize_ltx_output_type
@@ -73,6 +74,14 @@ class LTX23PipelineWithLogProb(LTX2Pipeline):
     """Sample LTX-2.3 with CPS/SDE transitions and return joint log-probs."""
 
     supports_request_batch = False
+
+    #: Declares the joint video/audio rollout streams. The runtime audio sample
+    #: rate (from the vocoder) is attached via rollout metadata and takes
+    #: precedence over this declared default.
+    diffusion_io_spec = DiffusionIOSpec(
+        primary=MediaSpec("video"),
+        auxiliary=(MediaSpec("audio", sample_rate=24000),),
+    )
 
     def __init__(self, *, od_config: OmniDiffusionConfig, prefix: str = "") -> None:
         super().__init__(od_config=od_config, prefix=prefix)

--- a/verl_omni/pipelines/minimax_h3_diffusion_nft/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/minimax_h3_diffusion_nft/vllm_omni_rollout_adapter.py
@@ -27,6 +27,7 @@ from vllm_omni.diffusion.models.minimax_h3.time_request import minimax_h3_time_s
 
 from verl_omni.pipelines.diffusion_rollout_output import with_rollout_data
 from verl_omni.pipelines.model_base import VllmOmniPipelineBase
+from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
 
 from .common import MiniMaxH3RolloutWeightSyncMixin, pack_video_audio_rows
 
@@ -38,6 +39,13 @@ _VIDEO_PATCH_SIZE = (1, 2, 2)
 @VllmOmniPipelineBase.register("MiniMaxH3Pipeline", algorithm="diffusion_nft")
 class MiniMaxH3DiffusionNFTPipeline(MiniMaxH3RolloutWeightSyncMixin, MiniMaxH3Pipeline):
     """Rollout pipeline for MiniMax H3 used by DiffusionNFT."""
+
+    #: Declares the joint video/audio rollout streams so the diffusion strategy
+    #: does not hard-code the audio tuple position or its 32 kHz sample rate.
+    diffusion_io_spec = DiffusionIOSpec(
+        primary=MediaSpec("video"),
+        auxiliary=(MediaSpec("audio", sample_rate=32000),),
+    )
 
     def __init__(self, *, od_config: Any, prefix: str = "") -> None:
         super().__init__(od_config=od_config, prefix=prefix)

--- a/verl_omni/pipelines/minimax_h3_flow_grpo/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/minimax_h3_flow_grpo/vllm_omni_rollout_adapter.py
@@ -35,6 +35,7 @@ from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
 
 from verl_omni.pipelines.diffusion_rollout_output import with_rollout_data
 from verl_omni.pipelines.model_base import VllmOmniPipelineBase
+from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
 from verl_omni.pipelines.schedulers import FlowMatchSDEDiscreteScheduler
 
 from .common import (
@@ -71,6 +72,13 @@ class MiniMaxH3PipelineWithLogProb(MiniMaxH3WeightSyncMixin, MiniMaxH3Pipeline):
     """
 
     supports_request_batch = False
+
+    #: Declares the joint video/audio rollout streams so the diffusion strategy
+    #: does not hard-code the audio tuple position or its 32 kHz sample rate.
+    diffusion_io_spec = DiffusionIOSpec(
+        primary=MediaSpec("video"),
+        auxiliary=(MediaSpec("audio", sample_rate=32000),),
+    )
 
     def __init__(self, *, od_config: OmniDiffusionConfig, prefix: str = ""):
         super().__init__(od_config=od_config, prefix=prefix)

--- a/verl_omni/pipelines/qwen_image_diffusion_nft/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/qwen_image_diffusion_nft/vllm_omni_rollout_adapter.py
@@ -30,6 +30,7 @@ from verl_omni.pipelines.qwen_image_flow_grpo.common import (
     build_img_shapes,
     coalesce_not_none,
 )
+from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
 
 __all__ = ["QwenImageDiffusionNFTPipeline"]
 
@@ -42,6 +43,10 @@ class QwenImageDiffusionNFTPipeline(QwenImageTokenIdPromptMixin, QwenImagePipeli
     objective, so the rollout side does not collect reverse-SDE trajectories or
     log-probabilities.
     """
+
+    #: Declares the primary rollout media stream so downstream consumers read
+    #: the modality from the adapter instead of inferring it from tensor rank.
+    diffusion_io_spec = DiffusionIOSpec(primary=MediaSpec("image"))
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/verl_omni/pipelines/qwen_image_dpo/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/qwen_image_dpo/vllm_omni_rollout_adapter.py
@@ -27,6 +27,7 @@ from vllm_omni.diffusion.worker.utils import StepRequestState
 from verl_omni.pipelines.diffusion_rollout_output import rollout_output, with_rollout_data
 from verl_omni.pipelines.model_base import VllmOmniPipelineBase
 from verl_omni.pipelines.qwen_image_flow_grpo.common import apply_true_cfg, build_img_shapes
+from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
 
 __all__ = ["QwenImageDPOPipeline"]
 
@@ -38,6 +39,10 @@ def _coalesce_not_none(value, default):
 @VllmOmniPipelineBase.register("QwenImagePipeline", algorithm="dpo")
 class QwenImageDPOPipeline(QwenImagePipeline):
     """Rollout pipeline that returns DPO training tensors with generated images."""
+
+    #: Declares the primary rollout media stream so downstream consumers read
+    #: the modality from the adapter instead of inferring it from tensor rank.
+    diffusion_io_spec = DiffusionIOSpec(primary=MediaSpec("image"))
 
     def __init__(self, *, od_config: OmniDiffusionConfig, prefix: str = ""):
         super().__init__(od_config=od_config, prefix=prefix)

--- a/verl_omni/pipelines/qwen_image_edit_flow_grpo/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/qwen_image_edit_flow_grpo/vllm_omni_rollout_adapter.py
@@ -38,6 +38,7 @@ from verl_omni.pipelines.qwen_image_flow_grpo.common import (
     apply_true_cfg,
     coalesce_not_none,
 )
+from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
 from verl_omni.pipelines.schedulers import FlowMatchSDEDiscreteScheduler
 from verl_omni.pipelines.utils import ImageGenerationRequest
 
@@ -114,6 +115,10 @@ def _validate_condition_image_sizes(condition_images, vae_image_sizes, target_si
 @VllmOmniPipelineBase.register("QwenImageEditPlusPipeline", algorithm="flow_grpo")
 class QwenImageEditPlusPipelineWithLogProb(QwenImageTokenIdPromptMixin, QwenImageEditPlusPipeline):
     """Qwen-Image-Edit-Plus rollout pipeline for FlowGRPO."""
+
+    #: Declares the primary rollout media stream so downstream consumers read
+    #: the modality from the adapter instead of inferring it from tensor rank.
+    diffusion_io_spec = DiffusionIOSpec(primary=MediaSpec("image"))
 
     def __init__(self, *, od_config: OmniDiffusionConfig, prefix: str = ""):
         super().__init__(od_config=od_config, prefix=prefix)

--- a/verl_omni/pipelines/qwen_image_flow_grpo/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/qwen_image_flow_grpo/vllm_omni_rollout_adapter.py
@@ -39,6 +39,7 @@ from verl_omni.pipelines.request_batch import (
 from verl_omni.pipelines.request_batch import (
     split_diffusion_output_by_request as _split_diffusion_output_by_request,
 )
+from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
 from verl_omni.pipelines.schedulers import FlowMatchSDEDiscreteScheduler
 
 from .common import QwenImageTokenIdPromptMixin, apply_true_cfg, build_img_shapes, coalesce_not_none
@@ -60,6 +61,11 @@ class QwenImagePipelineWithLogProb(QwenImageTokenIdPromptMixin, QwenImagePipelin
     """
 
     supports_request_batch = True
+
+    #: Declares the primary rollout media stream so downstream consumers read
+    #: the modality from the adapter instead of inferring it from tensor rank.
+    #: Inherited by the dual-GRPO and mix-GRPO Qwen-Image subclasses.
+    diffusion_io_spec = DiffusionIOSpec(primary=MediaSpec("image"))
 
     def __init__(self, *, od_config: OmniDiffusionConfig, prefix: str = ""):
         super().__init__(od_config=od_config, prefix=prefix)

--- a/verl_omni/pipelines/rollout_media.py
+++ b/verl_omni/pipelines/rollout_media.py
@@ -1,0 +1,70 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Typed, CPU-importable contracts for diffusion rollout media.
+
+These types let a diffusion adapter *declare* what media its pipeline emits
+(primary stream plus any auxiliary streams such as joint audio) instead of the
+rollout strategy hard-coding model-specific conventions like "audio lives at
+tuple position 1" or "the audio sample rate is 32000 Hz". The diffusion
+strategy consults the adapter-owned :class:`DiffusionIOSpec` when it converts an
+engine result into a rollout output, so adding a new combination of existing
+modalities only touches the adapter, not the shared server/strategy code.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, Optional
+
+#: Media kinds a diffusion pipeline can emit.
+Modality = Literal["image", "video", "audio"]
+
+
+@dataclass(frozen=True)
+class MediaSpec:
+    """Declaration of a single media stream produced by a diffusion pipeline.
+
+    Attributes:
+        modality: The media kind (``"image"``, ``"video"`` or ``"audio"``).
+        sample_rate: Default audio sample rate in Hz. Audio streams only; used
+            as a fallback when the adapter does not attach a runtime sample rate
+            through the rollout metadata.
+        fps: Default frames-per-second. Video streams only; ``None`` when the
+            pipeline does not declare one.
+
+    The float-latent vs. uint8-pixel distinction is intentionally *not* declared
+    here: it is decided per request by the sampling ``output_type`` (``latent``
+    keeps floats, otherwise pixels are quantized to uint8 in ``[0, 255]``).
+    """
+
+    modality: Modality
+    sample_rate: Optional[int] = None
+    fps: Optional[int] = None
+
+
+@dataclass(frozen=True)
+class DiffusionIOSpec:
+    """Adapter-owned declaration of a diffusion pipeline's rollout outputs.
+
+    Attributes:
+        primary: The main media stream. It is carried on
+            ``DiffusionOutput.diffusion_output`` and, when the pipeline emits a
+            media tuple, occupies position 0.
+        auxiliary: Additional media streams in tuple order, so ``auxiliary[i]``
+            describes media-tuple position ``i + 1`` (e.g. a single ``audio``
+            entry describes the joint-audio stream at position 1).
+    """
+
+    primary: MediaSpec
+    auxiliary: tuple[MediaSpec, ...] = ()

--- a/verl_omni/pipelines/sd3_flow_grpo/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/sd3_flow_grpo/vllm_omni_rollout_adapter.py
@@ -39,6 +39,7 @@ from verl_omni.pipelines.request_batch import (
 from verl_omni.pipelines.request_batch import (
     split_diffusion_output_by_request as _split_diffusion_output_by_request,
 )
+from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
 from verl_omni.pipelines.schedulers import FlowMatchSDEDiscreteScheduler
 from verl_omni.pipelines.sd3_flow_grpo.common import (
     SD3_CLIP_TOKENS_KEY,
@@ -188,6 +189,10 @@ class StableDiffusion3PipelineWithLogProb(SD3TokenIdPromptMixin, StableDiffusion
     """
 
     supports_request_batch = True
+
+    #: Declares the primary rollout media stream so downstream consumers read
+    #: the modality from the adapter instead of inferring it from tensor rank.
+    diffusion_io_spec = DiffusionIOSpec(primary=MediaSpec("image"))
 
     def __init__(self, *, od_config: OmniDiffusionConfig, prefix: str = ""):
         super().__init__(od_config=od_config, prefix=prefix)

--- a/verl_omni/pipelines/wan22_dance_grpo/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/wan22_dance_grpo/vllm_omni_rollout_adapter.py
@@ -42,6 +42,7 @@ from verl_omni.pipelines.diffusion_rollout_output import (
     wrap_rollout_postprocessor,
 )
 from verl_omni.pipelines.model_base import VllmOmniPipelineBase
+from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
 from verl_omni.pipelines.schedulers import FlowMatchSDEDiscreteScheduler
 
 from .common import sd3_time_shift, seed_from_prompt_ids
@@ -107,6 +108,10 @@ class Wan22DanceGRPOPipelineWithLogProb(Wan22Pipeline):
 
     Registered under ``("WanPipeline", "dance_grpo")``.
     """
+
+    #: Declares the primary rollout media stream so downstream consumers read
+    #: the modality from the adapter instead of inferring it from tensor rank.
+    diffusion_io_spec = DiffusionIOSpec(primary=MediaSpec("video"))
 
     def __init__(self, *, od_config: OmniDiffusionConfig, prefix: str = ""):
         super().__init__(od_config=od_config, prefix=prefix)

--- a/verl_omni/workers/rollout/vllm_rollout/vllm_omni_diffusion_strategy.py
+++ b/verl_omni/workers/rollout/vllm_rollout/vllm_omni_diffusion_strategy.py
@@ -24,6 +24,7 @@ from vllm_omni.inputs.data import OmniCustomPrompt, OmniDiffusionSamplingParams
 from vllm_omni.lora.request import LoRARequest
 
 from verl_omni.pipelines.model_base import VllmOmniPipelineBase
+from verl_omni.pipelines.rollout_media import DiffusionIOSpec
 from verl_omni.workers.config import DiffusionModelConfig, DiffusionRolloutConfig
 from verl_omni.workers.rollout.replica import DiffusionOutput
 from verl_omni.workers.rollout.vllm_rollout.vllm_omni_strategy_base import OmniStrategyBase
@@ -190,6 +191,23 @@ class DiffusionStrategy(OmniStrategyBase):
             )
         )
 
+    def _diffusion_io_spec(self) -> Optional[DiffusionIOSpec]:
+        """Resolve the adapter-declared media I/O spec for the active pipeline.
+
+        The spec lets a diffusion adapter declare its auxiliary media streams
+        (e.g. joint audio and its sample rate) so this strategy does not have to
+        hard-code model-specific tuple positions or sample rates. Returns
+        ``None`` when the pipeline (or a bare test server) declares no spec.
+        """
+        model_config = getattr(self.server, "model_config", None)
+        if model_config is None:
+            return None
+        pipeline_cls = VllmOmniPipelineBase.get_class(
+            architecture=model_config.architecture,
+            algorithm=model_config.algorithm,
+        )
+        return getattr(pipeline_cls, "diffusion_io_spec", None)
+
     def process_output(self, final_res: Any, params: Any, sampling_params: dict[str, Any]) -> DiffusionOutput:
         output_type = _diffusion_output_type(sampling_params)
         if final_res is None or not final_res.images:
@@ -221,10 +239,16 @@ class DiffusionStrategy(OmniStrategyBase):
                 if key in diffusion_output and diffusion_output[key] is not None:
                     diffusion_output = diffusion_output[key]
                     break
+        io_spec = self._diffusion_io_spec()
+        audio_sample_rate: Optional[int] = None
         rollout_audio: Any = None
         if isinstance(diffusion_output, tuple | list):
             rollout_audio = diffusion_output[1] if len(diffusion_output) > 1 else None
             diffusion_output = diffusion_output[0]
+            if io_spec is not None:
+                audio_spec = next((spec for spec in io_spec.auxiliary if spec.modality == "audio"), None)
+                if audio_spec is not None:
+                    audio_sample_rate = audio_spec.sample_rate
         if output_type == "latent":
             diffusion_output = torch.as_tensor(diffusion_output).float()
         else:
@@ -251,7 +275,11 @@ class DiffusionStrategy(OmniStrategyBase):
                 extra_fields[key] = _maybe_unbatch(value)
         if rollout_audio is not None:
             extra_fields["audio"] = _maybe_unbatch(rollout_audio)
-            extra_fields.setdefault("audio_sample_rate", 32000)
+            # The audio sample rate is declared by the adapter's DiffusionIOSpec
+            # (or provided at runtime through rollout metadata); no model-specific
+            # default lives in this shared strategy.
+            if audio_sample_rate is not None:
+                extra_fields.setdefault("audio_sample_rate", audio_sample_rate)
 
         req_output = getattr(final_res, "request_output", None) or final_res
         if hasattr(req_output, "outputs") and req_output.outputs:


### PR DESCRIPTION
## Summary

Part of the [#403 RFC](https://github.com/verl-project/verl-omni/issues/403), stacked on the merged PR1 generation-strategy split (#444). This is **PR2 — the typed diffusion output vertical slice**.

It moves the model-specific joint video/audio conventions out of the shared diffusion rollout strategy and into **adapter-owned declarations**, and makes **every** diffusion pipeline declare the modality it produces.

- Before: `DiffusionStrategy.process_output` hard-coded "audio lives at tuple position 1" **and** `extra_fields.setdefault("audio_sample_rate", 32000)` — a MiniMax-specific constant in shared code. Consumers infer image-vs-video from tensor rank (`is_video = outputs.ndim == 5`).
- After: adapters declare a `DiffusionIOSpec`; the strategy resolves the active pipeline's spec and takes the audio sample rate from it (or from runtime rollout metadata). **The 32 kHz literal is gone from the strategy.**

### Changes
- **New** `verl_omni/pipelines/rollout_media.py`: `MediaSpec` + `DiffusionIOSpec` (CPU-importable typed contracts).
- **Every registered diffusion pipeline declares `diffusion_io_spec`:**
  - `primary=image`: BAGEL, Boogu-Image, Qwen-Image (`flow_grpo`/`diffusion_nft`/`dpo`/`edit`; `dual_grpo`/`mix_grpo` inherit), SD3.
  - `primary=video`: Wan2.2 (single video).
  - `primary=video` + auxiliary `audio`: MiniMax H3 (`flow_grpo` 32000, `diffusion_nft` 32000), LTX-2 (24000; runtime vocoder rate takes precedence).
- `vllm_omni_diffusion_strategy.py`: `_diffusion_io_spec()` resolves the adapter-declared spec; audio sample rate is spec-driven; the model-specific 32 kHz default is removed.
- CPU characterization + completeness tests.

### Exit criterion (met)
Adding another combination of existing output modalities now changes an **adapter and its tests**, not the server or the strategy.

### Deferred (not in this PR)
- Typed `DiffusionOutput.primary/auxiliary` fields + `MediaOutput` container → a later PR, once a consumer exists (avoids landing unused code).
- Consumer migration to read the declared modality (and dropping `ndim == 5` inference in `ray_diffusion_trainer.py`) → PR4.
- Request-side `ImageGenerationRequest` generalization → PR3.

## Not a duplicate
Step 0 duplicate-work checks against `verl-project/verl-omni`:
- `gh pr list --search "DiffusionIOSpec in:body OR MediaSpec in:body"` → none.
- `gh pr list --search "diffusion media output"` → only #314 (adds a LingBot T2V pipeline; unrelated to this refactor).
- `gh pr list --search "403 in:body"` → no other open PR references #403.

## Tests
Pin-exact env (verl `fefb080`, vllm-omni `444485650`) with `TORCH_COMPILE_DISABLE=1 TORCHINDUCTOR_DISABLE=1 FLASHINFER_DISABLE_VERSION_CHECK=1`:

```
pytest $(find tests/pipelines tests/workers/rollout -name '*_on_cpu.py')
# 313 passed
```

New/updated tests:
- `test_diffusion_io_spec_on_cpu.py` — every registered pipeline declares the expected primary modality; joint pipelines declare an audio stream with the expected sample rate (32000 MiniMax, 24000 LTX-2).
- `test_diffusion_strategy_uses_declared_audio_sample_rate` — spec drives a distinctive 48000 (proves the mechanism, not the old default).
- `test_diffusion_strategy_omits_audio_sample_rate_without_declared_spec` — no spec ⇒ audio surfaced, no model-specific rate.
- `test_minimax_h3_rollout_contract_on_cpu` / `test_minimax_h3_flow_grpo_on_cpu` — updated to resolve 32000 from the real adapter spec.

Sanity: `ruff check` / `ruff format --check` clean on all touched files; `check_device_api_usage.py` exit 0 on `verl_omni/pipelines` and `verl_omni/workers/rollout`; `git diff --cached --check` clean; `check_pr_title.py` accepts the title.

> GPU smoke is not re-run here: this PR does not touch the sampling loop or the engine boundary. The joint-media envelope was already validated end-to-end on GPU for MiniMax H3 (T2VA) in PR1.

## Disclosure
AI assistance (Pi coding agent / OpenAI Codex) was used for this change. A human submitter has reviewed every changed line.
