### PR TITLE
[rollout] feat: prototype train-side diffusers SDE sampler

### DIFF
--- a/tests/workers/rollout/test_diffusers_train_rollout_on_cpu.py
+++ b/tests/workers/rollout/test_diffusers_train_rollout_on_cpu.py
@@ -1,0 +1,325 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU parity test for the train-side diffusers rollouter prototype.
+
+Validates ``sde_denoise_loop`` against an independently-written reference
+loop that batches CFG the way production SD3 pipelines actually do (a single
+concatenated forward instead of two separate forwards). Same
+``FlowMatchSDEDiscreteScheduler``, same tiny offline SD3 checkpoint (see
+``tests/special_e2e/build_sd3_tiny_random.py``), same seeds.
+
+This is the CPU-runnable, CI-wired counterpart of the GPU parity check
+posted as a comment on the PR that adds this file (a real T4 GPU run on
+Modal). float32 throughout, since fp16 on CPU is not well supported by all
+of the ops this loop touches and isn't the point of this test -- the fp16
+run on GPU covers that regime separately.
+"""
+
+import os
+import sys
+import types
+
+import pytest
+import torch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "special_e2e"))
+
+diffusers = pytest.importorskip("diffusers")
+
+
+def _stub_heavy_parent_packages() -> None:
+    """Let ``verl_omni.workers.rollout.diffusers_train_rollout`` import without
+    the full install (``verl``, ``vllm_omni``) this module doesn't need.
+
+    ``verl_omni/__init__.py`` and ``verl_omni/workers/rollout/__init__.py``
+    eagerly import ``verl``-dependent submodules at package-import time (see
+    ``tests/utils/test_stable_diffusion_3_flops_on_cpu.py``-style PRs for the
+    same pre-existing environment limitation, unrelated to this change).
+    Pre-registering empty namespace packages -- pointed at the real source
+    tree via ``__path__`` -- skips only those heavy ``__init__``s while still
+    resolving submodule imports (this file, and
+    ``verl_omni.pipelines.schedulers``) to the real, unmodified source.
+    """
+    repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+    for dotted_path in (
+        "verl_omni",
+        "verl_omni.pipelines",
+        "verl_omni.workers",
+        "verl_omni.workers.rollout",
+    ):
+        if dotted_path in sys.modules:
+            continue
+        module = types.ModuleType(dotted_path)
+        module.__path__ = [os.path.join(repo_root, *dotted_path.split("."))]
+        sys.modules[dotted_path] = module
+
+
+_stub_heavy_parent_packages()
+
+
+def _build_pipeline_and_scheduler():
+    import build_sd3_tiny_random
+    from diffusers import StableDiffusion3Pipeline
+
+    from verl_omni.pipelines.schedulers import FlowMatchSDEDiscreteScheduler
+
+    # The repo's helper assumes a T5Tokenizer(vocab=...) API from a
+    # transformers version/fork not pinned by this test; substitute a real
+    # sentencepiece-backed T5Tokenizer trained on the same tiny corpus.
+    def _real_t5_tokenizer(*, vocab_size: int = 32, model_max_length: int = 512):
+        import tempfile
+
+        import sentencepiece as spm
+        from transformers import T5Tokenizer
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            corpus_path = os.path.join(tmp_dir, "corpus.txt")
+            with open(corpus_path, "w") as f:
+                f.write("a red circle on a white background\n")
+                f.write("a blue square on a black background\n")
+                f.write("a green triangle next to an orange rectangle\n")
+            model_prefix = os.path.join(tmp_dir, "spm")
+            spm.SentencePieceTrainer.train(
+                input=corpus_path,
+                model_prefix=model_prefix,
+                vocab_size=vocab_size,
+                model_type="unigram",
+                pad_id=0,
+                unk_id=2,
+                eos_id=1,
+                bos_id=-1,
+                pad_piece="<pad>",
+                unk_piece="<unk>",
+                eos_piece="</s>",
+            )
+            return T5Tokenizer(vocab_file=model_prefix + ".model", model_max_length=model_max_length)
+
+    build_sd3_tiny_random._build_tiny_t5_tokenizer = _real_t5_tokenizer
+
+    components = build_sd3_tiny_random.get_dummy_sd3_components(hidden_size=8, seed=42)
+    components.pop("image_encoder", None)
+    components.pop("feature_extractor", None)
+    pipe = StableDiffusion3Pipeline(**components).to(dtype=torch.float32)
+    pipe.transformer.eval()
+    pipe.set_progress_bar_config(disable=True)
+
+    scheduler = FlowMatchSDEDiscreteScheduler.from_config(pipe.scheduler.config)
+    return pipe, scheduler
+
+
+@pytest.mark.parametrize("do_cfg", [True, False])
+def test_sde_denoise_loop_matches_concatenated_cfg_reference(do_cfg: bool) -> None:
+    from verl_omni.workers.rollout.diffusers_train_rollout import sde_denoise_loop
+
+    pipe, base_scheduler = _build_pipeline_and_scheduler()
+    device = "cpu"
+    dtype = torch.float32
+
+    prompt = ["a red circle on a white background"]
+    negative_prompt = [""]
+    (
+        prompt_embeds,
+        negative_prompt_embeds,
+        pooled_prompt_embeds,
+        negative_pooled_prompt_embeds,
+    ) = pipe.encode_prompt(
+        prompt=prompt,
+        prompt_2=prompt,
+        prompt_3=prompt,
+        negative_prompt=negative_prompt,
+        negative_prompt_2=negative_prompt,
+        negative_prompt_3=negative_prompt,
+        do_classifier_free_guidance=True,
+        device=device,
+        num_images_per_prompt=1,
+        max_sequence_length=32,
+    )
+
+    num_channels = pipe.transformer.config.in_channels
+    latent_h = latent_w = pipe.default_sample_size
+    latent_shape = (1, num_channels, latent_h, latent_w)
+
+    num_inference_steps = 4
+    guidance_scale = 3.5
+    noise_level = 0.7
+    sde_window_range = (0, num_inference_steps)
+
+    def fresh_scheduler():
+        from verl_omni.pipelines.schedulers import FlowMatchSDEDiscreteScheduler
+
+        s = FlowMatchSDEDiscreteScheduler.from_config(pipe.scheduler.config)
+        s.set_timesteps(num_inference_steps, device=device)
+        return s
+
+    scheduler = fresh_scheduler()
+    timesteps = scheduler.timesteps
+
+    def make_initial_latents(seed: int) -> torch.Tensor:
+        g = torch.Generator(device=device).manual_seed(seed)
+        return torch.randn(latent_shape, generator=g, device=device, dtype=torch.float32)
+
+    latents_seed, sde_seed = 1234, 5678
+
+    result = sde_denoise_loop(
+        pipe.transformer,
+        fresh_scheduler(),
+        prompt_embeds=prompt_embeds,
+        pooled_prompt_embeds=pooled_prompt_embeds,
+        negative_prompt_embeds=negative_prompt_embeds if do_cfg else None,
+        negative_pooled_prompt_embeds=negative_pooled_prompt_embeds if do_cfg else None,
+        latents=make_initial_latents(latents_seed),
+        timesteps=timesteps,
+        do_cfg=do_cfg,
+        guidance_scale=guidance_scale,
+        noise_level=noise_level,
+        sde_window_range=sde_window_range,
+        sde_type="sde",
+        generator=torch.Generator(device=device).manual_seed(sde_seed),
+        logprobs=True,
+        model_dtype=dtype,
+    )
+
+    @torch.no_grad()
+    def reference_loop(latents: torch.Tensor, scheduler, generator: torch.Generator):
+        all_latents = [latents.detach().float().clone()]
+        all_log_probs = []
+        for t in timesteps:
+            if do_cfg:
+                latent_in = torch.cat([latents, latents], dim=0)
+                timestep_in = t.expand(latent_in.shape[0]).to(device=device, dtype=dtype)
+                embeds_in = torch.cat([negative_prompt_embeds, prompt_embeds], dim=0)
+                pooled_in = torch.cat([negative_pooled_prompt_embeds, pooled_prompt_embeds], dim=0)
+            else:
+                latent_in = latents
+                timestep_in = t.expand(latent_in.shape[0]).to(device=device, dtype=dtype)
+                embeds_in = prompt_embeds
+                pooled_in = pooled_prompt_embeds
+
+            noise_pred = pipe.transformer(
+                hidden_states=latent_in,
+                timestep=timestep_in,
+                encoder_hidden_states=embeds_in,
+                pooled_projections=pooled_in,
+                return_dict=False,
+            )[0]
+            if do_cfg:
+                noise_uncond, noise_cond = noise_pred.chunk(2)
+                noise_pred = noise_uncond + guidance_scale * (noise_cond - noise_uncond)
+
+            latents, log_prob, _, _ = scheduler.step(
+                noise_pred.float(),
+                t,
+                latents,
+                generator=generator,
+                noise_level=noise_level,
+                sde_type="sde",
+                return_logprobs=True,
+                return_dict=False,
+            )
+            all_latents.append(latents.detach().float().clone())
+            all_log_probs.append(log_prob)
+        return latents, torch.stack(all_latents, dim=0), torch.stack(all_log_probs, dim=0)
+
+    final_ref, all_latents_ref, all_log_probs_ref = reference_loop(
+        make_initial_latents(latents_seed),
+        fresh_scheduler(),
+        torch.Generator(device=device).manual_seed(sde_seed),
+    )
+
+    # float32: the two CFG-batching strategies should agree near machine precision.
+    torch.testing.assert_close(result.all_latents, all_latents_ref, atol=1e-4, rtol=1e-4)
+    torch.testing.assert_close(result.final_latents, final_ref, atol=1e-4, rtol=1e-4)
+    torch.testing.assert_close(result.log_probs, all_log_probs_ref, atol=1e-5, rtol=1e-5)
+    assert torch.isfinite(result.final_latents).all()
+
+
+def test_do_cfg_changes_output() -> None:
+    """Guard against a no-op test: CFG must actually change the sampled trajectory."""
+    from verl_omni.workers.rollout.diffusers_train_rollout import sde_denoise_loop
+
+    pipe, _ = _build_pipeline_and_scheduler()
+    device = "cpu"
+    dtype = torch.float32
+
+    prompt = ["a red circle on a white background"]
+    (
+        prompt_embeds,
+        negative_prompt_embeds,
+        pooled_prompt_embeds,
+        negative_pooled_prompt_embeds,
+    ) = pipe.encode_prompt(
+        prompt=prompt,
+        prompt_2=prompt,
+        prompt_3=prompt,
+        negative_prompt=[""],
+        negative_prompt_2=[""],
+        negative_prompt_3=[""],
+        do_classifier_free_guidance=True,
+        device=device,
+        num_images_per_prompt=1,
+        max_sequence_length=32,
+    )
+
+    num_channels = pipe.transformer.config.in_channels
+    latent_h = latent_w = pipe.default_sample_size
+    latent_shape = (1, num_channels, latent_h, latent_w)
+    num_inference_steps = 4
+
+    def fresh_scheduler():
+        from verl_omni.pipelines.schedulers import FlowMatchSDEDiscreteScheduler
+
+        s = FlowMatchSDEDiscreteScheduler.from_config(pipe.scheduler.config)
+        s.set_timesteps(num_inference_steps, device=device)
+        return s
+
+    timesteps = fresh_scheduler().timesteps
+
+    def make_latents():
+        g = torch.Generator(device=device).manual_seed(1234)
+        return torch.randn(latent_shape, generator=g, device=device, dtype=torch.float32)
+
+    common_kwargs = dict(
+        prompt_embeds=prompt_embeds,
+        pooled_prompt_embeds=pooled_prompt_embeds,
+        latents=make_latents(),
+        timesteps=timesteps,
+        guidance_scale=3.5,
+        noise_level=0.7,
+        sde_window_range=(0, num_inference_steps),
+        sde_type="sde",
+        model_dtype=dtype,
+    )
+
+    result_cfg = sde_denoise_loop(
+        pipe.transformer,
+        fresh_scheduler(),
+        negative_prompt_embeds=negative_prompt_embeds,
+        negative_pooled_prompt_embeds=negative_pooled_prompt_embeds,
+        do_cfg=True,
+        generator=torch.Generator(device=device).manual_seed(5678),
+        logprobs=True,
+        **common_kwargs,
+    )
+    result_no_cfg = sde_denoise_loop(
+        pipe.transformer,
+        fresh_scheduler(),
+        negative_prompt_embeds=None,
+        negative_pooled_prompt_embeds=None,
+        do_cfg=False,
+        generator=torch.Generator(device=device).manual_seed(5678),
+        logprobs=True,
+        **common_kwargs,
+    )
+
+    assert (result_cfg.final_latents - result_no_cfg.final_latents).abs().max().item() > 1e-4

--- a/verl_omni/workers/rollout/diffusers_train_rollout.py
+++ b/verl_omni/workers/rollout/diffusers_train_rollout.py
@@ -1,0 +1,190 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Train-side diffusers rollouter.
+
+Prototype for the Q3 roadmap item "Support diffusers rollouter ... via
+train-side engine" (verl-project/verl-omni#97). Runs the SDE denoising loop
+directly against the training FSDP transformer, in-process, with no
+vLLM-Omni server/engine involved.
+
+Scope note: this module intentionally covers only the sampling core shared
+by every SD3-family rollout adapter (``StableDiffusion3PipelineWithLogProb``
+in ``verl_omni.pipelines.sd3_flow_grpo``) -- the fixed-window SDE loop over
+``FlowMatchSDEDiscreteScheduler``. It is a numerically-verified building
+block, not a drop-in ``AsyncRollout`` implementation: request batching,
+async server plumbing, and rollout config schema wiring are follow-up work
+once the sampling core itself is trusted. Do not register this in
+``_ROLLOUT_REGISTRY`` until that wiring exists -- an incomplete registry
+entry would silently break rollout backend selection for every other model.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+import torch
+
+from verl_omni.pipelines.schedulers import FlowMatchSDEDiscreteScheduler
+
+
+@dataclass
+class TrainSideDiffusionOutput:
+    """Trajectory data produced by :func:`sde_denoise_loop`.
+
+    Field names mirror ``verl_omni.workers.rollout.replica.DiffusionOutput``'s
+    ``extra_fields`` (``all_latents`` / ``all_timesteps``) and ``log_probs`` so
+    downstream FlowGRPO log-prob recomputation code needs no branching on
+    which rollout backend produced the trajectory.
+    """
+
+    final_latents: torch.Tensor
+    all_latents: torch.Tensor
+    all_timesteps: torch.Tensor
+    log_probs: torch.Tensor | None = None
+    extra_fields: dict[str, Any] = field(default_factory=dict)
+
+
+def predict_noise_with_cfg(
+    transformer: torch.nn.Module,
+    *,
+    hidden_states: torch.Tensor,
+    timestep: torch.Tensor,
+    encoder_hidden_states: torch.Tensor,
+    pooled_projections: torch.Tensor,
+    do_cfg: bool,
+    guidance_scale: float,
+    negative_encoder_hidden_states: torch.Tensor | None = None,
+    negative_pooled_projections: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Run the transformer once (or twice, for CFG) and combine the noise predictions.
+
+    Matches the plain SD3 guidance formula used by
+    ``StableDiffusion3PipelineWithLogProb.predict_noise_maybe_with_cfg``:
+    ``uncond + guidance_scale * (cond - uncond)``.
+    """
+    noise_pred_cond = transformer(
+        hidden_states=hidden_states,
+        timestep=timestep,
+        encoder_hidden_states=encoder_hidden_states,
+        pooled_projections=pooled_projections,
+        return_dict=False,
+    )[0]
+    if not do_cfg:
+        return noise_pred_cond
+
+    if negative_encoder_hidden_states is None or negative_pooled_projections is None:
+        raise ValueError("do_cfg=True requires negative_encoder_hidden_states/negative_pooled_projections.")
+
+    noise_pred_uncond = transformer(
+        hidden_states=hidden_states,
+        timestep=timestep,
+        encoder_hidden_states=negative_encoder_hidden_states,
+        pooled_projections=negative_pooled_projections,
+        return_dict=False,
+    )[0]
+    return noise_pred_uncond + guidance_scale * (noise_pred_cond - noise_pred_uncond)
+
+
+@torch.no_grad()
+def sde_denoise_loop(
+    transformer: torch.nn.Module,
+    scheduler: FlowMatchSDEDiscreteScheduler,
+    *,
+    prompt_embeds: torch.Tensor,
+    pooled_prompt_embeds: torch.Tensor,
+    negative_prompt_embeds: torch.Tensor | None,
+    negative_pooled_prompt_embeds: torch.Tensor | None,
+    latents: torch.Tensor,
+    timesteps: torch.Tensor,
+    do_cfg: bool,
+    guidance_scale: float,
+    noise_level: float,
+    sde_window_range: tuple[int, int],
+    sde_type: Literal["sde", "cps", "dance_sde"] = "sde",
+    generator: torch.Generator | None = None,
+    logprobs: bool = True,
+    model_dtype: torch.dtype | None = None,
+) -> TrainSideDiffusionOutput:
+    """Run the full SDE diffusion loop directly against ``transformer``.
+
+    This is a device/engine-agnostic port of
+    ``StableDiffusion3PipelineWithLogProb.diffuse`` (see
+    ``verl_omni/pipelines/sd3_flow_grpo/vllm_omni_rollout_adapter.py``): same
+    scheduler class, same per-step SDE-window bookkeeping, same trajectory
+    fields. ``transformer`` may be a plain ``nn.Module`` or an FSDP-wrapped
+    training module -- both expose the same ``SD3Transformer2DModel.forward``
+    signature, so the loop body is identical either way.
+    """
+    batch_size = latents.shape[0]
+    start, end = sde_window_range
+    if not (0 <= start < end <= len(timesteps)):
+        raise ValueError(f"sde_window_range {sde_window_range} out of bounds for {len(timesteps)} timesteps.")
+
+    model_dtype = model_dtype if model_dtype is not None else prompt_embeds.dtype
+    device = latents.device
+
+    all_latents: list[torch.Tensor] = []
+    all_log_probs: list[torch.Tensor] = []
+    all_timesteps: list[torch.Tensor] = []
+
+    scheduler.set_begin_index(0)
+
+    for i, timestep_value in enumerate(timesteps):
+        if i == start:
+            all_latents.append(latents.detach().float().clone())
+
+        cur_noise_level = float(noise_level) if start <= i < end else 0.0
+        timestep = timestep_value.expand(batch_size).to(device=device, dtype=model_dtype)
+        x = latents.to(model_dtype)
+
+        noise_pred = predict_noise_with_cfg(
+            transformer,
+            hidden_states=x,
+            timestep=timestep,
+            encoder_hidden_states=prompt_embeds,
+            pooled_projections=pooled_prompt_embeds,
+            do_cfg=do_cfg,
+            guidance_scale=guidance_scale,
+            negative_encoder_hidden_states=negative_prompt_embeds,
+            negative_pooled_projections=negative_pooled_prompt_embeds,
+        )
+
+        latents, log_prob, _, _ = scheduler.step(
+            noise_pred.float(),
+            timestep_value,
+            latents,
+            generator=generator,
+            noise_level=cur_noise_level,
+            sde_type=sde_type,
+            return_logprobs=logprobs,
+            return_dict=False,
+        )
+
+        if start <= i < end:
+            all_latents.append(latents.detach().float().clone())
+            all_timesteps.append(timestep_value)
+            if log_prob is not None:
+                all_log_probs.append(log_prob)
+
+    all_latents_t = torch.stack(all_latents, dim=0)
+    all_timesteps_t = torch.stack(all_timesteps, dim=0) if all_timesteps else torch.empty(0)
+    all_log_probs_t = torch.stack(all_log_probs, dim=0) if all_log_probs else None
+
+    return TrainSideDiffusionOutput(
+        final_latents=latents,
+        all_latents=all_latents_t,
+        all_timesteps=all_timesteps_t,
+        log_probs=all_log_probs_t,
+    )

--- a/verl_omni/workers/rollout/diffusers_train_rollout.py
+++ b/verl_omni/workers/rollout/diffusers_train_rollout.py
@@ -27,6 +27,23 @@ async server plumbing, and rollout config schema wiring are follow-up work
 once the sampling core itself is trusted. Do not register this in
 ``_ROLLOUT_REGISTRY`` until that wiring exists -- an incomplete registry
 entry would silently break rollout backend selection for every other model.
+
+Why a separate train-side path at all, instead of routing everything
+through vLLM-Omni: #97 also names an already-merged alternative, vLLM-Omni's
+generic ``DiffusersAdapterPipeline`` (``--diffusion-load-format diffusers``,
+vllm-project/vllm-omni#2724). That adapter is a black-box wrapper around
+any diffusers pipeline's own ``__call__()`` -- it works today, but by design
+exposes none of the per-step trajectory data (latents, timesteps, log-probs)
+that FlowGRPO-style RL training needs, and explicitly does not support CFG
+parallel, sequence parallel, or step-wise/continuous batching. Calling the
+transformer directly, as this module does, is what makes the SDE-window
+bookkeeping and log-prob collection in ``sde_denoise_loop`` possible in the
+first place; a black-box adapter has no hook for either. Once wired up,
+this path is meant to sit alongside the vLLM-Omni rollout as another
+``_ROLLOUT_REGISTRY`` backend for models/algorithms that need in-process
+sampling (e.g. no vLLM-Omni rollout adapter exists yet, or the trajectory
+data must come from the exact weights currently being trained rather than a
+periodically-synced inference copy) -- not a replacement for it.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
### What does this PR do?

Prototype for the Q3 roadmap item "Support diffusers rollouter ... via train-side engine" (#97).

Adds `verl_omni/workers/rollout/diffusers_train_rollout.py::sde_denoise_loop`, a device/engine-agnostic port of the SD3 FlowGRPO rollout adapter's SDE denoising loop (`FlowMatchSDEDiscreteScheduler`) that runs directly against the training transformer in-process, with no vLLM-Omni server involved.

Scope note: this covers only the sampling core shared by the SD3-family rollout adapters -- not a drop-in `AsyncRollout` implementation. Request batching, async server plumbing, and rollout config schema wiring are left as follow-up once the sampling core itself is trusted, so it is intentionally **not** registered in `_ROLLOUT_REGISTRY` yet.

## Duplicate-work check

- `gh pr list --repo verl-project/verl-omni --state all --search "train-side rollout"` -- no other PR (open, merged, or closed) targets this roadmap item.
- `gh pr list --repo verl-project/verl-omni --state all --search "diffusers rollout"` -- no overlap; matches are unrelated diffusion-rollout work (attention backends, video export, MiniMax H3, etc.).
- Issue #97 (the Q3 roadmap tracking issue) has no assignee or prior claim comment on this specific line item.

## Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl-omni/pulls?q=train-side+rollout
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)

### Test

CPU unit tests (new, wired into CI via `tests/**/*_on_cpu.py` auto-discovery): `tests/workers/rollout/test_diffusers_train_rollout_on_cpu.py`. float32, tiny offline SD3 checkpoint (random weights, built the same way as `tests/special_e2e/build_sd3_tiny_random.py`). Validates `sde_denoise_loop` against an independently-written reference loop that batches CFG the way production SD3 pipelines actually do (single concatenated forward instead of two separate forwards), for both `do_cfg=True` and `do_cfg=False`, plus a sanity check that CFG actually changes the output.

Run locally (Python 3.12, CPU-only venv: `torch==2.4.0 diffusers==0.31.0 transformers==4.46.0`), with `verl_omni`'s and `verl_omni.workers.rollout`'s package-init eagerly importing `verl`/`vllm_omni` stubbed out the same way prior CPU-test PRs have worked around this pre-existing, unrelated environment limitation:

```
$ python3 -m pytest -v tests/workers/rollout/test_diffusers_train_rollout_on_cpu.py
tests/workers/rollout/test_diffusers_train_rollout_on_cpu.py::test_sde_denoise_loop_matches_concatenated_cfg_reference[True] PASSED
tests/workers/rollout/test_diffusers_train_rollout_on_cpu.py::test_sde_denoise_loop_matches_concatenated_cfg_reference[False] PASSED
tests/workers/rollout/test_diffusers_train_rollout_on_cpu.py::test_do_cfg_changes_output PASSED
3 passed in 3.92s
```

**GPU run (Modal, T4, fp16)**: see comment below with the parity-test results against the same reference-loop methodology at fp16 on real GPU hardware.

**vLLM-Omni diffusers-backend adapter cross-check**: see the other comment below -- separately verified the merged upstream `DiffusersAdapterPipeline` alternative also works end to end against the same tiny checkpoint, for context on the two options named in #97.

## API and Usage Example

`sde_denoise_loop` is a plain function, not yet wired into any config-driven entrypoint (see scope note above). Direct usage:

```python
from verl_omni.workers.rollout.diffusers_train_rollout import sde_denoise_loop

result = sde_denoise_loop(
    transformer,             # plain nn.Module or FSDP-wrapped SD3Transformer2DModel
    scheduler,               # a fresh FlowMatchSDEDiscreteScheduler, timesteps already set
    prompt_embeds=prompt_embeds,
    pooled_prompt_embeds=pooled_prompt_embeds,
    negative_prompt_embeds=negative_prompt_embeds,       # None to skip CFG
    negative_pooled_prompt_embeds=negative_pooled_prompt_embeds,
    latents=initial_latents,
    timesteps=scheduler.timesteps,
    do_cfg=True,
    guidance_scale=3.5,
    noise_level=0.7,
    sde_window_range=(0, num_inference_steps),
    sde_type="sde",
    generator=torch.Generator(device=device).manual_seed(seed),
    logprobs=True,
)
# result.final_latents, result.all_latents, result.all_timesteps, result.log_probs
```

`TrainSideDiffusionOutput`'s field names (`all_latents` / `all_timesteps` / `log_probs`) intentionally mirror `DiffusionOutput.extra_fields` from the existing vLLM-Omni rollout path, so downstream FlowGRPO log-prob recomputation code needs no branching on which backend produced the trajectory.

## Design & Code Changes

- `predict_noise_with_cfg`: runs the transformer once (no CFG) or twice with two separate forwards (CFG) and combines via the standard `uncond + guidance_scale * (cond - uncond)` formula. Verified equivalent to the single-concatenated-batch forward real SD3 pipelines use (see the parity tests) -- two separate forwards is simpler to read and doesn't require batch-dim bookkeeping, at the cost of one extra kernel-launch round trip per step.
- `sde_denoise_loop`: line-for-line structurally matches `StableDiffusion3PipelineWithLogProb.diffuse` (`verl_omni/pipelines/sd3_flow_grpo/vllm_omni_rollout_adapter.py`) so the two stay easy to diff against each other as either evolves, but takes plain tensors instead of `OmniDiffusionRequest`/`DiffusionRequestBatch` -- there is no request/batch abstraction on the train side to translate through.
- Deliberately not registered in `_ROLLOUT_REGISTRY` (see module docstring) until request batching, async server plumbing, and config schema wiring exist -- an incomplete registry entry would silently break rollout backend selection for every other model.

## Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`. All hooks pass except `autogen-trainer-cfg`, which fails on `ModuleNotFoundError: No module named 'omegaconf'` in this local env -- a pre-existing, unrelated environment gap (this PR touches no config files); confirmed the same failure exists on `main` before this diff.
- [x] Add / Update the documentation. Added a module-docstring paragraph explaining why this path exists separately from vLLM-Omni's merged `DiffusersAdapterPipeline` black-box adapter (see Design & Code Changes) -- there is no other user-facing doc surface yet since this prototype has no config-driven entrypoint.
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl-omni/tree/main/.github/workflows) to cover all the code. `tests/workers/rollout/test_diffusers_train_rollout_on_cpu.py` is auto-discovered by `cpu_unit_tests.yml`'s `tests/**/*_on_cpu.py` pattern.

- [x] AI assistance (Claude Code) was used for this change.
- [x] A human submitter (onepunchmonk) has reviewed every changed line.