### PR TITLE
[4/N][diffusion, rollout, trainer, tests] refactor: consume declared media kind

### DIFF
--- a/docs/contributing/integrating_a_diffusion_model.md
+++ b/docs/contributing/integrating_a_diffusion_model.md
@@ -442,9 +442,10 @@ by 255 again before PIL, JPEG, or HTTP serialization.
 Set a `diffusion_io_spec` class attribute on the registered pipeline so the
 shared `DiffusionStrategy` knows what media your `forward` emits. The strategy
 reads it (via `VllmOmniPipelineBase.get_class(architecture, algorithm)`) when it
-converts the raw pipeline output into the rollout response, so model-specific
-conventions — which tuple position carries audio, what audio sample rate to
-attach — live in the adapter instead of being hardcoded in the shared strategy.
+converts the raw pipeline output into the rollout response. The primary modality
+and default audio sample rate come from the adapter.
+The current transport supports a single primary output or a `(visual, audio)`
+tuple; it does not support arbitrary auxiliary streams.
 
 ```python
 from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
@@ -457,9 +458,10 @@ class MyModelPipelineWithLogProb(MyModelPipeline):
 
 - **`primary`** — the main media stream (`MediaSpec("image")` or
   `MediaSpec("video")`), carried in `responses`.
-- **`auxiliary`** — additional streams in tuple order: `auxiliary[i]` maps to
-  output tuple position `i + 1` (position `0` is the primary). A `forward` that
-  returns `(video, audio)` declares one auxiliary audio stream:
+- **`auxiliary`** — either empty or one audio stream at tuple position `1`
+  (position `0` is the primary visual output). Other auxiliary declarations and
+  extra tuple elements are rejected, not silently discarded. A `forward` that
+  returns `(video, audio)` declares:
 
 ```python
     diffusion_io_spec = DiffusionIOSpec(
@@ -472,8 +474,10 @@ class MyModelPipelineWithLogProb(MyModelPipeline):
   `forward` attaches a runtime rate through the `rl` rollout metadata, that value
   takes precedence and the strategy only falls back to this default. Declare the
   rate your model actually decodes (MiniMax H3 → `32000`, LTX-2 → `24000`).
-- `MediaSpec.fps` is an optional video default; `Modality` is
-  `image | video | audio`.
+- `MediaSpec.fps` is an optional declaration; current exporters still use
+  `trainer.video_fps`, not this field. `Modality` is `image | video | audio`.
+- The strategy propagates the primary modality as `media_kind`. Runtime metadata
+  may repeat the same value, but a conflicting modality raises an error.
 - Subclasses inherit the attribute, so a pipeline that subclasses another adapter
   (e.g. `qwen_image_dual_grpo` extends `qwen_image_flow_grpo`) reuses its
   `diffusion_io_spec` unless it overrides it.

--- a/tests/agent_loop/test_diffusion_agent_loop_correctness_on_cpu.py
+++ b/tests/agent_loop/test_diffusion_agent_loop_correctness_on_cpu.py
@@ -212,6 +212,9 @@ async def test_tq_writer_preserves_allowlisted_non_tensor_trajectory_metadata(mo
         num_turns=2,
         extra_fields={
             "condition_image_latents": torch.zeros(1, 4096, 64),
+            "audio": torch.zeros(1, 1, 16),
+            "audio_sample_rate": 32_000,
+            "media_kind": "video",
             "img_shapes": img_shapes,
             "unrelated_metadata": "do-not-forward",
         },
@@ -233,9 +236,16 @@ async def test_tq_writer_preserves_allowlisted_non_tensor_trajectory_metadata(mo
     )
 
     field = captured["fields"][0]
-    assert field["extra_fields"]["img_shapes"] == img_shapes
+    assert field["extra_fields"] == {
+        "img_shapes": img_shapes,
+        "media_kind": "video",
+        "audio_sample_rate": 32_000,
+        "min_global_steps": 3,
+        "max_global_steps": 3,
+    }
     assert "unrelated_metadata" not in field["extra_fields"]
     assert field["condition_image_latents"].shape == (4096, 64)
+    assert field["audio"].shape == (1, 16)
 
 
 def test_tq_batch_restores_non_tensor_trajectory_metadata(monkeypatch):
@@ -249,7 +259,10 @@ def test_tq_batch_restores_non_tensor_trajectory_metadata(monkeypatch):
         "kv_batch_get",
         lambda **kwargs: {
             "all_latents": torch.zeros(2, 4, 1024, 64),
-            "extra_fields": [{"img_shapes": value} for value in img_shapes],
+            "extra_fields": [
+                {"img_shapes": img_shapes[0], "media_kind": "video", "audio_sample_rate": 32_000},
+                {"img_shapes": img_shapes[1]},
+            ],
         },
     )
 
@@ -258,6 +271,8 @@ def test_tq_batch_restores_non_tensor_trajectory_metadata(monkeypatch):
     )
 
     assert data.non_tensor_batch["img_shapes"].tolist() == img_shapes
+    assert data.non_tensor_batch["media_kind"].tolist() == ["video", None]
+    assert data.non_tensor_batch["audio_sample_rate"].tolist() == [32_000, None]
     assert tu.get(data.to_tensordict(), "img_shapes") == img_shapes
 
 

--- a/tests/pipelines/test_diffusion_io_spec_on_cpu.py
+++ b/tests/pipelines/test_diffusion_io_spec_on_cpu.py
@@ -22,6 +22,7 @@ import pytest
 
 pytest.importorskip("verl_omni.pipelines.model_base")
 from verl_omni.pipelines.model_base import VllmOmniPipelineBase
+from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
 
 # (adapter module, architecture, algorithm, primary modality)
 _PRIMARY_MODALITY = [
@@ -72,6 +73,19 @@ _JOINT_AUDIO_SAMPLE_RATE = [
     ),
     ("verl_omni.pipelines.ltx2_flow_grpo.vllm_omni_rollout_adapter", "LTX2Pipeline", "flow_grpo", 24000),
 ]
+
+
+@pytest.mark.parametrize(
+    "auxiliary",
+    [
+        (MediaSpec("image"),),
+        (MediaSpec("image"), MediaSpec("audio", sample_rate=48000)),
+        (MediaSpec("audio"), MediaSpec("audio")),
+    ],
+)
+def test_unsupported_auxiliary_declarations_are_rejected(auxiliary):
+    with pytest.raises(ValueError, match="at most one auxiliary audio stream"):
+        DiffusionIOSpec(primary=MediaSpec("video"), auxiliary=auxiliary)
 
 
 @pytest.mark.parametrize(("module", "architecture", "algorithm", "modality"), _PRIMARY_MODALITY)

--- a/tests/pipelines/test_minimax_h3_rollout_contract_on_cpu.py
+++ b/tests/pipelines/test_minimax_h3_rollout_contract_on_cpu.py
@@ -93,6 +93,9 @@ class TestH3RolloutOutputContract:
         assert result.extra_fields["audio"] is not None
         assert "audio_sample_rate" in result.extra_fields
         assert result.extra_fields["audio_sample_rate"] == _AUDIO_SR
+        # The real MiniMax H3 adapter declares primary=video, which reaches
+        # downstream consumers so they need not infer the modality from rank.
+        assert result.extra_fields["media_kind"] == "video"
 
     def test_rl_metadata_reaches_extra_fields(self):
         """rl and prompt_embeddings groups flatten into extra_fields."""

--- a/tests/reward_loop/test_audio_reward_manager_on_cpu.py
+++ b/tests/reward_loop/test_audio_reward_manager_on_cpu.py
@@ -160,6 +160,41 @@ def test_run_single_forwards_reward_router_arguments():
     assert result["reward_score"] == 0.5
 
 
+@pytest.mark.parametrize("field,value", [("audio_sample_rate", 16000), ("audio", np.zeros(8)), ("media_kind", "video")])
+def test_conflicting_media_fails_before_audio_scoring(field, value):
+    data = _data(np.ones(8, dtype=np.float32))
+    data.non_tensor_batch["tool_extra_fields"][0]["media_kind"] = "audio"
+    data.non_tensor_batch[field] = np.array([value], dtype=object)
+    manager = _manager(lambda **kwargs: pytest.fail("Conflicting media reached the scorer"))
+    with pytest.raises(ValueError, match=f"Conflicting rollout media field.*{field}"):
+        manager.loop.run_until_complete(manager.run_single(data))
+
+
+def test_audio_metadata_projection_keeps_copy_and_scalar_mapping_compatibility():
+    data = _data(np.ones(8, dtype=np.float32))
+    original = {"id": "kept", "audio": "conditioning audio"}
+    data.non_tensor_batch["extra_info"][0] = np.array(original, dtype=object)
+    data.non_tensor_batch["tool_extra_fields"][0] = np.array(
+        data.non_tensor_batch["tool_extra_fields"][0], dtype=object
+    )
+    data.non_tensor_batch["media_kind"] = np.array(["audio"], dtype=object)
+    data.non_tensor_batch["__num_turns__"] = np.array([2])
+    data.non_tensor_batch["global_steps"] = np.array([7])
+
+    def scorer(extra_info, **kwargs):
+        assert extra_info["media_kind"] == "audio"
+        assert extra_info["num_turns"] == 2
+        assert extra_info["global_steps"] == 7
+        assert extra_info["id"] == "kept"
+        assert extra_info["audio_sample_rate"] == 24000
+        extra_info["id"] = "changed"
+        return 0.5
+
+    manager = _manager(scorer)
+    manager.loop.run_until_complete(manager.run_single(data))
+    assert original == {"id": "kept", "audio": "conditioning audio"}
+
+
 def test_run_single_reads_finalized_top_level_audio_layout():
     def compute_score(solution_audio, extra_info, **kwargs):
         waveform, sample_rate = solution_audio

--- a/tests/reward_loop/test_media_metadata_on_cpu.py
+++ b/tests/reward_loop/test_media_metadata_on_cpu.py
@@ -1,0 +1,96 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Generated media must reach scorers through both reward execution paths."""
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+from omegaconf import OmegaConf
+from verl import DataProto
+
+from verl_omni.reward_loop.reward_manager import multi
+from verl_omni.reward_loop.reward_manager.visual import VisualRewardManager
+from verl_omni.trainer.diffusion.v1 import tq_utils
+
+
+def _manager(monkeypatch, manager_cls, scorer):
+    config = OmegaConf.create(
+        {
+            "actor_rollout_ref": {"rollout": {"pipeline": {"output_type": "pt"}}},
+            "reward": {"reward_functions": {"audio": {"path": "test", "name": "score", "required": True}}},
+        }
+    )
+    monkeypatch.setattr(multi, "load_extern_object", lambda *args: scorer)
+    return manager_cls(config, tokenizer=None, compute_score=scorer)
+
+
+def _data(monkeypatch, transport):
+    audio = torch.arange(16, dtype=torch.float16).reshape(1, 1, 16)
+    tensors = {"responses": torch.zeros(1, 4, 3, 8, 8, dtype=torch.uint8)}
+    non_tensors = {
+        "data_source": ["test"],
+        "reward_model": [{"ground_truth": "prompt"}],
+        "extra_info": [{"dataset_field": "kept", "audio": "reference audio"}],
+    }
+    metadata = {"media_kind": "video", "audio_sample_rate": 32000}
+    if transport == "tool":
+        non_tensors["tool_extra_fields"] = [{"audio": audio[0], **metadata}]
+    elif transport in ("top", "both"):
+        tensors["audio"] = audio
+        non_tensors.update({key: [value] for key, value in metadata.items()})
+        if transport == "both":
+            non_tensors["tool_extra_fields"] = [{"audio": audio[0].clone(), **metadata}]
+    else:
+        payload = {**tensors, **non_tensors, "audio": audio, "extra_fields": [metadata]}
+        monkeypatch.setattr(tq_utils.tq, "kv_batch_get", lambda **kwargs: payload)
+        return tq_utils.diffusion_tq_batch_to_dataproto(SimpleNamespace(keys=["sample"], partition_id="train")), audio
+    return DataProto.from_dict(tensors=tensors, non_tensors=non_tensors), audio
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("manager_cls", [VisualRewardManager, multi.MultiVisualRewardManager])
+@pytest.mark.parametrize("transport", ["tool", "top", "tq", "both"])
+async def test_generated_media_reaches_scorer(monkeypatch, manager_cls, transport):
+    data, audio = _data(monkeypatch, transport)
+
+    async def scorer(data_source, solution_image, ground_truth, extra_info):
+        assert data_source == "test" and ground_truth == "prompt"
+        assert solution_image.dtype == torch.uint8
+        torch.testing.assert_close(extra_info["audio"], audio[0])
+        assert extra_info["audio_sample_rate"] == 32000
+        assert extra_info["media_kind"] == "video"
+        assert extra_info["dataset_field"] == "kept"
+        assert "responses" not in extra_info
+        return {"score": 1.0}
+
+    result = await _manager(monkeypatch, manager_cls, scorer).run_single(data)
+    assert result["reward_score"] == 1.0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("manager_cls", [VisualRewardManager, multi.MultiVisualRewardManager])
+@pytest.mark.parametrize(
+    "field, value", [("media_kind", "image"), ("audio_sample_rate", 24000), ("audio", torch.zeros(1, 16))]
+)
+async def test_conflicting_generated_media_sources_fail_before_scoring(monkeypatch, manager_cls, field, value):
+    data, _ = _data(monkeypatch, "top")
+    data.non_tensor_batch["tool_extra_fields"] = np.array([{field: value}], dtype=object)
+
+    async def scorer(**kwargs):
+        pytest.fail("Conflicting generated media must not reach the scorer")
+
+    with pytest.raises(ValueError, match=f"Conflicting rollout media field.*{field}"):
+        await _manager(monkeypatch, manager_cls, scorer).run_single(data)

--- a/tests/trainer/diffusion/test_dump_generations_video_on_cpu.py
+++ b/tests/trainer/diffusion/test_dump_generations_video_on_cpu.py
@@ -21,6 +21,7 @@ for the trainer.
 """
 
 import json
+import logging
 import os
 import subprocess
 from pathlib import Path
@@ -139,6 +140,39 @@ class TestDumpGenerations:
         rows = _read_jsonl(tmp_path)
         assert len(rows) == 2
         assert all(row["output"].endswith(".jpg") for row in rows)
+
+    def test_image_save_failure_is_recorded_without_losing_other_samples(self, monkeypatch, tmp_path, caplog):
+        caplog.set_level(logging.WARNING, logger=ray_diffusion_trainer.sys_logger.name)
+        original_save = ray_diffusion_trainer.Image.Image.save
+
+        def save(image, filename, *args, **kwargs):
+            if str(filename).endswith("0.jpg"):
+                raise OSError("simulated full filesystem")
+            return original_save(image, filename, *args, **kwargs)
+
+        monkeypatch.setattr(ray_diffusion_trainer.Image.Image, "save", save)
+        _dump(tmp_path, torch.zeros(2, 3, 8, 8, dtype=torch.uint8))
+
+        rows = _read_jsonl(tmp_path)
+        assert rows[0]["output"] is None
+        assert "simulated full filesystem" in rows[0]["image_export_error"]
+        assert rows[1]["output"].endswith("1.jpg")
+        assert "step 0 sample 0" in caplog.text
+
+    @pytest.mark.parametrize("operation", ["mkdir", "jsonl"])
+    def test_filesystem_failure_is_logged_and_skipped(self, monkeypatch, tmp_path, caplog, operation):
+        caplog.set_level(logging.WARNING, logger=ray_diffusion_trainer.sys_logger.name)
+
+        def fail(*args, **kwargs):
+            raise OSError("simulated filesystem failure")
+
+        if operation == "mkdir":
+            monkeypatch.setattr(ray_diffusion_trainer.os, "makedirs", fail)
+        else:
+            monkeypatch.setattr(ray_diffusion_trainer, "open", fail, raising=False)
+        _dump(tmp_path, torch.zeros(1, 3, 8, 8, dtype=torch.uint8), global_steps=7)
+        assert "step 7" in caplog.text
+        assert "simulated filesystem failure" in caplog.text
 
     def test_max_samples_bounds_video_dump(self, tmp_path):
         outputs = torch.randint(256, (3, 8, 3, 16, 16), dtype=torch.uint8)

--- a/tests/trainer/diffusion/test_v1_media_dump_on_cpu.py
+++ b/tests/trainer/diffusion/test_v1_media_dump_on_cpu.py
@@ -1,0 +1,144 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU tests for best-effort media dumping in the diffusion V1 trainer."""
+
+import json
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import torch
+from omegaconf import OmegaConf
+
+import verl_omni.trainer.diffusion.ray_diffusion_trainer as ray_diffusion_trainer
+import verl_omni.trainer.diffusion.v1.trainer_base as trainer_base_module
+from verl_omni.trainer.diffusion.v1.trainer_base import PolicyGradientDiffusionTrainerV1
+
+
+class _ConcreteTrainer(PolicyGradientDiffusionTrainerV1):
+    def on_step_end(self):
+        return None
+
+    def on_sample_end(self):
+        return None
+
+
+class _FakeData:
+    def __init__(self, batch, non_tensor_batch):
+        self.batch = batch
+        self.non_tensor_batch = non_tensor_batch
+
+    def __len__(self):
+        return len(self.batch["responses"])
+
+
+def _trainer(global_steps: int = 1) -> _ConcreteTrainer:
+    trainer = object.__new__(_ConcreteTrainer)
+    trainer.global_steps = global_steps
+    trainer._init_dump_executor()
+    return trainer
+
+
+def test_v1_video_dump_reuses_shared_export_and_honors_max_samples(monkeypatch, tmp_path):
+    exported = []
+
+    def fake_export(output, output_path, **kwargs):
+        exported.append((output.clone(), output_path, kwargs))
+        Path(output_path).write_bytes(b"video")
+
+    monkeypatch.setattr(ray_diffusion_trainer, "_export_video", fake_export)
+    trainer = _trainer(global_steps=7)
+    outputs = torch.randint(256, (2, 4, 3, 8, 8), dtype=torch.uint8)
+
+    trainer._dump_generations(
+        inputs=["first", "second"],
+        outputs=outputs,
+        gts=[None, None],
+        scores=[1.0, 2.0],
+        reward_extra_infos_dict={},
+        dump_path=str(tmp_path),
+        max_samples=1,
+        fps=12,
+        media_kind="video",
+    )
+    trainer._shutdown_dump_executor()
+
+    assert len(exported) == 1
+    torch.testing.assert_close(exported[0][0], outputs[0])
+    assert exported[0][1].endswith("7/0.mp4")
+    assert exported[0][2]["fps"] == 12
+    rows = [json.loads(line) for line in (tmp_path / "7.jsonl").read_text().splitlines()]
+    assert rows == [{"input": "first", "output": str(tmp_path / "7/0.mp4"), "gts": None, "score": 1.0, "step": 7}]
+
+
+def test_v1_background_dump_failure_is_logged_and_does_not_raise(caplog, tmp_path):
+    trainer = _trainer(global_steps=3)
+
+    with caplog.at_level(logging.WARNING):
+        trainer._dump_generations(
+            inputs=["prompt"],
+            outputs=torch.zeros(1, 3, 8, 8),
+            gts=[None],
+            scores=[0.0],
+            reward_extra_infos_dict={},
+            dump_path=str(tmp_path),
+            media_kind="image",
+        )
+        trainer._shutdown_dump_executor()
+
+    assert "Ignoring background media dump failure at step 3" in caplog.text
+
+
+def test_v1_rollout_dump_sorts_and_forwards_media_metadata(monkeypatch):
+    trainer = object.__new__(_ConcreteTrainer)
+    trainer.config = OmegaConf.create({"trainer": {"rollout_data_max_samples": 1, "video_fps": 12}})
+    trainer.tokenizer = SimpleNamespace(
+        pad_token_id=0,
+        batch_decode=lambda prompts, skip_special_tokens: ["second", "first"],
+    )
+    captured = {}
+    trainer._dump_generations = lambda **kwargs: captured.update(kwargs)
+
+    audio = torch.stack((torch.full((1, 4), 2.0), torch.full((1, 4), 1.0)))
+    data = _FakeData(
+        batch={
+            "prompts": torch.tensor([[2], [1]]),
+            "responses": torch.stack(
+                (
+                    torch.full((2, 3, 4, 4), 2, dtype=torch.uint8),
+                    torch.full((2, 3, 4, 4), 1, dtype=torch.uint8),
+                )
+            ),
+            "sample_level_scores": torch.tensor([[2.0], [1.0]]),
+            "audio": audio,
+        },
+        non_tensor_batch={
+            "media_kind": np.array(["video", "video"], dtype=object),
+            "audio_sample_rate": np.array([48_000, 48_000], dtype=object),
+        },
+    )
+    monkeypatch.setattr(trainer_base_module, "diffusion_tq_batch_to_dataproto", lambda *args, **kwargs: data)
+
+    batch_meta = SimpleNamespace(keys=["second_0_0", "first_0_0"], partition_id="train")
+    trainer._log_rollout_data(batch_meta, {}, "/tmp/unused")
+
+    assert captured["inputs"] == ["first", "second"]
+    assert captured["scores"] == [1.0, 2.0]
+    torch.testing.assert_close(captured["outputs"][0], data.batch["responses"][1])
+    torch.testing.assert_close(captured["audios"][0], audio[1])
+    assert captured["audio_sample_rates"] == [48_000, 48_000]
+    assert captured["media_kind"] == "video"
+    assert captured["max_samples"] == 1
+    assert captured["fps"] == 12

--- a/tests/trainer/diffusion/test_v1_media_dump_on_cpu.py
+++ b/tests/trainer/diffusion/test_v1_media_dump_on_cpu.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import numpy as np
+import pytest
 import torch
 from omegaconf import OmegaConf
 
@@ -99,6 +100,74 @@ def test_v1_background_dump_failure_is_logged_and_does_not_raise(caplog, tmp_pat
         trainer._shutdown_dump_executor()
 
     assert "Ignoring background media dump failure at step 3" in caplog.text
+
+
+@pytest.mark.parametrize("trainer_cls", [ray_diffusion_trainer.BaseRayDiffusionTrainer, _ConcreteTrainer])
+@pytest.mark.parametrize("failure", ["media", "table"])
+def test_validation_logger_failures_are_best_effort(monkeypatch, tmp_path, caplog, trainer_cls, failure):
+    import wandb
+
+    import verl_omni.utils.tracking as tracking
+
+    caplog.set_level(logging.WARNING, logger=ray_diffusion_trainer.sys_logger.name)
+    trainer = SimpleNamespace(global_steps=7)
+    trainer.config = OmegaConf.create({"trainer": {"logger": ["wandb"], "log_val_generations": 1}})
+    video_dir = tmp_path / "temporary-video"
+    video_dir.mkdir()
+    table_calls = []
+
+    def fail(*args, **kwargs):
+        raise OSError("simulated logger failure")
+
+    monkeypatch.setattr(
+        ray_diffusion_trainer,
+        "wrap_val_samples_for_wandb",
+        lambda *args, **kwargs: ([("prompt", "video", 1.0)], str(video_dir), {"val/videos/1": "video"}),
+    )
+    monkeypatch.setattr(wandb, "run", object())
+    monkeypatch.setattr(wandb, "log", fail if failure == "media" else lambda *args, **kwargs: None)
+    monkeypatch.setattr(ray_diffusion_trainer, "log_wandb_media", tracking.log_wandb_media)
+    trainer.validation_generations_logger = SimpleNamespace(
+        log=fail if failure == "table" else lambda *args: table_calls.append(args)
+    )
+
+    trainer_cls._maybe_log_val_generations(
+        trainer, ["prompt"], torch.zeros(1, 4, 3, 8, 8, dtype=torch.uint8), [1.0], media_kinds=["video"]
+    )
+    assert "step 7" in caplog.text and "simulated logger failure" in caplog.text
+    assert not video_dir.exists()
+    if failure == "media":
+        assert len(table_calls) == 1
+
+
+@pytest.mark.parametrize("trainer_cls", [ray_diffusion_trainer.BaseRayDiffusionTrainer, _ConcreteTrainer])
+def test_invalid_modality_is_not_hidden_by_logging(trainer_cls):
+    trainer = SimpleNamespace(
+        global_steps=1,
+        config=OmegaConf.create({"trainer": {"logger": ["wandb"], "log_val_generations": 1}}),
+    )
+    with pytest.raises(ValueError, match="Unsupported media kind"):
+        trainer_cls._maybe_log_val_generations(
+            trainer, ["prompt"], torch.zeros(1, 3, 8, 8, dtype=torch.uint8), [1.0], media_kinds=["depth"]
+        )
+
+
+def test_v1_invalid_modality_fails_before_background_submission(tmp_path):
+    trainer = _trainer()
+    try:
+        with pytest.raises(ValueError, match="Unsupported media kind"):
+            trainer._dump_generations(
+                inputs=["prompt"],
+                outputs=torch.zeros(1, 3, 8, 8, dtype=torch.uint8),
+                gts=[None],
+                scores=[1.0],
+                reward_extra_infos_dict={},
+                dump_path=str(tmp_path),
+                media_kind="depth",
+            )
+        assert trainer._dump_futures == []
+    finally:
+        trainer._shutdown_dump_executor()
 
 
 def test_v1_rollout_dump_sorts_and_forwards_media_metadata(monkeypatch):

--- a/tests/trainer/diffusion/test_v1_media_dump_on_cpu.py
+++ b/tests/trainer/diffusion/test_v1_media_dump_on_cpu.py
@@ -15,6 +15,7 @@
 
 import json
 import logging
+from concurrent.futures import Future
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -22,6 +23,7 @@ import numpy as np
 import pytest
 import torch
 from omegaconf import OmegaConf
+from verl import DataProto
 
 import verl_omni.trainer.diffusion.ray_diffusion_trainer as ray_diffusion_trainer
 import verl_omni.trainer.diffusion.v1.trainer_base as trainer_base_module
@@ -84,13 +86,17 @@ def test_v1_video_dump_reuses_shared_export_and_honors_max_samples(monkeypatch, 
     assert rows == [{"input": "first", "output": str(tmp_path / "7/0.mp4"), "gts": None, "score": 1.0, "step": 7}]
 
 
-def test_v1_background_dump_failure_is_logged_and_does_not_raise(caplog, tmp_path):
+def test_v1_background_dump_failure_is_logged_and_does_not_raise(monkeypatch, caplog, tmp_path):
     trainer = _trainer(global_steps=3)
 
+    def fail(*args, **kwargs):
+        raise OSError("simulated background I/O failure")
+
+    monkeypatch.setattr(trainer_base_module, "dump_generations", fail)
     with caplog.at_level(logging.WARNING):
         trainer._dump_generations(
             inputs=["prompt"],
-            outputs=torch.zeros(1, 3, 8, 8),
+            outputs=torch.zeros(1, 3, 8, 8, dtype=torch.uint8),
             gts=[None],
             scores=[0.0],
             reward_extra_infos_dict={},
@@ -100,6 +106,55 @@ def test_v1_background_dump_failure_is_logged_and_does_not_raise(caplog, tmp_pat
         trainer._shutdown_dump_executor()
 
     assert "Ignoring background media dump failure at step 3" in caplog.text
+
+
+def test_v1_background_export_uses_submission_step_snapshot(tmp_path):
+    queued = []
+    trainer = object.__new__(_ConcreteTrainer)
+    trainer.global_steps = 7
+    trainer._dump_futures = []
+    trainer._dump_executor = SimpleNamespace(submit=lambda *args: queued.append(args) or Future())
+    trainer._dump_generations(
+        ["prompt"], torch.zeros(1, 3, 8, 8, dtype=torch.uint8), [None], [1.0], {}, str(tmp_path), media_kind="image"
+    )
+    trainer.global_steps = 8
+    fn, *args = queued[0]
+    assert fn is ray_diffusion_trainer.dump_generations
+    fn(*args)
+    assert (tmp_path / "7" / "0.jpg").exists()
+    assert not (tmp_path / "8").exists()
+    assert json.loads((tmp_path / "7.jsonl").read_text())["step"] == 7
+
+
+@pytest.mark.parametrize("transport", ["top", "tool"])
+@pytest.mark.parametrize("kinds", [["image", "video"], [None, "video"], [None, None]])
+def test_v0_rollout_validates_all_declared_kinds(transport, kinds):
+    captured = {}
+    non_tensors = {"reward_model": [{}, {}]}
+    if transport == "top":
+        non_tensors["media_kind"] = kinds
+    else:
+        non_tensors["tool_extra_fields"] = [{"media_kind": kind} for kind in kinds]
+    data = DataProto.from_dict(
+        tensors={
+            "prompts": torch.ones(2, 1, dtype=torch.long),
+            "responses": torch.zeros(2, 4, 3, 8, 8, dtype=torch.uint8),
+            "sample_level_scores": torch.zeros(2, 1),
+        },
+        non_tensors=non_tensors,
+    )
+    trainer = SimpleNamespace(
+        config=OmegaConf.create({"trainer": {}}),
+        tokenizer=SimpleNamespace(batch_decode=lambda *args, **kwargs: ["first", "second"]),
+        _dump_generations=lambda **kwargs: captured.update(kwargs),
+    )
+    if kinds == ["image", "video"]:
+        with pytest.raises(ValueError, match="Conflicting media kinds"):
+            ray_diffusion_trainer.BaseRayDiffusionTrainer._log_rollout_data(trainer, data, {}, {}, "/tmp/unused")
+        assert captured == {}
+    else:
+        ray_diffusion_trainer.BaseRayDiffusionTrainer._log_rollout_data(trainer, data, {}, {}, "/tmp/unused")
+        assert captured["media_kind"] == kinds[-1]
 
 
 @pytest.mark.parametrize("trainer_cls", [ray_diffusion_trainer.BaseRayDiffusionTrainer, _ConcreteTrainer])
@@ -170,7 +225,19 @@ def test_v1_invalid_modality_fails_before_background_submission(tmp_path):
         trainer._shutdown_dump_executor()
 
 
-def test_v1_rollout_dump_sorts_and_forwards_media_metadata(monkeypatch):
+@pytest.mark.parametrize("outputs", [torch.zeros(1, 3, 8, 8), [torch.zeros(3, 8, 8)]])
+def test_v1_invalid_dtype_fails_before_background_submission(tmp_path, outputs):
+    trainer = _trainer()
+    try:
+        with pytest.raises(ValueError, match="uint8"):
+            trainer._dump_generations(["prompt"], outputs, [None], [0.0], {}, str(tmp_path), media_kind="image")
+        assert trainer._dump_futures == []
+    finally:
+        trainer._shutdown_dump_executor()
+
+
+@pytest.mark.parametrize("media_kinds", [["video", "video"], ["video", "image"], ["video", "depth"]])
+def test_v1_rollout_dump_sorts_and_forwards_media_metadata(monkeypatch, media_kinds):
     trainer = object.__new__(_ConcreteTrainer)
     trainer.config = OmegaConf.create({"trainer": {"rollout_data_max_samples": 1, "video_fps": 12}})
     trainer.tokenizer = SimpleNamespace(
@@ -194,13 +261,18 @@ def test_v1_rollout_dump_sorts_and_forwards_media_metadata(monkeypatch):
             "audio": audio,
         },
         non_tensor_batch={
-            "media_kind": np.array(["video", "video"], dtype=object),
+            "media_kind": np.array(media_kinds, dtype=object),
             "audio_sample_rate": np.array([48_000, 48_000], dtype=object),
         },
     )
     monkeypatch.setattr(trainer_base_module, "diffusion_tq_batch_to_dataproto", lambda *args, **kwargs: data)
 
     batch_meta = SimpleNamespace(keys=["second_0_0", "first_0_0"], partition_id="train")
+    if media_kinds != ["video", "video"]:
+        with pytest.raises(ValueError, match="media kind"):
+            trainer._log_rollout_data(batch_meta, {}, "/tmp/unused")
+        assert captured == {}
+        return
     trainer._log_rollout_data(batch_meta, {}, "/tmp/unused")
 
     assert captured["inputs"] == ["first", "second"]

--- a/tests/trainer/diffusion/test_v1_replay_buffer_on_cpu.py
+++ b/tests/trainer/diffusion/test_v1_replay_buffer_on_cpu.py
@@ -122,33 +122,35 @@ def _sample(trainer, batch_size):
     return PolicyGradientDiffusionTrainerV1._sample_training_batch(trainer, batch_size)
 
 
-def test_wandb_validation_logging_rejects_non_uint8_images():
+def test_wandb_validation_media_failure_is_best_effort():
+    calls = []
     trainer = SimpleNamespace(
-        config=OmegaConf.create({"trainer": {"log_val_generations": 1, "logger": ["wandb"]}}),
+        config=OmegaConf.create(
+            {
+                "trainer": {
+                    "log_val_generations": 1,
+                    "logger": ["wandb"],
+                    "video_fps": 24,
+                    "validation_data_dir": None,
+                    "default_local_dir": None,
+                }
+            }
+        ),
+        global_steps=1,
+        validation_generations_logger=SimpleNamespace(log=lambda *args: calls.append(args)),
     )
 
-    with pytest.raises(ValueError, match=r"Expected a uint8 image tensor, got torch\.float32\."):
-        PolicyGradientDiffusionTrainerV1._maybe_log_val_generations(
-            trainer,
-            inputs=["prompt"],
-            outputs=torch.zeros(1, 3, 8, 8),
-            scores=[0.0],
-        )
+    PolicyGradientDiffusionTrainerV1._maybe_log_val_generations(
+        trainer,
+        inputs=["prompt"],
+        outputs=torch.zeros(1, 3, 8, 8),
+        scores=[0.0],
+        media_kinds=["image"],
+    )
 
-
-def test_v1_generation_dump_rejects_non_uint8_outputs_before_submission():
-    trainer = SimpleNamespace()
-
-    with pytest.raises(ValueError, match=r"Expected generation outputs to be a uint8 tensor, got torch\.float32\."):
-        PolicyGradientDiffusionTrainerV1._dump_generations(
-            trainer,
-            inputs=["prompt"],
-            outputs=torch.zeros(1, 3, 8, 8),
-            gts=[""],
-            scores=[0.0],
-            reward_extra_infos_dict={},
-            dump_path="unused",
-        )
+    assert calls[0][1] == [
+        ("prompt", "[validation media unavailable: ValueError: Expected a uint8 image tensor, got torch.float32.]", 0.0)
+    ]
 
 
 def test_sample_evicts_partial_failure_and_refills_exact_prompt_count(monkeypatch):

--- a/tests/trainer/diffusion/test_v1_replay_buffer_on_cpu.py
+++ b/tests/trainer/diffusion/test_v1_replay_buffer_on_cpu.py
@@ -122,7 +122,7 @@ def _sample(trainer, batch_size):
     return PolicyGradientDiffusionTrainerV1._sample_training_batch(trainer, batch_size)
 
 
-def test_wandb_validation_media_failure_is_best_effort():
+def test_wandb_validation_logging_rejects_non_uint8_images():
     calls = []
     trainer = SimpleNamespace(
         config=OmegaConf.create(
@@ -140,17 +140,15 @@ def test_wandb_validation_media_failure_is_best_effort():
         validation_generations_logger=SimpleNamespace(log=lambda *args: calls.append(args)),
     )
 
-    PolicyGradientDiffusionTrainerV1._maybe_log_val_generations(
-        trainer,
-        inputs=["prompt"],
-        outputs=torch.zeros(1, 3, 8, 8),
-        scores=[0.0],
-        media_kinds=["image"],
-    )
-
-    assert calls[0][1] == [
-        ("prompt", "[validation media unavailable: ValueError: Expected a uint8 image tensor, got torch.float32.]", 0.0)
-    ]
+    with pytest.raises(ValueError, match="uint8"):
+        PolicyGradientDiffusionTrainerV1._maybe_log_val_generations(
+            trainer,
+            inputs=["prompt"],
+            outputs=torch.zeros(1, 3, 8, 8),
+            scores=[0.0],
+            media_kinds=["image"],
+        )
+    assert calls == []
 
 
 def test_sample_evicts_partial_failure_and_refills_exact_prompt_count(monkeypatch):

--- a/tests/utils/test_tracking_media_on_cpu.py
+++ b/tests/utils/test_tracking_media_on_cpu.py
@@ -1,0 +1,39 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the declared-media-kind resolution used by the diffusion trainer dump."""
+
+import pytest
+
+from verl_omni.utils.tracking import resolve_is_video
+
+
+class TestResolveIsVideo:
+    def test_declared_video_wins_over_rank(self):
+        # A short 3-frame video can share an image batch's rank; the declaration
+        # keeps it classified as video.
+        assert resolve_is_video(ndim=4, media_kind="video") is True
+
+    def test_declared_image_wins_over_rank(self):
+        assert resolve_is_video(ndim=5, media_kind="image") is False
+
+    def test_declared_audio_is_not_video(self):
+        assert resolve_is_video(ndim=2, media_kind="audio") is False
+
+    def test_falls_back_to_rank_when_undeclared(self):
+        assert resolve_is_video(ndim=5, media_kind=None) is True
+        assert resolve_is_video(ndim=4, media_kind=None) is False
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/utils/test_tracking_media_on_cpu.py
+++ b/tests/utils/test_tracking_media_on_cpu.py
@@ -20,8 +20,7 @@ from verl_omni.utils.tracking import resolve_is_video
 
 class TestResolveIsVideo:
     def test_declared_video_wins_over_rank(self):
-        # A short 3-frame video can share an image batch's rank; the declaration
-        # keeps it classified as video.
+        # A per-sample video and a batched image can both have rank four.
         assert resolve_is_video(ndim=4, media_kind="video") is True
 
     def test_declared_image_wins_over_rank(self):
@@ -29,6 +28,10 @@ class TestResolveIsVideo:
 
     def test_declared_audio_is_not_video(self):
         assert resolve_is_video(ndim=2, media_kind="audio") is False
+
+    def test_unknown_media_kind_is_rejected(self):
+        with pytest.raises(ValueError, match="Unsupported media kind"):
+            resolve_is_video(ndim=5, media_kind="depth")
 
     def test_falls_back_to_rank_when_undeclared(self):
         assert resolve_is_video(ndim=5, media_kind=None) is True

--- a/tests/utils/test_tracking_on_cpu.py
+++ b/tests/utils/test_tracking_on_cpu.py
@@ -134,11 +134,33 @@ def test_image_samples_become_wandb_image_and_no_temp_dir(monkeypatch):
     assert captured[0][1] == {"file_type": "jpg"}
 
 
-def test_image_samples_reject_non_uint8_input(monkeypatch):
+def test_image_media_failure_is_reported_without_raising(monkeypatch):
     monkeypatch.setattr(wandb, "Image", lambda *args, **kwargs: pytest.fail("wandb.Image should not be called"))
 
-    with pytest.raises(ValueError, match=r"Expected a uint8 image tensor, got torch\.float32\."):
-        wrap_val_samples_for_wandb([("prompt", torch.rand(3, 16, 16), 1.0)])
+    wrapped, video_tmp_dir, media_to_log = wrap_val_samples_for_wandb([("prompt", torch.rand(3, 16, 16), 1.0)])
+
+    assert wrapped == [
+        ("prompt", "[validation media unavailable: ValueError: Expected a uint8 image tensor, got torch.float32.]", 1.0)
+    ]
+    assert video_tmp_dir is None
+    assert media_to_log == {}
+
+
+def test_declared_image_kind_wins_over_video_rank(monkeypatch):
+    captured = []
+    monkeypatch.setattr(wandb, "Image", lambda output, **kwargs: captured.append(output) or "image")
+    monkeypatch.setattr(wandb, "Video", lambda *args, **kwargs: pytest.fail("wandb.Video should not be called"))
+    output = torch.zeros(1, 3, 8, 8, dtype=torch.uint8)
+
+    wrapped, video_tmp_dir, media_to_log = wrap_val_samples_for_wandb(
+        [("prompt", output, 1.0)],
+        media_kinds=["image"],
+    )
+
+    assert captured == [output]
+    assert wrapped == [("prompt", "image", 1.0)]
+    assert video_tmp_dir is None
+    assert media_to_log == {}
 
 
 def test_uint8_image_is_logged_by_real_wandb_offline_run(monkeypatch, tmp_path):

--- a/tests/workers/rollout/rollout_vllm/test_vllm_omni_strategy_on_cpu.py
+++ b/tests/workers/rollout/rollout_vllm/test_vllm_omni_strategy_on_cpu.py
@@ -826,6 +826,56 @@ def test_diffusion_strategy_uses_declared_audio_sample_rate(monkeypatch):
     assert processed.extra_fields["media_kind"] == "video"
 
 
+@pytest.mark.parametrize("runtime_kind", ["image", "depth"])
+def test_diffusion_strategy_rejects_conflicting_media_kind(monkeypatch, runtime_kind):
+    strategy = DiffusionStrategy(SimpleNamespace(global_steps=1))
+    monkeypatch.setattr(
+        strategy,
+        "_diffusion_io_spec",
+        lambda: DiffusionIOSpec(MediaSpec("video"), (MediaSpec("audio", sample_rate=48000),)),
+    )
+    final_res, _ = _joint_video_audio_final_res()
+    final_res.request_id = "request-conflict"
+    final_res.multimodal_output = {"metadata": {"rl": {"media_kind": runtime_kind}}}
+
+    with pytest.raises(ValueError, match="media_kind.*request-conflict.*video"):
+        strategy.process_output(final_res, None, {"output_type": "pt"})
+
+
+def test_diffusion_strategy_accepts_matching_kind_and_runtime_audio_rate(monkeypatch):
+    strategy = DiffusionStrategy(SimpleNamespace(global_steps=1))
+    monkeypatch.setattr(
+        strategy,
+        "_diffusion_io_spec",
+        lambda: DiffusionIOSpec(MediaSpec("video"), (MediaSpec("audio", sample_rate=48000),)),
+    )
+    final_res, _ = _joint_video_audio_final_res()
+    final_res.multimodal_output = {"metadata": {"rl": {"media_kind": "video", "audio_sample_rate": 24000}}}
+
+    result = strategy.process_output(final_res, None, {"output_type": "pt"})
+    assert result.extra_fields["media_kind"] == "video"
+    assert result.extra_fields["audio_sample_rate"] == 24000
+
+
+@pytest.mark.parametrize("declared", [False, True])
+def test_diffusion_strategy_rejects_extra_tuple_streams(monkeypatch, declared):
+    strategy = DiffusionStrategy(SimpleNamespace(global_steps=1))
+    spec = DiffusionIOSpec(MediaSpec("video"), (MediaSpec("audio", sample_rate=48000),)) if declared else None
+    monkeypatch.setattr(strategy, "_diffusion_io_spec", lambda: spec)
+    final_res, audio = _joint_video_audio_final_res()
+    final_res.images[0] += (audio.clone(),)
+    with pytest.raises(ValueError, match="Unsupported diffusion media tuple"):
+        strategy.process_output(final_res, None, {"output_type": "pt"})
+
+
+def test_diffusion_strategy_rejects_undeclared_tuple_audio(monkeypatch):
+    strategy = DiffusionStrategy(SimpleNamespace(global_steps=1))
+    monkeypatch.setattr(strategy, "_diffusion_io_spec", lambda: DiffusionIOSpec(MediaSpec("video")))
+    final_res, _ = _joint_video_audio_final_res()
+    with pytest.raises(ValueError, match="Unsupported diffusion media tuple"):
+        strategy.process_output(final_res, None, {"output_type": "pt"})
+
+
 def test_diffusion_strategy_omits_audio_sample_rate_without_declared_spec(monkeypatch):
     # Without an adapter-declared DiffusionIOSpec the strategy still surfaces the
     # auxiliary audio stream but attaches no model-specific sample-rate default.

--- a/tests/workers/rollout/rollout_vllm/test_vllm_omni_strategy_on_cpu.py
+++ b/tests/workers/rollout/rollout_vllm/test_vllm_omni_strategy_on_cpu.py
@@ -821,6 +821,9 @@ def test_diffusion_strategy_uses_declared_audio_sample_rate(monkeypatch):
     assert processed.extra_fields["audio_sample_rate"] == 48000
     # process_output unbatches the leading dimension of auxiliary media.
     torch.testing.assert_close(processed.extra_fields["audio"], audio[0])
+    # The declared primary modality rides to downstream consumers so they read
+    # the media kind instead of inferring it from the tensor rank.
+    assert processed.extra_fields["media_kind"] == "video"
 
 
 def test_diffusion_strategy_omits_audio_sample_rate_without_declared_spec(monkeypatch):
@@ -841,6 +844,8 @@ def test_diffusion_strategy_omits_audio_sample_rate_without_declared_spec(monkey
 
     torch.testing.assert_close(processed.extra_fields["audio"], audio[0])
     assert "audio_sample_rate" not in processed.extra_fields
+    # No declared spec => no declared media kind is surfaced either.
+    assert "media_kind" not in processed.extra_fields
 
 
 @pytest.mark.parametrize(

--- a/verl_omni/agent_loop/diffusion_agent_loop_tq.py
+++ b/verl_omni/agent_loop/diffusion_agent_loop_tq.py
@@ -238,6 +238,13 @@ class DiffusionAgentLoopWorkerTQ(DiffusionAgentLoopWorker):
             extra_fields_out["img_shapes"] = extra["img_shapes"]
         if reward_extra_info is not None:
             extra_fields_out["reward_extra_info"] = reward_extra_info
+        # Tensor media (for example generated audio) is already carried as a
+        # top-level TQ field above. Preserve its non-tensor declaration/metadata
+        # in the envelope that ``diffusion_tq_batch_to_dataproto`` restores.
+        for media_key in ("media_kind", "audio_sample_rate"):
+            media_value = extra.get(media_key)
+            if media_value is not None and not isinstance(media_value, torch.Tensor):
+                extra_fields_out[media_key] = media_value
         # Track the rollout model version this trajectory was generated against.
         step = trajectory["step"] if trajectory else global_steps
         extra_fields_out["min_global_steps"] = step

--- a/verl_omni/pipelines/rollout_media.py
+++ b/verl_omni/pipelines/rollout_media.py
@@ -61,10 +61,21 @@ class DiffusionIOSpec:
         primary: The main media stream. It is carried on
             ``DiffusionOutput.diffusion_output`` and, when the pipeline emits a
             media tuple, occupies position 0.
-        auxiliary: Additional media streams in tuple order, so ``auxiliary[i]``
-            describes media-tuple position ``i + 1`` (e.g. a single ``audio``
-            entry describes the joint-audio stream at position 1).
+        auxiliary: At most one audio stream, carried at position 1 of a
+            ``(visual, audio)`` tuple. Other auxiliary combinations are not
+            supported by the current rollout transport.
     """
 
     primary: MediaSpec
     auxiliary: tuple[MediaSpec, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.auxiliary and (
+            self.primary.modality not in ("image", "video")
+            or len(self.auxiliary) != 1
+            or self.auxiliary[0].modality != "audio"
+        ):
+            raise ValueError(
+                "DiffusionIOSpec supports image/video primary media with at most one auxiliary audio stream; "
+                f"got primary={self.primary.modality!r}, auxiliary={tuple(s.modality for s in self.auxiliary)!r}"
+            )

--- a/verl_omni/pipelines/rollout_media.py
+++ b/verl_omni/pipelines/rollout_media.py
@@ -24,11 +24,34 @@ modalities only touches the adapter, not the shared server/strategy code.
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import Literal, Optional
 
 #: Media kinds a diffusion pipeline can emit.
 Modality = Literal["image", "video", "audio"]
+
+
+def resolve_is_video(ndim: int, media_kind: str | None) -> bool:
+    """Prefer the declared modality, retaining rank fallback for legacy outputs."""
+    if media_kind is not None:
+        if media_kind not in ("image", "video", "audio"):
+            raise ValueError(f"Unsupported media kind: {media_kind!r}")
+        return media_kind == "video"
+    return ndim == 5
+
+
+def resolve_batch_media_kind(media_kinds: Iterable[str | None]) -> str | None:
+    """Require one declared modality per pipeline batch; ignore absent legacy metadata."""
+    resolved = None
+    for kind in media_kinds:
+        if kind is None:
+            continue
+        resolve_is_video(0, kind)
+        if resolved is not None and resolved != kind:
+            raise ValueError(f"Conflicting media kinds in one rollout batch: {resolved!r} and {kind!r}")
+        resolved = kind
+    return resolved
 
 
 @dataclass(frozen=True)

--- a/verl_omni/reward_loop/reward_manager/audio.py
+++ b/verl_omni/reward_loop/reward_manager/audio.py
@@ -16,7 +16,6 @@
 import asyncio
 import inspect
 import math
-from collections.abc import Mapping
 from functools import partial
 
 import numpy as np
@@ -24,6 +23,8 @@ import torch
 from verl import DataProto
 from verl.experimental.reward_loop.reward_manager.base import RewardManagerBase
 from verl.utils.reward_score import default_compute_score as _upstream_default_compute_score
+
+from verl_omni.reward_loop.reward_manager.media import _reward_extra_info
 
 
 class AudioRewardManager(RewardManagerBase):
@@ -40,16 +41,6 @@ class AudioRewardManager(RewardManagerBase):
         self.is_async_reward_score = inspect.iscoroutinefunction(compute_score)
         self.reward_router_address = reward_router_address
         self.reward_model_tokenizer = reward_model_tokenizer
-
-    @staticmethod
-    def _mapping(value):
-        if isinstance(value, np.ndarray) and value.shape == ():
-            value = value.item()
-        if value is None:
-            return {}
-        if not isinstance(value, Mapping):
-            raise TypeError(f"Audio reward metadata must be a mapping, got {type(value).__name__}.")
-        return dict(value)
 
     @classmethod
     def _extract_audio(cls, extra_info):
@@ -94,11 +85,7 @@ class AudioRewardManager(RewardManagerBase):
             raise ValueError(f"AudioRewardManager scores one sample at a time, got batch size {len(data)}.")
         item = data[0]
         batch = item.non_tensor_batch
-        extra_info = self._mapping(batch.get("extra_info", {}))
-        extra_info.update(self._mapping(batch.get("tool_extra_fields")))
-        for key in ("audio", "audio_sample_rate"):
-            if key in batch and batch[key] is not None:
-                extra_info[key] = batch[key]
+        extra_info = _reward_extra_info(item)
         if "__num_turns__" in batch:
             extra_info["num_turns"] = batch["__num_turns__"]
         if "global_steps" in batch:

--- a/verl_omni/reward_loop/reward_manager/media.py
+++ b/verl_omni/reward_loop/reward_manager/media.py
@@ -1,0 +1,53 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Shared generated-media projection for visual and audio reward managers."""
+
+from collections.abc import Mapping
+
+import numpy as np
+import torch
+
+
+def _metadata_mapping(value):
+    if isinstance(value, np.ndarray) and value.shape == ():
+        value = value.item()
+    if value is None:
+        return {}
+    if not isinstance(value, Mapping):
+        raise TypeError(f"Reward media metadata must be a mapping, got {type(value).__name__}.")
+    return dict(value)
+
+
+def _reward_extra_info(data_item) -> dict:
+    """Copy metadata and project generated media, rejecting conflicting sources."""
+    extra_info = _metadata_mapping(data_item.non_tensor_batch.get("extra_info"))
+    tool_extra_fields = _metadata_mapping(data_item.non_tensor_batch.get("tool_extra_fields"))
+    extra_info.update(tool_extra_fields)
+    tensor_fields = data_item.batch if data_item.batch is not None else {}
+    for key in ("audio", "audio_sample_rate", "media_kind"):
+        value = tensor_fields.get(key)
+        if value is None:
+            value = data_item.non_tensor_batch.get(key)
+        if value is None:
+            continue
+        tool_value = tool_extra_fields.get(key)
+        if tool_value is not None and tool_value is not value:
+            if isinstance(value, torch.Tensor) and isinstance(tool_value, torch.Tensor):
+                matches = value.device == tool_value.device and torch.equal(value, tool_value)
+            else:
+                matches = np.array_equal(value, tool_value)
+            if not matches:
+                raise ValueError(f"Conflicting rollout media field {key!r} in batch and tool_extra_fields")
+        extra_info[key] = value
+    return extra_info

--- a/verl_omni/reward_loop/reward_manager/multi.py
+++ b/verl_omni/reward_loop/reward_manager/multi.py
@@ -19,7 +19,8 @@ import logging
 from verl import DataProto
 from verl.utils.import_utils import load_extern_object
 
-from .visual import VisualRewardManager, _reward_extra_info, _validate_visual_response
+from .media import _reward_extra_info
+from .visual import VisualRewardManager, _validate_visual_response
 
 logger = logging.getLogger(__name__)
 

--- a/verl_omni/reward_loop/reward_manager/multi.py
+++ b/verl_omni/reward_loop/reward_manager/multi.py
@@ -19,7 +19,7 @@ import logging
 from verl import DataProto
 from verl.utils.import_utils import load_extern_object
 
-from .visual import VisualRewardManager, _validate_visual_response
+from .visual import VisualRewardManager, _reward_extra_info, _validate_visual_response
 
 logger = logging.getLogger(__name__)
 
@@ -118,10 +118,7 @@ class MultiVisualRewardManager(VisualRewardManager):
         _validate_visual_response(response_visual, self.config, is_validate=data_item.meta_info.get("validate", False))
         data_source = data_item.non_tensor_batch["data_source"]
         ground_truth = data_item.non_tensor_batch["reward_model"]["ground_truth"]
-        extra_info = data_item.non_tensor_batch.get("extra_info", {})
-        tool_extra_fields = data_item.non_tensor_batch.get("tool_extra_fields", None)
-        if tool_extra_fields is not None:
-            extra_info.update(tool_extra_fields.items())
+        extra_info = _reward_extra_info(data_item)
 
         num_turns = data_item.non_tensor_batch.get("__num_turns__", None)
         rollout_reward_scores = data_item.non_tensor_batch.get("reward_scores", {})

--- a/verl_omni/reward_loop/reward_manager/visual.py
+++ b/verl_omni/reward_loop/reward_manager/visual.py
@@ -14,6 +14,7 @@
 
 import inspect
 
+import numpy as np
 import torch
 from verl import DataProto
 from verl.experimental.reward_loop.reward_manager.base import RewardManagerBase
@@ -34,6 +35,29 @@ def _validate_visual_response(response_visual, config, *, is_validate: bool) -> 
     elif not isinstance(response_visual, torch.Tensor) or response_visual.dtype != torch.uint8:
         dtype = getattr(response_visual, "dtype", type(response_visual))
         raise ValueError(f"Expected uint8 pixel responses for output_type={output_type!r}, got {dtype}.")
+
+
+def _reward_extra_info(data_item) -> dict:
+    """Project generated media from ordinary/TQ batches into scorer metadata."""
+    extra_info = data_item.non_tensor_batch.get("extra_info", {})
+    tool_extra_fields = data_item.non_tensor_batch.get("tool_extra_fields") or {}
+    extra_info.update(tool_extra_fields)
+    for key in ("audio", "audio_sample_rate", "media_kind"):
+        value = data_item.batch.get(key)
+        if value is None:
+            value = data_item.non_tensor_batch.get(key)
+        if value is None:
+            continue
+        tool_value = tool_extra_fields.get(key)
+        if tool_value is not None and tool_value is not value:
+            if isinstance(value, torch.Tensor) and isinstance(tool_value, torch.Tensor):
+                matches = value.device == tool_value.device and torch.equal(value, tool_value)
+            else:
+                matches = np.array_equal(value, tool_value)
+            if not matches:
+                raise ValueError(f"Conflicting rollout media field {key!r} in batch and tool_extra_fields")
+        extra_info[key] = value
+    return extra_info
 
 
 class VisualRewardManager(RewardManagerBase):
@@ -63,10 +87,7 @@ class VisualRewardManager(RewardManagerBase):
         _validate_visual_response(response_visual, self.config, is_validate=data_item.meta_info.get("validate", False))
         data_source = data_item.non_tensor_batch["data_source"]
         ground_truth = data_item.non_tensor_batch["reward_model"]["ground_truth"]
-        extra_info = data_item.non_tensor_batch.get("extra_info", {})
-        tool_extra_fields = data_item.non_tensor_batch.get("tool_extra_fields", None)
-        if tool_extra_fields is not None:
-            extra_info.update(tool_extra_fields.items())
+        extra_info = _reward_extra_info(data_item)
 
         num_turns = data_item.non_tensor_batch.get("__num_turns__", None)
         rollout_reward_scores = data_item.non_tensor_batch.get("reward_scores", {})

--- a/verl_omni/reward_loop/reward_manager/visual.py
+++ b/verl_omni/reward_loop/reward_manager/visual.py
@@ -14,13 +14,14 @@
 
 import inspect
 
-import numpy as np
 import torch
 from verl import DataProto
 from verl.experimental.reward_loop.reward_manager.base import RewardManagerBase
 from verl.utils.reward_score import default_compute_score as _upstream_default_compute_score
 
 from verl_omni.utils.reward_score import default_compute_score_image
+
+from .media import _reward_extra_info
 
 
 def _validate_visual_response(response_visual, config, *, is_validate: bool) -> None:
@@ -35,29 +36,6 @@ def _validate_visual_response(response_visual, config, *, is_validate: bool) -> 
     elif not isinstance(response_visual, torch.Tensor) or response_visual.dtype != torch.uint8:
         dtype = getattr(response_visual, "dtype", type(response_visual))
         raise ValueError(f"Expected uint8 pixel responses for output_type={output_type!r}, got {dtype}.")
-
-
-def _reward_extra_info(data_item) -> dict:
-    """Project generated media from ordinary/TQ batches into scorer metadata."""
-    extra_info = data_item.non_tensor_batch.get("extra_info", {})
-    tool_extra_fields = data_item.non_tensor_batch.get("tool_extra_fields") or {}
-    extra_info.update(tool_extra_fields)
-    for key in ("audio", "audio_sample_rate", "media_kind"):
-        value = data_item.batch.get(key)
-        if value is None:
-            value = data_item.non_tensor_batch.get(key)
-        if value is None:
-            continue
-        tool_value = tool_extra_fields.get(key)
-        if tool_value is not None and tool_value is not value:
-            if isinstance(value, torch.Tensor) and isinstance(tool_value, torch.Tensor):
-                matches = value.device == tool_value.device and torch.equal(value, tool_value)
-            else:
-                matches = np.array_equal(value, tool_value)
-            if not matches:
-                raise ValueError(f"Conflicting rollout media field {key!r} in batch and tool_extra_fields")
-        extra_info[key] = value
-    return extra_info
 
 
 class VisualRewardManager(RewardManagerBase):

--- a/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
+++ b/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
@@ -81,10 +81,29 @@ from verl_omni.trainer.diffusion.rollout_correction import (
     rollout_correction_enabled,
 )
 from verl_omni.trainer.diffusion.teacher_manager import DiffusionTeacherManager
-from verl_omni.utils.tracking import _export_video, batch_items, log_wandb_media, wrap_val_samples_for_wandb
+from verl_omni.utils.tracking import (
+    _export_video,
+    batch_items,
+    log_wandb_media,
+    resolve_is_video,
+    wrap_val_samples_for_wandb,
+)
 from verl_omni.workers.utils.padding import embeds_padding_2_no_padding
 
 sys_logger = logging.getLogger(__name__)
+
+
+def _json_encode_default(obj):
+    """Encode NumPy values retained in rollout metadata for JSONL dumps."""
+    if isinstance(obj, np.integer):
+        return int(obj)
+    if isinstance(obj, np.floating):
+        return float(obj)
+    if isinstance(obj, np.bool_):
+        return bool(obj)
+    if hasattr(obj, "tolist"):
+        return obj.tolist()
+    raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
 
 
 def validate_separate_config(config) -> None:
@@ -363,6 +382,7 @@ class BaseRayDiffusionTrainer(ABC):
         fps=24,
         audios=None,
         audio_sample_rates=None,
+        media_kind=None,
     ):
         """Dump samples to disk as media files plus a JSONL index.
 
@@ -387,9 +407,11 @@ class BaseRayDiffusionTrainer(ABC):
             # Per-sample batch dim from single-seq rollouts: [N, 1, T, C, H, W].
             outputs = outputs.squeeze(1)
         if outputs.ndim == 5 and outputs.shape[1] == 3 and outputs.shape[2] != 3:
-            # Channels-first [N, C, T, H, W] -> [N, T, C, H, W].
+            # Channels-first [N, C, T, H, W] -> [N, T, C, H, W]. Layout normalization
+            # is still heuristic; declaring/normalizing it is deferred to the layout PR.
             outputs = outputs.permute(0, 2, 1, 3, 4)
-        is_video = outputs.ndim == 5  # [N, T, C, H, W] vs image [N, C, H, W]
+        # Prefer the adapter-declared media kind over the tensor rank.
+        is_video = resolve_is_video(outputs.ndim, media_kind)
 
         output_paths = []
         output_fallback_paths = [None] * n
@@ -464,7 +486,7 @@ class BaseRayDiffusionTrainer(ABC):
         lines = []
         for i in range(n):
             entry = {k: v[i] for k, v in base_data.items()}
-            lines.append(json.dumps(entry, ensure_ascii=False))
+            lines.append(json.dumps(entry, ensure_ascii=False, default=_json_encode_default))
 
         with open(filename, "w", encoding="utf-8") as f:
             f.write("\n".join(lines) + "\n")
@@ -510,6 +532,28 @@ class BaseRayDiffusionTrainer(ABC):
                     "audio_sample_rate", batch.batch.get("audio_sample_rate")
                 )
 
+            # The primary media kind is declared per adapter and is uniform across a
+            # rollout batch (one pipeline); take the first declared value. Direct
+            # diffusion loops project it as a top-level non-tensor field, while
+            # composite loops may retain the tool-extra envelope.
+            media_kind_values = batch.non_tensor_batch.get("media_kind")
+            if media_kind_values is not None:
+                media_kind = next(
+                    (value for value in batch_items(media_kind_values, len(batch), "media_kind") if value is not None),
+                    None,
+                )
+            elif tool_extra is not None:
+                media_kind = next(
+                    (
+                        item.get("media_kind")
+                        for item in tool_extra
+                        if isinstance(item, dict) and item.get("media_kind")
+                    ),
+                    None,
+                )
+            else:
+                media_kind = None
+
             self._dump_generations(
                 inputs=inputs,
                 outputs=outputs,
@@ -521,10 +565,19 @@ class BaseRayDiffusionTrainer(ABC):
                 fps=int(self.config.trainer.get("video_fps", 24)),
                 audios=audios_to_dump,
                 audio_sample_rates=audio_rates_to_dump,
+                media_kind=media_kind,
             )
 
-    def _maybe_log_val_generations(self, inputs, outputs, scores, audios=None, audio_sample_rates=None):
-        """Log a table of validation samples to the configured logger (wandb or swanlab)"""
+    def _maybe_log_val_generations(
+        self,
+        inputs,
+        outputs,
+        scores,
+        audios=None,
+        audio_sample_rates=None,
+        media_kinds=None,
+    ):
+        """Log a table of validation samples to the configured logger (wandb or swanlab)."""
 
         generations_to_log = self.config.trainer.log_val_generations
 
@@ -537,7 +590,8 @@ class BaseRayDiffusionTrainer(ABC):
 
         audios = batch_items(audios, len(inputs), "audio")
         audio_sample_rates = batch_items(audio_sample_rates, len(inputs), "audio_sample_rate")
-        samples = list(zip(inputs, list(outputs), scores, audios, audio_sample_rates, strict=True))
+        media_kinds = batch_items(media_kinds, len(inputs), "media_kind")
+        samples = list(zip(inputs, list(outputs), scores, audios, audio_sample_rates, media_kinds, strict=True))
         samples.sort(key=lambda x: x[0])  # Sort by input text
 
         # Use fixed random seed for deterministic shuffling
@@ -557,10 +611,13 @@ class BaseRayDiffusionTrainer(ABC):
             if wandb_video_dir:
                 wandb_video_dir = os.path.join(wandb_video_dir, "wandb_val_media", f"global_step_{self.global_steps}")
             samples, video_tmp_dir, wandb_media = wrap_val_samples_for_wandb(
-                samples, fps=int(self.config.trainer.get("video_fps", 24)), output_dir=wandb_video_dir
+                samples,
+                fps=int(self.config.trainer.get("video_fps", 24)),
+                output_dir=wandb_video_dir,
+                media_kinds=[sample[5] for sample in samples],
             )
         else:
-            samples = [(input_, output, score) for input_, output, score, _, _ in samples]
+            samples = [(input_, output, score) for input_, output, score, *_ in samples]
 
         # Log to each configured logger
         try:
@@ -603,6 +660,7 @@ class BaseRayDiffusionTrainer(ABC):
         sample_outputs = []
         sample_audios = []
         sample_audio_sample_rates = []
+        sample_media_kinds = []
         sample_gts = []
         sample_scores = []
         sample_turns = []
@@ -668,6 +726,9 @@ class BaseRayDiffusionTrainer(ABC):
                     "audio_sample_rate",
                 )
             )
+            sample_media_kinds.extend(
+                batch_items(test_output_gen_batch.non_tensor_batch.get("media_kind"), batch_size, "media_kind")
+            )
 
             test_batch = test_batch.union(test_output_gen_batch)
             test_batch.meta_info["validate"] = True
@@ -706,6 +767,7 @@ class BaseRayDiffusionTrainer(ABC):
             scores=sample_scores,
             audios=sample_audios,
             audio_sample_rates=sample_audio_sample_rates,
+            media_kinds=sample_media_kinds,
         )
 
         # dump generations
@@ -722,6 +784,7 @@ class BaseRayDiffusionTrainer(ABC):
                 fps=int(self.config.trainer.get("video_fps", 24)),
                 audios=sample_audios,
                 audio_sample_rates=sample_audio_sample_rates,
+                media_kind=next((kind for kind in sample_media_kinds if kind is not None), None),
             )
 
         for key_info, lst in reward_extra_infos_dict.items():

--- a/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
+++ b/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
@@ -389,17 +389,14 @@ class BaseRayDiffusionTrainer(ABC):
         ``outputs`` is a batch of images ``[N, C, H, W]`` (-> ``{i}.jpg``) or videos
         ``[N, T, C, H, W]`` (-> ``{i}.mp4`` at ``fps``). ``max_samples`` caps how many
         are written (``None`` = all). Optional generated audio is muxed into video files.
-        Failed video exports are preserved as ``{i}.pt`` fallback payloads and recorded
-        in the JSONL instead of terminating training.
+        Failed video exports are preserved as ``{i}.pt`` fallback payloads when possible.
+        Media failures are recorded in JSONL; filesystem failures warn and skip the dump.
         """
         if not isinstance(outputs, torch.Tensor) or outputs.dtype != torch.uint8:
             dtype = getattr(outputs, "dtype", type(outputs))
             raise ValueError(f"Expected generation outputs to be a uint8 tensor, got {dtype}.")
 
-        os.makedirs(dump_path, exist_ok=True)
-
         visual_folder = os.path.join(dump_path, f"{self.global_steps}")
-        os.makedirs(visual_folder, exist_ok=True)
 
         n_full = outputs.shape[0]
         n = n_full if max_samples is None else min(max_samples, n_full)
@@ -413,9 +410,16 @@ class BaseRayDiffusionTrainer(ABC):
         # Prefer the adapter-declared media kind over the tensor rank.
         is_video = resolve_is_video(outputs.ndim, media_kind)
 
+        try:
+            os.makedirs(visual_folder, exist_ok=True)
+        except OSError as error:
+            sys_logger.warning("Skipping media dump at step %s: %s", self.global_steps, error)
+            return
+
         output_paths = []
         output_fallback_paths = [None] * n
         video_export_errors = [None] * n
+        image_export_errors = [None] * n
         if is_video:
             audios = batch_items(audios, n_full, "audio")
             audio_sample_rates = batch_items(audio_sample_rates, n_full, "audio_sample_rate")
@@ -463,8 +467,16 @@ class BaseRayDiffusionTrainer(ABC):
             images_pil = outputs[:n].cpu().permute(0, 2, 3, 1).numpy()
             for i, image in enumerate(images_pil):
                 image_path = os.path.join(visual_folder, f"{i}.jpg")
-                Image.fromarray(image).save(image_path)
-                output_paths.append(image_path)
+                try:
+                    Image.fromarray(image).save(image_path)
+                except (OSError, ValueError) as error:
+                    image_export_errors[i] = f"{type(error).__name__}: {error}"
+                    sys_logger.warning(
+                        "Failed to export rollout image at step %s sample %s: %s", self.global_steps, i, error
+                    )
+                    output_paths.append(None)
+                else:
+                    output_paths.append(image_path)
 
         filename = os.path.join(dump_path, f"{self.global_steps}.jsonl")
 
@@ -483,13 +495,20 @@ class BaseRayDiffusionTrainer(ABC):
             base_data["output_fallback"] = output_fallback_paths
             base_data["video_export_error"] = video_export_errors
 
-        lines = []
-        for i in range(n):
-            entry = {k: v[i] for k, v in base_data.items()}
-            lines.append(json.dumps(entry, ensure_ascii=False, default=_json_encode_default))
+        if any(image_export_errors):
+            base_data["image_export_error"] = image_export_errors
 
-        with open(filename, "w", encoding="utf-8") as f:
-            f.write("\n".join(lines) + "\n")
+        try:
+            lines = []
+            for i in range(n):
+                entry = {k: v[i] for k, v in base_data.items()}
+                lines.append(json.dumps(entry, ensure_ascii=False, default=_json_encode_default))
+
+            with open(filename, "w", encoding="utf-8") as f:
+                f.write("\n".join(lines) + "\n")
+        except (OSError, TypeError, ValueError) as error:
+            sys_logger.warning("Skipping media index at step %s (%s): %s", self.global_steps, filename, error)
+            return
 
         print(f"Dumped generations to {filename}")
 
@@ -621,8 +640,14 @@ class BaseRayDiffusionTrainer(ABC):
 
         # Log to each configured logger
         try:
-            log_wandb_media(wandb_media, self.global_steps)
-            self.validation_generations_logger.log(self.config.trainer.logger, samples, self.global_steps)
+            try:
+                log_wandb_media(wandb_media, self.global_steps)
+            except Exception as error:
+                sys_logger.warning("Skipping validation media log at step %s: %s", self.global_steps, error)
+            try:
+                self.validation_generations_logger.log(self.config.trainer.logger, samples, self.global_steps)
+            except Exception as error:
+                sys_logger.warning("Skipping validation table log at step %s: %s", self.global_steps, error)
         finally:
             if video_tmp_dir is not None:
                 shutil.rmtree(video_tmp_dir, ignore_errors=True)

--- a/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
+++ b/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
@@ -54,6 +54,7 @@ from verl.utils.py_functional import rename_dict
 from verl.utils.tracking import ValidationGenerationsLogger
 from verl.workers.rollout.llm_server import LLMServerManager
 
+from verl_omni.pipelines.rollout_media import resolve_batch_media_kind, resolve_is_video
 from verl_omni.trainer.config import DiffusionAlgoConfig
 from verl_omni.trainer.diffusion.diffusion_algos import (
     DiffusionAdvantageEstimator,
@@ -85,7 +86,6 @@ from verl_omni.utils.tracking import (
     _export_video,
     batch_items,
     log_wandb_media,
-    resolve_is_video,
     wrap_val_samples_for_wandb,
 )
 from verl_omni.workers.utils.padding import embeds_padding_2_no_padding
@@ -187,6 +187,146 @@ def compute_advantage(
     data.batch["advantages"] = advantages
     data.batch["returns"] = returns
     return data
+
+
+def _validate_generation_outputs(outputs) -> None:
+    """Reject non-pixel outputs before best-effort logging or async submission."""
+    if not isinstance(outputs, torch.Tensor) or outputs.dtype != torch.uint8:
+        dtype = getattr(outputs, "dtype", type(outputs))
+        raise ValueError(f"Expected generation outputs to be a uint8 tensor, got {dtype}.")
+
+
+def dump_generations(
+    global_steps,
+    inputs,
+    outputs,
+    gts,
+    scores,
+    reward_extra_infos_dict,
+    dump_path,
+    max_samples=None,
+    fps=24,
+    audios=None,
+    audio_sample_rates=None,
+    media_kind=None,
+):
+    """Dump samples to disk as media files plus a JSONL index.
+
+    ``outputs`` is a batch of images ``[N, C, H, W]`` (-> ``{i}.jpg``) or videos
+    ``[N, T, C, H, W]`` (-> ``{i}.mp4`` at ``fps``). ``max_samples`` caps how many
+    are written (``None`` = all). Optional generated audio is muxed into video files.
+    Failed video exports are preserved as ``{i}.pt`` fallback payloads when possible.
+    Media failures are recorded in JSONL; filesystem failures warn and skip the dump.
+    """
+    _validate_generation_outputs(outputs)
+    visual_folder = os.path.join(dump_path, f"{global_steps}")
+
+    n_full = outputs.shape[0]
+    n = n_full if max_samples is None else min(max_samples, n_full)
+    if outputs.ndim == 6:
+        # Per-sample batch dim from single-seq rollouts: [N, 1, T, C, H, W].
+        outputs = outputs.squeeze(1)
+    if outputs.ndim == 5 and outputs.shape[1] == 3 and outputs.shape[2] != 3:
+        # Channels-first [N, C, T, H, W] -> [N, T, C, H, W]. Layout normalization
+        # is still heuristic; declaring/normalizing it is deferred to the layout PR.
+        outputs = outputs.permute(0, 2, 1, 3, 4)
+    # Prefer the adapter-declared media kind over the tensor rank.
+    is_video = resolve_is_video(outputs.ndim, media_kind)
+
+    try:
+        os.makedirs(visual_folder, exist_ok=True)
+    except OSError as error:
+        sys_logger.warning("Skipping media dump at step %s: %s", global_steps, error)
+        return
+
+    output_paths = []
+    output_fallback_paths = [None] * n
+    video_export_errors = [None] * n
+    image_export_errors = [None] * n
+    if is_video:
+        audios = batch_items(audios, n_full, "audio")
+        audio_sample_rates = batch_items(audio_sample_rates, n_full, "audio_sample_rate")
+        for i in range(n):
+            video_path = os.path.join(visual_folder, f"{i}.mp4")
+            try:
+                _export_video(
+                    outputs[i],
+                    video_path,
+                    fps=fps,
+                    audio=audios[i],
+                    audio_sample_rate=audio_sample_rates[i],
+                )
+            except (OSError, subprocess.SubprocessError, ValueError) as error:
+                error_message = f"{type(error).__name__}: {error}"
+                fallback_path = os.path.join(visual_folder, f"{i}.pt")
+                fallback_audio = audios[i]
+                if isinstance(fallback_audio, torch.Tensor):
+                    fallback_audio = fallback_audio.detach().cpu()
+                fallback = {
+                    "video": outputs[i].detach().cpu(),
+                    "audio": fallback_audio,
+                    "audio_sample_rate": audio_sample_rates[i],
+                }
+                try:
+                    torch.save(fallback, fallback_path)
+                except Exception as fallback_error:
+                    fallback_path = None
+                    error_message = (
+                        f"{error_message}; fallback save failed: {type(fallback_error).__name__}: {fallback_error}"
+                    )
+                else:
+                    output_fallback_paths[i] = fallback_path
+                video_export_errors[i] = error_message
+                sys_logger.warning(
+                    "Failed to export rollout video at step %s sample %s: %s",
+                    global_steps,
+                    i,
+                    error_message,
+                )
+                output_paths.append(None)
+            else:
+                output_paths.append(video_path)
+    else:
+        images_pil = outputs[:n].cpu().permute(0, 2, 3, 1).numpy()
+        for i, image in enumerate(images_pil):
+            image_path = os.path.join(visual_folder, f"{i}.jpg")
+            try:
+                Image.fromarray(image).save(image_path)
+            except (OSError, ValueError) as error:
+                image_export_errors[i] = f"{type(error).__name__}: {error}"
+                sys_logger.warning("Failed to export rollout image at step %s sample %s: %s", global_steps, i, error)
+                output_paths.append(None)
+            else:
+                output_paths.append(image_path)
+
+    filename = os.path.join(dump_path, f"{global_steps}.jsonl")
+    base_data = {
+        "input": list(inputs)[:n],
+        "output": output_paths,
+        "gts": list(gts)[:n],
+        "score": list(scores)[:n],
+        "step": [global_steps] * n,
+    }
+    for k, v in reward_extra_infos_dict.items():
+        if len(v) == n_full:
+            base_data[k] = list(v)[:n]
+    if any(video_export_errors):
+        base_data["output_fallback"] = output_fallback_paths
+        base_data["video_export_error"] = video_export_errors
+    if any(image_export_errors):
+        base_data["image_export_error"] = image_export_errors
+
+    try:
+        lines = []
+        for i in range(n):
+            entry = {k: v[i] for k, v in base_data.items()}
+            lines.append(json.dumps(entry, ensure_ascii=False, default=_json_encode_default))
+        with open(filename, "w", encoding="utf-8") as f:
+            f.write("\n".join(lines) + "\n")
+    except (OSError, TypeError, ValueError) as error:
+        sys_logger.warning("Skipping media index at step %s (%s): %s", global_steps, filename, error)
+        return
+    print(f"Dumped generations to {filename}")
 
 
 class BaseRayDiffusionTrainer(ABC):
@@ -384,133 +524,21 @@ class BaseRayDiffusionTrainer(ABC):
         audio_sample_rates=None,
         media_kind=None,
     ):
-        """Dump samples to disk as media files plus a JSONL index.
-
-        ``outputs`` is a batch of images ``[N, C, H, W]`` (-> ``{i}.jpg``) or videos
-        ``[N, T, C, H, W]`` (-> ``{i}.mp4`` at ``fps``). ``max_samples`` caps how many
-        are written (``None`` = all). Optional generated audio is muxed into video files.
-        Failed video exports are preserved as ``{i}.pt`` fallback payloads when possible.
-        Media failures are recorded in JSONL; filesystem failures warn and skip the dump.
-        """
-        if not isinstance(outputs, torch.Tensor) or outputs.dtype != torch.uint8:
-            dtype = getattr(outputs, "dtype", type(outputs))
-            raise ValueError(f"Expected generation outputs to be a uint8 tensor, got {dtype}.")
-
-        visual_folder = os.path.join(dump_path, f"{self.global_steps}")
-
-        n_full = outputs.shape[0]
-        n = n_full if max_samples is None else min(max_samples, n_full)
-        if outputs.ndim == 6:
-            # Per-sample batch dim from single-seq rollouts: [N, 1, T, C, H, W].
-            outputs = outputs.squeeze(1)
-        if outputs.ndim == 5 and outputs.shape[1] == 3 and outputs.shape[2] != 3:
-            # Channels-first [N, C, T, H, W] -> [N, T, C, H, W]. Layout normalization
-            # is still heuristic; declaring/normalizing it is deferred to the layout PR.
-            outputs = outputs.permute(0, 2, 1, 3, 4)
-        # Prefer the adapter-declared media kind over the tensor rank.
-        is_video = resolve_is_video(outputs.ndim, media_kind)
-
-        try:
-            os.makedirs(visual_folder, exist_ok=True)
-        except OSError as error:
-            sys_logger.warning("Skipping media dump at step %s: %s", self.global_steps, error)
-            return
-
-        output_paths = []
-        output_fallback_paths = [None] * n
-        video_export_errors = [None] * n
-        image_export_errors = [None] * n
-        if is_video:
-            audios = batch_items(audios, n_full, "audio")
-            audio_sample_rates = batch_items(audio_sample_rates, n_full, "audio_sample_rate")
-            for i in range(n):
-                video_path = os.path.join(visual_folder, f"{i}.mp4")
-                try:
-                    _export_video(
-                        outputs[i],
-                        video_path,
-                        fps=fps,
-                        audio=audios[i],
-                        audio_sample_rate=audio_sample_rates[i],
-                    )
-                except (OSError, subprocess.SubprocessError, ValueError) as error:
-                    error_message = f"{type(error).__name__}: {error}"
-                    fallback_path = os.path.join(visual_folder, f"{i}.pt")
-                    fallback_audio = audios[i]
-                    if isinstance(fallback_audio, torch.Tensor):
-                        fallback_audio = fallback_audio.detach().cpu()
-                    fallback = {
-                        "video": outputs[i].detach().cpu(),
-                        "audio": fallback_audio,
-                        "audio_sample_rate": audio_sample_rates[i],
-                    }
-                    try:
-                        torch.save(fallback, fallback_path)
-                    except Exception as fallback_error:
-                        fallback_path = None
-                        error_message = (
-                            f"{error_message}; fallback save failed: {type(fallback_error).__name__}: {fallback_error}"
-                        )
-                    else:
-                        output_fallback_paths[i] = fallback_path
-                    video_export_errors[i] = error_message
-                    sys_logger.warning(
-                        "Failed to export rollout video at step %s sample %s: %s",
-                        self.global_steps,
-                        i,
-                        error_message,
-                    )
-                    output_paths.append(None)
-                else:
-                    output_paths.append(video_path)
-        else:
-            images_pil = outputs[:n].cpu().permute(0, 2, 3, 1).numpy()
-            for i, image in enumerate(images_pil):
-                image_path = os.path.join(visual_folder, f"{i}.jpg")
-                try:
-                    Image.fromarray(image).save(image_path)
-                except (OSError, ValueError) as error:
-                    image_export_errors[i] = f"{type(error).__name__}: {error}"
-                    sys_logger.warning(
-                        "Failed to export rollout image at step %s sample %s: %s", self.global_steps, i, error
-                    )
-                    output_paths.append(None)
-                else:
-                    output_paths.append(image_path)
-
-        filename = os.path.join(dump_path, f"{self.global_steps}.jsonl")
-
-        base_data = {
-            "input": list(inputs)[:n],
-            "output": output_paths,
-            "gts": list(gts)[:n],
-            "score": list(scores)[:n],
-            "step": [self.global_steps] * n,
-        }
-
-        for k, v in reward_extra_infos_dict.items():
-            if len(v) == n_full:
-                base_data[k] = list(v)[:n]
-        if any(video_export_errors):
-            base_data["output_fallback"] = output_fallback_paths
-            base_data["video_export_error"] = video_export_errors
-
-        if any(image_export_errors):
-            base_data["image_export_error"] = image_export_errors
-
-        try:
-            lines = []
-            for i in range(n):
-                entry = {k: v[i] for k, v in base_data.items()}
-                lines.append(json.dumps(entry, ensure_ascii=False, default=_json_encode_default))
-
-            with open(filename, "w", encoding="utf-8") as f:
-                f.write("\n".join(lines) + "\n")
-        except (OSError, TypeError, ValueError) as error:
-            sys_logger.warning("Skipping media index at step %s (%s): %s", self.global_steps, filename, error)
-            return
-
-        print(f"Dumped generations to {filename}")
+        """Dump media with the shared exporter at the current training step."""
+        return dump_generations(
+            self.global_steps,
+            inputs,
+            outputs,
+            gts,
+            scores,
+            reward_extra_infos_dict,
+            dump_path,
+            max_samples=max_samples,
+            fps=fps,
+            audios=audios,
+            audio_sample_rates=audio_sample_rates,
+            media_kind=media_kind,
+        )
 
     def _log_rollout_data(
         self, batch: DataProto, reward_extra_infos_dict: dict, timing_raw: dict, rollout_data_dir: str
@@ -551,27 +579,12 @@ class BaseRayDiffusionTrainer(ABC):
                     "audio_sample_rate", batch.batch.get("audio_sample_rate")
                 )
 
-            # The primary media kind is declared per adapter and is uniform across a
-            # rollout batch (one pipeline); take the first declared value. Direct
-            # diffusion loops project it as a top-level non-tensor field, while
-            # composite loops may retain the tool-extra envelope.
+            # One pipeline owns the batch; validate rather than silently choosing
+            # one sample's kind. Composite loops may retain the tool-extra envelope.
             media_kind_values = batch.non_tensor_batch.get("media_kind")
-            if media_kind_values is not None:
-                media_kind = next(
-                    (value for value in batch_items(media_kind_values, len(batch), "media_kind") if value is not None),
-                    None,
-                )
-            elif tool_extra is not None:
-                media_kind = next(
-                    (
-                        item.get("media_kind")
-                        for item in tool_extra
-                        if isinstance(item, dict) and item.get("media_kind")
-                    ),
-                    None,
-                )
-            else:
-                media_kind = None
+            if media_kind_values is None and tool_extra is not None:
+                media_kind_values = [item.get("media_kind") if isinstance(item, dict) else None for item in tool_extra]
+            media_kind = resolve_batch_media_kind(batch_items(media_kind_values, len(batch), "media_kind"))
 
             self._dump_generations(
                 inputs=inputs,
@@ -602,6 +615,7 @@ class BaseRayDiffusionTrainer(ABC):
 
         if generations_to_log == 0:
             return
+        _validate_generation_outputs(outputs)
 
         import shutil
 
@@ -610,6 +624,7 @@ class BaseRayDiffusionTrainer(ABC):
         audios = batch_items(audios, len(inputs), "audio")
         audio_sample_rates = batch_items(audio_sample_rates, len(inputs), "audio_sample_rate")
         media_kinds = batch_items(media_kinds, len(inputs), "media_kind")
+        resolve_batch_media_kind(media_kinds)
         samples = list(zip(inputs, list(outputs), scores, audios, audio_sample_rates, media_kinds, strict=True))
         samples.sort(key=lambda x: x[0])  # Sort by input text
 
@@ -809,7 +824,7 @@ class BaseRayDiffusionTrainer(ABC):
                 fps=int(self.config.trainer.get("video_fps", 24)),
                 audios=sample_audios,
                 audio_sample_rates=sample_audio_sample_rates,
-                media_kind=next((kind for kind in sample_media_kinds if kind is not None), None),
+                media_kind=resolve_batch_media_kind(sample_media_kinds),
             )
 
         for key_info, lst in reward_extra_infos_dict.items():

--- a/verl_omni/trainer/diffusion/v1/tq_utils.py
+++ b/verl_omni/trainer/diffusion/v1/tq_utils.py
@@ -136,7 +136,7 @@ def diffusion_tq_batch_to_dataproto(
                 continue
             for k, v in extra.items():
                 if k not in non_tensor_batch:
-                    non_tensor_batch[k] = np.empty(len(extra_fields_arr), dtype=object)
+                    non_tensor_batch[k] = np.full(len(extra_fields_arr), None, dtype=object)
                 non_tensor_batch[k][i] = v
 
     batch = TensorDict(batch_dict, batch_size=len(keys))

--- a/verl_omni/trainer/diffusion/v1/trainer_base.py
+++ b/verl_omni/trainer/diffusion/v1/trainer_base.py
@@ -20,7 +20,6 @@ from abc import ABC, abstractmethod
 from collections import Counter, defaultdict
 from concurrent.futures import ThreadPoolExecutor
 from pprint import pprint
-from types import SimpleNamespace
 
 import numpy as np
 import ray
@@ -57,6 +56,7 @@ from verl.utils.skip import SkipManager
 from verl.utils.tracking import Tracking, ValidationGenerationsLogger
 from verl.workers.rollout.llm_server import LLMServerManager
 
+from verl_omni.pipelines.rollout_media import resolve_batch_media_kind, resolve_is_video
 from verl_omni.trainer.diffusion.diffusion_algos import get_diffusion_loss_fn
 from verl_omni.trainer.diffusion.diffusion_metric_utils import (
     compute_data_metrics_diffusion,
@@ -73,7 +73,9 @@ from verl_omni.trainer.diffusion.diffusion_trainer_utils import (
 from verl_omni.trainer.diffusion.ray_diffusion_trainer import (
     BaseRayDiffusionTrainer,
     _to_diffusion_worker_tensordict,
+    _validate_generation_outputs,
     compute_advantage,
+    dump_generations,
 )
 from verl_omni.trainer.diffusion.rollout_correction import (
     apply_bypass_mode_to_diffusion_batch,
@@ -87,7 +89,7 @@ from verl_omni.trainer.diffusion.v1.tq_utils import (
     put_dataproto_fields_to_tq,
     sort_diffusion_tq_keys,
 )
-from verl_omni.utils.tracking import batch_items, resolve_is_video
+from verl_omni.utils.tracking import batch_items
 from verl_omni.workers.engine_workers import ActorRolloutRefWorker, resolve_teacher_infer_micro_batch_size
 from verl_omni.workers.utils.padding import embeds_padding_2_no_padding
 
@@ -1382,7 +1384,7 @@ class PolicyGradientDiffusionTrainerV1(ABC):
                 fps=int(self.config.trainer.get("video_fps", 24)),
                 audios=sample_audios,
                 audio_sample_rates=sample_audio_sample_rates,
-                media_kind=next((kind for kind in sample_media_kinds if kind is not None), None),
+                media_kind=resolve_batch_media_kind(sample_media_kinds),
             )
 
         data_sources_arr = np.concatenate(data_sources, axis=0) if data_sources else np.array([])
@@ -1422,18 +1424,19 @@ class PolicyGradientDiffusionTrainerV1(ABC):
         audio_sample_rates=None,
         media_kind=None,
     ):
-        """Submit a best-effort image/video dump to the background executor."""
+        """Validate media synchronously, then submit best-effort I/O with a step snapshot."""
+        _validate_generation_outputs(outputs)
         resolve_is_video(outputs.ndim, media_kind)
         global_step = self.global_steps
         future = self._dump_executor.submit(
-            self._write_generations,
+            dump_generations,
+            global_step,
             inputs,
             outputs,
             gts,
             scores,
             reward_extra_infos_dict,
             dump_path,
-            global_step,
             max_samples,
             fps,
             audios,
@@ -1442,38 +1445,6 @@ class PolicyGradientDiffusionTrainerV1(ABC):
         )
         self._dump_futures.append((future, global_step))
         self._drain_dump_futures()
-
-    @staticmethod
-    def _write_generations(
-        inputs,
-        outputs,
-        gts,
-        scores,
-        reward_extra_infos_dict,
-        dump_path,
-        global_step,
-        max_samples,
-        fps,
-        audios,
-        audio_sample_rates,
-        media_kind,
-    ):
-        """Reuse the V0 media exporter with a step snapshot for thread safety."""
-        dump_context = SimpleNamespace(global_steps=global_step)
-        BaseRayDiffusionTrainer._dump_generations(
-            dump_context,
-            inputs,
-            outputs,
-            gts,
-            scores,
-            reward_extra_infos_dict,
-            dump_path,
-            max_samples=max_samples,
-            fps=fps,
-            audios=audios,
-            audio_sample_rates=audio_sample_rates,
-            media_kind=media_kind,
-        )
 
     def _log_rollout_data(self, batch_meta: KVBatchMeta, timing_raw: dict, rollout_data_dir: str):
         """Fetch rollout rows from TQ and dump sorted by uid."""
@@ -1522,7 +1493,7 @@ class PolicyGradientDiffusionTrainerV1(ABC):
                 fps=int(self.config.trainer.get("video_fps", 24)),
                 audios=audios,
                 audio_sample_rates=audio_sample_rates,
-                media_kind=next((kind for kind in media_kinds if kind is not None), None),
+                media_kind=resolve_batch_media_kind(media_kinds),
             )
 
     def _val_metrics_update(self, data_sources, sample_uids, reward_extra_infos_dict, sample_turns) -> dict:

--- a/verl_omni/trainer/diffusion/v1/trainer_base.py
+++ b/verl_omni/trainer/diffusion/v1/trainer_base.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
 import logging
 import math
 import os
@@ -21,13 +20,13 @@ from abc import ABC, abstractmethod
 from collections import Counter, defaultdict
 from concurrent.futures import ThreadPoolExecutor
 from pprint import pprint
+from types import SimpleNamespace
 
 import numpy as np
 import ray
 import torch
 import transfer_queue as tq
 from omegaconf import OmegaConf, open_dict
-from PIL import Image
 from torchdata.stateful_dataloader import StatefulDataLoader
 from tqdm import tqdm
 from transfer_queue import KVBatchMeta
@@ -71,7 +70,11 @@ from verl_omni.trainer.diffusion.diffusion_trainer_utils import (
     validate_distillation_config,
     worker_group_port_ranges,
 )
-from verl_omni.trainer.diffusion.ray_diffusion_trainer import _to_diffusion_worker_tensordict, compute_advantage
+from verl_omni.trainer.diffusion.ray_diffusion_trainer import (
+    BaseRayDiffusionTrainer,
+    _to_diffusion_worker_tensordict,
+    compute_advantage,
+)
 from verl_omni.trainer.diffusion.rollout_correction import (
     apply_bypass_mode_to_diffusion_batch,
     apply_rollout_correction_to_diffusion_batch,
@@ -84,6 +87,7 @@ from verl_omni.trainer.diffusion.v1.tq_utils import (
     put_dataproto_fields_to_tq,
     sort_diffusion_tq_keys,
 )
+from verl_omni.utils.tracking import batch_items
 from verl_omni.workers.engine_workers import ActorRolloutRefWorker, resolve_teacher_infer_micro_batch_size
 from verl_omni.workers.utils.padding import embeds_padding_2_no_padding
 
@@ -255,7 +259,8 @@ class PolicyGradientDiffusionTrainerV1(ABC):
             self._compute_metrics(batch, metrics, self.timing_raw, self.global_steps, current_epoch)
 
             rollout_data_dir = self.config.trainer.get("rollout_data_dir", None)
-            if rollout_data_dir:
+            rollout_data_save_freq = self.config.trainer.get("rollout_data_save_freq", 1)
+            if rollout_data_dir and rollout_data_save_freq > 0 and self.global_steps % rollout_data_save_freq == 0:
                 self._log_rollout_data(batch, self.timing_raw, rollout_data_dir)
 
             tq.kv_clear(keys=batch.keys, partition_id=batch.partition_id)
@@ -756,11 +761,33 @@ class PolicyGradientDiffusionTrainerV1(ABC):
         self._dump_executor = ThreadPoolExecutor(max_workers=1)
         self._dump_futures = []
 
+    @staticmethod
+    def _report_dump_failure(future, global_step: int) -> None:
+        """Log a completed media-dump failure without interrupting training."""
+        try:
+            future.result()
+        except Exception as error:
+            logger.warning(
+                "Ignoring background media dump failure at step %s: %s",
+                global_step,
+                error,
+                exc_info=(type(error), error, error.__traceback__),
+            )
+
+    def _drain_dump_futures(self) -> None:
+        still_pending = []
+        for future, global_step in self._dump_futures:
+            if future.done():
+                self._report_dump_failure(future, global_step)
+            else:
+                still_pending.append((future, global_step))
+        self._dump_futures = still_pending
+
     def _shutdown_dump_executor(self):
-        for f in self._dump_futures:
-            f.result()
-        self._dump_futures.clear()
         self._dump_executor.shutdown(wait=True)
+        for future, global_step in self._dump_futures:
+            self._report_dump_failure(future, global_step)
+        self._dump_futures.clear()
 
     def _shutdown_dataloaders(self):
         for attr in ("train_dataloader", "val_dataloader"):
@@ -1230,9 +1257,12 @@ class PolicyGradientDiffusionTrainerV1(ABC):
         return DataProto.from_single_dict(data={}, meta_info={"metrics": actor_output})
 
     def _validate(self) -> dict:
-        """Validation via TransferQueue: dispatch, sample, convert, reward, dump images."""
+        """Validation via TransferQueue: dispatch, sample, convert, reward, dump media."""
         sample_inputs: list[str] = []
         sample_outputs: list[torch.Tensor] = []
+        sample_audios: list = []
+        sample_audio_sample_rates: list = []
+        sample_media_kinds: list = []
         sample_gts: list = []
         sample_scores: list[float] = []
         sample_turns: list = []
@@ -1286,7 +1316,7 @@ class PolicyGradientDiffusionTrainerV1(ABC):
                 else 0
             )
             logger.info(
-                "Validation batch (step=%d): %d trajectories, responses shape=%s, real_images=%s",
+                "Validation batch (step=%d): %d trajectories, responses shape=%s, real_media=%s",
                 self.global_steps,
                 len(data),
                 tuple(output_images.shape) if isinstance(output_images, torch.Tensor) else None,
@@ -1294,6 +1324,16 @@ class PolicyGradientDiffusionTrainerV1(ABC):
             )
             sample_inputs.extend(input_texts)
             sample_outputs.append(output_images)
+            batch_size = len(output_images)
+            sample_audios.extend(batch_items(data.batch.get("audio"), batch_size, "audio"))
+            sample_audio_sample_rates.extend(
+                batch_items(
+                    data.non_tensor_batch.get("audio_sample_rate", data.batch.get("audio_sample_rate")),
+                    batch_size,
+                    "audio_sample_rate",
+                )
+            )
+            sample_media_kinds.extend(batch_items(data.non_tensor_batch.get("media_kind"), batch_size, "media_kind"))
             uids = data.non_tensor_batch.get("uid")
             sample_uids.extend(list(uids) if uids is not None else [None] * len(data))
 
@@ -1320,7 +1360,14 @@ class PolicyGradientDiffusionTrainerV1(ABC):
             tq.kv_clear(keys=batch_meta.keys, partition_id=batch_meta.partition_id)
 
         sample_outputs = torch.cat(sample_outputs, dim=0) if sample_outputs else torch.empty(0)
-        self._maybe_log_val_generations(inputs=sample_inputs, outputs=sample_outputs, scores=sample_scores)
+        self._maybe_log_val_generations(
+            inputs=sample_inputs,
+            outputs=sample_outputs,
+            scores=sample_scores,
+            audios=sample_audios,
+            audio_sample_rates=sample_audio_sample_rates,
+            media_kinds=sample_media_kinds,
+        )
 
         val_data_dir = self.config.trainer.get("validation_data_dir", None)
         if val_data_dir and len(sample_outputs) > 0:
@@ -1331,35 +1378,52 @@ class PolicyGradientDiffusionTrainerV1(ABC):
                 scores=sample_scores,
                 reward_extra_infos_dict=reward_extra_infos_dict,
                 dump_path=val_data_dir,
+                max_samples=self.config.trainer.get("validation_data_max_samples", None),
+                fps=int(self.config.trainer.get("video_fps", 24)),
+                audios=sample_audios,
+                audio_sample_rates=sample_audio_sample_rates,
+                media_kind=next((kind for kind in sample_media_kinds if kind is not None), None),
             )
 
         data_sources_arr = np.concatenate(data_sources, axis=0) if data_sources else np.array([])
         return self._val_metrics_update(data_sources_arr, sample_uids, reward_extra_infos_dict, sample_turns)
 
-    def _maybe_log_val_generations(self, inputs, outputs, scores):
-        generations_to_log = self.config.trainer.log_val_generations
-        if generations_to_log == 0:
-            return
-        if "wandb" in self.config.trainer.logger:
-            for image in outputs:
-                if not isinstance(image, torch.Tensor) or image.dtype != torch.uint8:
-                    raise ValueError(f"Expected a uint8 image tensor, got {getattr(image, 'dtype', type(image))}.")
-            import wandb
+    def _maybe_log_val_generations(
+        self,
+        inputs,
+        outputs,
+        scores,
+        audios=None,
+        audio_sample_rates=None,
+        media_kinds=None,
+    ):
+        """Use the shared image/video W&B path with declared media metadata."""
+        return BaseRayDiffusionTrainer._maybe_log_val_generations(
+            self,
+            inputs,
+            outputs,
+            scores,
+            audios=audios,
+            audio_sample_rates=audio_sample_rates,
+            media_kinds=media_kinds,
+        )
 
-            outputs = [wandb.Image(image, file_type="jpg") for image in outputs]
-        samples = list(zip(inputs, outputs, scores, strict=True))
-        samples.sort(key=lambda x: x[0])
-        rng = np.random.RandomState(42)
-        rng.shuffle(samples)
-        samples = samples[:generations_to_log]
-        self.validation_generations_logger.log(self.config.trainer.logger, samples, self.global_steps)
-
-    def _dump_generations(self, inputs, outputs, gts, scores, reward_extra_infos_dict, dump_path):
-        """Dump validation/rollout samples as images + JSONL (runs in background)."""
-        if not isinstance(outputs, torch.Tensor) or outputs.dtype != torch.uint8:
-            dtype = getattr(outputs, "dtype", type(outputs))
-            raise ValueError(f"Expected generation outputs to be a uint8 tensor, got {dtype}.")
-
+    def _dump_generations(
+        self,
+        inputs,
+        outputs,
+        gts,
+        scores,
+        reward_extra_infos_dict,
+        dump_path,
+        max_samples=None,
+        fps=24,
+        audios=None,
+        audio_sample_rates=None,
+        media_kind=None,
+    ):
+        """Submit a best-effort image/video dump to the background executor."""
+        global_step = self.global_steps
         future = self._dump_executor.submit(
             self._write_generations,
             inputs,
@@ -1368,64 +1432,47 @@ class PolicyGradientDiffusionTrainerV1(ABC):
             scores,
             reward_extra_infos_dict,
             dump_path,
-            self.global_steps,
+            global_step,
+            max_samples,
+            fps,
+            audios,
+            audio_sample_rates,
+            media_kind,
         )
-        self._dump_futures.append(future)
-        still_pending = []
-        for f in self._dump_futures:
-            if f.done():
-                f.result()
-            else:
-                still_pending.append(f)
-        self._dump_futures = still_pending
+        self._dump_futures.append((future, global_step))
+        self._drain_dump_futures()
 
     @staticmethod
-    def _write_generations(inputs, outputs, gts, scores, reward_extra_infos_dict, dump_path, global_steps):
-        os.makedirs(dump_path, exist_ok=True)
-        visual_folder = os.path.join(dump_path, f"{global_steps}")
-        os.makedirs(visual_folder, exist_ok=True)
-
-        output_paths = []
-        images_pil = outputs.cpu()
-        # images: [N, C, H, W] -> [N, H, W, C]
-        if images_pil.dim() == 4:
-            images_pil = images_pil.permute(0, 2, 3, 1).numpy()
-        else:
-            images_pil = images_pil.numpy()
-        for i, image in enumerate(images_pil):
-            image_path = os.path.join(visual_folder, f"{i}.jpg")
-            Image.fromarray(image).save(image_path)
-            output_paths.append(image_path)
-
-        filename = os.path.join(dump_path, f"{global_steps}.jsonl")
-        n = len(inputs)
-        base_data = {
-            "input": inputs,
-            "output": output_paths,
-            "gts": gts,
-            "score": scores,
-            "step": [global_steps] * n,
-        }
-        for k, v in reward_extra_infos_dict.items():
-            if len(v) == n:
-                base_data[k] = v
-
-        def json_encode_default(obj):
-            if isinstance(obj, np.integer):
-                return int(obj)
-            if isinstance(obj, np.floating):
-                return float(obj)
-            if isinstance(obj, np.bool_):
-                return bool(obj)
-            if hasattr(obj, "tolist"):
-                return obj.tolist()
-            raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
-
-        with open(filename, "w") as f:
-            for i in range(n):
-                entry = {k: v[i] for k, v in base_data.items()}
-                f.write(json.dumps(entry, ensure_ascii=False, default=json_encode_default) + "\n")
-        print(f"Dumped diffusion generations to {filename}")
+    def _write_generations(
+        inputs,
+        outputs,
+        gts,
+        scores,
+        reward_extra_infos_dict,
+        dump_path,
+        global_step,
+        max_samples,
+        fps,
+        audios,
+        audio_sample_rates,
+        media_kind,
+    ):
+        """Reuse the V0 media exporter with a step snapshot for thread safety."""
+        dump_context = SimpleNamespace(global_steps=global_step)
+        BaseRayDiffusionTrainer._dump_generations(
+            dump_context,
+            inputs,
+            outputs,
+            gts,
+            scores,
+            reward_extra_infos_dict,
+            dump_path,
+            max_samples=max_samples,
+            fps=fps,
+            audios=audios,
+            audio_sample_rates=audio_sample_rates,
+            media_kind=media_kind,
+        )
 
     def _log_rollout_data(self, batch_meta: KVBatchMeta, timing_raw: dict, rollout_data_dir: str):
         """Fetch rollout rows from TQ and dump sorted by uid."""
@@ -1446,12 +1493,22 @@ class PolicyGradientDiffusionTrainerV1(ABC):
                 if rm_meta is not None
                 else [None] * len(data)
             )
+            audios = batch_items(data.batch.get("audio"), len(data), "audio")
+            audio_sample_rates = batch_items(
+                data.non_tensor_batch.get("audio_sample_rate", data.batch.get("audio_sample_rate")),
+                len(data),
+                "audio_sample_rate",
+            )
+            media_kinds = batch_items(data.non_tensor_batch.get("media_kind"), len(data), "media_kind")
 
             sort_idx = sort_diffusion_tq_keys(list(batch_meta.keys))
             inputs = [inputs[i] for i in sort_idx]
             outputs = outputs[torch.tensor(sort_idx)]
             gts = [gts[i] for i in sort_idx]
             scores = [scores[i] for i in sort_idx]
+            audios = [audios[i] for i in sort_idx]
+            audio_sample_rates = [audio_sample_rates[i] for i in sort_idx]
+            media_kinds = [media_kinds[i] for i in sort_idx]
             reward_extra_infos_dict = {"uid": [batch_meta.keys[i] for i in sort_idx]}
             self._dump_generations(
                 inputs=inputs,
@@ -1460,6 +1517,11 @@ class PolicyGradientDiffusionTrainerV1(ABC):
                 scores=scores,
                 reward_extra_infos_dict=reward_extra_infos_dict,
                 dump_path=rollout_data_dir,
+                max_samples=self.config.trainer.get("rollout_data_max_samples", None),
+                fps=int(self.config.trainer.get("video_fps", 24)),
+                audios=audios,
+                audio_sample_rates=audio_sample_rates,
+                media_kind=next((kind for kind in media_kinds if kind is not None), None),
             )
 
     def _val_metrics_update(self, data_sources, sample_uids, reward_extra_infos_dict, sample_turns) -> dict:

--- a/verl_omni/trainer/diffusion/v1/trainer_base.py
+++ b/verl_omni/trainer/diffusion/v1/trainer_base.py
@@ -87,7 +87,7 @@ from verl_omni.trainer.diffusion.v1.tq_utils import (
     put_dataproto_fields_to_tq,
     sort_diffusion_tq_keys,
 )
-from verl_omni.utils.tracking import batch_items
+from verl_omni.utils.tracking import batch_items, resolve_is_video
 from verl_omni.workers.engine_workers import ActorRolloutRefWorker, resolve_teacher_infer_micro_batch_size
 from verl_omni.workers.utils.padding import embeds_padding_2_no_padding
 
@@ -1423,6 +1423,7 @@ class PolicyGradientDiffusionTrainerV1(ABC):
         media_kind=None,
     ):
         """Submit a best-effort image/video dump to the background executor."""
+        resolve_is_video(outputs.ndim, media_kind)
         global_step = self.global_steps
         future = self._dump_executor.submit(
             self._write_generations,

--- a/verl_omni/utils/tracking.py
+++ b/verl_omni/utils/tracking.py
@@ -81,6 +81,19 @@ def _video_tensor_to_rgb24(video: torch.Tensor) -> tuple[np.ndarray, int, int]:
     return frames, int(frames.shape[2]), int(frames.shape[1])
 
 
+def resolve_is_video(ndim: int, media_kind: str | None) -> bool:
+    """Decide whether a rollout output is a video.
+
+    Prefers the adapter-declared media kind (from ``DiffusionIOSpec``); the tensor
+    rank is only a fallback for outputs that do not carry a declared kind. This
+    avoids misclassifying, e.g., a short 3-frame video whose rank happens to match
+    an image batch.
+    """
+    if media_kind is not None:
+        return media_kind == "video"
+    return ndim == 5
+
+
 def _export_video(
     output: torch.Tensor,
     output_path: str,
@@ -165,31 +178,36 @@ def _export_video(
             audio_path.unlink(missing_ok=True)
 
 
-def wrap_val_samples_for_wandb(samples, fps=24, output_dir=None):
-    """Wrap validation samples and prepare top-level ``wandb`` video media.
+def wrap_val_samples_for_wandb(samples, fps=24, output_dir=None, media_kinds=None):
+    """Wrap validation samples and prepare top-level ``wandb`` media.
 
-    Video outputs in ``[T, C, H, W]``, ``[C, T, H, W]``, or ``[T, H, W, C]``
-    layouts are encoded to mp4 and passed to
-    ``wandb.Video`` by path. Provide ``output_dir`` to keep the media available
-    for asynchronous upload; otherwise a temp dir is returned for cleanup.
-    Optional tuple elements four and five carry audio and its sample rate. The
-    table stores a stable media key because offline ``wandb`` tables do not
-    reliably persist nested videos. Other outputs become ``wandb.Image``.
+    Declared ``media_kinds`` decide whether each output is an image or video;
+    tensor rank is retained only as a compatibility fallback. Video outputs in
+    ``[T, C, H, W]``, ``[C, T, H, W]``, or ``[T, H, W, C]`` layouts are encoded
+    to mp4 and passed to ``wandb.Video`` by path. Provide ``output_dir`` to keep
+    the media available for asynchronous upload; otherwise a temp dir is
+    returned for cleanup. Optional tuple elements four and five carry audio and
+    its sample rate. Media conversion failures are represented in the table and
+    logged instead of propagating into the training loop.
     """
     import wandb
 
+    samples = list(samples)
+    media_kinds = batch_items(media_kinds, len(samples), "media_kind")
     video_dir = output_dir
     video_tmp_dir = None
     wrapped = []
     media_to_log = {}
-    for sample in samples:
+    for sample, media_kind in zip(samples, media_kinds, strict=True):
         inp, out, score = sample[:3]
         audio = sample[3] if len(sample) > 3 else None
         audio_sample_rate = sample[4] if len(sample) > 4 else None
-        if hasattr(out, "ndim") and out.ndim == 5:
+        output_ndim = getattr(out, "ndim", -1)
+        is_video = media_kind == "video" if media_kind is not None else output_ndim in (4, 5)
+        if is_video and output_ndim == 5:
             # Batched video [B, T, C, H, W], [B, C, T, H, W], or [B, T, H, W, C].
             out = out[0]
-        if hasattr(out, "ndim") and out.ndim == 4:
+        if is_video:
             try:
                 if video_dir is None:
                     video_tmp_dir = tempfile.mkdtemp(prefix="val_video_")
@@ -205,9 +223,13 @@ def wrap_val_samples_for_wandb(samples, fps=24, output_dir=None):
                 logger.warning("Could not log validation sample %d video: %s", len(wrapped), error)
                 media = f"[validation media unavailable: {type(error).__name__}: {error}]"
         else:
-            if not isinstance(out, torch.Tensor) or out.dtype != torch.uint8:
-                raise ValueError(f"Expected a uint8 image tensor, got {getattr(out, 'dtype', type(out))}.")
-            media = wandb.Image(out, file_type="jpg")
+            try:
+                if not isinstance(out, torch.Tensor) or out.dtype != torch.uint8:
+                    raise ValueError(f"Expected a uint8 image tensor, got {getattr(out, 'dtype', type(out))}.")
+                media = wandb.Image(out, file_type="jpg")
+            except Exception as error:
+                logger.warning("Could not log validation sample %d image: %s", len(wrapped), error)
+                media = f"[validation media unavailable: {type(error).__name__}: {error}]"
         wrapped.append((inp, media, score))
     return wrapped, video_tmp_dir, media_to_log
 

--- a/verl_omni/utils/tracking.py
+++ b/verl_omni/utils/tracking.py
@@ -90,6 +90,8 @@ def resolve_is_video(ndim: int, media_kind: str | None) -> bool:
     an image batch.
     """
     if media_kind is not None:
+        if media_kind not in ("image", "video", "audio"):
+            raise ValueError(f"Unsupported media kind: {media_kind!r}")
         return media_kind == "video"
     return ndim == 5
 
@@ -203,7 +205,7 @@ def wrap_val_samples_for_wandb(samples, fps=24, output_dir=None, media_kinds=Non
         audio = sample[3] if len(sample) > 3 else None
         audio_sample_rate = sample[4] if len(sample) > 4 else None
         output_ndim = getattr(out, "ndim", -1)
-        is_video = media_kind == "video" if media_kind is not None else output_ndim in (4, 5)
+        is_video = resolve_is_video(output_ndim, media_kind) if media_kind is not None else output_ndim in (4, 5)
         if is_video and output_ndim == 5:
             # Batched video [B, T, C, H, W], [B, C, T, H, W], or [B, T, H, W, C].
             out = out[0]

--- a/verl_omni/utils/tracking.py
+++ b/verl_omni/utils/tracking.py
@@ -26,6 +26,7 @@ from typing import Any
 import numpy as np
 import torch
 
+from verl_omni.pipelines.rollout_media import resolve_is_video
 from verl_omni.utils.reward_score.reward_utils import normalize_video_tensor
 
 logger = logging.getLogger(__name__)
@@ -79,21 +80,6 @@ def _video_tensor_to_rgb24(video: torch.Tensor) -> tuple[np.ndarray, int, int]:
     video = normalize_video_tensor(video)
     frames = video.detach().permute(0, 2, 3, 1).to(device="cpu").contiguous().numpy()
     return frames, int(frames.shape[2]), int(frames.shape[1])
-
-
-def resolve_is_video(ndim: int, media_kind: str | None) -> bool:
-    """Decide whether a rollout output is a video.
-
-    Prefers the adapter-declared media kind (from ``DiffusionIOSpec``); the tensor
-    rank is only a fallback for outputs that do not carry a declared kind. This
-    avoids misclassifying, e.g., a short 3-frame video whose rank happens to match
-    an image batch.
-    """
-    if media_kind is not None:
-        if media_kind not in ("image", "video", "audio"):
-            raise ValueError(f"Unsupported media kind: {media_kind!r}")
-        return media_kind == "video"
-    return ndim == 5
 
 
 def _export_video(

--- a/verl_omni/workers/rollout/vllm_rollout/vllm_omni_diffusion_strategy.py
+++ b/verl_omni/workers/rollout/vllm_rollout/vllm_omni_diffusion_strategy.py
@@ -288,6 +288,10 @@ class DiffusionStrategy(OmniStrategyBase):
             # default lives in this shared strategy.
             if audio_sample_rate is not None:
                 extra_fields.setdefault("audio_sample_rate", audio_sample_rate)
+        # Surface the adapter-declared primary media kind so downstream consumers
+        # read the modality instead of inferring it from the response tensor rank.
+        if io_spec is not None:
+            extra_fields.setdefault("media_kind", io_spec.primary.modality)
 
         req_output = getattr(final_res, "request_output", None) or final_res
         if hasattr(req_output, "outputs") and req_output.outputs:

--- a/verl_omni/workers/rollout/vllm_rollout/vllm_omni_diffusion_strategy.py
+++ b/verl_omni/workers/rollout/vllm_rollout/vllm_omni_diffusion_strategy.py
@@ -202,9 +202,8 @@ class DiffusionStrategy(OmniStrategyBase):
     def _diffusion_io_spec(self) -> Optional[DiffusionIOSpec]:
         """Resolve the adapter-declared media I/O spec for the active pipeline.
 
-        The spec lets a diffusion adapter declare its auxiliary media streams
-        (e.g. joint audio and its sample rate) so this strategy does not have to
-        hard-code model-specific tuple positions or sample rates. Returns
+        The spec declares primary modality and the optional joint audio stream's
+        sample rate. The current transport fixes audio at tuple position 1. Returns
         ``None`` when the pipeline (or a bare test server) declares no spec.
         """
         model_config = getattr(self.server, "model_config", None)
@@ -248,15 +247,29 @@ class DiffusionStrategy(OmniStrategyBase):
                     diffusion_output = diffusion_output[key]
                     break
         io_spec = self._diffusion_io_spec()
+        req_output = getattr(final_res, "request_output", None) or final_res
+        request_id = getattr(req_output, "request_id", getattr(final_res, "request_id", "unknown"))
+        model_config = getattr(self.server, "model_config", None)
+        context = (
+            f"pipeline={getattr(model_config, 'architecture', 'unknown')}/"
+            f"{getattr(model_config, 'algorithm', 'unknown')}, request_id={request_id}"
+        )
         audio_sample_rate: Optional[int] = None
         rollout_audio: Any = None
         if isinstance(diffusion_output, tuple | list):
+            expected_streams = 1 + len(io_spec.auxiliary) if io_spec is not None else None
+            if len(diffusion_output) not in (1, 2) or (
+                expected_streams is not None and len(diffusion_output) != expected_streams
+            ):
+                raise ValueError(
+                    f"Unsupported diffusion media tuple ({context}): expected "
+                    f"{expected_streams if expected_streams is not None else '1 or 2'} streams, "
+                    f"got {len(diffusion_output)}"
+                )
             rollout_audio = diffusion_output[1] if len(diffusion_output) > 1 else None
             diffusion_output = diffusion_output[0]
-            if io_spec is not None:
-                audio_spec = next((spec for spec in io_spec.auxiliary if spec.modality == "audio"), None)
-                if audio_spec is not None:
-                    audio_sample_rate = audio_spec.sample_rate
+            if io_spec is not None and io_spec.auxiliary:
+                audio_sample_rate = io_spec.auxiliary[0].sample_rate
         if output_type == "latent":
             diffusion_output = torch.as_tensor(diffusion_output).float()
         else:
@@ -291,9 +304,13 @@ class DiffusionStrategy(OmniStrategyBase):
         # Surface the adapter-declared primary media kind so downstream consumers
         # read the modality instead of inferring it from the response tensor rank.
         if io_spec is not None:
-            extra_fields.setdefault("media_kind", io_spec.primary.modality)
+            runtime_kind = extra_fields.get("media_kind")
+            if runtime_kind is not None and runtime_kind != io_spec.primary.modality:
+                raise ValueError(
+                    f"Conflicting media_kind ({context}): expected {io_spec.primary.modality!r}, got {runtime_kind!r}"
+                )
+            extra_fields["media_kind"] = io_spec.primary.modality
 
-        req_output = getattr(final_res, "request_output", None) or final_res
         if hasattr(req_output, "outputs") and req_output.outputs:
             finish_reason = req_output.outputs[0].finish_reason or "stop"
         elif hasattr(req_output, "finish_reason"):


### PR DESCRIPTION
## Summary

Make diffusion logging, export and reward consumers use the pipeline's declared media metadata, and keep observability failures from interrupting training. Invalid media contracts still fail fast.

Part 4 of RFC #403: merged #480 → **#481** → #556 → #557.

- **Integrated main:** `2905603`, including merged PR3 #480, DMD2/reward-pool support and TransferQueue checkpoint recovery.
- **Tested head:** `e7692c1` (latest-main conflict integration).
- **PR4 review range:** `2905603..e7692c1` for the merge integration; the full branch still retains the earlier PR4 commits.

## Changes

- **Declared modality:** V0/V1 dumps, validation and W&B prefer `media_kind` over tensor rank. Rank remains a compatibility fallback only when no declaration exists; unknown kinds and conflicting declarations fail.
- **Shared export path:** V0/V1 call module-level `dump_generations(global_steps, ...)`. V1 captures the step at submission, without a fake trainer object, honors dump frequency/sample limits, and keeps metadata aligned when sorting rollout rows.
- **Metadata transport:** Ordinary and TransferQueue batches retain generated audio, sample rate and media kind, including mixed present/missing rows. V0/V1 validation and V1 TransferQueue dump collection use the same batch-first/tool-fallback resolver as rollout dumping; conflicts fail before scoring or export. Audio, Visual and MultiVisual reward managers share generated-media projection into scorer `extra_info`, and dataset conditioning `audio` / sample-rate / kind cannot be inherited as rollout media. Scalar NumPy mapping compatibility and copied input metadata are retained.
- **Best-effort observability:** W&B and filesystem failures warn and skip or fall back. Failed image exports record a null output and an error in JSONL without blocking later samples. V1 copies visual/audio/sample-rate tensors to independent CPU storage before its background exporter runs, so the exporter never owns live rollout-buffer tensors. Background I/O failures are reported rather than rethrown at shutdown.
- **Fail-fast contracts:** Dtype, declared rank, and modality validation run before V1 background submission and best-effort validation logging. Empty V1 validation collections remain a no-op rather than failing uint8 validation on `torch.empty(0)`. Declared image/video batches are checked before legacy layout normalization. Batch export validates all nonempty modality declarations rather than taking the first one. V0 dump paths prefer current batch audio/sample-rate/media-kind fields and reject conflicts with retained tool envelopes. `resolve_is_video` lives beside `MediaSpec`, with its legacy fallback unchanged. The supported output contract remains one primary stream or a fixed `(visual, audio)` pair; unsupported declarations and extra streams are rejected. Flux DanceGRPO is covered by the declared-primary-modality registry test.

## Scope and compatibility

This is a consumer migration, not an output-schema redesign. Request wire cleanup belongs to #556; named artifacts, explicit layouts and removal of axis heuristics belong to #557. Existing trainer/ImageBind/CLAP layout heuristics remain in this slice. Queue memory-pressure and backpressure stress testing is not covered here.

The branch retains #480's processor-hook tests, documentation fixes and Qwen3-TTS typed-request CI repair, along with the subsequent main updates. The separate V1 validation-logging delegate remains intentionally: V1 does not inherit V0, and extracting the exporter does not replace that entrypoint.

## Validation

### Current head: local CPU and static checks

**2071 passed, 8 skipped, 31 warnings** at `e7692c1` after merging current main; the focused integration selection passed **150 tests, 1 skipped**. Coverage includes the earlier declared-media/reward/export regressions plus upstream V1 TransferQueue checkpoint recovery and hybrid-rollout warmup paths. AST comparison confirms the three V1 media methods (`_maybe_log_val_generations`, `_dump_generations`, `_log_rollout_data`) are unchanged from the pre-merge PR head.

<details>
<summary>Command, environment and check details</summary>

Pinned environment: verl `fefb080`, vllm-omni `ded893462` (0.28).

```bash
# Match the CPU workflow selector, while keeping loopback scorer traffic local.
printf '[pytest]\npython_files = *_on_cpu.py\n' > pytest.ini
env -u HTTP_PROXY -u HTTPS_PROXY -u http_proxy -u https_proxy \
  NO_PROXY=localhost,127.0.0.1 no_proxy=localhost,127.0.0.1 \
  PYTHONPATH="$PWD" TORCH_COMPILE_DISABLE=1 TORCHINDUCTOR_DISABLE=1 OMP_NUM_THREADS=1 \
  python -m pytest -s -x --asyncio-mode=auto --cov=verl_omni tests/
rm pytest.ini
# 2071 passed, 8 skipped, 31 warnings
```

Ruff check/format, mypy on the eleven changed Python files, compileall and whitespace checks passed. The earlier staged-file pre-commit evidence remains recorded; repository-wide pre-commit is blocked by this host's Git 2.29 lacking `ls-files --deduplicate`, so no all-files success is claimed.

Current full-suite evidence: `/dockerdata/pr481-main-2905603-20260918/full-cpu-final.log`.

</details>

### GPU smoke: earlier repaired PR4 source (`5211f21`)

**PASS, `rc=0`: MiniMax H3 NFT V1/TransferQueue.** A frozen snapshot of the parent repaired source completed one training step, actor update/weight sync, required CLAP/ImageBind scoring and capped audiovisual export. This ran with `trainer.use_v1=True` and `transfer_queue.enable=True`, not the V0 fallback. The follow-up CPU ownership/rank/source-precedence fix at `bea5cb6` was not included in this prior GPU snapshot.

| Check | Result |
| --- | --- |
| CLAP / ImageBind mean | `0.218008` / `0.039211` |
| Combined reward mean | `0.257219` |
| Export | H.264 384×256, 24 fps, 107 frames; AAC 32000 Hz stereo |
| Retained samples | One MP4; no export error or `.pt` fallback |

```bash
# Local runner; requires the isolated tiny fixture, cached scorers and data.
bash /dockerdata/pr481-review-fix-20260910/run-h3-v1.sh
```

The runner uses the PR4-supported `output_type=pt`, four train/rollout GPUs, TP=2, 4 inference steps, one training step and `required=True` for both scorers. Existing GPU/Ray tasks were not stopped. Commands, logs, return code and `h3-v1-ffprobe.json` are preserved in that directory.

The tested snapshot and `5211f21` have the same production-source SHA256:

```text
256c00c58bc81ca16d0674710e64623da09fe6fbac869ca9bc14da9b814dc39d
```

This is tiny-fixture plumbing evidence, not full-model quality or convergence acceptance. Final validation metrics were `None`; the colocated-scorer variant remains unverified on GPU.

### Historical GPU smoke: `34da705`

These runs completed on September 7. **They were not rerun on the rebased head.**

| Path | Result |
| --- | --- |
| AR GSPO Qwen3-Omni | Two training steps, validation, real rollout and LoRA weight sync; `rc=0`. A nonfatal DataLoader shutdown warning followed completion. |
| MiniMax H3 T2VA NFT, V0 | Retry completed one training step, real CLAP/ImageBind scoring and audiovisual MP4 export; `rc=0`. |
| Export inspection | H.264 384×256 at 24 fps, AAC 32000 Hz stereo, no `.pt` fallback. H3's `17n+5` planner aligns the requested 96 frames to 107. |

The MiniMax retry used an isolated compatible tiny VAE fixture after the original fixture failed on missing `vae_ratio`/`split_tiles`. No PR code, shared checkpoint or installed package was changed for that retry. These are plumbing checks, not full-weight quality or latent-layout acceptance. Diffusion V1/TransferQueue and the colocated scorer variant have CPU coverage only in this PR's recorded run.

<details>
<summary>Historical GPU reproduction settings</summary>

Requires locally provisioned tiny models/data and cached scorers; this is not a self-contained CI test. Run against the recorded source snapshot.

```bash
export PYTHONPATH=$PWD OMP_NUM_THREADS=8 WANDB_MODE=offline
# Prepend the venv's nvidia/*/lib directories to LD_LIBRARY_PATH on this host.
MODEL_PATH=/tmp/rfc403-qwen3-omni-tiny DATA_DIR=/tmp/rfc403-dummy-math CUDA_VISIBLE_DEVICES=0,1 NUM_GPUS=2 \
  bash tests/special_e2e/run_gspo_qwen3_omni_thinker_lora_v1_smoke.sh \
  +ray_kwargs.ray_init.num_cpus=32

# Train/rollout on two GPUs; scorer processes use visible devices 6/7.
CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
MODEL_PATH="$TINY_MINIMAX_MODEL" DATA_DIR="$TINY_T2VA_DATA" \
NUM_GPUS=2 ROLLOUT_TP=2 ROLLOUT_N=2 NUM_FRAMES=96 INFER_STEPS=4 \
ACTOR_ATTN_BACKEND=native ROLLOUT_ATTN_BACKEND=TORCH_SDPA TOTAL_TRAINING_STEPS=1 \
  bash examples/diffusionnft_trainer/minimax_h3/run_minimax_h3_t2va_lora.sh \
  +ray_kwargs.ray_init.num_cpus=32 trainer.logger=console \
  trainer.val_before_train=False trainer.save_freq=-1 trainer.test_freq=-1 \
  trainer.total_epochs=1 trainer.resume_mode=disable \
  trainer.rollout_data_save_freq=1 trainer.rollout_data_max_samples=1 \
  data.train_batch_size=4 data.val_max_samples=2 \
  actor_rollout_ref.actor.ppo_mini_batch_size=4 \
  actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=1 \
  actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=2 \
  actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=2 \
  reward.reward_functions.clap.device=cuda:6 \
  reward.reward_functions.imagebind.device=cuda:7 \
  reward.reward_functions.imagebind.model_name_or_path="$IMAGEBIND_CKPT"
```

Logs and export probes: `/dockerdata/rfc403-gpu-20260907/`.

</details>

**Self-review:** no new blocking code issue found. AST comparison confirms that exporter extraction and modality-helper relocation preserve their original logic; regression and GPU results cover the intentional validation changes.

**Pending:** hosted CI and maintainer review of `e7692c1`, current-head GPU coverage, colocated-scorer GPU coverage, and queue-pressure stress testing. The V1/TQ result above does not imply coverage of those variants. PR5/PR6 branches have not been synchronized with this follow-up.

## Non-duplication and disclosure

The September 7 checks of #403 and open PR searches for `403 in:body`, `media_kind in:body` and `OmniRolloutRequest in:body` identified this existing series. This updates its consumer slice rather than opening a competing fix; the separate V0 Wan layout issue is outside scope.

AI assistance (Pi coding agent / OpenAI Codex) was used. The human submitter reviewed every changed line in the latest-main integration and authorized this update; relevant validation is recorded above.
