### PR TITLE
[trainer, cfg, tests] fix: give each ray worker group its own rendezvous port slice

### DIFF
--- a/tests/special_e2e/run_diffusion_teacher_smoke.sh
+++ b/tests/special_e2e/run_diffusion_teacher_smoke.sh
@@ -119,8 +119,6 @@ case "${SMOKE}" in
             "${two_teachers[@]}"
             distillation.n_gpus_per_node=2
             distillation.nnodes=1
-            # The default fixed port range hands every worker group the same rendezvous port.
-            trainer.ray_master_port_range=null
         )
         objective=("${pure_distill[@]}")
         ;;

--- a/tests/trainer/diffusion/test_distillation_trainer_wiring_on_cpu.py
+++ b/tests/trainer/diffusion/test_distillation_trainer_wiring_on_cpu.py
@@ -111,3 +111,32 @@ class TestTeacherPoolRegistration:
         cfg, runner = self._runner(["distillation.n_gpus_per_node=0", "distillation.nnodes=1"])
         with pytest.raises(ValueError, match="config.distillation.n_gpus_per_node must be greater than 0"):
             runner.init_resource_pool_mgr(cfg)
+
+
+class TestWorkerGroupPortRanges:
+    def test_default_has_no_port_range(self):
+        assert compose_cfg([]).trainer.ray_master_port_range is None
+
+    def test_null_range_gives_no_range_per_group(self):
+        from verl_omni.trainer.diffusion.diffusion_trainer_utils import worker_group_port_ranges
+
+        assert worker_group_port_ranges(None, 3) == [None, None, None]
+
+    def test_range_is_sliced_disjointly_per_group(self):
+        from omegaconf import OmegaConf
+
+        from verl_omni.trainer.diffusion.diffusion_trainer_utils import worker_group_port_ranges
+
+        ranges = worker_group_port_ranges(OmegaConf.create({"r": [20000, 20010]}).r, 3)
+        assert len(ranges) == 3
+        for lo, hi in ranges:
+            assert isinstance(lo, int) and isinstance(hi, int)
+            assert 20000 <= lo < hi <= 20010
+        for (_, prev_hi), (lo, _) in zip(ranges, ranges[1:], strict=False):
+            assert lo >= prev_hi
+
+    def test_range_too_small_raises(self):
+        from verl_omni.trainer.diffusion.diffusion_trainer_utils import worker_group_port_ranges
+
+        with pytest.raises(ValueError, match="ray_master_port_range"):
+            worker_group_port_ranges([20000, 20002], 3)

--- a/verl_omni/trainer/config/_generated_diffusion_trainer.yaml
+++ b/verl_omni/trainer/config/_generated_diffusion_trainer.yaml
@@ -542,9 +542,7 @@ trainer:
   default_local_dir: checkpoints/${trainer.project_name}/${trainer.experiment_name}
   max_actor_ckpt_to_keep: null
   ray_wait_register_center_timeout: 300
-  ray_master_port_range:
-  - 20000
-  - 30000
+  ray_master_port_range: null
   device: cuda
   use_v1: false
   v1:

--- a/verl_omni/trainer/config/_generated_diffusion_veomni_trainer.yaml
+++ b/verl_omni/trainer/config/_generated_diffusion_veomni_trainer.yaml
@@ -583,9 +583,7 @@ trainer:
   default_local_dir: checkpoints/${trainer.project_name}/${trainer.experiment_name}
   max_actor_ckpt_to_keep: null
   ray_wait_register_center_timeout: 300
-  ray_master_port_range:
-  - 20000
-  - 30000
+  ray_master_port_range: null
   device: cuda
   use_v1: false
   v1:

--- a/verl_omni/trainer/config/diffusion_trainer.yaml
+++ b/verl_omni/trainer/config/diffusion_trainer.yaml
@@ -213,8 +213,9 @@ trainer:
   # Timeout (in seconds) for Ray worker to wait for registration
   ray_wait_register_center_timeout: 300
 
-  # Stable port range used by RayWorkerGroup for torch distributed rendezvous.
-  ray_master_port_range: [20000, 30000]
+  # Port range for torch distributed rendezvous, sliced per worker group. Leave null for ephemeral
+  # ports; set it only to isolate concurrent training jobs on one machine.
+  ray_master_port_range: null
 
   # Device to run training on (e.g., "cuda", "cpu")
   device: cuda

--- a/verl_omni/trainer/diffusion/diffusion_trainer_utils.py
+++ b/verl_omni/trainer/diffusion/diffusion_trainer_utils.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 """Shared helpers for diffusion Ray trainers."""
 
-from typing import Any
+from collections.abc import Sequence
+from typing import Any, Optional
 
 from verl import DataProto
 from verl.trainer.distillation import is_distillation_enabled
@@ -46,6 +47,23 @@ def old_policy_decay(step: int, schedule: str) -> float:
     else:
         raise ValueError(f"Unsupported old_policy_decay_schedule: {schedule}")
     return 0.0 if step < warmup_steps else min((step - warmup_steps) * ramp_rate, max_decay)
+
+
+def worker_group_port_ranges(master_port_range: Optional[Sequence[int]], num_groups: int) -> list[Optional[list[int]]]:
+    """Slice a rendezvous port range into one disjoint sub-range per worker group.
+
+    Ports are only bound at ``init_model``, after every group has been spawned, so groups
+    sharing a range would all pick its first free port.
+    """
+    if master_port_range is None:
+        return [None] * num_groups
+    lo, hi = (int(port) for port in master_port_range)
+    stride = (hi - lo) // num_groups
+    if stride < 1:
+        raise ValueError(
+            f"trainer.ray_master_port_range={master_port_range} has fewer ports than worker groups ({num_groups})."
+        )
+    return [[lo + i * stride, hi if i == num_groups - 1 else lo + (i + 1) * stride] for i in range(num_groups)]
 
 
 def validate_distillation_config(config) -> None:

--- a/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
+++ b/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
@@ -72,6 +72,7 @@ from verl_omni.trainer.diffusion.diffusion_trainer_utils import (
     _to_diffusion_worker_tensordict,
     old_policy_decay,
     validate_distillation_config,
+    worker_group_port_ranges,
 )
 from verl_omni.trainer.diffusion.rollout_correction import (
     apply_bypass_mode_to_diffusion_batch,
@@ -827,8 +828,6 @@ class BaseRayDiffusionTrainer(ABC):
         wg_kwargs = {}  # Setting up kwargs for RayWorkerGroup
         if OmegaConf.select(self.config.trainer, "ray_wait_register_center_timeout") is not None:
             wg_kwargs["ray_wait_register_center_timeout"] = self.config.trainer.ray_wait_register_center_timeout
-        if OmegaConf.select(self.config.trainer, "ray_master_port_range") is not None:
-            wg_kwargs["master_port_range"] = OmegaConf.to_container(self.config.trainer.ray_master_port_range)
         # Forward profiling steps and (when nsys is selected) per-worker Nsight options to the
         # Ray worker group so that workers can be launched under nsys with the right capture range.
         if OmegaConf.select(self.config, "global_profiler.steps") is not None:
@@ -844,9 +843,12 @@ class BaseRayDiffusionTrainer(ABC):
                 wg_kwargs["worker_nsight_options"] = OmegaConf.to_container(worker_nsight_options)
         wg_kwargs["device_name"] = self.device_name
 
-        for resource_pool, class_dict in self.resource_pool_to_cls.items():
-            if not class_dict:
-                continue
+        pools = [(pool, class_dict) for pool, class_dict in self.resource_pool_to_cls.items() if class_dict]
+        master_port_range = OmegaConf.select(self.config.trainer, "ray_master_port_range")
+        port_ranges = worker_group_port_ranges(master_port_range, len(pools))
+        for (resource_pool, class_dict), port_range in zip(pools, port_ranges, strict=True):
+            if port_range is not None:
+                wg_kwargs["master_port_range"] = port_range
             worker_dict_cls = create_colocated_worker_cls(class_dict=class_dict)
             wg_dict = self.ray_worker_group_cls(
                 resource_pool=resource_pool,

--- a/verl_omni/trainer/diffusion/v1/trainer_base.py
+++ b/verl_omni/trainer/diffusion/v1/trainer_base.py
@@ -62,6 +62,7 @@ from verl_omni.trainer.diffusion.diffusion_metric_utils import (
     compute_throughput_metrics_diffusion,
     compute_timing_metrics_diffusion,
 )
+from verl_omni.trainer.diffusion.diffusion_trainer_utils import worker_group_port_ranges
 from verl_omni.trainer.diffusion.ray_diffusion_trainer import _to_diffusion_worker_tensordict, compute_advantage
 from verl_omni.trainer.diffusion.rollout_correction import (
     apply_bypass_mode_to_diffusion_batch,
@@ -629,11 +630,12 @@ class PolicyGradientDiffusionTrainerV1(ABC):
 
         all_wg = {}
         wg_kwargs = {"device_name": self.config.trainer.device}
-        if OmegaConf.select(self.config.trainer, "ray_master_port_range") is not None:
-            wg_kwargs["master_port_range"] = OmegaConf.to_container(self.config.trainer.ray_master_port_range)
-        for resource_pool, class_dict in self.resource_pool_to_cls.items():
-            if not class_dict:
-                continue
+        pools = [(pool, class_dict) for pool, class_dict in self.resource_pool_to_cls.items() if class_dict]
+        master_port_range = OmegaConf.select(self.config.trainer, "ray_master_port_range")
+        port_ranges = worker_group_port_ranges(master_port_range, len(pools))
+        for (resource_pool, class_dict), port_range in zip(pools, port_ranges, strict=True):
+            if port_range is not None:
+                wg_kwargs["master_port_range"] = port_range
             worker_dict_cls = create_colocated_worker_cls(class_dict=class_dict)
             wg_dict = RayWorkerGroup(resource_pool=resource_pool, ray_cls_with_init=worker_dict_cls, **wg_kwargs)
             spawn_wg = wg_dict.spawn(prefix_set=class_dict.keys())


### PR DESCRIPTION
### What does this PR do?
`diffusion_trainer.yaml` defaults `trainer.ray_master_port_range` to `[20000, 30000]`, and verl's `get_master_addr_port` returns the first *currently free* port of the range at worker-group **spawn** time — the port is only really bound later, in `init_model`'s `init_process_group`. Both the v0 and v1 trainers spawn every worker group before any `init_model`, so with two or more worker groups every group gets port 20000 and the run dies with `EADDRINUSE`. #427's standalone `teacher_pool` is the first config that actually creates a second worker group here (the standalone reward model only reserves a `reward_pool` — its servers are `RolloutReplica`s, not a worker group), which is why the default never fired before.

Fix, keeping both properties:

- `diffusion_trainer.yaml`: `ray_master_port_range: null` by default (ephemeral ports, as upstream); the range is only for isolating concurrent training jobs on one machine.
- v0 (`ray_diffusion_trainer.py`) and v1 (`trainer_base.py`): when a range **is** configured, `worker_group_port_ranges` slices it into disjoint per-group sub-ranges, so CI's per-job `RAY_MASTER_PORT_RANGE` injection keeps working with any number of worker groups.
- Drops the temporary `trainer.ray_master_port_range=null` pin the standalone teacher smoke carried since #427 — with the default now `null` it is a no-op and its comment no longer describes the default.

### Checklist Before Starting

- [x] Duplicate check: open-PR searches for `port` / `master_port` / `EADDRINUSE` return no overlapping PR; this commit originally sat in #427, where the reviewer asked for it to be a separate PR.
- [x] PR title format `[trainer, cfg, tests] fix: ...`

### Test

CPU (`python -m pytest … -q`, verl 0.10.0.dev):

```
tests/trainer/diffusion/test_distillation_trainer_wiring_on_cpu.py   (TestWorkerGroupPortRanges: default null; null → no per-group range; slicing disjoint & in-range; range smaller than group count raises)
tests/trainer/diffusion/test_worker_batch_projection_on_cpu.py
→ 25 passed; full tests/trainer/diffusion → 229 passed
pre-commit run → all hooks pass (autogen-trainer-cfg skipped, known-broken locally)
```

GPU (4× RTX PRO 6000 Blackwell 96GB), `SMOKE=standalone NUM_GPUS=3` teacher smoke = 3 worker groups (actor + 2 standalone teachers):

- **Repro on current `main` (`783ea1f`)**: `trainer.ray_master_port_range=[20000,30000]` → dies at rendezvous with `DistNetworkError … port: 20000 … EADDRINUSE` (exit 1).
- **This branch, same command** → passes; `distill_kl_loss` bit-identical to the same smoke without a range.
- **This branch, tight range `[20000,20010]`** (3 groups slice 10 ports) → passes, bit-identical.
- **This branch, default (`null`, pin removed from the smoke)** → passes, bit-identical.
- **This branch, single worker group (`SMOKE=distill NUM_GPUS=1`) with `[20000,30000]`** → passes (whole range for the one group).

### Note on AI assistance

AI assistance (Claude) was used for this change. I reviewed every changed line and ran the tests above myself.
