### PR TITLE
[1/N][diffusion, rollout] feat: support HunyuanImage-3.0 Flow-GRPO training

### DIFF
--- a/tests/pipelines/test_hunyuan_image3_flow_grpo_on_cpu.py
+++ b/tests/pipelines/test_hunyuan_image3_flow_grpo_on_cpu.py
@@ -1,0 +1,490 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from verl_omni.pipelines.hunyuan_image3_flow_grpo.common import (
+    HUNYUAN_IMAGE3_SCHEDULER_KWARGS,
+    HUNYUAN_IMAGE3_TIMESTEP_SHIFT,
+    apply_hunyuan_cfg,
+    build_hunyuan_image3_scheduler,
+    setup_hunyuan_image3_sigmas,
+)
+from verl_omni.pipelines.hunyuan_image3_flow_grpo.diffusers_training_adapter import HunyuanImage3FlowGRPO
+from verl_omni.pipelines.hunyuan_image3_flow_grpo.hunyuan_image3_model import (
+    HunyuanImage3ForTraining,
+    HunyuanImage3TrainingConfig,
+    HunyuanTopKGate,
+)
+from verl_omni.pipelines.hunyuan_image3_flow_grpo.vllm_omni_rollout_adapter import HunyuanImage3PipelineWithLogProb
+from verl_omni.pipelines.model_base import DiffusionModelBase, VllmOmniPipelineBase
+
+
+def _tiny_config() -> HunyuanImage3TrainingConfig:
+    return HunyuanImage3TrainingConfig(
+        vocab_size=256,
+        hidden_size=32,
+        intermediate_size=16,
+        moe_intermediate_size=16,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        attention_head_dim=8,
+        num_experts=2,
+        moe_topk=1,
+        num_shared_expert=1,
+        use_mixed_mlp_moe=True,
+        patch_size=1,
+        patch_embed_hidden_dim=32,
+        latent_channels=4,
+        pad_token_id=0,
+        image_token_id=7,
+    )
+
+
+def test_architecture_registers_both_adapters() -> None:
+    assert DiffusionModelBase.get_class_by_name("HunyuanImage3ForCausalMM", "flow_grpo") is HunyuanImage3FlowGRPO
+    assert VllmOmniPipelineBase.get_class("HunyuanImage3ForCausalMM", "flow_grpo") is HunyuanImage3PipelineWithLogProb
+
+
+def test_scheduler_config_matches_hunyuan() -> None:
+    assert HUNYUAN_IMAGE3_TIMESTEP_SHIFT == 3.0
+    assert HUNYUAN_IMAGE3_SCHEDULER_KWARGS["shift"] == 3.0
+    assert HUNYUAN_IMAGE3_SCHEDULER_KWARGS["time_shift_type"] == "exponential"
+    assert HUNYUAN_IMAGE3_SCHEDULER_KWARGS["use_dynamic_shifting"] is False
+
+
+def test_scheduler_matches_vllm_omni_constructor() -> None:
+    # The SDE subclass must share the exact sigma schedule with the diffusers
+    # scheduler vllm-omni builds (same constructor kwargs, same set_timesteps).
+    from diffusers import FlowMatchEulerDiscreteScheduler
+
+    reference = FlowMatchEulerDiscreteScheduler(**HUNYUAN_IMAGE3_SCHEDULER_KWARGS)
+    ours = build_hunyuan_image3_scheduler()
+    reference.set_timesteps(num_inference_steps=8)
+    ours.set_timesteps(num_inference_steps=8)
+    torch.testing.assert_close(ours.sigmas, reference.sigmas)
+    torch.testing.assert_close(ours.timesteps, reference.timesteps)
+
+
+def test_cfg_combine_standard_guidance() -> None:
+    cond = torch.tensor([[[2.0]]])
+    uncond = torch.tensor([[[1.0]]])
+    combined = apply_hunyuan_cfg(cond, uncond, guidance_scale=2.5)
+    assert combined.item() == pytest.approx(1.0 + 2.5 * (2.0 - 1.0))
+
+
+def test_sigma_schedule_configures_scheduler() -> None:
+    scheduler = build_hunyuan_image3_scheduler()
+    sigmas = setup_hunyuan_image3_sigmas(scheduler, num_steps=4, device="cpu")
+    # vllm-omni runs set_timesteps(num_inference_steps=4): timesteps holds N
+    # entries (0-1000 denoise scale), sigmas holds N+1 with the terminal 0.
+    assert scheduler.timesteps.numel() == 4
+    assert scheduler.sigmas.numel() == 5
+    assert scheduler.sigmas[0].item() == pytest.approx(1.0)
+    assert scheduler.sigmas[-1].item() == pytest.approx(0.0)
+    # shift=3.0 keeps the first non-trivial sigma high (vs ~0.75 at shift=1.0).
+    assert scheduler.sigmas[1].item() > 0.85
+    # The wrapper returns the denoise timesteps unchanged.
+    assert sigmas == scheduler.timesteps.tolist()
+    assert len(sigmas) == 4
+
+
+def test_training_adapter_builds_model_inputs() -> None:
+    config = _tiny_config()
+    module = HunyuanImage3ForTraining(config)
+
+    batch_size, num_steps = 2, 3
+    latents = torch.randn(batch_size, num_steps, config.latent_channels, 2, 2)
+    timesteps = torch.tensor([[900.0, 700.0, 500.0]]).expand(batch_size, -1)
+
+    positive_ids = [[3, 5, 6, 8, 7, 7, 7, 7], [3, 5, 6, 8, 7, 7, 7, 7]]
+    negative_ids = [[6, 8, 7, 7, 7, 7], [6, 8, 7, 7, 7, 7]]
+
+    micro_batch = MagicMock()
+    fields = {
+        "prompt_token_ids": positive_ids,
+        "negative_prompt_token_ids": negative_ids,
+        "gen_timestep_scatter_index": [[3], [3]],
+        "negative_gen_timestep_scatter_index": [[1], [1]],
+        "rope_image_info": [[4, 8, 2, 2], [4, 8, 2, 2]],
+        "negative_rope_image_info": [[2, 6, 2, 2], [2, 6, 2, 2]],
+    }
+    micro_batch.__getitem__.side_effect = lambda key: fields[key]
+    micro_batch.get.side_effect = lambda key, default=None: fields.get(key, default)
+
+    model_config = SimpleNamespace(
+        pipeline=SimpleNamespace(num_inference_steps=4, guidance_scale=2.5, guidance_rescale=0.0),
+    )
+
+    positive, negative = HunyuanImage3FlowGRPO.prepare_model_inputs(
+        module=module,
+        model_config=model_config,
+        latents=latents,
+        timesteps=timesteps,
+        prompt_embeds=None,
+        prompt_embeds_mask=None,
+        negative_prompt_embeds=None,
+        negative_prompt_embeds_mask=None,
+        micro_batch=micro_batch,
+        step=1,
+    )
+
+    assert positive["input_ids"].shape == (batch_size, 8)
+    assert positive["images"].shape == (batch_size, config.latent_channels, 2, 2)
+    assert positive["timesteps"].tolist() == [700.0, 700.0]
+    assert positive["image_mask"].sum(dim=1).tolist() == [4, 4]
+    assert negative["input_ids"].shape == (batch_size, 6)
+    # Positive and negative branches carry distinct <timestep> scatter indices and
+    # RoPE spans (their text lengths differ).
+    assert positive["gen_timestep_scatter_index"].tolist() == [[3], [3]]
+    assert negative["gen_timestep_scatter_index"].tolist() == [[1], [1]]
+    assert positive["rope_image_info"] == [[(slice(4, 8), (2, 2))], [(slice(4, 8), (2, 2))]]
+    assert negative["rope_image_info"] == [[(slice(2, 6), (2, 2))], [(slice(2, 6), (2, 2))]]
+
+
+def test_tiny_model_forward_returns_latent_velocity() -> None:
+    config = _tiny_config()
+    model = HunyuanImage3ForTraining(config)
+
+    batch_size, seq_len = 2, 8
+    input_ids = torch.zeros(batch_size, seq_len, dtype=torch.long)
+    images = torch.randn(batch_size, config.latent_channels, 2, 2)
+    timesteps = torch.tensor([0.8, 0.6])
+    image_mask = torch.zeros(batch_size, seq_len, dtype=torch.bool)
+    image_mask[:, 4:8] = True
+    gen_timestep_scatter_index = torch.tensor([[3], [3]])
+    rope_image_info = [[(slice(4, 8), (2, 2))], [(slice(4, 8), (2, 2))]]
+
+    velocity = model(
+        input_ids=input_ids,
+        images=images,
+        timesteps=timesteps,
+        image_mask=image_mask,
+        gen_timestep_scatter_index=gen_timestep_scatter_index,
+        rope_image_info=rope_image_info,
+    )
+
+    assert isinstance(velocity, tuple)
+    assert velocity[0].shape == (batch_size, config.latent_channels, 2, 2)
+
+
+def test_from_model_path_parses_checkpoint_config(tmp_path) -> None:
+    import json
+
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "vocab_size": 133120,
+                "hidden_size": 64,
+                "num_hidden_layers": 2,
+                "num_attention_heads": 8,
+                "num_key_value_heads": 4,
+                "attention_head_dim": 8,
+                "num_experts": 8,
+                "moe_topk": [8, 8],
+                "num_shared_expert": [1, 1],
+                "moe_intermediate_size": [16, 16],
+                "vae": {"latent_channels": 16},
+            }
+        )
+    )
+    config = HunyuanImage3TrainingConfig.from_model_path(str(tmp_path))
+    assert config.hidden_size == 64
+    assert config.num_experts == 8
+    assert config.moe_topk == 8
+    assert config.latent_channels == 16
+
+
+def test_moe_gate_routing_is_deterministic_under_ties() -> None:
+    """Tied gate scores must route to the same experts on every invocation.
+
+    ``torch.topk`` leaves tied indices unstable, so a checkpoint recompute can
+    flip a token's expert and produce wrong gradients.  The gate uses a stable
+    sort, which breaks ties by ascending expert id; the test locks the
+    tie-break and normalization semantics.
+    """
+    config = HunyuanImage3TrainingConfig(hidden_size=8, num_experts=8, moe_topk=4)
+    gate = HunyuanTopKGate(config)
+    with torch.no_grad():
+        # Zero router weights -> uniform softmax -> every expert is tied.
+        gate.wg.weight.zero_()
+        hidden = torch.zeros(2, 1, config.hidden_size)
+        weights, indices = gate(hidden)
+        weights_again, indices_again = gate(hidden)
+
+    # Ties break by ascending expert id, so the first moe_topk experts are chosen.
+    assert indices.tolist() == [[0, 1, 2, 3], [0, 1, 2, 3]]
+    # Re-invoking the same gate yields identical routing.
+    assert indices.tolist() == indices_again.tolist()
+    assert weights.tolist() == weights_again.tolist()
+    # Normalization is preserved: top-k weights sum to 1 per token.
+    assert torch.allclose(weights.sum(dim=1), torch.ones(weights.shape[0], dtype=weights.dtype))
+    # The sort-based top-k slice must stay dense: the MoE dispatch flattens the
+    # index with ``view(-1)``, which rejects a non-contiguous row slice.
+    assert indices.is_contiguous()
+    assert weights.is_contiguous()
+    assert indices.view(-1).tolist() == [0, 1, 2, 3, 0, 1, 2, 3]
+
+
+def test_text_forward_returns_lm_head_logits_rmpad() -> None:
+    """AR text forward is rmpad (upstream verl LM layout): input_ids is
+    ``(1, total_nnz)`` with ``cu_seqlens`` marking sample boundaries."""
+    config = _tiny_config()
+    model = HunyuanImage3ForTraining(config)
+
+    # Two samples of lengths 4 and 6 concatenated end-to-end.
+    seq_lens = [4, 6]
+    total_nnz = sum(seq_lens)
+    input_ids = torch.randint(0, config.vocab_size - 1, (1, total_nnz))
+    cu_seqlens = torch.tensor([0, seq_lens[0], sum(seq_lens)], dtype=torch.int32)
+
+    logits = model(input_ids, mode="text", cu_seqlens=cu_seqlens, max_seqlen=max(seq_lens))
+
+    assert logits.shape == (1, total_nnz, config.vocab_size)
+    # lm_head is a real (non-tied) parameter, distinct from wte.
+    assert model.lm_head.weight is not model.wte.weight
+    assert model.lm_head.weight.shape == (config.vocab_size, config.hidden_size)
+
+
+def test_text_forward_rmpad_matches_padded_sample_by_sample() -> None:
+    """Equivalence check: running each sample through the rmpad path in
+    isolation must yield the same logits at each token as running the whole
+    batch concatenated. Locks the varlen attention's block-diagonal masking
+    (samples must not attend across boundaries) via the SDPA fallback path."""
+    config = _tiny_config()
+    model = HunyuanImage3ForTraining(config).eval()
+
+    seq_lens = [3, 5]
+    samples = [torch.randint(0, config.vocab_size - 1, (L,)) for L in seq_lens]
+    total_nnz = sum(seq_lens)
+
+    # Rmpad batched call.
+    input_ids_flat = torch.cat(samples).unsqueeze(0)  # (1, total_nnz)
+    cu = torch.tensor([0, seq_lens[0], sum(seq_lens)], dtype=torch.int32)
+    with torch.no_grad():
+        logits_batched = model(input_ids_flat, mode="text", cu_seqlens=cu, max_seqlen=max(seq_lens))
+
+    # Per-sample isolated calls (each its own rmpad batch of one).
+    logits_isolated = []
+    for L, s in zip(seq_lens, samples):
+        cu_solo = torch.tensor([0, L], dtype=torch.int32)
+        with torch.no_grad():
+            logits_isolated.append(model(s.unsqueeze(0), mode="text", cu_seqlens=cu_solo, max_seqlen=L))
+    logits_isolated_cat = torch.cat([x.squeeze(0) for x in logits_isolated], dim=0).unsqueeze(0)
+
+    # If sample 0 could attend to sample 1 (or vice versa) in the batched call,
+    # its logits at every position would drift from the isolated case.
+    assert torch.allclose(logits_batched, logits_isolated_cat, atol=1e-5, rtol=1e-4)
+
+
+def test_forward_mode_dispatch() -> None:
+    """Routing both paths through ``forward`` is what lets the root FSDP hook fire.
+
+    Locks four invariants: (a) ``mode`` is the sole switch — no separate public
+    entry point; (b) unknown modes fail loudly; (c) ``HunyuanFinalRMSNorm`` is
+    not in ``_no_split_modules``; (d) ``mode="text"`` requires the rmpad
+    kwargs (varlen FA layout).
+    """
+    config = _tiny_config()
+    model = HunyuanImage3ForTraining(config)
+
+    # Only forward() is a public entry: both paths must go through the root
+    # forward hook for FSDP2 param all-gather.
+    assert not hasattr(model, "forward_text")
+    assert "HunyuanFinalRMSNorm" not in HunyuanImage3ForTraining._no_split_modules
+
+    input_ids = torch.randint(0, config.vocab_size - 1, (1, 4))
+    with pytest.raises(ValueError, match="Unknown forward mode"):
+        model(input_ids, mode="not_a_mode")
+
+    # mode='text' without rmpad kwargs is a caller-side error (varlen FA layout
+    # is not optional).
+    with pytest.raises(ValueError, match="rmpad"):
+        model(input_ids, mode="text")
+
+
+def test_from_pretrained_loads_sharded_checkpoint(tmp_path) -> None:
+    """The source-rank materialize path round-trips a sharded checkpoint exactly.
+
+    On a single CPU process ``from_pretrained`` takes the source-rank branch (no
+    ``meta`` device, ``nullcontext`` fallback) and streams the shards in.  Covers
+    the checkpoint-key remap (``model.`` prefix on the transformer body, none on
+    the image-pathway + ``lm_head`` modules) and the strict-free load.
+    """
+    import json
+    import os
+
+    from safetensors.torch import save_file
+
+    # from_model_path reads latent_channels from a nested "vae" block (the vllm-omni
+    # checkpoint layout), so write the config in that shape rather than the flat
+    # dataclass `asdict` used by save_pretrained.
+    config_json = {
+        "vocab_size": 256,
+        "hidden_size": 32,
+        "intermediate_size": 16,
+        "moe_intermediate_size": 16,
+        "num_hidden_layers": 2,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 2,
+        "attention_head_dim": 8,
+        "num_experts": 2,
+        "moe_topk": 1,
+        "num_shared_expert": 1,
+        "use_mixed_mlp_moe": True,
+        "patch_size": 1,
+        "patch_embed_hidden_dim": 32,
+        "vae": {"latent_channels": 4},
+        "pad_token_id": 0,
+        "image_token_id": 7,
+    }
+    with open(os.path.join(tmp_path, "config.json"), "w") as f:
+        json.dump(config_json, f)
+
+    source = HunyuanImage3ForTraining(_tiny_config())
+
+    def _checkpoint_key(name: str) -> str:
+        return f"model.{name}" if name.startswith(("wte.", "layers.", "ln_f.")) else name
+
+    weights = {_checkpoint_key(k): v for k, v in source.state_dict().items() if isinstance(v, torch.Tensor)}
+    save_file(weights, os.path.join(tmp_path, "model.safetensors"))
+    with open(os.path.join(tmp_path, "model.safetensors.index.json"), "w") as f:
+        json.dump({"weight_map": {k: "model.safetensors" for k in weights}}, f)
+
+    loaded = HunyuanImage3ForTraining.from_pretrained(str(tmp_path), torch_dtype=torch.float32)
+
+    assert not next(loaded.parameters()).is_meta
+    for (name, weight), (loaded_name, loaded_weight) in zip(source.state_dict().items(), loaded.state_dict().items()):
+        assert name == loaded_name
+        torch.testing.assert_close(loaded_weight, weight)
+
+def test_hi3_common_message_helpers() -> None:
+    from verl_omni.pipelines.hunyuan_image3_flow_grpo.common import messages_to_text, normalize_ar_cot_text
+
+    assert messages_to_text("plain text") == "plain text"
+    assert messages_to_text([{"role": "user", "content": "a"}, {"role": "user", "content": "b"}]) == "a\nb"
+    assert messages_to_text([{"role": "user", "content": [{"type": "text", "text": "x"}]}]) == "x"
+
+    # The AR generation omits the trigger tag; the helper restores it exactly
+    # like vllm-omni's HunyuanImage3Pipeline._normalize_cot_text.
+    assert normalize_ar_cot_text(None) is None
+    assert normalize_ar_cot_text("") == ""
+    assert normalize_ar_cot_text("hello  responsex") == " thinkinghello  responsex"
+    assert normalize_ar_cot_text("x</recaption>y") == "<recaption>x</recaption>y"
+    assert normalize_ar_cot_text(" thinkinga  responseb") == " thinkinga  responseb"
+
+
+def test_hi3_agent_loop_registered() -> None:
+    import verl_omni.agent_loop  # noqa: F401
+    from verl.experimental.agent_loop.agent_loop import _agent_loop_registry
+
+    assert "hunyuan_image3_diffusion_single_turn_agent" in _agent_loop_registry
+
+
+class _FakeColumn:
+    def __init__(self, rows):
+        self._rows = list(rows)
+        self.shape = (len(rows),)
+
+    def __getitem__(self, i):
+        return self._rows[i]
+
+
+def test_fused_dit_inputs_rebuilds_rollout_prefix(monkeypatch) -> None:
+    from verl_omni.pipelines.hunyuan_image3_flow_grpo import diffusers_training_adapter as adapter
+
+    from vllm_omni.diffusion.models.hunyuan_image3.pipeline_hunyuan_image3 import HunyuanImage3Pipeline
+
+    captured = {}
+
+    class _FakeTokenizerWrapper:
+        def apply_chat_template(self, **kwargs):
+            captured.update(kwargs)
+            batch_size = len(kwargs["batch_prompt"])
+            seq_len = 6
+            output = SimpleNamespace(
+                tokens=torch.zeros(batch_size, seq_len, dtype=torch.long),
+                gen_image_mask=torch.zeros(batch_size, seq_len, dtype=torch.bool),
+                gen_timestep_scatter_index=torch.arange(batch_size).unsqueeze(-1),
+            )
+            return {"output": output, "sections": None}
+
+    ctx = {
+        "tkw": _FakeTokenizerWrapper(),
+        "image_processor": SimpleNamespace(build_image_info=lambda size: "image_info"),
+        "drop_think": False,
+        "image_base_size": None,
+        "sequence_template": "instruct",
+        "system_prompt": "SYS",
+    }
+    monkeypatch.setattr(adapter, "_get_hunyuan_image3_tokenizer_ctx", lambda path: ctx)
+    monkeypatch.setattr(
+        HunyuanImage3Pipeline,
+        "build_batch_rope_image_info",
+        lambda output, sections: [["rope"]] * output.tokens.shape[0],
+    )
+
+    micro_batch = MagicMock()
+    fields = {
+        "ar_prompt_token_ids": _FakeColumn([[1, 2], [3, 4]]),
+        "ar_generated_text": _FakeColumn(["x  responsey", "</recaption>z"]),
+        "raw_prompt": _FakeColumn([[{"role": "user", "content": "cap0"}], [{"role": "user", "content": "cap1"}]]),
+    }
+    micro_batch.get.side_effect = lambda key, default=None: fields.get(key, default)
+
+    latents = torch.randn(2, 3, 4, 1, 1)
+    config = SimpleNamespace(vae_downsample_factor=(16, 16))
+    model_config = SimpleNamespace(local_path="/fake/model")
+
+    result = adapter.HunyuanImage3FlowGRPO._build_fused_dit_inputs(
+        model_config, config, micro_batch, latents, step=1, device=torch.device("cpu")
+    )
+    assert result is not None
+    positive_ids, image_mask, scatter, rope = result
+    assert positive_ids.shape == (2, 6)
+    assert image_mask.shape == (2, 6)
+    assert scatter.tolist() == [[0], [1]]
+    assert rope == [["rope"], ["rope"]]
+
+    # Rollout-parity knobs: cot re-parse affects the fused ids, so the rebuild
+    # must apply the same normalization as the engine template.
+    assert captured["batch_prompt"] == ["cap0", "cap1"]
+    assert captured["batch_cot_text"] == [" thinkingx  responsey", "<recaption></recaption>z"]
+    assert captured["batch_system_prompt"] == ["SYS", "SYS"]
+    assert captured["mode"] == "gen_image"
+    assert captured["bot_task"] == "auto"
+    assert captured["sequence_template"] == "instruct"
+    assert captured["cfg_factor"] == 1
+    assert captured["drop_think"] is False
+
+
+def test_fused_dit_inputs_falls_back_when_ar_fields_absent() -> None:
+    from verl_omni.pipelines.hunyuan_image3_flow_grpo import diffusers_training_adapter as adapter
+
+    micro_batch = MagicMock()
+    micro_batch.get.side_effect = lambda key, default=None: None
+    config = SimpleNamespace(vae_downsample_factor=(16, 16))
+    model_config = SimpleNamespace(local_path="/fake/model")
+    latents = torch.randn(2, 3, 4, 1, 1)
+
+    result = adapter.HunyuanImage3FlowGRPO._build_fused_dit_inputs(
+        model_config, config, micro_batch, latents, step=0, device=torch.device("cpu")
+    )
+    assert result is None

--- a/verl_omni/agent_loop/__init__.py
+++ b/verl_omni/agent_loop/__init__.py
@@ -16,6 +16,8 @@
 # @register decorator fires when the agent_loop package is imported. Do not
 # re-export the class from the pipeline package __init__ (import cycle).
 from verl_omni.pipelines.minimax_h3_diffusion_nft.agent_loop import MiniMaxH3DiffusionSingleTurnAgentLoop
+# Same for the HunyuanImage-3 agent loop.
+from verl_omni.pipelines.hunyuan_image3_flow_grpo.agent_loop import HunyuanImage3DiffusionSingleTurnAgentLoop
 
 from .composite_agent_loop import CompositeAgentLoopWorker
 from .diffusion_agent_loop import DiffusionAgentLoopOutput, DiffusionAgentLoopWorker
@@ -33,4 +35,5 @@ __all__ = [
     "create_diffusion_agent_loop_manager",
     "DiffusionSingleTurnAgentLoop",
     "MiniMaxH3DiffusionSingleTurnAgentLoop",
+    "HunyuanImage3DiffusionSingleTurnAgentLoop",
 ]

--- a/verl_omni/pipelines/__init__.py
+++ b/verl_omni/pipelines/__init__.py
@@ -14,6 +14,7 @@
 
 from . import (
     bagel_flow_grpo,
+    hunyuan_image3_flow_grpo,
     ltx2_flow_grpo,
     minimax_h3_diffusion_nft,
     qwen3_omni,
@@ -28,6 +29,7 @@ from . import (
     wan22_dance_grpo,
 )
 from .bagel_flow_grpo import *  # noqa: F401, F403
+from .hunyuan_image3_flow_grpo import *  # noqa: F401, F403
 from .ltx2_flow_grpo import *  # noqa: F401, F403
 from .minimax_h3_diffusion_nft import *  # noqa: F401, F403
 from .qwen3_omni import *  # noqa: F401, F403
@@ -46,6 +48,7 @@ __all__ += list(qwen_image_flow_grpo.__all__)
 __all__ += list(qwen_image_diffusion_nft.__all__)
 __all__ += list(qwen_image_mix_grpo.__all__)
 __all__ += list(bagel_flow_grpo.__all__)
+__all__ += list(hunyuan_image3_flow_grpo.__all__)
 __all__ += list(ltx2_flow_grpo.__all__)
 __all__ += list(minimax_h3_diffusion_nft.__all__)
 __all__ += list(sd3_dpo.__all__)

--- a/verl_omni/pipelines/hunyuan_image3_flow_grpo/__init__.py
+++ b/verl_omni/pipelines/hunyuan_image3_flow_grpo/__init__.py
@@ -1,0 +1,40 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .common import (
+    HUNYUAN_IMAGE3_FLOWGRPO_CFG_DEFAULTS,
+    HUNYUAN_IMAGE3_SCHEDULER_KWARGS,
+    HUNYUAN_IMAGE3_TIMESTEP_SHIFT,
+    apply_hunyuan_cfg,
+    build_hunyuan_image3_scheduler,
+    maybe_to_cpu,
+    setup_hunyuan_image3_sigmas,
+)
+from .diffusers_training_adapter import HunyuanImage3FlowGRPO
+from .hunyuan_image3_model import HunyuanImage3ForTraining, HunyuanImage3TrainingConfig
+from .vllm_omni_rollout_adapter import HunyuanImage3PipelineWithLogProb
+
+__all__ = [
+    "HunyuanImage3FlowGRPO",
+    "HunyuanImage3PipelineWithLogProb",
+    "HunyuanImage3ForTraining",
+    "HunyuanImage3TrainingConfig",
+    "HUNYUAN_IMAGE3_FLOWGRPO_CFG_DEFAULTS",
+    "HUNYUAN_IMAGE3_SCHEDULER_KWARGS",
+    "HUNYUAN_IMAGE3_TIMESTEP_SHIFT",
+    "apply_hunyuan_cfg",
+    "build_hunyuan_image3_scheduler",
+    "maybe_to_cpu",
+    "setup_hunyuan_image3_sigmas",
+]

--- a/verl_omni/pipelines/hunyuan_image3_flow_grpo/agent_loop.py
+++ b/verl_omni/pipelines/hunyuan_image3_flow_grpo/agent_loop.py
@@ -1,0 +1,132 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""HunyuanImage3 agent loop that builds the official AR think/recaption prompt.
+
+The HF HunyuanImage-3.0-Instruct checkpoint ships no Jinja chat template, so a
+generic ``apply_chat_template`` cannot render its official prompt structure
+(``<|startoftext|>`` + ``en_unified`` system prompt + ``User: <caption>`` +
+``Assistant:  thinking`` trigger).  This loop builds it through vllm-omni's
+``prompt_utils`` builder and forwards the raw caption plus ``use_system_prompt``
+to the engine so the DiT stage rebuilds the identical prefix.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import uuid4
+
+from verl.experimental.agent_loop.agent_loop import register
+from verl.utils.profiler import simple_timer
+from verl.utils.ray_utils import get_event_loop
+from verl.utils.tokenizer import normalize_token_ids
+
+from verl_omni.agent_loop.diffusion_agent_loop import DiffusionAgentLoopOutput
+from verl_omni.agent_loop.single_turn_agent_loop import DiffusionSingleTurnAgentLoop
+
+from .common import HUNYUAN_IMAGE3_AR_SYS_TYPE, HUNYUAN_IMAGE3_AR_TASK, messages_to_text
+
+
+@register("hunyuan_image3_diffusion_single_turn_agent")
+class HunyuanImage3DiffusionSingleTurnAgentLoop(DiffusionSingleTurnAgentLoop):
+    """hi3 two-stage loop: official AR prompt ids (client-built) -> engine."""
+
+    def __init__(
+        self,
+        trainer_config,
+        server_manager,
+        tokenizer,
+        processor,
+        dataset_cls,
+        data_config,
+        extra_tokenizer_map: dict[str, dict[str, Any]] | None = None,
+        **kwargs,
+    ) -> None:
+        # hi3 has no chat template to probe; skip AgentLoopBase.__init__ the same
+        # way the ltx2 / minimax pipelines do.
+        del kwargs
+        self.config = trainer_config.config
+        self.rollout_config = self.config.actor_rollout_ref.rollout
+        self.server_manager = server_manager
+        self.tokenizer = tokenizer
+        self.processor = processor
+        self.dataset_cls = dataset_cls
+        self.data_config = data_config.config
+        self.apply_chat_template_kwargs = self.data_config.get("apply_chat_template_kwargs", {})
+        self.mm_processor_kwargs = self.data_config.get("mm_processor_kwargs", {})
+        self.extra_tokenizer_map = extra_tokenizer_map or {}
+        self.system_prompt = []
+        self.loop = get_event_loop()
+
+    async def _official_prompt_ids(self, text: str) -> list[int]:
+        """Tokenize ``text`` into the official AR prompt sequence."""
+
+        def _build() -> list[int]:
+            from vllm_omni.diffusion.models.hunyuan_image3.prompt_utils import build_prompt_tokens
+
+            return build_prompt_tokens(
+                text,
+                self.tokenizer,
+                task=HUNYUAN_IMAGE3_AR_TASK,
+                sys_type=HUNYUAN_IMAGE3_AR_SYS_TYPE,
+            ).token_ids
+
+        prompt_length = self.rollout_config.prompt_length
+        token_ids = await self.loop.run_in_executor(None, _build)
+        if len(token_ids) > prompt_length:
+            raise ValueError(
+                f"HunyuanImage3 AR prompt length ({len(token_ids)}) exceeds "
+                f"rollout.prompt_length ({prompt_length}); raise prompt_length."
+            )
+        return normalize_token_ids(token_ids)
+
+    async def run(self, sampling_params: dict[str, Any], **kwargs) -> DiffusionAgentLoopOutput:
+        """One hi3 turn: render the official AR prompt, then generate the image."""
+        raw_prompt = kwargs["raw_prompt"]
+        raw_negative_prompt = kwargs.get("raw_negative_prompt")
+
+        multi_modal_data = await self.process_vision_info(raw_prompt)
+        images = multi_modal_data.get("images")
+        videos = multi_modal_data.get("videos")
+
+        caption = messages_to_text(raw_prompt)
+        prompt_ids = await self._official_prompt_ids(caption)
+
+        negative_prompt_ids = None
+        if raw_negative_prompt is not None:
+            negative_prompt_ids = await self._official_prompt_ids(messages_to_text(raw_negative_prompt))
+
+        metrics = {}
+        with simple_timer("generate_sequences", metrics):
+            output = await self.server_manager.generate(
+                request_id=uuid4().hex,
+                prompt_ids=prompt_ids,
+                sampling_params=sampling_params,
+                image_data=images,
+                video_data=videos,
+                negative_prompt_ids=negative_prompt_ids,
+                prompt_text=caption,
+                use_system_prompt=HUNYUAN_IMAGE3_AR_SYS_TYPE,
+            )
+        if metrics.get("num_preempted") is None:
+            metrics["num_preempted"] = output.num_preempted if output.num_preempted is not None else -1
+
+        return DiffusionAgentLoopOutput(
+            prompt_ids=prompt_ids,
+            response_diffusion_output=output.diffusion_output,
+            response_logprobs=output.log_probs,
+            num_turns=2,
+            metrics=metrics,
+            extra_fields=output.extra_fields,
+        )

--- a/verl_omni/pipelines/hunyuan_image3_flow_grpo/common.py
+++ b/verl_omni/pipelines/hunyuan_image3_flow_grpo/common.py
@@ -1,0 +1,143 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared utilities for HunyuanImage3 FlowGRPO adapters.
+
+Training and rollout must construct the identical scheduler and call the same
+``set_timesteps`` so their sigma schedules match to floating-point precision --
+otherwise the importance-sampling ratio is biased. Values below mirror
+vllm-omni's ``HunyuanImage3Pipeline``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import torch
+
+from verl_omni.pipelines.schedulers import FlowMatchSDEDiscreteScheduler
+
+HUNYUAN_IMAGE3_TIMESTEP_SHIFT = 3.0
+
+# Official HunyuanImage-3.0-Instruct AR prompt structure (vllm-omni
+# ``prompt_utils`` builder): ``t2i_think`` -> ``en_unified`` system prompt +
+# ``Assistant:  thinking`` trigger.  UniRL drives the same task/sys pair.
+HUNYUAN_IMAGE3_AR_TASK = "t2i_think"
+HUNYUAN_IMAGE3_AR_SYS_TYPE = "en_unified"
+
+HUNYUAN_IMAGE3_SCHEDULER_KWARGS: dict[str, float | int | bool] = {
+    "num_train_timesteps": 1000,
+    "shift": HUNYUAN_IMAGE3_TIMESTEP_SHIFT,
+    "use_dynamic_shifting": False,
+    "base_shift": 0.5,
+    "max_shift": 1.15,
+    "time_shift_type": "exponential",
+    "stochastic_sampling": False,
+}
+
+# ``guidance_scale`` mirrors HunyuanImage3's ``diff_guidance_scale``; override in
+# the launch script if the rollout uses a different value.
+HUNYUAN_IMAGE3_FLOWGRPO_CFG_DEFAULTS = {
+    "guidance_scale": 2.5,
+    "guidance_rescale": 0.0,
+}
+
+
+def maybe_to_cpu(value):
+    """Move a single value to CPU if it is a ``torch.Tensor``; else return unchanged."""
+    if isinstance(value, torch.Tensor):
+        return value.detach().cpu()
+    return value
+
+
+def messages_to_text(messages: Any) -> str:
+    """Extract plain text content without applying a chat template."""
+    if isinstance(messages, str):
+        return messages
+    if isinstance(messages, dict):
+        messages = [messages]
+
+    parts = []
+    for message in messages or []:
+        if not isinstance(message, dict):
+            continue
+        content = message.get("content", "")
+        if isinstance(content, str):
+            parts.append(content)
+            continue
+        for item in content or []:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, dict) and item.get("type") == "text":
+                parts.append(item.get("text", ""))
+    return "\n".join(part for part in parts if part).strip()
+
+
+def normalize_ar_cot_text(cot: Optional[str]) -> Optional[str]:
+    """Prepend the trigger tag the AR generation omitted (mirrors the engine's
+    ``HunyuanImage3Pipeline._normalize_cot_text`` applied before the DiT template).
+    """
+    if not cot:
+        return cot
+    if " response" in cot and not cot.startswith(" thinking"):
+        return " thinking" + cot
+    if "</recaption>" in cot and not cot.startswith("<recaption>"):
+        return "<recaption>" + cot
+    return cot
+
+
+def build_hunyuan_image3_scheduler() -> FlowMatchSDEDiscreteScheduler:
+    """Construct the SDE scheduler with vllm-omni's exact HunyuanImage3 config."""
+    return FlowMatchSDEDiscreteScheduler(**HUNYUAN_IMAGE3_SCHEDULER_KWARGS)
+
+
+def setup_hunyuan_image3_sigmas(
+    scheduler: FlowMatchSDEDiscreteScheduler,
+    num_steps: int,
+    device: str | None = None,
+) -> list[float]:
+    """Configure the scheduler with vllm-omni's sigmas and return them.
+
+    ``scheduler`` must be built by :func:`build_hunyuan_image3_scheduler` first
+    (``shift`` is a construction-time knob). The returned list is the N denoise
+    sigmas, terminal 0 excluded.
+    """
+    if num_steps <= 0:
+        raise ValueError(f"num_steps must be positive, got {num_steps}")
+
+    if device is not None:
+        scheduler.set_timesteps(num_inference_steps=num_steps, device=device)
+    else:
+        scheduler.set_timesteps(num_inference_steps=num_steps)
+    scheduler.set_begin_index(0)
+    return scheduler.timesteps.tolist()
+
+
+def apply_hunyuan_cfg(
+    noise_pred: torch.Tensor,
+    negative_noise_pred: torch.Tensor,
+    guidance_scale: float,
+    guidance_rescale: float = 0.0,
+) -> torch.Tensor:
+    """Standard CFG combine: ``v_uncond + scale * (v_cond - v_uncond)`` with optional rescale."""
+    noise_pred_text = noise_pred
+    noise_pred_uncond = negative_noise_pred
+    noise_pred = noise_pred_uncond + guidance_scale * (noise_pred_text - noise_pred_uncond)
+    if guidance_rescale > 0.0:
+        norm_dims = tuple(range(1, noise_pred.ndim))
+        noise_pred = noise_pred * (
+            noise_pred_uncond.norm(dim=norm_dims, keepdim=True) / noise_pred.norm(dim=norm_dims, keepdim=True)
+        )
+        noise_pred = guidance_rescale * noise_pred + (1 - guidance_rescale) * noise_pred_uncond
+    return noise_pred

--- a/verl_omni/pipelines/hunyuan_image3_flow_grpo/diffusers_training_adapter.py
+++ b/verl_omni/pipelines/hunyuan_image3_flow_grpo/diffusers_training_adapter.py
@@ -1,0 +1,409 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""HunyuanImage3 training-side adapter for FlowGRPO.
+
+Registered as ``HunyuanImage3ForCausalMM`` in the DiffusionModelBase registry.
+HunyuanImage3 is a unified flow-matching MoE transformer: the noisy VAE latent
+is patched into the sequence next to the text tokens, the ``<timestep>`` is a
+scalar token, and the velocity is unpatchified back to latent space.  CFG is
+performed by batch doubling (conditional vs. empty prompt), matching vllm-omni.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+import numpy as np
+import torch
+from tensordict import TensorDict
+from tensordict.tensorclass import NonTensorStack
+from verl.trainer.ppo.core_algos import compute_grpo_outcome_advantage
+from verl.utils import tensordict_utils as tu
+from verl.utils.device import get_device_name
+
+from verl_omni.pipelines.model_base import DiffusionModelBase
+from verl_omni.pipelines.schedulers import FlowMatchSDEDiscreteScheduler
+from verl_omni.workers.config import DiffusionModelConfig
+
+from .common import (
+    HUNYUAN_IMAGE3_AR_SYS_TYPE,
+    HUNYUAN_IMAGE3_FLOWGRPO_CFG_DEFAULTS,
+    apply_hunyuan_cfg,
+    build_hunyuan_image3_scheduler,
+    messages_to_text,
+    normalize_ar_cot_text,
+    setup_hunyuan_image3_sigmas,
+)
+from .hunyuan_image3_model import HunyuanImage3ForTraining
+
+logger = logging.getLogger(__name__)
+
+
+def _token_ids_to_batch(token_ids_field, device: torch.device, pad_id: int) -> tuple[torch.Tensor, torch.Tensor]:
+    """Pad a ragged ``prompt_token_ids`` field into ``(ids, mask)`` of shape ``(B, L)``.
+
+    Accepts a ``NonTensorStack`` (the dataset column), a ``torch.Tensor`` (1-D or
+    2-D), or a plain list of token-id sequences.
+    """
+    if isinstance(token_ids_field, NonTensorStack):
+        token_ids_field = [tu.unwrap_non_tensor_data(token_ids_field[i]) for i in range(token_ids_field.shape[0])]
+    elif isinstance(token_ids_field, torch.Tensor):
+        if token_ids_field.ndim == 1:
+            token_ids_field = [token_ids_field.tolist()]
+        else:
+            token_ids_field = token_ids_field.tolist()
+    else:
+        token_ids_field = list(token_ids_field)
+
+    batch = len(token_ids_field)
+    max_len = max(len(ids) for ids in token_ids_field)
+    ids = torch.full((batch, max_len), pad_id, dtype=torch.long, device=device)
+    mask = torch.zeros(batch, max_len, dtype=torch.bool, device=device)
+    for i, seq in enumerate(token_ids_field):
+        n = len(seq)
+        ids[i, :n] = torch.as_tensor(seq, dtype=torch.long, device=device)
+        mask[i, :n] = True
+    return ids, mask
+
+
+def _extract_image_mask(token_ids: torch.Tensor, image_token_id: int) -> torch.Tensor:
+    """Derive the image-token mask from ``<img>`` placeholder positions."""
+    return token_ids == image_token_id
+
+
+def _scatter_index_to_tensor(field, device: torch.device) -> torch.Tensor:
+    """Batch a per-sample ``<timestep>`` position into a ``(B, 1)`` tensor."""
+    if isinstance(field, torch.Tensor):
+        value = field.to(device)
+    elif isinstance(field, NonTensorStack):
+        rows = [tu.unwrap_non_tensor_data(field[i]) for i in range(field.shape[0])]
+        value = torch.as_tensor(rows, dtype=torch.long, device=device).reshape(-1, 1)
+    else:
+        value = torch.as_tensor(list(field), dtype=torch.long, device=device).reshape(-1, 1)
+    return value.reshape(-1, 1)
+
+
+def _rope_info_to_slices(field) -> list[list[tuple[slice, tuple[int, int]]]]:
+    """Rebuild ``list[list[(slice, (h, w))]]`` from serialized ``[start, stop, h, w]`` rows.
+
+    Accepts a tensor ``(B, 4)`` (or a ``NonTensorStack`` / nested Python list) of
+    single-span rows produced by the data preprocessor; the actor reconstructs the
+    ``(slice, (h, w))`` the rollout records.
+    """
+    if isinstance(field, torch.Tensor):
+        rows = field.detach().cpu().tolist()
+    elif isinstance(field, NonTensorStack):
+        rows = []
+        for i in range(field.shape[0]):
+            element = tu.unwrap_non_tensor_data(field[i])
+            rows.append(element.tolist() if isinstance(element, torch.Tensor) else list(element))
+    else:
+        rows = list(field)
+
+    rope_info: list[list[tuple[slice, tuple[int, int]]]] = []
+    for sample in rows:
+        start, stop, h, w = int(sample[0]), int(sample[1]), int(sample[2]), int(sample[3])
+        rope_info.append([(slice(start, stop), (h, w))])
+    return rope_info
+
+
+_FUSED_TOKENIZER_CTX_CACHE: dict[str, dict[str, Any]] = {}
+
+
+def _get_hunyuan_image3_tokenizer_ctx(model_path: str) -> dict[str, Any]:
+    """Load the vllm-omni tokenizer context once per worker.
+
+    The DiT train forward rebuilds the rollout text prefix through the same
+    ``TokenizerWrapper`` the engine uses, so template decisions (sequence
+    template, system prompt body, cot re-parse) match the rollout by construction.
+    """
+    ctx = _FUSED_TOKENIZER_CTX_CACHE.get(model_path)
+    if ctx is not None:
+        return ctx
+
+    import transformers
+    from vllm_omni.diffusion.models.hunyuan_image3.hunyuan_image3_tokenizer import TokenizerWrapper
+    from vllm_omni.diffusion.models.hunyuan_image3.hunyuan_image3_transformer import (
+        HunyuanImage3ImageProcessor,
+    )
+    from vllm_omni.diffusion.models.hunyuan_image3.system_prompt import get_system_prompt
+
+    config = transformers.AutoConfig.from_pretrained(model_path, trust_remote_code=True)
+    gen_cfg = transformers.GenerationConfig.from_pretrained(model_path)
+    system_prompt = get_system_prompt(HUNYUAN_IMAGE3_AR_SYS_TYPE, "image")
+    ctx = {
+        "tkw": TokenizerWrapper(transformers.AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)),
+        "image_processor": HunyuanImage3ImageProcessor(config),
+        "drop_think": bool(getattr(gen_cfg, "drop_think", False)),
+        "image_base_size": getattr(config, "image_base_size", None),
+        "sequence_template": getattr(gen_cfg, "sequence_template", "pretrain"),
+        "system_prompt": system_prompt.strip() if system_prompt else None,
+    }
+    _FUSED_TOKENIZER_CTX_CACHE[model_path] = ctx
+    return ctx
+
+
+def propagate_image_rewards_to_ar(
+    image_rewards: torch.Tensor,
+    ar_traj_group_id: torch.Tensor,
+) -> torch.Tensor:
+    """Mean-pool per-image rewards up to their parent AR trajectory.
+
+    The unified AR + DiT rollout expands one prompt into N AR trajectories and
+    each AR trajectory into M images. The AR reward is the mean of its
+    downstream image rewards; this helper implements that group-by-mean.
+    Consumed by :meth:`HunyuanImage3FlowGRPO.postprocess_advantage`.
+
+    Args:
+        image_rewards: ``(N_img,)`` scalar outcome reward per image.
+        ar_traj_group_id: ``(N_img,)`` integer id of the AR trajectory each
+            image descends from. Ids need not be contiguous or sorted.
+
+    Returns:
+        ``(N_ar,)`` mean image reward per AR trajectory, indexed by the sorted
+        unique values of ``ar_traj_group_id``.
+    """
+    if image_rewards.numel() == 0:
+        return torch.empty(0, dtype=image_rewards.dtype, device=image_rewards.device)
+
+    ids, inverse = torch.unique(ar_traj_group_id.to(image_rewards.device), sorted=True, return_inverse=True)
+    sums = torch.zeros(ids.numel(), dtype=image_rewards.dtype, device=image_rewards.device).scatter_add(
+        0, inverse, image_rewards
+    )
+    counts = torch.zeros(ids.numel(), dtype=image_rewards.dtype, device=image_rewards.device).scatter_add(
+        0, inverse, torch.ones(inverse.numel(), dtype=image_rewards.dtype, device=image_rewards.device)
+    )
+    return sums / counts.clamp_min(1)
+
+
+@DiffusionModelBase.register("HunyuanImage3ForCausalMM", algorithm="flow_grpo")
+class HunyuanImage3FlowGRPO(DiffusionModelBase):
+    """DiffusionModelBase wrapper for ``HunyuanImage3ForTraining``."""
+
+    @classmethod
+    def build_module(cls, model_config: DiffusionModelConfig, torch_dtype: torch.dtype):
+        logger.info("Loading HunyuanImage3ForTraining from %s", model_config.local_path)
+        return HunyuanImage3ForTraining.from_pretrained(model_config.local_path, torch_dtype=torch_dtype)
+
+    @classmethod
+    def postprocess_advantage(cls, data, *, adv_kwargs: dict, norm_adv_by_std_in_grpo: bool):
+        """Attach ``ar_advantages`` for the recaption segment (unified AR + DiT).
+
+        The scalar image reward is propagated up to its parent AR trajectory
+        (mean-pool) and then GRPO-normalized per original prompt. In the
+        current flat 1:1 rollout (one image per AR trajectory) the propagation
+        is identity; a two-level rollout would key on the real
+        ``ar_traj_group_id`` column instead.
+        """
+        if "ar_prompt_token_ids" not in data.non_tensor_batch or "sample_level_scores" not in data.batch:
+            return data
+
+        bsz = data.batch["sample_level_scores"].shape[0]
+        prompt_group_id = adv_kwargs.get("index", np.arange(bsz))
+        ar_traj_group_id = torch.arange(bsz)
+        ar_rewards = propagate_image_rewards_to_ar(data.batch["sample_level_scores"].squeeze(-1), ar_traj_group_id)
+        ar_adv, _ = compute_grpo_outcome_advantage(
+            token_level_rewards=ar_rewards.unsqueeze(-1),
+            response_mask=torch.ones_like(ar_rewards).unsqueeze(-1),
+            index=prompt_group_id,
+            norm_adv_by_std_in_grpo=norm_adv_by_std_in_grpo,
+        )
+        data.batch["ar_advantages"] = ar_adv.squeeze(-1)
+        return data
+
+    @classmethod
+    def build_scheduler(cls, model_config: DiffusionModelConfig):
+        scheduler = build_hunyuan_image3_scheduler()
+        cls.set_timesteps(scheduler, model_config, get_device_name())
+        return scheduler
+
+    @classmethod
+    def set_timesteps(cls, scheduler: FlowMatchSDEDiscreteScheduler, model_config: DiffusionModelConfig, device: str):
+        setup_hunyuan_image3_sigmas(
+            scheduler,
+            model_config.pipeline.num_inference_steps,
+            device=device,
+        )
+
+    @staticmethod
+    def _build_fused_dit_inputs(
+        model_config: DiffusionModelConfig,
+        config: Any,
+        micro_batch: TensorDict,
+        latents: torch.Tensor,
+        step: int,
+        device: torch.device,
+    ) -> Optional[tuple[torch.Tensor, torch.Tensor, torch.Tensor, list]]:
+        """Rebuild the rollout DiT text prefix from the AR rollout fields.
+
+        The engine DiT conditions on the official instruct template with the AR
+        recaption spliced in (``TokenizeWrapper.apply_chat_template``); replaying
+        the cot-free preprocessor layout would compute the flow log-prob under a
+        different text condition than the rollout sampled.  Returns ``None`` when
+        the AR fields are absent, letting the caller use the precomputed columns.
+        """
+        ar_prompt_field = micro_batch.get("ar_prompt_token_ids")
+        cot_field = micro_batch.get("ar_generated_text")
+        raw_prompt_field = micro_batch.get("raw_prompt")
+        if ar_prompt_field is None or cot_field is None or raw_prompt_field is None:
+            return None
+
+        from vllm_omni.diffusion.models.hunyuan_image3.pipeline_hunyuan_image3 import (
+            HunyuanImage3Pipeline,
+        )
+
+        ctx = _get_hunyuan_image3_tokenizer_ctx(model_config.local_path)
+        batch_size = int(cot_field.shape[0])
+        captions = [messages_to_text(tu.unwrap_non_tensor_data(raw_prompt_field[i])) for i in range(batch_size)]
+        cot_texts = [normalize_ar_cot_text(tu.unwrap_non_tensor_data(cot_field[i])) for i in range(batch_size)]
+        if any(text is None for text in cot_texts):
+            return None
+
+        ffactor_h, ffactor_w = tuple(config.vae_downsample_factor)
+        image_latents = latents[:, step]
+        height = image_latents.shape[-2] * ffactor_h
+        width = image_latents.shape[-1] * ffactor_w
+        image_info = ctx["image_processor"].build_image_info((height, width))
+
+        out = ctx["tkw"].apply_chat_template(
+            batch_prompt=captions,
+            batch_cot_text=cot_texts,
+            batch_system_prompt=[ctx["system_prompt"]] * batch_size,
+            mode="gen_image",
+            batch_gen_image_info=[image_info] * batch_size,
+            bot_task="auto",
+            image_base_size=ctx["image_base_size"],
+            sequence_template=ctx["sequence_template"],
+            cfg_factor=1,
+            drop_think=ctx["drop_think"],
+        )
+        output, sections = out["output"], out["sections"]
+
+        positive_ids = output.tokens.to(device)
+        image_mask = output.gen_image_mask.to(device)
+        gen_timestep_scatter_index = output.gen_timestep_scatter_index.to(device)
+        rope_image_info = HunyuanImage3Pipeline.build_batch_rope_image_info(output, sections)
+        return positive_ids, image_mask, gen_timestep_scatter_index, rope_image_info
+
+    @classmethod
+    def prepare_model_inputs(
+        cls,
+        module: HunyuanImage3ForTraining,
+        model_config: DiffusionModelConfig,
+        latents: torch.Tensor,
+        timesteps: torch.Tensor,
+        prompt_embeds: torch.Tensor,
+        prompt_embeds_mask: torch.Tensor,
+        negative_prompt_embeds: torch.Tensor,
+        negative_prompt_embeds_mask: torch.Tensor,
+        micro_batch: TensorDict,
+        step: int,
+    ) -> tuple[dict, Optional[dict]]:
+        """Build positive/negative model-input dicts.
+
+        When the batch carries the AR rollout fields, the positive branch is
+        rebuilt from the rollout text prefix (see :meth:`_build_fused_dit_inputs`);
+        otherwise it falls back to the precomputed ``[text, <boi>, <size>,
+        <ratio>, <timestep>, <eoi>, <img>*]`` columns.  The negative branch always
+        uses the precomputed columns.
+        """
+        device = latents.device
+        config = module.config
+
+        fused = cls._build_fused_dit_inputs(model_config, config, micro_batch, latents, step, device)
+        if fused is not None:
+            positive_ids, image_mask, gen_timestep_scatter_index, rope_image_info = fused
+        else:
+            positive_ids, _ = _token_ids_to_batch(micro_batch["prompt_token_ids"], device, config.pad_token_id)
+            image_mask = _extract_image_mask(positive_ids, config.image_token_id)
+            gen_timestep_scatter_index = _scatter_index_to_tensor(micro_batch.get("gen_timestep_scatter_index"), device)
+            rope_image_info = _rope_info_to_slices(micro_batch.get("rope_image_info"))
+
+        negative_ids, _ = _token_ids_to_batch(micro_batch["negative_prompt_token_ids"], device, config.pad_token_id)
+        negative_image_mask = _extract_image_mask(negative_ids, config.image_token_id)
+
+        # The <timestep> token position and 2-D RoPE spans differ between the
+        # conditional and empty-prompt branches (their text lengths differ), so
+        # the data preprocessor emits them separately.
+        negative_gen_timestep_scatter_index = _scatter_index_to_tensor(
+            micro_batch.get("negative_gen_timestep_scatter_index"), device
+        )
+        negative_rope_image_info = _rope_info_to_slices(micro_batch.get("negative_rope_image_info"))
+
+        image = latents[:, step]
+        timestep = timesteps[:, step]
+
+        model_inputs = {
+            "input_ids": positive_ids,
+            "images": image,
+            "timesteps": timestep,
+            "image_mask": image_mask,
+            "gen_timestep_scatter_index": gen_timestep_scatter_index,
+            "rope_image_info": rope_image_info,
+        }
+        negative_model_inputs = {
+            "input_ids": negative_ids,
+            "images": image,
+            "timesteps": timestep,
+            "image_mask": negative_image_mask,
+            "gen_timestep_scatter_index": negative_gen_timestep_scatter_index,
+            "rope_image_info": negative_rope_image_info,
+        }
+        return model_inputs, negative_model_inputs
+
+    @classmethod
+    def forward_and_sample_previous_step(
+        cls,
+        module: HunyuanImage3ForTraining,
+        scheduler: FlowMatchSDEDiscreteScheduler,
+        model_config: DiffusionModelConfig,
+        model_inputs: dict[str, torch.Tensor],
+        negative_model_inputs: Optional[dict[str, torch.Tensor]],
+        scheduler_inputs: Optional[TensorDict | dict[str, torch.Tensor]],
+        step: int,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        assert scheduler_inputs is not None
+        latents = scheduler_inputs["all_latents"]
+        timesteps = scheduler_inputs["all_timesteps"]
+
+        noise_pred = cls.forward(module, model_config, model_inputs)
+        guidance_scale = float(
+            getattr(model_config.pipeline, "guidance_scale", HUNYUAN_IMAGE3_FLOWGRPO_CFG_DEFAULTS["guidance_scale"])
+        )
+        guidance_rescale = float(
+            getattr(
+                model_config.pipeline,
+                "guidance_rescale",
+                HUNYUAN_IMAGE3_FLOWGRPO_CFG_DEFAULTS["guidance_rescale"],
+            )
+        )
+        if guidance_scale > 1.0:
+            assert negative_model_inputs is not None, "HunyuanImage3 CFG requires the empty-prompt branch"
+            negative_noise_pred = cls.forward(module, model_config, negative_model_inputs)
+            noise_pred = apply_hunyuan_cfg(noise_pred, negative_noise_pred, guidance_scale, guidance_rescale)
+
+        _, log_prob, prev_sample_mean, std_dev_t, sqrt_dt = scheduler.sample_previous_step(
+            sample=latents[:, step].float(),
+            model_output=noise_pred.float(),
+            timestep=timesteps[:, step],
+            noise_level=model_config.algo.noise_level,
+            prev_sample=latents[:, step + 1].float(),
+            sde_type=model_config.algo.sde_type,
+            return_logprobs=True,
+            return_sqrt_dt=True,
+            include_logprob_normalizer=False,
+        )
+        return log_prob, prev_sample_mean, std_dev_t, sqrt_dt

--- a/verl_omni/pipelines/hunyuan_image3_flow_grpo/hunyuan_image3_model.py
+++ b/verl_omni/pipelines/hunyuan_image3_flow_grpo/hunyuan_image3_model.py
@@ -1,0 +1,1081 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""HunyuanImage3ForTraining — FSDP2-compatible HunyuanImage3 module for flow-GRPO training.
+
+Ported from Tencent HunyuanImage-3.0 (``modeling_hunyuan_image_3.py``, Tencent Hunyuan
+Community License).  Only the generation backbone is ported: the unified MoE transformer
+(text + image share one 64-expert / topk-8 backbone), the UNet latent patchifier /
+unpatchifier, timestep embedding, and 2-D RoPE.  The VAE, ViT, tokenizer, and generation
+cache are left to the rollout side (vllm-omni).
+
+The training ``forward`` reproduces the vllm-omni ``forward_call`` gen-image path:
+embed text tokens, scatter noisy latent patches and the ``<timestep>`` token into the
+embedding sequence, run the decoder stack with a causal-text / full-image attention
+mask, then unpatch the image tokens back to a latent-space velocity.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import os
+from contextlib import nullcontext
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch import Tensor
+
+from verl_omni.pipelines.non_diffusers_model_base import NonDiffusersModelBase
+
+logger = logging.getLogger(__name__)
+
+# ===================================================================
+#  Config
+# ===================================================================
+
+
+@dataclass
+class HunyuanImage3TrainingConfig:
+    """Training-side subset of ``HunyuanImage3Config`` (generation backbone only).
+
+    Values default to the HunyuanImage-3.0-Instruct checkpoint and are overridden
+    from the checkpoint ``config.json`` when loaded through ``from_model_path``.
+    """
+
+    vocab_size: int = 133120
+    hidden_size: int = 4096
+    intermediate_size: int = 3072
+    moe_intermediate_size: int = 3072
+    num_hidden_layers: int = 32
+    num_attention_heads: int = 32
+    num_key_value_heads: int = 8
+    attention_head_dim: int = 128
+    hidden_act: str = "silu"
+    rms_norm_eps: float = 1e-5
+    norm_type: str = "rms"
+    max_position_embeddings: int = 22800
+    rope_theta: float = 10000.0
+    use_qk_norm: bool = True
+    use_rotary_pos_emb: bool = True
+    attention_bias: bool = False
+    mlp_bias: bool = False
+    num_experts: int = 64
+    use_mixed_mlp_moe: bool = True
+    num_shared_expert: int = 1
+    moe_topk: int = 8
+    moe_layer_num_skipped: int = 0
+    norm_topk_prob: bool = True
+    routed_scaling_factor: float = 1.0
+    group_limited_greedy: bool = False
+    n_group: Optional[int] = None
+    topk_group: Optional[int] = None
+    # image generation
+    img_proj_type: str = "unet"
+    patch_size: int = 1
+    patch_embed_hidden_dim: int = 1024
+    latent_channels: int = 32
+    vae_downsample_factor: tuple[int, int] = (16, 16)
+    # token ids
+    pad_token_id: int = 128009
+    bos_token_id: int = 127958
+    eos_token_id: int = 127957
+    im_start_id: int = 128000
+    im_end_id: int = 128001
+    image_token_id: int = 128006
+
+    def save_pretrained(self, save_directory: str) -> None:
+        """Save config as JSON beside the weights."""
+        from dataclasses import asdict
+
+        os.makedirs(save_directory, exist_ok=True)
+        output_path = os.path.join(save_directory, "config.json")
+        with open(output_path, "w") as f:
+            json.dump(asdict(self), f, indent=4, sort_keys=True)
+
+    @classmethod
+    def from_model_path(cls, model_path: str) -> HunyuanImage3TrainingConfig:
+        """Parse the training config from the checkpoint ``config.json``."""
+        cfg_path = os.path.join(model_path, "config.json")
+        with open(cfg_path) as f:
+            raw = json.load(f)
+
+        # moe_topk / num_experts / num_shared_expert may be per-layer lists; the
+        # checkpoint uses uniform values so take the first element.
+        def _scalar(value, default):
+            if value is None:
+                return default
+            if isinstance(value, list):
+                return value[0] if value else default
+            return value
+
+        vae = raw.get("vae") or {}
+        return cls(
+            vocab_size=int(raw.get("vocab_size", 133120)),
+            hidden_size=int(raw.get("hidden_size", 4096)),
+            intermediate_size=int(raw.get("intermediate_size", 3072)),
+            moe_intermediate_size=int(_scalar(raw.get("moe_intermediate_size"), 3072)),
+            num_hidden_layers=int(raw.get("num_hidden_layers", 32)),
+            num_attention_heads=int(raw.get("num_attention_heads", 32)),
+            num_key_value_heads=int(raw.get("num_key_value_heads", 8) or 8),
+            attention_head_dim=int(raw.get("attention_head_dim", raw.get("head_dim", 128))),
+            hidden_act=str(raw.get("hidden_act", "silu")),
+            rms_norm_eps=float(raw.get("rms_norm_eps", 1e-5)),
+            norm_type=str(raw.get("norm_type", "rms")),
+            max_position_embeddings=int(raw.get("max_position_embeddings", 22800)),
+            rope_theta=float(raw.get("rope_theta", 10000.0)),
+            use_qk_norm=bool(raw.get("use_qk_norm", True)),
+            use_rotary_pos_emb=bool(raw.get("use_rotary_pos_emb", True)),
+            attention_bias=bool(raw.get("attention_bias", False)),
+            mlp_bias=bool(raw.get("mlp_bias", False)),
+            num_experts=int(_scalar(raw.get("num_experts"), 64)),
+            use_mixed_mlp_moe=bool(raw.get("use_mixed_mlp_moe", True)),
+            num_shared_expert=int(_scalar(raw.get("num_shared_expert"), 1)),
+            moe_topk=int(_scalar(raw.get("moe_topk"), 8)),
+            moe_layer_num_skipped=int(raw.get("moe_layer_num_skipped", 0)),
+            norm_topk_prob=bool(raw.get("norm_topk_prob", True)),
+            routed_scaling_factor=float(raw.get("routed_scaling_factor", 1.0)),
+            group_limited_greedy=bool(raw.get("group_limited_greedy", False)),
+            n_group=raw.get("n_group"),
+            topk_group=raw.get("topk_group"),
+            img_proj_type=str(raw.get("img_proj_type", "unet")),
+            patch_size=int(raw.get("patch_size", 1)),
+            patch_embed_hidden_dim=int(raw.get("patch_embed_hidden_dim", 1024)),
+            latent_channels=int(vae.get("latent_channels", 32)),
+            vae_downsample_factor=tuple(raw.get("vae_downsample_factor", (16, 16))),
+            pad_token_id=int(raw.get("pad_token_id", 128009)),
+            bos_token_id=int(raw.get("bos_token_id", 127958)),
+            eos_token_id=int(raw.get("eos_token_id", 127957)),
+            im_start_id=int(raw.get("im_start_id", 128000)),
+            im_end_id=int(raw.get("im_end_id", 128001)),
+            image_token_id=int(raw.get("image_token_id", 128006)),
+        )
+
+
+# ===================================================================
+#  Helper functions (ported from modeling_hunyuan_image_3.py)
+# ===================================================================
+
+
+def timestep_embedding(t: Tensor, dim: int, max_period: int = 10000) -> Tensor:
+    """Create GLIDE-style sinusoidal timestep embeddings (``(N, dim)``)."""
+    half = dim // 2
+    freqs = torch.exp(
+        -math.log(max_period) * torch.arange(start=0, end=half, dtype=torch.float32, device=t.device) / half
+    )
+    args = t[:, None].float() * freqs[None]
+    embedding = torch.cat([torch.cos(args), torch.sin(args)], dim=-1)
+    if dim % 2:
+        embedding = torch.cat([embedding, torch.zeros_like(embedding[:, :1])], dim=-1)
+    return embedding
+
+
+def conv_nd(dims: int, *args, **kwargs) -> nn.Module:
+    """Create a 1D/2D/3D convolution module."""
+    if dims == 1:
+        return nn.Conv1d(*args, **kwargs)
+    if dims == 2:
+        return nn.Conv2d(*args, **kwargs)
+    if dims == 3:
+        return nn.Conv3d(*args, **kwargs)
+    raise ValueError(f"unsupported dimensions: {dims}")
+
+
+def zero_module(module: nn.Module) -> nn.Module:
+    """Zero out the parameters of a module and return it."""
+    for p in module.parameters():
+        p.detach().zero_()
+    return module
+
+
+def normalization(channels: int, **kwargs) -> nn.Module:
+    """Standard GroupNorm (32 groups) used by the ResBlock."""
+    return nn.GroupNorm(32, channels, **kwargs)
+
+
+def _to_tuple(x, dim: int = 2):
+    if isinstance(x, int):
+        return (x,) * dim
+    if len(x) == dim:
+        return x
+    raise ValueError(f"Expected length {dim} or int, but got {x}")
+
+
+def get_meshgrid_nd(start, *args, dim: int = 2, device: str = "cpu") -> Tensor:
+    """Get n-D meshgrid with start/stop/num (``[dim, ...]``) for 2-D RoPE."""
+    if len(args) == 0:
+        num = _to_tuple(start, dim=dim)
+        start = (0,) * dim
+        stop = num
+    elif len(args) == 1:
+        start = _to_tuple(start, dim=dim)
+        stop = _to_tuple(args[0], dim=dim)
+        num = [int(stop[i] - start[i]) for i in range(dim)]
+    elif len(args) == 2:
+        start = _to_tuple(start, dim=dim)
+        stop = _to_tuple(args[0], dim=dim)
+        num = _to_tuple(args[1], dim=dim)
+    else:
+        raise ValueError("len(args) should be 0, 1 or 2")
+
+    axis_grid = []
+    for i in range(dim):
+        a, b, n = start[i], stop[i], num[i]
+        g = torch.linspace(a, b, n + 1, dtype=torch.float32, device=device)[:n]
+        axis_grid.append(g)
+    return torch.stack(torch.meshgrid(*axis_grid, indexing="ij"), dim=0)  # [dim, H, W]
+
+
+def build_2d_rope(
+    seq_len: int,
+    n_elem: int,
+    image_infos: Optional[list[tuple[slice, tuple[int, int]]]] = None,
+    device: Optional[torch.device] = None,
+    base: int = 10000,
+) -> tuple[Tensor, Tensor]:
+    """Build 2-D RoPE cos/sin of shape ``(seq_len, n_elem)``.
+
+    Image tokens get 2-D positions ``(beta_y, beta_x)`` derived from their grid
+    coordinates; text tokens get linear positions.
+    """
+    assert n_elem % 4 == 0, f"n_elem must be divisible by 4, but got {n_elem}."
+
+    theta = 1.0 / (base ** (torch.arange(0, n_elem, 2, device=device).float() / n_elem))
+    theta = theta.reshape(1, n_elem // 4, 2)  # [1, half_d, 2]
+
+    image_infos_list = [image_infos or []]
+    x_sections = []
+    y_sections = []
+    for sample_image_infos in image_infos_list:
+        last_pos = 0
+        for sec_slice, (h, w) in sample_image_infos:
+            ll = sec_slice.start
+            if last_pos < ll:
+                y_sections.append(torch.arange(last_pos, ll, device=device))
+                x_sections.append(torch.arange(last_pos, ll, device=device))
+            elif h is None:
+                # Special boundary tokens (<boi>/<size>/<ratio>/<timestep>/<eoi>) share
+                # overlapped positions; use linear ids for them.
+                y_sections.append(torch.arange(sec_slice.start, sec_slice.stop, device=device))
+                x_sections.append(torch.arange(sec_slice.start, sec_slice.stop, device=device))
+                continue
+            beta_y = ll + (w * h - h) / 2
+            beta_x = ll + (w * h - w) / 2
+            grid = get_meshgrid_nd((beta_y, beta_x), (beta_y + h, beta_x + w), device=device)  # [2, h, w]
+            grid = grid.reshape(2, -1)
+            y_sections.append(grid[0])
+            x_sections.append(grid[1])
+            last_pos = ll + w * h
+        y_sections.append(torch.arange(last_pos, seq_len, device=device))
+        x_sections.append(torch.arange(last_pos, seq_len, device=device))
+
+    x_pos = torch.cat(x_sections).long()
+    y_pos = torch.cat(y_sections).long()
+    x_pos = x_pos[:seq_len]
+    y_pos = y_pos[:seq_len]
+    all_pos = torch.stack((y_pos, x_pos), dim=1).unsqueeze(1)  # [seq_len, 1, 2]
+
+    idx_theta = (all_pos * theta).reshape(all_pos.shape[0], n_elem // 2).repeat(1, 2)
+    return torch.cos(idx_theta), torch.sin(idx_theta)
+
+
+def build_batch_2d_rope(
+    seq_len: int,
+    n_elem: int,
+    image_infos: Optional[list[list[tuple[slice, tuple[int, int]]]]] = None,
+    device: Optional[torch.device] = None,
+    base: int = 10000,
+) -> tuple[Tensor, Tensor]:
+    """Batch 2-D RoPE: returns ``(cos, sin)`` of shape ``(B, seq_len, n_elem)``."""
+    if image_infos is None:
+        image_infos = [None]
+    cos_list, sin_list = [], []
+    for image_info in image_infos:
+        cos, sin = build_2d_rope(seq_len, n_elem, image_infos=image_info, device=device, base=base)
+        cos_list.append(cos)
+        sin_list.append(sin)
+    return torch.stack(cos_list, dim=0), torch.stack(sin_list, dim=0)
+
+
+def rotate_half(x: Tensor) -> Tensor:
+    """Rotate half the hidden dims of the input."""
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return torch.cat((-x2, x1), dim=-1)
+
+
+def apply_rotary_pos_emb(q: Tensor, k: Tensor, cos: Tensor, sin: Tensor) -> tuple[Tensor, Tensor]:
+    """Apply 2-D rotary embeddings to q/k of shape ``(B, H, L, D)``."""
+    cos = cos.unsqueeze(1)
+    sin = sin.unsqueeze(1)
+    q_embed = (q * cos) + (rotate_half(q) * sin)
+    k_embed = (k * cos) + (rotate_half(k) * sin)
+    return q_embed, k_embed
+
+
+def repeat_kv(hidden_states: Tensor, n_rep: int) -> Tensor:
+    """Repeat KV heads ``n_rep`` times for GQA."""
+    batch, num_key_value_heads, slen, head_dim = hidden_states.shape
+    if n_rep == 1:
+        return hidden_states
+    hidden_states = hidden_states[:, :, None, :, :].expand(batch, num_key_value_heads, n_rep, slen, head_dim)
+    return hidden_states.reshape(batch, num_key_value_heads * n_rep, slen, head_dim)
+
+
+# ===================================================================
+#  Building blocks
+# ===================================================================
+
+
+class HunyuanRMSNorm(nn.Module):
+    """Hunyuan RMSNorm (T5-style, fp32 variance)."""
+
+    def __init__(self, hidden_size: int, eps: float = 1e-6):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(hidden_size))
+        self.variance_epsilon = eps
+
+    def forward(self, hidden_states: Tensor) -> Tensor:
+        input_dtype = hidden_states.dtype
+        hidden_states = hidden_states.to(torch.float32)
+        variance = hidden_states.pow(2).mean(-1, keepdim=True)
+        hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
+        return self.weight * hidden_states.to(input_dtype)
+
+
+class HunyuanMLP(nn.Module):
+    """SwiGLU MLP, shared by experts and the shared expert."""
+
+    def __init__(self, config: HunyuanImage3TrainingConfig, is_shared_mlp: bool = False, is_moe: bool = False):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.hidden_act = config.hidden_act
+
+        intermediate_size = config.intermediate_size
+        if is_shared_mlp or is_moe:
+            intermediate_size = config.moe_intermediate_size
+        if is_shared_mlp:
+            intermediate_size *= config.num_shared_expert
+        if config.hidden_act == "silu":
+            intermediate_size *= 2  # SwiGLU
+            self.gate_and_up_proj = nn.Linear(self.hidden_size, intermediate_size, bias=config.mlp_bias)
+            self.down_proj = nn.Linear(intermediate_size // 2, self.hidden_size, bias=config.mlp_bias)
+        else:
+            raise ValueError(f"Unsupported hidden_act: {config.hidden_act}")
+
+    def forward(self, x: Tensor) -> Tensor:
+        gate_and_up_proj = self.gate_and_up_proj(x)
+        x1, x2 = gate_and_up_proj.chunk(2, dim=-1)
+        return self.down_proj(x1 * F.silu(x2))
+
+
+class HunyuanTopKGate(nn.Module):
+    """Router gate with the simple top-k path used by the eager MoE."""
+
+    def __init__(self, config: HunyuanImage3TrainingConfig):
+        super().__init__()
+        self.moe_topk = config.moe_topk
+        self.wg = nn.Linear(config.hidden_size, config.num_experts, bias=False, dtype=torch.float32)
+
+    def forward(self, hidden_states: Tensor) -> tuple[Tensor, Tensor]:
+        bsz, seq_len, hidden_size = hidden_states.shape
+        hidden_states = hidden_states.reshape(-1, hidden_size)
+        if self.wg.weight.dtype == torch.float32:
+            hidden_states = hidden_states.float()
+        logits = self.wg(hidden_states)
+        gates = F.softmax(logits, dim=1)
+        # Stable sort so a checkpoint recompute can't flip a tied-score token to
+        # a different expert (torch.topk is not stable for ties, breaking grad).
+        sorted_gates, sorted_idx = torch.sort(gates, dim=-1, descending=True, stable=True)
+        # Densify the top-k slice so MoE dispatch's ``view(-1)`` sees contiguous memory.
+        topk_weight = sorted_gates[:, : self.moe_topk].contiguous()
+        expert_index = sorted_idx[:, : self.moe_topk].contiguous()
+        weight_sums = topk_weight.sum(dim=1, keepdim=True)
+        weight_sums = torch.clamp(weight_sums, min=1e-8)
+        topk_weight = topk_weight / weight_sums
+        return topk_weight, expert_index
+
+
+class HunyuanMoE(nn.Module):
+    """DeepSeek-style MoE with an optional shared expert (mixed MLP MoE)."""
+
+    def __init__(self, config: HunyuanImage3TrainingConfig):
+        super().__init__()
+        self.moe_topk = config.moe_topk
+        self.num_experts = config.num_experts
+        self.use_mixed_mlp_moe = config.use_mixed_mlp_moe
+        if self.use_mixed_mlp_moe:
+            self.shared_mlp = HunyuanMLP(config, is_shared_mlp=True)
+        self.gate = HunyuanTopKGate(config)
+        self.experts = nn.ModuleList([HunyuanMLP(config, is_moe=True) for _ in range(self.num_experts)])
+
+    def forward(self, hidden_states: Tensor) -> Tensor:
+        bsz, seq_len, hidden_size = hidden_states.shape
+        input_hidden_states = hidden_states
+
+        shared_out = self.shared_mlp(hidden_states) if self.use_mixed_mlp_moe else None
+
+        # Gate weights are fp32; keep them out of autocast so routing logits stay numerically stable.
+        with torch.autocast(device_type=hidden_states.device.type, enabled=False):
+            topk_weights, topk_idx = self.gate(hidden_states)
+        topk_weights = topk_weights.to(hidden_states.dtype)
+
+        flat_topk_idx = topk_idx.view(-1)
+        hidden_states_flat = input_hidden_states.view(-1, hidden_size)
+        hidden_states_repeated = hidden_states_flat.repeat_interleave(self.moe_topk, dim=0)
+
+        expert_outputs = torch.zeros_like(hidden_states_repeated)
+        for i in range(self.num_experts):
+            expert_mask = flat_topk_idx == i
+            if not expert_mask.any():
+                continue
+            expert_outputs[expert_mask] = self.experts[i](hidden_states_repeated[expert_mask])
+
+        combined_output = (
+            expert_outputs.view(bsz * seq_len, self.moe_topk, hidden_size) * topk_weights.unsqueeze(-1)
+        ).sum(dim=1)
+        combined_output = combined_output.to(hidden_states.dtype).view(bsz, seq_len, hidden_size)
+
+        if shared_out is not None:
+            combined_output = shared_out + combined_output
+        return combined_output
+
+
+class HunyuanImage3SDPAAttention(nn.Module):
+    """SDPA self-attention with fused QKV, GQA, QK-norm, and 2-D RoPE."""
+
+    def __init__(self, config: HunyuanImage3TrainingConfig):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.num_heads = config.num_attention_heads
+        self.head_dim = config.attention_head_dim
+        self.num_key_value_heads = config.num_key_value_heads
+        self.num_key_value_groups = self.num_heads // self.num_key_value_heads
+        self.hidden_size_q = self.head_dim * self.num_heads
+        self.hidden_size_kv = self.head_dim * self.num_key_value_heads
+        self.use_qk_norm = config.use_qk_norm
+        self.use_rotary_pos_emb = config.use_rotary_pos_emb
+
+        self.qkv_proj = nn.Linear(
+            self.hidden_size, self.hidden_size_q + 2 * self.hidden_size_kv, bias=config.attention_bias
+        )
+        self.o_proj = nn.Linear(self.hidden_size_q, self.hidden_size, bias=config.attention_bias)
+
+        if self.use_qk_norm:
+            self.query_layernorm = HunyuanRMSNorm(self.head_dim, eps=config.rms_norm_eps)
+            self.key_layernorm = HunyuanRMSNorm(self.head_dim, eps=config.rms_norm_eps)
+
+    def forward(
+        self,
+        hidden_states: Tensor,
+        attention_mask: Optional[Tensor] = None,
+        custom_pos_emb: Optional[tuple[Tensor, Tensor]] = None,
+        cu_seqlens: Optional[Tensor] = None,
+        max_seqlen: Optional[int] = None,
+    ) -> Tensor:
+        bsz, q_len, _ = hidden_states.size()
+
+        qkv_states = self.qkv_proj(hidden_states)
+        qkv_states = qkv_states.reshape(
+            bsz, q_len, self.num_key_value_heads, self.num_key_value_groups + 2, self.head_dim
+        )
+        query_states, key_states, value_states = torch.split(qkv_states, [self.num_key_value_groups, 1, 1], dim=3)
+
+        query_states = query_states.reshape(bsz, q_len, self.num_heads, self.head_dim).transpose(1, 2)
+        key_states = key_states.reshape(bsz, q_len, self.num_key_value_heads, self.head_dim).transpose(1, 2)
+        value_states = value_states.reshape(bsz, q_len, self.num_key_value_heads, self.head_dim).transpose(1, 2)
+
+        if self.use_rotary_pos_emb:
+            cos, sin = custom_pos_emb
+            query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin)
+
+        if self.use_qk_norm:
+            query_states = self.query_layernorm(query_states)
+            key_states = self.key_layernorm(key_states)
+
+        query_states = query_states.to(value_states.dtype)
+        key_states = key_states.to(value_states.dtype)
+
+        key_states = repeat_kv(key_states, self.num_key_value_groups)
+        value_states = repeat_kv(value_states, self.num_key_value_groups)
+
+        if cu_seqlens is not None:
+            # rmpad path (AR text): bsz == 1, cu_seqlens marks sample boundaries.
+            attn_output = _varlen_attention(
+                query_states, key_states, value_states, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen
+            )
+        else:
+            attn_output = F.scaled_dot_product_attention(
+                query_states, key_states, value_states, attn_mask=attention_mask, dropout_p=0.0
+            )
+        attn_output = attn_output.transpose(1, 2).contiguous().reshape(bsz, q_len, -1)
+        return self.o_proj(attn_output)
+
+
+def _varlen_attention(
+    query_states: Tensor,
+    key_states: Tensor,
+    value_states: Tensor,
+    cu_seqlens: Tensor,
+    max_seqlen: Optional[int],
+) -> Tensor:
+    """Varlen causal self-attention over concatenated variable-length samples.
+
+    Prefers ``flash_attn.flash_attn_varlen_func``; falls back to SDPA with a
+    per-sample block-diagonal causal mask on CPU / without flash-attn. Inputs
+    and output are ``(1, H, total_nnz, D)``.
+    """
+    is_cuda = query_states.is_cuda
+    if is_cuda:
+        try:
+            from flash_attn import flash_attn_varlen_func
+        except ImportError:
+            flash_attn_varlen_func = None
+    else:
+        flash_attn_varlen_func = None
+
+    if flash_attn_varlen_func is not None:
+        # flash_attn_varlen_func expects (total_nnz, H, D).
+        q = query_states.squeeze(0).transpose(0, 1).contiguous()
+        k = key_states.squeeze(0).transpose(0, 1).contiguous()
+        v = value_states.squeeze(0).transpose(0, 1).contiguous()
+        cu = cu_seqlens.to(torch.int32)
+        max_s = int(max_seqlen) if max_seqlen is not None else int((cu[1:] - cu[:-1]).max().item())
+        out = flash_attn_varlen_func(
+            q, k, v, cu_seqlens_q=cu, cu_seqlens_k=cu, max_seqlen_q=max_s, max_seqlen_k=max_s, causal=True
+        )
+        return out.transpose(0, 1).unsqueeze(0)
+
+    total_nnz = query_states.shape[2]
+    device = query_states.device
+    mask = torch.zeros(total_nnz, total_nnz, dtype=torch.bool, device=device)
+    cu_list = cu_seqlens.tolist()
+    for start, end in zip(cu_list[:-1], cu_list[1:], strict=False):
+        block = torch.ones(end - start, end - start, dtype=torch.bool, device=device).tril()
+        mask[start:end, start:end] = block
+    mask = mask.unsqueeze(0).unsqueeze(0)
+    return F.scaled_dot_product_attention(query_states, key_states, value_states, attn_mask=mask, dropout_p=0.0)
+
+
+class HunyuanImage3DecoderLayer(nn.Module):
+    """Single decoder layer: pre-norm attention + pre-norm MoE MLP."""
+
+    def __init__(self, config: HunyuanImage3TrainingConfig):
+        super().__init__()
+        self.self_attn = HunyuanImage3SDPAAttention(config)
+        self.mlp = HunyuanMoE(config) if config.num_experts > 1 else HunyuanMLP(config, is_moe=True)
+        self.input_layernorm = HunyuanRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = HunyuanRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+    def forward(
+        self,
+        hidden_states: Tensor,
+        attention_mask: Optional[Tensor] = None,
+        custom_pos_emb: Optional[tuple[Tensor, Tensor]] = None,
+        cu_seqlens: Optional[Tensor] = None,
+        max_seqlen: Optional[int] = None,
+    ) -> Tensor:
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+        hidden_states = self.self_attn(
+            hidden_states,
+            attention_mask=attention_mask,
+            custom_pos_emb=custom_pos_emb,
+            cu_seqlens=cu_seqlens,
+            max_seqlen=max_seqlen,
+        )
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        return residual + hidden_states
+
+
+class TimestepEmbedder(nn.Module):
+    """Embeds scalar (or per-image) timesteps into vectors."""
+
+    def __init__(self, hidden_size: int, frequency_embedding_size: int = 256, max_period: int = 10000):
+        super().__init__()
+        self.frequency_embedding_size = frequency_embedding_size
+        self.max_period = max_period
+        self.mlp = nn.Sequential(
+            nn.Linear(frequency_embedding_size, hidden_size, bias=True),
+            nn.GELU(),
+            nn.Linear(hidden_size, hidden_size, bias=True),
+        )
+
+    def forward(self, t: Tensor) -> Tensor:
+        t_freq = timestep_embedding(t, self.frequency_embedding_size, self.max_period).type(self.mlp[0].weight.dtype)
+        return self.mlp(t_freq)
+
+
+class Upsample(nn.Module):
+    """Forward module: nearest upsample with optional conv."""
+
+    def __init__(self, channels: int, use_conv: bool, dims: int = 2, out_channels: Optional[int] = None):
+        super().__init__()
+        self.channels = channels
+        self.out_channels = out_channels or channels
+        self.use_conv = use_conv
+        if use_conv:
+            self.conv = conv_nd(dims, self.channels, self.out_channels, 3, padding=1)
+
+    def forward(self, x: Tensor) -> Tensor:
+        x = F.interpolate(x, scale_factor=2, mode="nearest")
+        if self.use_conv:
+            x = self.conv(x)
+        return x
+
+
+class Downsample(nn.Module):
+    """Downsample module: strided conv or average pool."""
+
+    def __init__(self, channels: int, use_conv: bool, dims: int = 2, out_channels: Optional[int] = None):
+        super().__init__()
+        self.channels = channels
+        self.out_channels = out_channels or channels
+        self.use_conv = use_conv
+        stride = 2 if dims != 3 else (1, 2, 2)
+        if use_conv:
+            self.op = conv_nd(dims, self.channels, self.out_channels, 3, stride=stride, padding=1)
+        else:
+            self.op = nn.AvgPool2d(kernel_size=stride, stride=stride)
+
+    def forward(self, x: Tensor) -> Tensor:
+        return self.op(x)
+
+
+class ResBlock(nn.Module):
+    """Residual block with adaptive group normalization (timestep-conditioned)."""
+
+    def __init__(
+        self,
+        in_channels: int,
+        emb_channels: int,
+        out_channels: Optional[int] = None,
+        dropout: float = 0.0,
+        use_conv: bool = False,
+        up: bool = False,
+        down: bool = False,
+    ):
+        super().__init__()
+        self.in_channels = in_channels
+        self.out_channels = out_channels or in_channels
+
+        self.in_layers = nn.Sequential(
+            normalization(in_channels),
+            nn.SiLU(),
+            conv_nd(2, in_channels, self.out_channels, 3, padding=1),
+        )
+        self.updown = up or down
+        if up:
+            self.h_upd = Upsample(in_channels, False)
+            self.x_upd = Upsample(in_channels, False)
+        elif down:
+            self.h_upd = Downsample(in_channels, False)
+            self.x_upd = Downsample(in_channels, False)
+        else:
+            self.h_upd = self.x_upd = nn.Identity()
+
+        self.emb_layers = nn.Sequential(nn.SiLU(), nn.Linear(emb_channels, 2 * self.out_channels))
+        self.out_layers = nn.Sequential(
+            normalization(self.out_channels),
+            nn.SiLU(),
+            nn.Dropout(p=dropout),
+            zero_module(conv_nd(2, self.out_channels, self.out_channels, 3, padding=1)),
+        )
+
+        if self.out_channels == in_channels:
+            self.skip_connection = nn.Identity()
+        elif use_conv:
+            self.skip_connection = conv_nd(2, in_channels, self.out_channels, 3, padding=1)
+        else:
+            self.skip_connection = conv_nd(2, in_channels, self.out_channels, 1)
+
+    def forward(self, x: Tensor, emb: Tensor) -> Tensor:
+        if self.updown:
+            in_rest, in_conv = self.in_layers[:-1], self.in_layers[-1]
+            h = in_rest(x)
+            h = self.h_upd(h)
+            x = self.x_upd(x)
+            h = in_conv(h)
+        else:
+            h = self.in_layers(x)
+
+        emb_out = self.emb_layers(emb)
+        while len(emb_out.shape) < len(h.shape):
+            emb_out = emb_out[..., None]
+
+        out_norm, out_rest = self.out_layers[0], self.out_layers[1:]
+        scale, shift = torch.chunk(emb_out, 2, dim=1)
+        h = out_norm(h) * (1.0 + scale) + shift
+        h = out_rest(h)
+        return self.skip_connection(x) + h
+
+
+class UNetDown(nn.Module):
+    """Latent patchifier: VAE latent ``(B, C, H, W)`` -> ``(B, num_patches, D)``."""
+
+    def __init__(self, patch_size: int, in_channels: int, emb_channels: int, hidden_channels: int, out_channels: int):
+        super().__init__()
+        self.patch_size = patch_size
+        assert patch_size in [1, 2, 4, 8]
+
+        self.model: nn.ModuleList = nn.ModuleList([conv_nd(2, in_channels, hidden_channels, 3, padding=1)])
+        if patch_size == 1:
+            self.model.append(ResBlock(hidden_channels, emb_channels, out_channels=out_channels))
+        else:
+            for i in range(patch_size // 2):
+                self.model.append(
+                    ResBlock(
+                        hidden_channels,
+                        emb_channels,
+                        out_channels=hidden_channels if (i + 1) * 2 != patch_size else out_channels,
+                        down=True,
+                    )
+                )
+
+    def forward(self, x: Tensor, t: Tensor) -> tuple[Tensor, int, int]:
+        for module in self.model:
+            x = module(x, t) if isinstance(module, ResBlock) else module(x)
+        _, _, token_h, token_w = x.shape
+        x = x.reshape(x.shape[0], x.shape[1], -1).transpose(1, 2)
+        return x, token_h, token_w
+
+
+class UNetUp(nn.Module):
+    """Latent unpatchifier: ``(B, num_patches, D)`` -> VAE latent ``(B, C, H, W)``."""
+
+    def __init__(
+        self,
+        patch_size: int,
+        in_channels: int,
+        emb_channels: int,
+        hidden_channels: int,
+        out_channels: int,
+        out_norm: bool = False,
+    ):
+        super().__init__()
+        self.patch_size = patch_size
+        assert patch_size in [1, 2, 4, 8]
+
+        self.model: nn.ModuleList = nn.ModuleList()
+        if patch_size == 1:
+            self.model.append(ResBlock(in_channels, emb_channels, out_channels=hidden_channels))
+        else:
+            for i in range(patch_size // 2):
+                self.model.append(
+                    ResBlock(
+                        in_channels if i == 0 else hidden_channels,
+                        emb_channels,
+                        out_channels=hidden_channels,
+                        up=True,
+                    )
+                )
+
+        if out_norm:
+            self.model.append(
+                nn.Sequential(
+                    normalization(hidden_channels),
+                    nn.SiLU(),
+                    conv_nd(2, hidden_channels, out_channels, 3, padding=1),
+                )
+            )
+        else:
+            self.model.append(conv_nd(2, hidden_channels, out_channels, 3, padding=1))
+
+    def forward(self, x: Tensor, t: Tensor, token_h: int, token_w: int) -> Tensor:
+        x = x.transpose(1, 2)  # (B, D, token_h * token_w)
+        x = x.reshape(x.shape[0], x.shape[1], token_h, token_w)  # (B, D, token_h, token_w)
+        for module in self.model:
+            x = module(x, t) if isinstance(module, ResBlock) else module(x)
+        return x
+
+
+# ===================================================================
+#  Main module: HunyuanImage3ForTraining
+# ===================================================================
+
+
+class HunyuanImage3ForTraining(NonDiffusersModelBase):
+    """Training-side generation backbone for HunyuanImage3 (flow-matching).
+
+    ``_no_split_modules`` enables layer-level FSDP2 sharding; the encoder-side
+    VAE/ViT are rollout-only, but the non-tied ``lm_head`` is kept so the unified
+    AR+DiT loss can compute AR token log-probs over the recaption segment.
+    """
+
+    _no_split_modules = ["HunyuanImage3DecoderLayer"]
+    _supports_gradient_checkpointing = True
+
+    def __init__(self, config: HunyuanImage3TrainingConfig):
+        super().__init__()
+        self.config = config
+
+        self.wte = nn.Embedding(config.vocab_size, config.hidden_size, config.pad_token_id)
+        self.layers = nn.ModuleList([HunyuanImage3DecoderLayer(config) for _ in range(config.num_hidden_layers)])
+        self.ln_f = HunyuanRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+
+        # Image generation pathway (img_proj_type == "unet").
+        self.timestep_emb = TimestepEmbedder(config.hidden_size)
+        self.time_embed = TimestepEmbedder(config.hidden_size)
+        self.time_embed_2 = TimestepEmbedder(config.hidden_size)
+        self.patch_embed = UNetDown(
+            patch_size=config.patch_size,
+            in_channels=config.latent_channels,
+            emb_channels=config.hidden_size,
+            hidden_channels=config.patch_embed_hidden_dim,
+            out_channels=config.hidden_size,
+        )
+        self.final_layer = UNetUp(
+            patch_size=config.patch_size,
+            in_channels=config.hidden_size,
+            emb_channels=config.hidden_size,
+            hidden_channels=config.patch_embed_hidden_dim,
+            out_channels=config.latent_channels,
+            out_norm=True,
+        )
+
+    def forward(self, input_ids: Tensor, *, mode: str = "gen_image", **kwargs):
+        """Dispatch entry: both paths must reach the transformer body through this
+        method so FSDP2's root forward hook fires and all-gathers root-owned
+        DTensor params (e.g. ``ln_f.weight``).
+
+        Args:
+            input_ids: gen-image ``(B, L)`` or text rmpad ``(1, total_nnz)``.
+            mode: ``"gen_image"`` (default) or ``"text"``. Text requires the
+                rmpad kwargs ``cu_seqlens`` (``(B+1,)`` int32) and ``max_seqlen``.
+        """
+        if mode == "text":
+            if "cu_seqlens" not in kwargs or "max_seqlen" not in kwargs:
+                raise ValueError("mode='text' requires 'cu_seqlens' and 'max_seqlen' kwargs (rmpad + varlen FA path)")
+            return self._forward_text(input_ids, cu_seqlens=kwargs["cu_seqlens"], max_seqlen=kwargs["max_seqlen"])
+        if mode == "gen_image":
+            return self._forward_gen_image(input_ids, **kwargs)
+        raise ValueError(f"Unknown forward mode: {mode!r}")
+
+    def _forward_gen_image(
+        self,
+        input_ids: Tensor,
+        images: Tensor,
+        timesteps: Tensor,
+        image_mask: Tensor,
+        gen_timestep_scatter_index: Tensor,
+        rope_image_info: list[list[tuple[slice, tuple[int, int]]]],
+        attention_mask: Optional[Tensor] = None,
+        **kwargs,
+    ) -> tuple[Tensor]:
+        """Gen-image forward pass reproducing the vllm-omni ``forward_call`` path.
+
+        Args:
+            input_ids: ``(B, L)`` token sequence with ``<img>`` placeholders.
+            images: ``(B, C, H, W)`` noisy latent at the current timestep.
+            timesteps: ``(B,)`` flow-matching timestep.
+            image_mask: ``(B, L)`` bool — True at image-token positions.
+            gen_timestep_scatter_index: ``(B, k)`` positions of the ``<timestep>`` token.
+            rope_image_info: per-sample list of ``(slice, (h, w))`` for 2-D RoPE.
+            attention_mask: ``(B, 1, L, L)`` bool (built from rope_image_info if None).
+
+        Returns:
+            ``(velocity,)`` of shape ``(B, C, H, W)`` in latent space.
+        """
+        device = input_ids.device
+        bsz, seqlen = input_ids.shape
+        n_embd = self.config.hidden_size
+
+        hidden_states = self.wte(input_ids)  # (B, L, D)
+
+        # Pin RoPE cos/sin to activation dtype so ``use_reentrant=False`` recompute
+        # sees the same saved dtypes as the initial forward. TODO: align with
+        # vllm-omni which runs RoPE fully in fp32.
+        cos, sin = build_batch_2d_rope(seqlen, self.config.attention_head_dim, rope_image_info, device)
+        cos = cos.to(hidden_states.dtype)
+        sin = sin.to(hidden_states.dtype)
+
+        # Scatter noisy latent patches into the sequence.
+        t_emb = self.time_embed(timesteps)
+        image_seq, token_h, token_w = self.patch_embed(images, t_emb)  # (B, num_patches, D)
+        index = torch.arange(seqlen, device=device).unsqueeze(0).repeat(bsz, 1)
+        image_scatter_index = index.masked_select(image_mask.bool()).reshape(bsz, -1)
+        hidden_states.scatter_(
+            dim=1,
+            index=image_scatter_index.unsqueeze(-1).repeat(1, 1, n_embd),
+            src=image_seq,
+        )
+
+        # Scatter the <timestep> token.
+        timestep_emb = self.timestep_emb(timesteps)  # (B, D)
+        hidden_states.scatter_(
+            dim=1,
+            index=gen_timestep_scatter_index.unsqueeze(-1).repeat(1, 1, n_embd),
+            src=timestep_emb.unsqueeze(1),
+        )
+
+        if attention_mask is None:
+            attention_mask = self._build_attention_mask(rope_image_info, seqlen, device)
+
+        for layer in self.layers:
+
+            def _layer_fn(hs, *, _layer=layer, _mask=attention_mask, _cos=cos, _sin=sin):
+                return _layer(hs, attention_mask=_mask, custom_pos_emb=(_cos, _sin))
+
+            hidden_states = self._checkpointed_call(_layer_fn, hidden_states)
+
+        # Unpatch the image-token outputs back to latent space.
+        image_output = hidden_states.masked_select(image_mask.unsqueeze(-1).bool()).reshape(
+            bsz, token_h * token_w, n_embd
+        )
+        velocity = self.final_layer(image_output, self.time_embed_2(timesteps), token_h, token_w)
+        return (velocity,)
+
+    def _forward_text(self, input_ids: Tensor, cu_seqlens: Tensor, max_seqlen: int) -> Tensor:
+        """AR text forward with rmpad + varlen FA (upstream verl LM layout).
+
+        Args:
+            input_ids: ``(1, total_nnz)`` flat token ids, samples concatenated.
+            cu_seqlens: ``(B+1,)`` int32 sample offsets into the flat sequence.
+            max_seqlen: max sample length (drives RoPE precompute).
+
+        Returns:
+            ``logits`` of shape ``(1, total_nnz, vocab_size)``.
+        """
+        device = input_ids.device
+
+        hidden_states = self.wte(input_ids)  # (1, total_nnz, D)
+
+        # Per-token position ids from cu_seqlens: each sample starts fresh at 0.
+        seq_lens = (cu_seqlens[1:] - cu_seqlens[:-1]).to(torch.int64)
+        position_ids = torch.cat(
+            [torch.arange(int(L), device=device, dtype=torch.long) for L in seq_lens.tolist()]
+        )  # (total_nnz,)
+
+        # Text-only 1-D RoPE (image_infos=None): build once for max_seqlen, gather by position id.
+        cos_full, sin_full = build_2d_rope(
+            int(max_seqlen), self.config.attention_head_dim, image_infos=None, device=device
+        )
+        cos = cos_full[position_ids].unsqueeze(0).to(hidden_states.dtype)
+        sin = sin_full[position_ids].unsqueeze(0).to(hidden_states.dtype)
+
+        for layer in self.layers:
+
+            def _layer_fn(hs, *, _layer=layer, _cos=cos, _sin=sin, _cu=cu_seqlens, _max=int(max_seqlen)):
+                return _layer(hs, custom_pos_emb=(_cos, _sin), cu_seqlens=_cu, max_seqlen=_max)
+
+            hidden_states = self._checkpointed_call(_layer_fn, hidden_states)
+
+        hidden_states = self.ln_f(hidden_states)
+        return self.lm_head(hidden_states)
+
+    @staticmethod
+    def _build_attention_mask(
+        rope_image_info: list[list[tuple[slice, tuple[int, int]]]], seqlen: int, device: torch.device
+    ) -> Tensor:
+        """Build the causal-text / full-image 4-D attention mask from image spans."""
+        bsz = len(rope_image_info)
+        causal = torch.ones(seqlen, seqlen, dtype=torch.bool, device=device).tril()
+        mask = causal.unsqueeze(0).unsqueeze(0).repeat(bsz, 1, 1, 1)
+        for i, image_infos in enumerate(rope_image_info):
+            for sec_slice, (h, w) in image_infos:
+                start, stop = sec_slice.start, sec_slice.start + w * h
+                mask[i, :, start:stop, start:stop] = True
+        return mask
+
+    @classmethod
+    def from_pretrained(cls, model_path: str, torch_dtype: torch.dtype = torch.bfloat16) -> HunyuanImage3ForTraining:
+        """Load the generation backbone from the sharded checkpoint.
+
+        Args:
+            model_path: Directory containing ``config.json`` and sharded ``.safetensors``.
+            torch_dtype: Target dtype.
+
+        Returns:
+            ``HunyuanImage3ForTraining`` with the generation backbone loaded.
+
+        The 32-shard backbone is ~150 GB in bf16, so only the FSDP source rank
+        (global rank 0) materializes real weights and streams the shards in;
+        every other rank builds on ``meta`` and receives weights during the
+        FSDP2 wrap via ``fsdp2_load_full_state_dict``'s broadcast-from-rank-0.
+        """
+        from safetensors.torch import load_file
+        from verl.utils.fsdp_utils import get_init_weight_context_manager
+
+        config = HunyuanImage3TrainingConfig.from_model_path(model_path)
+        index_path = os.path.join(model_path, "model.safetensors.index.json")
+        with open(index_path) as f:
+            index = json.load(f)
+        shard_files = sorted(set(index["weight_map"].values()))
+
+        # Build in the target dtype (MoE gate self-promotes to fp32) so we never
+        # transiently hold an fp32 copy of the ~80B-param MoE. Non-source ranks
+        # build on ``meta``; the source rank builds on CPU.
+        default_dtype = torch.get_default_dtype()
+        torch.set_default_dtype(torch_dtype)
+        try:
+            if torch.distributed.is_available() and torch.distributed.is_initialized():
+                init_context = get_init_weight_context_manager(use_meta_tensor=True)
+            else:
+                init_context = nullcontext
+            with init_context():
+                model = cls(config)
+        finally:
+            torch.set_default_dtype(default_dtype)
+
+        # Non-source ranks build on ``meta``; weights arrive via the FSDP2 wrap broadcast.
+        if next(model.parameters()).is_meta:
+            return model
+
+        missing: set[str] = set()
+        unexpected: set[str] = set()
+        with torch.no_grad():
+            for shard in shard_files:
+                shard_state = {
+                    mapped: tensor
+                    for key, tensor in load_file(os.path.join(model_path, shard)).items()
+                    if (mapped := _map_checkpoint_key(key)) is not None
+                }
+                result = model.load_state_dict(shard_state, strict=False)
+                missing.update(result.missing_keys)
+                unexpected.update(result.unexpected_keys)
+                del shard_state, result
+
+        if missing:
+            logger.warning("Missing keys when loading HunyuanImage3ForTraining: %d keys", len(missing))
+        if unexpected:
+            logger.warning("Unexpected keys when loading HunyuanImage3ForTraining: %d keys", len(unexpected))
+        return model
+
+
+_SKIP_PREFIXES = ("vae.", "vision_model.", "vision_aligner.")
+
+
+def _map_checkpoint_key(key: str) -> Optional[str]:
+    """Map a checkpoint key to a ``HunyuanImage3ForTraining`` parameter name.
+
+    Returns ``None`` for rollout-only modules (VAE, vision encoder).
+    """
+    if any(key.startswith(prefix) for prefix in _SKIP_PREFIXES):
+        return None
+    if key.startswith("model.wte."):
+        return key[len("model.") :]
+    if key.startswith("model.layers."):
+        return key[len("model.") :]
+    if key.startswith("model.ln_f."):
+        return key[len("model.") :]
+    return key

--- a/verl_omni/pipelines/hunyuan_image3_flow_grpo/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/hunyuan_image3_flow_grpo/vllm_omni_rollout_adapter.py
@@ -1,0 +1,283 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""HunyuanImage3 rollout-side adapter for FlowGRPO.
+
+HunyuanImage3 runs vllm-omni's step-execution loop (``prepare_encode`` ->
+``denoise_step`` -> ``step_scheduler`` -> ``post_decode``). This adapter swaps
+in the SDE scheduler and records the per-step trajectory at the
+``step_scheduler`` hook, like ``qwen_image_flow_grpo``'s rollout adapter;
+``denoise_step`` already applies CFG via ``state.extra[_STEP_GUIDANCE_SCALE]``.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+from typing import Any
+
+import torch
+from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
+from vllm_omni.diffusion.models.hunyuan_image3.pipeline_hunyuan_image3 import (
+    _STEP_GENERATOR,
+    HunyuanImage3Pipeline,
+)
+from vllm_omni.diffusion.request import OmniDiffusionRequest
+from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
+
+from verl_omni.pipelines.model_base import VllmOmniPipelineBase
+
+from .common import HUNYUAN_IMAGE3_FLOWGRPO_CFG_DEFAULTS, build_hunyuan_image3_scheduler
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["HunyuanImage3PipelineWithLogProb"]
+
+
+@VllmOmniPipelineBase.register("HunyuanImage3ForCausalMM", algorithm="flow_grpo")
+class HunyuanImage3PipelineWithLogProb(HunyuanImage3Pipeline):
+    """HunyuanImage3 pipeline variant that records per-step SDE log-probs."""
+
+    def __init__(self, *, od_config: OmniDiffusionConfig, prefix: str = ""):
+        del prefix  # HunyuanImage3Pipeline.__init__ takes only od_config
+        super().__init__(od_config=od_config)
+        self.scheduler = build_hunyuan_image3_scheduler()
+
+        # Pre-build the inner diffusers pipeline with our SDE scheduler so the base
+        # ``pipeline`` property's lazy path never overwrites ``self.scheduler``.
+        from vllm_omni.diffusion.models.hunyuan_image3.hunyuan_image3_transformer import (
+            HunyuanImage3Text2ImagePipeline,
+        )
+
+        self._pipeline = HunyuanImage3Text2ImagePipeline(model=self, scheduler=self.scheduler, vae=self.vae)
+        logger.info("HunyuanImage3PipelineWithLogProb: SDE scheduler enabled for RL rollouts")
+
+    def map_lora_update_to_engine(
+        self, tensors: dict[str, torch.Tensor], peft_config: dict
+    ) -> tuple[dict[str, torch.Tensor], dict]:
+        """Split fused ``self_attn.qkv_proj`` LoRA into per-slice sub-loras.
+
+        Actor-side PEFT injects LoRA on the fused ``qkv_proj`` linear, so the
+        pushed ``lora_B`` is ``[q+k+v, r]`` = ``[6144, r]`` for the reference
+        HunyuanImage-3.0 (Q=4096, K=V=1024). vllm-omni's LoRA manager splits
+        that tensor by the per-TP-shard ``output_slices`` sum
+        (``manager.py:610``), which is ``1536`` at ``tensor_parallel_size=4``;
+        the shape check rejects it. Emit three sub-loras keyed on
+        ``q_proj``/``k_proj``/``v_proj`` with a shared ``lora_A`` and a
+        per-slice ``lora_B``; the manager's sub-lora fallback path TP-shards
+        each slice correctly.
+
+        TODO: drop once vllm-omni's ``DiffusionLoRAManager`` splits packed
+        LoRA-B by ``base_layer.output_sizes`` instead of ``output_slices``.
+        """
+        transformer = getattr(self, "transformer", None)
+        first_qkv = None
+        if transformer is not None:
+            for module in transformer.modules():
+                if type(module).__name__ == "QKVParallelLinear" and hasattr(module, "output_sizes"):
+                    first_qkv = module
+                    break
+        if first_qkv is None:
+            return tensors, peft_config
+
+        q_full, k_full, v_full = first_qkv.output_sizes
+        expected_full = q_full + k_full + v_full
+
+        mapped: dict[str, torch.Tensor] = {}
+        for name, tensor in tensors.items():
+            is_lora_a = name.endswith(".lora_A.weight")
+            is_lora_b = name.endswith(".lora_B.weight")
+            if not (is_lora_a or is_lora_b):
+                mapped[name] = tensor
+                continue
+            suffix = ".lora_A.weight" if is_lora_a else ".lora_B.weight"
+            module = name[: -len(suffix)]
+            if not module.endswith(".qkv_proj"):
+                mapped[name] = tensor
+                continue
+
+            prefix = module[: -len(".qkv_proj")]
+            if is_lora_a:
+                for sub in ("q_proj", "k_proj", "v_proj"):
+                    mapped[f"{prefix}.{sub}{suffix}"] = tensor
+                continue
+
+            # lora_B: split ``[Q+K+V, r]`` into three per-slice tensors.
+            if tensor.shape[0] != expected_full:
+                logger.warning(
+                    "map_lora_update_to_engine: unexpected fused qkv_proj lora_B "
+                    "shape %s for %s (expected first-dim=%d); passing through unchanged",
+                    tuple(tensor.shape),
+                    name,
+                    expected_full,
+                )
+                mapped[name] = tensor
+                continue
+            q_b, k_b, v_b = torch.split(tensor, [q_full, k_full, v_full], dim=0)
+            mapped[f"{prefix}.q_proj{suffix}"] = q_b.contiguous()
+            mapped[f"{prefix}.k_proj{suffix}"] = k_b.contiguous()
+            mapped[f"{prefix}.v_proj{suffix}"] = v_b.contiguous()
+
+        new_config = dict(peft_config) if peft_config is not None else {}
+        target_modules = new_config.get("target_modules")
+        if isinstance(target_modules, list | tuple) and any("qkv_proj" in t for t in target_modules):
+            expanded = []
+            for t in target_modules:
+                if isinstance(t, str) and "qkv_proj" in t:
+                    for sub in ("q_proj", "k_proj", "v_proj"):
+                        expanded.append(t.replace("qkv_proj", sub))
+                else:
+                    expanded.append(t)
+            seen = set()
+            deduped = []
+            for t in expanded:
+                if t not in seen:
+                    seen.add(t)
+                    deduped.append(t)
+            new_config["target_modules"] = deduped
+        return mapped, new_config
+
+    def prepare_encode(self, state, **kwargs: Any):
+        """Populate rollout SDE state after the base ``prepare_encode``.
+
+        The base method sets ``state.timesteps`` via ``retrieve_timesteps(self.scheduler, N)``
+        (already SD3-shifted because ``self.scheduler`` carries HunyuanImage3's
+        ``shift=3.0`` config) plus ``state.latents`` / ``state.scheduler`` / the
+        ``_STEP_*`` payloads.  Here we resolve the SDE knobs from the sampling
+        ``extra_args`` and initialise the trajectory buffers consumed by
+        :meth:`step_scheduler` and :meth:`post_decode`.
+        """
+        sampling = state.sampling
+        # HunyuanImage3's diff_guidance_scale is 2.5; the vllm-omni base hardcodes 5.0.
+        if not getattr(sampling, "guidance_scale_provided", False):
+            sampling.guidance_scale = HUNYUAN_IMAGE3_FLOWGRPO_CFG_DEFAULTS["guidance_scale"]
+            sampling.guidance_scale_provided = True
+
+        state = super().prepare_encode(state, **kwargs)
+
+        # Base ``prepare_encode`` seeds latents in bf16 but ``step_scheduler`` keeps
+        # them in fp32; promote up front so mixed-request batches share one dtype.
+        state.latents = state.latents.to(torch.float32)
+
+        num_timesteps = state.total_steps
+        extra = sampling.extra_args or {}
+        noise_level = float(extra.get("noise_level", 1.0))
+        sde_type = extra.get("sde_type", "sde")
+        logprobs = bool(extra.get("logprobs", True))
+        sde_window_size = extra.get("sde_window_size", None)
+
+        if sde_window_size is not None:
+            size = int(sde_window_size)
+            window_range = extra.get("sde_window_range", (0, num_timesteps))
+            low, high = int(window_range[0]), int(window_range[1])
+            if high - low < size:
+                # Window does not fit; clamp to the lowest valid begin.
+                begin = low
+            else:
+                generator = state.extra.get(_STEP_GENERATOR)
+                begin = int(
+                    torch.randint(
+                        low,
+                        high - size + 1,
+                        (1,),
+                        generator=generator,
+                        device=state.latents.device,
+                    ).item()
+                )
+            sde_window = (begin, begin + size)
+        else:
+            # Full trajectory except the final deterministic (ODE) step.
+            sde_window = (0, max(num_timesteps - 1, 0))
+
+        state.sde_window = sde_window
+        state.noise_level = noise_level
+        state.sde_type = sde_type
+        state.logprobs = logprobs
+        state.all_latents = []
+        state.all_log_probs = []
+        state.all_timesteps = []
+        return state
+
+    def step_scheduler(self, state, noise_pred: torch.Tensor, **kwargs: Any) -> None:
+        """One SDE denoise step, recording the trajectory inside the SDE window."""
+        del kwargs
+        if getattr(self, "interrupt", False):
+            return
+
+        i = state.step_index
+        timestep_value = state.current_timestep
+        begin, end = state.sde_window
+        in_window = begin <= i < end
+        cur_noise_level = state.noise_level if in_window else 0.0
+        cur_logprobs = state.logprobs and in_window
+
+        if i == begin:
+            state.all_latents.append(state.latents.to(torch.float32))
+
+        new_latents, log_prob, _, _ = state.scheduler.step(
+            noise_pred.to(torch.float32),
+            timestep_value,
+            state.latents.to(torch.float32),
+            generator=state.extra.get(_STEP_GENERATOR),
+            noise_level=cur_noise_level,
+            sde_type=state.sde_type,
+            return_logprobs=cur_logprobs,
+            return_dict=False,
+        )
+
+        if in_window:
+            state.all_latents.append(new_latents.to(torch.float32))
+            state.all_log_probs.append(None if log_prob is None else log_prob)
+            state.all_timesteps.append(timestep_value)
+
+        # Keep live state in fp32 throughout so freshly-added requests and
+        # stepped requests share one dtype in the engine batch.
+        state.latents = new_latents.to(torch.float32)
+        state.step_index += 1
+
+    def post_decode(self, state, **kwargs: Any) -> DiffusionOutput:
+        """Decode final latents and package the recorded rollout trajectory."""
+        output = super().post_decode(state, **kwargs)
+        if not isinstance(output, DiffusionOutput):
+            return output
+
+        all_latents = state.all_latents
+        all_log_probs = state.all_log_probs
+        all_timesteps = state.all_timesteps
+
+        # A complete trajectory needs at least one recorded denoise step; the
+        # engine's dummy/warmup run can leave the SDE window empty.
+        if not all_latents or not all_timesteps:
+            return output
+
+        stacked_latents = torch.stack(all_latents, dim=1)
+        stacked_log_probs = (
+            torch.stack(all_log_probs, dim=1) if all_log_probs and all_log_probs[0] is not None else None
+        )
+        stacked_timesteps = torch.stack(all_timesteps).unsqueeze(0).expand(state.latents.shape[0], -1)
+
+        # HunyuanImage3 has no ``get_<model>_post_process_func`` in vllm-omni, so
+        # attach the trajectory fields directly on ``output`` (whose payload is
+        # a bare PIL image reaching ``_process_output`` unchanged).
+        return dataclasses.replace(
+            output,
+            trajectory_latents=stacked_latents,
+            trajectory_log_probs=stacked_log_probs,
+            trajectory_timesteps=stacked_timesteps,
+            to_cpu=True,
+        )
+
+    def forward(self, req: OmniDiffusionRequest | DiffusionRequestBatch) -> DiffusionOutput:
+        """Monolithic fallback (warmup/dummy runs); step-execution is the RL path."""
+        return super().forward(req)

--- a/verl_omni/trainer/diffusion/diffusion_metric_utils.py
+++ b/verl_omni/trainer/diffusion/diffusion_metric_utils.py
@@ -15,11 +15,12 @@
 Metrics for diffusion (image generation) training.
 """
 
-from typing import Any, Literal
+from typing import Any, Literal, Optional
 
 import numpy as np
 import torch
 from verl import DataProto
+from verl.utils import tensordict_utils as tu
 
 
 def compute_data_metrics_diffusion(batch: DataProto) -> dict[str, Any]:
@@ -134,13 +135,58 @@ def compute_timing_metrics_diffusion(timing_raw: dict[str, float], num_images: i
     }
 
 
-def compute_throughput_metrics_diffusion(batch: DataProto, timing_raw: dict[str, float], n_gpus: int) -> dict[str, Any]:
+def _iter_prompt_token_ids(batch: DataProto):
+    """Yield per-row token-id sequences from ``batch.non_tensor_batch['prompt_token_ids']``.
+
+    Returns ``None`` if the field is not present. Rows may be numpy arrays,
+    tensors, plain lists, or wrapped in ``NonTensorData`` — normalise to a
+    ``numpy.ndarray[int64]`` for downstream counting.
+    """
+    field = batch.non_tensor_batch.get("prompt_token_ids", None) if hasattr(batch, "non_tensor_batch") else None
+    if field is None:
+        return None
+    rows = []
+    for i in range(len(field)):
+        row = tu.unwrap_non_tensor_data(field[i])
+        if isinstance(row, torch.Tensor):
+            row = row.detach().cpu().numpy()
+        rows.append(np.asarray(row, dtype=np.int64))
+    return rows
+
+
+def _iter_ar_response_lengths(batch: DataProto) -> Optional[np.ndarray]:
+    """Per-sample AR response lengths; ``None`` when the field is absent."""
+    field = batch.non_tensor_batch.get("ar_generated_token_ids", None) if hasattr(batch, "non_tensor_batch") else None
+    if field is None:
+        return None
+    lengths: list[int] = []
+    for i in range(len(field)):
+        row = tu.unwrap_non_tensor_data(field[i])
+        if isinstance(row, torch.Tensor):
+            lengths.append(int(row.numel()))
+        else:
+            lengths.append(int(len(row)))
+    return np.asarray(lengths, dtype=np.int64)
+
+
+def compute_throughput_metrics_diffusion(
+    batch: DataProto,
+    timing_raw: dict[str, float],
+    n_gpus: int,
+) -> dict[str, Any]:
     """
     Computes throughput metrics for diffusion (image/video generation) training.
 
-    Unlike language model training where throughput is measured in tokens/sec,
-    diffusion training generates images, so throughput is reported as images
-    per second.
+    Headline throughput is images/sec.  Unified AR+diffusion models (e.g.
+    HunyuanImage-3) also burn a tokenised sequence through the transformer, so
+    token metrics are reported too when ``prompt_token_ids`` is on the batch:
+
+    * ``perf/total_num_tokens`` — the full interleaved sequence length summed
+      over the batch. Matches what the actor forward propagates through.
+    * ``perf/ar_response_len_{mean,std,min,max}`` — per-sample length of the
+      newly generated AR response (``ar_generated_token_ids`` in the batch,
+      populated only by the HunyuanImage-3 unified rollout). The distribution
+      catches truncation and unbalanced trajectory lengths.
 
     Args:
         batch: A DataProto object containing diffusion batch data.
@@ -153,17 +199,35 @@ def compute_throughput_metrics_diffusion(batch: DataProto, timing_raw: dict[str,
             - perf/total_num_images: Number of images processed in the batch
             - perf/time_per_step: Time taken for the step in seconds
             - perf/throughput: Images generated per second per GPU
+            - perf/total_num_tokens: Total tokens in the batch's ``prompt_token_ids``
+              (only when the field is present).
+            - perf/tokens_per_sec: Token throughput per GPU.
     """
     if "advantages" in batch.batch:
         batch_size = batch.batch["advantages"].shape[0]
     else:
         batch_size = batch.batch["sample_level_rewards"].shape[0]
     time = timing_raw["step"]
-    return {
+    metrics: dict[str, Any] = {
         "perf/total_num_images": batch_size,
         "perf/time_per_step": time,
         "perf/throughput": batch_size / (time * n_gpus),
     }
+
+    rows = _iter_prompt_token_ids(batch)
+    if rows is not None:
+        total_tokens = int(sum(row.size for row in rows))
+        metrics["perf/total_num_tokens"] = total_tokens
+        metrics["perf/tokens_per_sec"] = total_tokens / (time * n_gpus)
+
+    ar_lens = _iter_ar_response_lengths(batch)
+    if ar_lens is not None and ar_lens.size > 0:
+        metrics["perf/ar_response_len_mean"] = float(ar_lens.mean())
+        metrics["perf/ar_response_len_std"] = float(ar_lens.std())
+        metrics["perf/ar_response_len_min"] = int(ar_lens.min())
+        metrics["perf/ar_response_len_max"] = int(ar_lens.max())
+
+    return metrics
 
 
 def compute_reward_extra_metrics_diffusion(reward_extra_infos_dict: dict) -> dict[str, Any]:

--- a/verl_omni/workers/rollout/vllm_rollout/vllm_omni_async_server.py
+++ b/verl_omni/workers/rollout/vllm_rollout/vllm_omni_async_server.py
@@ -61,6 +61,16 @@ logger.setLevel(logging.INFO)
 # Sentinel: ``None`` is a valid cached value (LoRA not loaded).
 _LORA_REQUEST_CACHE_MISS = object()
 
+# AR recaption fields the diffusion pipeline surfaces via
+# ``OmniRequestOutput.custom_output`` and forwards to the actor for
+# teacher-forced replay.
+_AR_RECAPTION_FIELDS = (
+    "ar_prompt_token_ids",
+    "ar_generated_token_ids",
+    "ar_generated_text",
+    "ar_generated_logprobs",
+)
+
 
 def _drop_none_mapping_values(value: Any) -> Any:
     if isinstance(value, dict):
@@ -285,6 +295,12 @@ class vLLMOmniHttpServer(vLLMHttpServer):
         deploy_config = getattr(args, "deploy_config", None)
         if deploy_config:
             engine_args["deploy_config"] = deploy_config
+            if not self._ar_mode:
+                # A multi-stage deploy config owns each stage's parallelism.  Drop
+                # the top-level ``--tensor-parallel-size`` (derived from
+                # ``rollout.tensor_model_parallel_size``), otherwise vllm-omni folds
+                # it into every diffusion stage and overrides the per-stage TP.
+                engine_args.pop("tensor_parallel_size", None)
 
         if self._ar_mode:
             for timeout_key in ("stage_init_timeout", "init_timeout"):
@@ -292,10 +308,6 @@ class vLLMOmniHttpServer(vLLMHttpServer):
                 if timeout_value is not None:
                     engine_args[timeout_key] = int(timeout_value)
             engine_args["logprobs_mode"] = getattr(self.config, "logprobs_mode", "processed_logprobs")
-            # AR mode: no diffusion pipeline. Drop None entries from
-            # compilation_config that OmniEngineArgs may leave behind.
-            if isinstance(engine_args.get("compilation_config"), dict):
-                engine_args["compilation_config"] = _drop_none_mapping_values(engine_args["compilation_config"])
         else:
             import_external_libs(self.config.external_lib)
 
@@ -327,6 +339,14 @@ class vLLMOmniHttpServer(vLLMHttpServer):
                         pipeline_cls.__name__,
                     )
                     engine_args["max_num_seqs"] = 1
+
+        # Drop None entries from compilation_config (both AR and diffusion paths).
+        # ``asdict(OmniEngineArgs)`` expands the default CompilationConfig into a
+        # dict whose unset fields are None; the deploy-config path feeds that dict
+        # back through a pydantic CompilationConfig (vllm 0.27), which rejects
+        # explicit None.
+        if isinstance(engine_args.get("compilation_config"), dict):
+            engine_args["compilation_config"] = _drop_none_mapping_values(engine_args["compilation_config"])
 
         if getattr(self.config, "step_execution", False):
             engine_args["step_execution"] = True
@@ -432,6 +452,8 @@ class vLLMOmniHttpServer(vLLMHttpServer):
         prompt_mask: torch.BoolTensor | None = None,
         extra_prompt_ids: Optional[dict[str, list[int]]] = None,
         negative_extra_prompt_ids: Optional[dict[str, list[int]]] = None,
+        prompt_text: Optional[str] = None,
+        use_system_prompt: Optional[str] = None,
         priority: int = 0,
     ) -> DiffusionOutput | TokenOutput:
         prompt_ids = normalize_token_ids(prompt_ids)
@@ -447,6 +469,8 @@ class vLLMOmniHttpServer(vLLMHttpServer):
             mm_processor_kwargs,
             extra_prompt_ids,
             negative_extra_prompt_ids,
+            prompt_text,
+            use_system_prompt,
         )
         final_res = await self._run_generation(prompt, params, request_id, lora_request, priority)
         return self._process_output(final_res, params, sampling_params)
@@ -529,6 +553,8 @@ class vLLMOmniHttpServer(vLLMHttpServer):
         mm_processor_kwargs: Optional[dict[str, Any]] = None,
         extra_prompt_ids: Optional[dict[str, list[int]]] = None,
         negative_extra_prompt_ids: Optional[dict[str, list[int]]] = None,
+        prompt_text: Optional[str] = None,
+        use_system_prompt: Optional[str] = None,
     ):
         """Build the engine prompt + sampling params for the active mode.
 
@@ -589,6 +615,12 @@ class vLLMOmniHttpServer(vLLMHttpServer):
             custom_prompt["modalities"] = ["image"]
         if negative_prompt_ids is not None:
             custom_prompt["negative_prompt_ids"] = negative_prompt_ids
+        # Forwarded verbatim so the AR->DiT bridge (``ar2diffusion``) rebuilds
+        # the same chat prefix the AR stage prefilled with.
+        if prompt_text is not None:
+            custom_prompt["prompt"] = prompt_text
+        if use_system_prompt is not None:
+            custom_prompt["use_system_prompt"] = use_system_prompt
         # Per-text-encoder token ids for multi-encoder models (e.g. SD3.5),
         # produced by the agent loop so pipelines never decode/re-encode text.
         if extra_prompt_ids is not None:
@@ -749,6 +781,12 @@ class vLLMOmniHttpServer(vLLMHttpServer):
                 if key in extra_fields:
                     raise ValueError(f"Duplicate rollout metadata field: {key}")
                 extra_fields[key] = _maybe_unbatch(value)
+        custom_output = final_res.custom_output or {}
+        for key in _AR_RECAPTION_FIELDS:
+            if key in custom_output:
+                if key in extra_fields:
+                    raise ValueError(f"Duplicate rollout metadata field: {key}")
+                extra_fields[key] = custom_output[key]
         if rollout_audio is not None:
             extra_fields["audio"] = _maybe_unbatch(rollout_audio)
             extra_fields.setdefault("audio_sample_rate", 32000)


### PR DESCRIPTION
Close https://github.com/verl-project/verl-omni/issues/207

### What does this PR do?

Brings HunyuanImage-3.0-Instruct into verl-omni as a pipeline package. It is an 80B unified AR+DiT MoE transformer whose checkpoint is in transformers (non-diffusers) format, and whose rollout is a native two-stage vllm-omni pipeline (AR stage samples think/recaption text → DiT stage produces the image). This PR delivers four pieces:

1. **Training-side model definition** `HunyuanImage3ForTraining` — FSDP2-compatible with layer-level sharding, generation backbone ported from Tencent's official `modeling_hunyuan_image_3.py`;
2. **FlowGRPO training adapter** — the text condition at training time matches the rollout's sampled condition token-for-token (see below), CFG via batch doubling aligned with vllm-omni;
3. **Rollout adapter + agent loop** — both sides construct the same scheduler so the sigma schedule matches to the bit (prerequisite for an unbiased importance-sampling ratio); the agent loop builds the official AR prompt client-side through `prompt_utils` (the checkpoint ships no chat template);
4. **Two small shared-code changes** — the vllm-omni async server forwards AR sampling metadata through a whitelist; throughput metrics gain token counts. Both are backward compatible (details below).

**Scope boundary (stated up front):**
- This PR alone cannot run end-to-end training. The AR segment only samples during rollout and receives no gradient here; joint training lands in [2/N].
- End-to-end additionally requires: [the [1/N] multi-stage weight-sync ZMQ rank fix](https://github.com/verl-project/verl-omni/pull/483), two small upstream vllm-omni fixes [(#6768 sampling metadata](https://github.com/vllm-project/vllm-omni/issues/6768), [#6770](https://github.com/vllm-project/vllm-omni/issues/6770)), and the config / data-preprocessing scripts from the follow-up recipe PR.
- At the code level this PR depends on none of the above commits / upstream patches: it references nothing unmerged, degrades gracefully when metadata is absent, is self-contained for review, and does not affect existing models.


### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `vllm_omni`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `diffusion`, `omni`, `tests`, `docker`
  - If this PR involves multiple modules, separate them with `,` like `[diffusion, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][diffusion, fsdp] feat: new rollout scheduler`

### Test

17 new CPU test cases, all passing:

```text
$ python -m pytest tests/pipelines/test_hunyuan_image3_flow_grpo_on_cpu.py -x -q
17 passed, 23 warnings in 0.29s
```

Coverage:

- `(HunyuanImage3ForCausalMM, flow_grpo)` registration on both the training and rollout sides, plus agent-loop registration;
- the local scheduler matches diffusers `FlowMatchEulerDiscreteScheduler` (same constructor kwargs as vllm-omni) on sigma/timesteps **to the bit**;
- CFG formula and sigma config (shift=3.0 exponential schedule);
- `prepare_model_inputs` positive/negative branches (each with its own `<timestep>` position and 2D RoPE spans);
- tiny-model forward returns a latent-space velocity; checkpoint `config.json` parsing; `from_pretrained` sharded-checkpoint round-trip;
- **deterministic MoE routing under ties** (upstream `torch.topk` is unstable for ties, so a recompute can flip a token's expert and corrupt gradients; fixed with a stable sort, locked by the test);
- AR text rmpad forward + varlen attention per-sample isolation equivalence (locks out cross-sample attention);
- fused DiT input rebuild (mocked vllm-omni tokenizer: cot normalization, system prompt, cfg_factor, and other rollout-alignment knobs) + fallback when AR fields are absent.

Note: server-side metadata forwarding and the real rollout trajectory are runtime behavior not covered by CPU tests; GPU smoke coverage is planned for a follow-up PR (TBD).

### API and Usage Example

Full training config / launch script / data preprocessing will follow in a later PR.


### Design & Code Changes

New package `verl_omni/pipelines/hunyuan_image3_flow_grpo/` (~2.4k lines).

Shared-file changes (no effect on other models by default, but flagged for reviewer attention):

- `vllm_omni_async_server.py`:
  1. Forwards `ar_prompt_token_ids / ar_generated_token_ids / ar_generated_text / ar_generated_logprobs` from `custom_output` through a whitelist (depends on upstream #6768; without the patch these fields are naturally absent and nothing errors);
  2. **in deploy-config mode, no longer passes the top-level `--tensor-parallel-size` to vllm-omni**. Reason: vllm-omni folds the top-level value into every stage's `parallel_config`, overriding the per-stage TP in the deploy config. No impact on existing in-repo users: bagel is single-GPU TP=1; the server-generated deploy config already writes TP into each stage;
  3. the `compilation_config` None-cleanup moves from AR-only to the shared path (a no-op on the vllm 0.24 dataclass path; avoids the explicit-None rejection on the 0.27 pydantic path).
- `diffusion_metric_utils.py`: token metrics (`perf/total_num_tokens`, `perf/tokens_per_sec`, `perf/ar_response_len_*`) are appended only when the batch carries `prompt_token_ids` / `ar_generated_token_ids`; output is byte-identical to before when they are absent.
- `pipelines/__init__.py`, `agent_loop/__init__.py`: register the new pipeline / agent loop (same pattern as the existing minimax and ltx2 ones).

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update the documentation.
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl-omni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
