### PR TITLE
[diffusion] fix: preserve Qwen-Image metadata in V1 TransferQueue

### DIFF
--- a/tests/agent_loop/test_diffusion_agent_loop_correctness_on_cpu.py
+++ b/tests/agent_loop/test_diffusion_agent_loop_correctness_on_cpu.py
@@ -28,8 +28,8 @@ from verl_omni.agent_loop.diffusion_agent_loop import (
     _pad_prompt_extra_field,
 )
 from verl_omni.agent_loop.diffusion_agent_loop_tq import DiffusionAgentLoopWorkerTQ
-from verl_omni.trainer.diffusion.v1 import tq_utils
 from verl_omni.agent_loop.single_turn_agent_loop import DiffusionSingleTurnAgentLoop
+from verl_omni.trainer.diffusion.v1 import tq_utils
 
 
 class _FakeRemoteComputeScore:

--- a/tests/agent_loop/test_diffusion_agent_loop_correctness_on_cpu.py
+++ b/tests/agent_loop/test_diffusion_agent_loop_correctness_on_cpu.py
@@ -19,6 +19,7 @@ import pytest
 import torch
 from verl.experimental.agent_loop.agent_loop import AgentLoopMetrics
 from verl.protocol import DataProto
+from verl.utils import tensordict_utils as tu
 
 from verl_omni.agent_loop import diffusion_agent_loop_tq
 from verl_omni.agent_loop.diffusion_agent_loop import (
@@ -27,6 +28,7 @@ from verl_omni.agent_loop.diffusion_agent_loop import (
     _pad_prompt_extra_field,
 )
 from verl_omni.agent_loop.diffusion_agent_loop_tq import DiffusionAgentLoopWorkerTQ
+from verl_omni.trainer.diffusion.v1 import tq_utils
 from verl_omni.agent_loop.single_turn_agent_loop import DiffusionSingleTurnAgentLoop
 
 
@@ -114,6 +116,69 @@ def test_pad_prompt_extra_field_pads_without_truncation(key, value, expected_sha
 def test_pad_prompt_extra_field_rejects_truncation(key, value):
     with pytest.raises(ValueError, match="exceeds max_prompt_embed_length=3"):
         _pad_prompt_extra_field(key, value, target_length=3)
+
+
+@pytest.mark.asyncio
+async def test_tq_writer_preserves_allowlisted_non_tensor_trajectory_metadata(monkeypatch):
+    worker_cls = DiffusionAgentLoopWorkerTQ.__ray_metadata__.modified_class
+    worker = object.__new__(worker_cls)
+    captured = {}
+    img_shapes = [(1, 32, 32), (1, 64, 64)]
+    internal = SimpleNamespace(
+        prompt_ids=torch.tensor([[1, 2]]),
+        response_diffusion_output=torch.zeros(1, 3, 2, 2),
+        response_logprobs=None,
+        reward_score=None,
+        num_turns=2,
+        extra_fields={
+            "condition_image_latents": torch.zeros(1, 4096, 64),
+            "img_shapes": img_shapes,
+            "unrelated_metadata": "do-not-forward",
+        },
+    )
+
+    monkeypatch.setattr(diffusion_agent_loop_tq, "list_of_dict_to_tensordict", lambda rows: rows)
+
+    async def fake_kv_batch_put(*, keys, fields, tags, partition_id):
+        captured.update(keys=keys, fields=fields, tags=tags, partition_id=partition_id)
+
+    monkeypatch.setattr(diffusion_agent_loop_tq.tq, "async_kv_batch_put", fake_kv_batch_put)
+
+    await worker._write_trajectory_to_tq(
+        internal,
+        uid="sample",
+        session_id=0,
+        trajectory={"step": 3},
+        validate=False,
+    )
+
+    field = captured["fields"][0]
+    assert field["extra_fields"]["img_shapes"] == img_shapes
+    assert "unrelated_metadata" not in field["extra_fields"]
+    assert field["condition_image_latents"].shape == (4096, 64)
+
+
+def test_tq_batch_restores_non_tensor_trajectory_metadata(monkeypatch):
+    img_shapes = [
+        [(1, 32, 32), (1, 64, 64)],
+        [(1, 32, 32), (1, 64, 64)],
+    ]
+
+    monkeypatch.setattr(
+        tq_utils.tq,
+        "kv_batch_get",
+        lambda **kwargs: {
+            "all_latents": torch.zeros(2, 4, 1024, 64),
+            "extra_fields": [{"img_shapes": value} for value in img_shapes],
+        },
+    )
+
+    data = tq_utils.diffusion_tq_batch_to_dataproto(
+        SimpleNamespace(keys=["sample_0", "sample_1"], partition_id="train")
+    )
+
+    assert data.non_tensor_batch["img_shapes"].tolist() == img_shapes
+    assert tu.get(data.to_tensordict(), "img_shapes") == img_shapes
 
 
 @pytest.mark.asyncio

--- a/tests/pipelines/test_qwen_image_edit_on_cpu.py
+++ b/tests/pipelines/test_qwen_image_edit_on_cpu.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import json
+import math
 from pathlib import Path
 from unittest.mock import patch
 
@@ -150,6 +151,7 @@ def test_inject_condition_updates_qwen_image_shapes():
     assert output["img_shapes"] == image_shapes
     assert negative_output["img_shapes"] == image_shapes
     assert output["hidden_states"].shape == (1, 5, 4)
+    assert output["hidden_states"].shape[1] == sum(math.prod(shape) for shape in output["img_shapes"][0])
 
 
 def test_inject_condition_validates_qwen_sequence_parallel_alignment():

--- a/verl_omni/agent_loop/diffusion_agent_loop_tq.py
+++ b/verl_omni/agent_loop/diffusion_agent_loop_tq.py
@@ -35,6 +35,9 @@ from verl_omni.agent_loop.utils import _derive_rollout_seed
 logger = logging.getLogger(__name__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "INFO"))
 
+# Structured model metadata is carried inside the existing non-tensor envelope.
+_NON_TENSOR_TRAJECTORY_FIELDS = frozenset({"img_shapes"})
+
 
 @ray.remote
 class DiffusionAgentLoopWorkerTQ(DiffusionAgentLoopWorker):
@@ -234,6 +237,9 @@ class DiffusionAgentLoopWorkerTQ(DiffusionAgentLoopWorker):
 
         reward_extra_info = extra.get("reward_extra_info")
         extra_fields_out: dict[str, Any] = {}
+        for metadata_key in _NON_TENSOR_TRAJECTORY_FIELDS:
+            if metadata_key in extra:
+                extra_fields_out[metadata_key] = extra[metadata_key]
         if reward_extra_info is not None:
             extra_fields_out["reward_extra_info"] = reward_extra_info
         # Track the rollout model version this trajectory was generated against.

--- a/verl_omni/agent_loop/diffusion_agent_loop_tq.py
+++ b/verl_omni/agent_loop/diffusion_agent_loop_tq.py
@@ -35,9 +35,6 @@ from verl_omni.agent_loop.utils import _derive_rollout_seed
 logger = logging.getLogger(__name__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "INFO"))
 
-# Structured model metadata is carried inside the existing non-tensor envelope.
-_NON_TENSOR_TRAJECTORY_FIELDS = frozenset({"img_shapes"})
-
 
 @ray.remote
 class DiffusionAgentLoopWorkerTQ(DiffusionAgentLoopWorker):
@@ -237,9 +234,8 @@ class DiffusionAgentLoopWorkerTQ(DiffusionAgentLoopWorker):
 
         reward_extra_info = extra.get("reward_extra_info")
         extra_fields_out: dict[str, Any] = {}
-        for metadata_key in _NON_TENSOR_TRAJECTORY_FIELDS:
-            if metadata_key in extra:
-                extra_fields_out[metadata_key] = extra[metadata_key]
+        if "img_shapes" in extra:
+            extra_fields_out["img_shapes"] = extra["img_shapes"]
         if reward_extra_info is not None:
             extra_fields_out["reward_extra_info"] = reward_extra_info
         # Track the rollout model version this trajectory was generated against.


### PR DESCRIPTION
### What does this PR do?

This PR preserves condition-aware Qwen-Image `img_shapes` metadata across the
V1 TransferQueue trajectory boundary.

The Qwen-Image-Edit rollout adapter returns `img_shapes` as structured,
non-tensor metadata. The TransferQueue writer previously forwarded tensor
fields and selected reward metadata, but dropped this list before actor
training. The training adapter therefore could not reliably restore the target
and condition image shapes required by Qwen-Image 2D RoPE.

The fix adds `img_shapes` to a narrow allowlist and carries it through the
existing `extra_fields` envelope. The existing TransferQueue reader already
unpacks that envelope into `DataProto.non_tensor_batch`, so no wire-format or
public API change is required. Arbitrary rollout metadata remains filtered.

### Checklist Before Starting

- [x] Searched for similar PRs: [open PRs matching `TransferQueue img_shapes`](https://github.com/verl-project/verl-omni/pulls?q=is%3Apr+is%3Aopen+TransferQueue+img_shapes).
  - No matching open PR was found.
  - [PR #478](https://github.com/verl-project/verl-omni/pull/478) declares diffusion media modalities at the rollout adapter/strategy boundary. It does not modify the TransferQueue writer, the non-tensor `extra_fields` envelope, or `img_shapes` restoration, so it does not overlap with this fix.
- [x] PR title follows `[{modules}] {type}: {description}`:
  `[diffusion] fix: preserve Qwen-Image metadata in V1 TransferQueue`.

### Test

Focused CPU tests were run with `/data/8T/wangmb/LLM-Infra/myenv`, the local
`verl` and `vllm` source checkouts, and the `vllm-omni` checkout pinned by the
current `verl-omni` main branch (`444485650b19b792403b12976f1b0eeb2ac1451c`):

```bash
PYTHONPATH=<this-verl-omni-checkout>:/data/8T/wangmb/LLM-Infra/verl:/data/8T/wangmb/LLM-Infra/vllm:<pinned-vllm-omni-checkout> \
    /data/8T/wangmb/LLM-Infra/myenv/bin/python -m pytest -q \
    tests/agent_loop/test_diffusion_agent_loop_correctness_on_cpu.py \
    tests/pipelines/test_qwen_image_edit_on_cpu.py
```

Result:

```text
28 passed, 29 warnings in 11.48s
```

Additional checks:

```text
python3 -m py_compile <three changed Python files>  # passed
git diff --check                                    # passed
```

Full `pre-commit` and Ruff were not run because those tools are not installed
in the available environment.

### API and Usage Example

No public API or configuration changes.

Qwen-Image-Edit V1 rollouts continue to emit `img_shapes` through the existing
adapter output. The transport now preserves it automatically for actor
training.

### Design & Code Changes

- Add `img_shapes` to an explicit non-tensor trajectory metadata allowlist in
  `DiffusionAgentLoopWorkerTQ`.
- Store allowlisted metadata inside the existing per-row `extra_fields`
  envelope without forwarding unrelated values.
- Verify that the TQ writer preserves `img_shapes` and continues to reject
  unrelated metadata.
- Verify that `diffusion_tq_batch_to_dataproto()` restores the per-sample
  metadata into `DataProto.non_tensor_batch` and its TensorDict view.
- Strengthen the Qwen-Image-Edit condition-injection test by checking that the
  packed hidden-state length matches the target-plus-condition `img_shapes`.