### PR TITLE
[trainer, recipe, tests, doc] feat: multi-teacher OPD on the v1 sync diffusion trainer

### DIFF
--- a/docs/algo/diffusion_opd.md
+++ b/docs/algo/diffusion_opd.md
@@ -1,6 +1,6 @@
 # Diffusion On-Policy Distillation
 
-Last updated: 08/26/2026.
+Last updated: 08/31/2026.
 
 ## Background
 
@@ -155,16 +155,26 @@ rejected at startup. The teacher runtime produces `teacher_prev_sample_mean`,
 which only `distill_kl` consumes; `distill_fm_mse` has no producer on the
 policy-gradient path and is rejected.
 
-### Scoring batch size
+### Scoring configuration
 
 The teacher reuses the reference model's scoring configuration:
 `actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu`, falling back to
 `actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu`.
 
+The same applies to the engine dtype: teachers load with
+`actor_rollout_ref.ref.fsdp_config.model_dtype`, which defaults to fp32.
+Scoring-only teachers compute in bf16 either way (FSDP mixed precision casts
+parameters per forward), so overriding it to `bfloat16` — as the example
+recipes do — only removes the fp32 parameter streaming and roughly halves the
+teacher stage time without changing the scores.
+
 ## Usage
 
 Supported scope: the policy-gradient trainer with online sampling and
-FSDP/FSDP2 engines. Unsupported combinations raise at startup.
+FSDP/FSDP2 engines, on both the legacy trainer (`main_diffusion`) and the v1
+sync trainer (`main_diffusion_v1` with `trainer.v1.trainer_mode=sync`; the
+v1 `separate_async` mode does not support distillation yet). Unsupported
+combinations raise at startup.
 
 A complete working recipe is
 [`examples/diffusionopd_trainer/sd35/run_sd35_medium_ocr_distill.sh`](../examples/diffusionopd_trainer.md):

--- a/examples/diffusionopd_trainer/README.md
+++ b/examples/diffusionopd_trainer/README.md
@@ -1,6 +1,6 @@
 # Diffusion On-Policy Distillation Trainer
 
-Last updated: 08/10/2026
+Last updated: 08/31/2026
 
 This example distills an OCR-tuned `SD3.5-Medium` teacher into a fresh `SD3.5-Medium` student. The student generates images with its own policy, a frozen teacher scores every denoising step of those trajectories, and the student minimizes the KL between its transition and the teacher's (`distill_kl`). The OCR reward is only monitored, never optimized — the reward curve shows the student reaching the teacher's reward level through distillation alone.
 
@@ -47,6 +47,10 @@ The teacher is a full diffusers checkpoint from the same pipeline family as the 
 TEACHER_PATH=/path/to/merged-teacher \
   bash examples/diffusionopd_trainer/sd35/run_sd35_medium_ocr_distill.sh
 ```
+
+The multi-teacher recipe (`run_sd35_medium_mopd_distill.sh`) routes each row to
+its task's teacher by `data_source`; `run_sd35_medium_mopd_distill_v1.sh` is
+the same recipe on the v1 sync trainer.
 
 ## What to expect
 

--- a/examples/diffusionopd_trainer/sd35/run_sd35_medium_mopd_distill.sh
+++ b/examples/diffusionopd_trainer/sd35/run_sd35_medium_mopd_distill.sh
@@ -106,6 +106,7 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=28 \
     actor_rollout_ref.rollout.val_kwargs.algo.noise_level=0.0 \
     actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=8 \
+    actor_rollout_ref.ref.fsdp_config.model_dtype=bfloat16 \
     reward.num_workers=$((NUM_GPUS_REWARD / REWARD_TP)) \
     reward.reward_model.enable=True \
     reward.reward_model.model_path=$reward_model_name \

--- a/examples/diffusionopd_trainer/sd35/run_sd35_medium_mopd_distill_v1.sh
+++ b/examples/diffusionopd_trainer/sd35/run_sd35_medium_mopd_distill_v1.sh
@@ -1,25 +1,25 @@
 #!/usr/bin/env bash
-# SD3.5-Medium on-policy distillation on the OCR task.
+# SD3.5-Medium multi-teacher on-policy distillation (V1 trainer: sync mode).
 #
-# A frozen teacher (e.g. an OCR-tuned SD3.5-Medium with its LoRA merged) replays
-# the student's rollout trajectories, and the student minimizes distill_kl toward
-# the teacher's transition means. The OCR GenRM reward is monitored only -- it
-# never enters the loss -- so the reward curve shows the student reaching the
-# teacher's reward level through distillation alone.
-#
-# Set TEACHER_PATH to the merged teacher checkpoint. Data layout and the reward
-# model follow examples/flowgrpo_trainer/sd35/run_sd35_medium_ocr_lora.sh.
+# V1 counterpart of run_sd35_medium_mopd_distill.sh: same data, teachers,
+# routing, and objective, run through `verl_omni.trainer.main_diffusion_v1`,
+# which selects `PolicyGradientDiffusionTrainerV1Sync` via
+# `trainer.v1.trainer_mode=sync`. See the v0 script for teacher-merge and
+# data-preparation notes.
 set -x
 
 WORKSPACE=${OCR_WORKSPACE:-${WORKSPACE:-$HOME}}
 
 ocr_train_path=$WORKSPACE/data/ocr/sd3/train.parquet
 ocr_test_path=$WORKSPACE/data/ocr/sd3/test.parquet
+pickscore_train_path=$WORKSPACE/data/pickscore_sfw/sd3/train.parquet
+pickscore_test_path=$WORKSPACE/data/pickscore_sfw/sd3/test.parquet
 
 model_name=stabilityai/stable-diffusion-3.5-medium
-teacher_path=${TEACHER_PATH:?set TEACHER_PATH to the frozen teacher checkpoint}
+ocr_teacher_path=${OCR_TEACHER_PATH:?set OCR_TEACHER_PATH to the merged OCR teacher checkpoint}
+aes_teacher_path=${AES_TEACHER_PATH:?set AES_TEACHER_PATH to the merged Aes teacher checkpoint}
 reward_model_name=Qwen/Qwen2.5-VL-3B-Instruct
-reward_function_path=verl_omni/utils/reward_score/genrm_ocr.py
+reward_function_path=examples/diffusionopd_trainer/sd35/mixed_task_reward.py
 custom_chat_template='{% for message in messages %}{% if message['\''role'\''] == '\''user'\'' %}{{ message['\''content'\''] }}{% endif %}{% endfor %}'
 
 NUM_GPUS_ACTOR_ROLLOUT=2
@@ -42,11 +42,11 @@ fi
 ENGINE=vllm_omni
 REWARD_ENGINE=vllm
 
-python3 -m verl_omni.trainer.main_diffusion \
-    data.train_files=$ocr_train_path \
-    data.val_files=$ocr_test_path \
+python3 -m verl_omni.trainer.main_diffusion_v1 \
+    data.train_files="[\"$ocr_train_path\",\"$pickscore_train_path\"]" \
+    data.val_files="[\"$ocr_test_path\",\"$pickscore_test_path\"]" \
     data.train_batch_size=8 \
-    data.val_max_samples=32 \
+    data.val_max_samples=64 \
     data.max_prompt_length=512 \
     data.truncation=error \
     data.seed=42 \
@@ -59,7 +59,10 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.model.lora_alpha=64 \
     actor_rollout_ref.model.target_modules="['to_q','to_k','to_v','to_out.0','add_q_proj','add_k_proj','add_v_proj','to_add_out']" \
     distillation.enabled=True \
-    distillation.teacher_models.teacher_model.model_path=$teacher_path \
+    +distillation.teacher_models.ocr_teacher.key=flow_grpo/ocr \
+    +distillation.teacher_models.ocr_teacher.model_path=$ocr_teacher_path \
+    +distillation.teacher_models.pickscore_teacher.key=flow_grpo/pickscore_sfw \
+    +distillation.teacher_models.pickscore_teacher.model_path=$aes_teacher_path \
     actor_rollout_ref.actor.diffusion_loss.loss_mode=distill_kl \
     actor_rollout_ref.actor.diffusion_loss.clip_ratio=1e-5 \
     actor_rollout_ref.actor.use_kl_loss=False \
@@ -109,10 +112,10 @@ python3 -m verl_omni.trainer.main_diffusion \
     reward.reward_model.rollout.tensor_model_parallel_size=$REWARD_TP \
     reward.reward_model.rollout.enforce_eager=False \
     reward.custom_reward_function.path=$reward_function_path \
-    reward.custom_reward_function.name=compute_score_ocr \
+    reward.custom_reward_function.name=compute_score_mixed \
     trainer.logger='["console", "wandb"]' \
     trainer.project_name=diffusion_opd \
-    trainer.experiment_name=sd35_medium_ocr_distill \
+    trainer.experiment_name=sd35_medium_mopd_distill_v1 \
     trainer.log_val_generations=8 \
     trainer.val_before_train=True \
     trainer.n_gpus_per_node=$NUM_GPUS_ACTOR_ROLLOUT \
@@ -121,4 +124,6 @@ python3 -m verl_omni.trainer.main_diffusion \
     trainer.test_freq=20 \
     trainer.total_epochs=15 \
     trainer.total_training_steps=$TOTAL_TRAINING_STEPS \
+    trainer.use_v1=true \
+    trainer.v1.trainer_mode=sync \
     "$@"

--- a/tests/gpu_smoke/run_gpu_smoke_diffusion_e2e.sh
+++ b/tests/gpu_smoke/run_gpu_smoke_diffusion_e2e.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # ci-e2e-diffusion GPU smoke tests (4-GPU): end-to-end diffusion training paths.
 # Includes FlowGRPO / online DPO / DiffusionNFT (v0), synchronous separate,
-# and FlowGRPO v1 separate_async.
+# FlowGRPO v1 separate_async, and OPD teachers on v0 and the v1 sync trainer.
 
 set -euo pipefail
 
@@ -60,5 +60,9 @@ run_test 8 "Diffusion OPD standalone teacher pool e2e" \
 run_test 9 "FlowGRPO synchronous separate trainer e2e" \
     env CUDA_VISIBLE_DEVICES="${CUDA_DEVICE_LIST}" NUM_GPUS="${NUM_GPUS}" \
     bash tests/special_e2e/run_flowgrpo_qwen_image_separate.sh "${diffusion_trainer_args[@]}"
+
+run_test 10 "Diffusion OPD v1 sync standalone teachers e2e" \
+    env CUDA_VISIBLE_DEVICES="${CUDA_DEVICE_LIST}" NUM_GPUS="${NUM_GPUS}" V1=1 SMOKE=standalone \
+    bash tests/special_e2e/run_diffusion_teacher_smoke.sh
 
 gpu_smoke_summary

--- a/tests/special_e2e/run_diffusion_teacher_smoke.sh
+++ b/tests/special_e2e/run_diffusion_teacher_smoke.sh
@@ -21,10 +21,13 @@
 # so the step-1 KL is positive) and needs no downloads; set MODEL_PATH and
 # TEACHER_PATH to run against real checkpoints instead.
 #
-# Override via env: NUM_GPUS, MODEL_PATH, TEACHER_PATH, TEACHER2_PATH, DATA_DIR, TOTAL_TRAIN_STEPS, SMOKE
+# V1=1 runs the same smoke through the v1 sync trainer (`main_diffusion_v1`).
+#
+# Override via env: NUM_GPUS, MODEL_PATH, TEACHER_PATH, TEACHER2_PATH, DATA_DIR, TOTAL_TRAIN_STEPS, SMOKE, V1
 set -euo pipefail
 
 NUM_GPUS=${NUM_GPUS:-1}
+V1=${V1:-0}
 MODEL_PATH=${MODEL_PATH:-${HOME}/models/tiny-random/sd3-teacher-smoke-student}
 TEACHER_PATH=${TEACHER_PATH:-${HOME}/models/tiny-random/sd3-teacher-smoke-teacher}
 TEACHER2_PATH=${TEACHER2_PATH:-${HOME}/models/tiny-random/sd3-teacher-smoke-teacher2}
@@ -128,7 +131,14 @@ case "${SMOKE}" in
         ;;
 esac
 
-python3 -m verl_omni.trainer.main_diffusion \
+entrypoint=verl_omni.trainer.main_diffusion
+v1_flags=()
+if [[ "${V1}" == "1" ]]; then
+    entrypoint=verl_omni.trainer.main_diffusion_v1
+    v1_flags=(trainer.use_v1=true trainer.v1.trainer_mode=sync)
+fi
+
+python3 -m ${entrypoint} \
     data.train_files="${DATA_DIR}/train.parquet" \
     data.val_files="${DATA_DIR}/test.parquet" \
     data.train_batch_size=${train_batch_size} \
@@ -188,6 +198,7 @@ python3 -m verl_omni.trainer.main_diffusion \
     trainer.save_freq=-1 \
     trainer.resume_mode=disable \
     trainer.total_training_steps=${TOTAL_TRAIN_STEPS} \
+    "${v1_flags[@]}" \
     "$@"
 
 echo "Diffusion teacher e2e smoke (${SMOKE}) passed."

--- a/tests/trainer/diffusion/test_v1_distillation_wiring_on_cpu.py
+++ b/tests/trainer/diffusion/test_v1_distillation_wiring_on_cpu.py
@@ -1,0 +1,90 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU tests for multi-teacher distillation wiring in the v1 diffusion trainer."""
+
+import os
+
+import pytest
+from hydra import compose, initialize_config_dir
+
+import verl_omni
+
+CONFIG_DIR = os.path.join(os.path.dirname(os.path.abspath(verl_omni.__file__)), "trainer", "config")
+
+ENABLE = [
+    "distillation.enabled=true",
+    "distillation.teacher_models.teacher_model.model_path=/ckpt/teacher",
+    "actor_rollout_ref.actor.diffusion_loss.loss_mode=distill_kl",
+]
+
+
+def compose_cfg(overrides):
+    with initialize_config_dir(config_dir=CONFIG_DIR, version_base=None):
+        return compose(config_name="diffusion_trainer", overrides=overrides)
+
+
+def make_trainer(overrides):
+    from verl_omni.trainer.diffusion.v1.trainer_sync import PolicyGradientDiffusionTrainerV1Sync
+
+    return PolicyGradientDiffusionTrainerV1Sync(compose_cfg(overrides))
+
+
+class TestV1DistillationInit:
+    def test_teacher_policy_enabled(self):
+        trainer = make_trainer(ENABLE)
+        assert trainer.use_teacher_policy
+        assert trainer.distillation_config is not None
+
+    def test_default_config_has_no_teacher(self):
+        trainer = make_trainer([])
+        assert not trainer.use_teacher_policy
+        assert trainer.distillation_config is None
+
+    def test_enabled_but_no_distill_loss_raises(self):
+        with pytest.raises(ValueError, match="distill"):
+            make_trainer(
+                [
+                    "distillation.enabled=true",
+                    "distillation.teacher_models.teacher_model.model_path=/ckpt/teacher",
+                ]
+            )
+
+    def test_separate_async_mode_rejected(self):
+        with pytest.raises(NotImplementedError, match="sync"):
+            make_trainer(ENABLE + ["trainer.v1.trainer_mode=separate_async"])
+
+
+class TestV1TeacherPoolRegistration:
+    def test_standalone_registers_teacher_pool(self):
+        from verl.trainer.ppo.utils import Role
+
+        trainer = make_trainer(ENABLE + ["distillation.n_gpus_per_node=2", "distillation.nnodes=1"])
+        trainer._init_resource_pool_mgr()
+        assert trainer.resource_pool_manager.resource_pool_spec["teacher_pool"] == [2]
+        assert trainer.mapping[Role.TeacherModel] == "teacher_pool"
+        assert Role.TeacherModel in trainer.role_worker_mapping
+
+    def test_colocated_registers_nothing(self):
+        from verl.trainer.ppo.utils import Role
+
+        trainer = make_trainer(ENABLE)
+        trainer._init_resource_pool_mgr()
+        assert "teacher_pool" not in trainer.resource_pool_manager.resource_pool_spec
+        assert Role.TeacherModel not in trainer.mapping
+        assert Role.TeacherModel not in trainer.role_worker_mapping
+
+    def test_standalone_requires_gpus_per_node(self):
+        trainer = make_trainer(ENABLE + ["distillation.n_gpus_per_node=0", "distillation.nnodes=1"])
+        with pytest.raises(ValueError, match="config.distillation.n_gpus_per_node must be greater than 0"):
+            trainer._init_resource_pool_mgr()

--- a/verl_omni/trainer/diffusion/v1/trainer_base.py
+++ b/verl_omni/trainer/diffusion/v1/trainer_base.py
@@ -41,6 +41,8 @@ from verl.single_controller.ray import (
     ResourcePoolManager,
     create_colocated_worker_cls,
 )
+from verl.single_controller.ray.base import split_resource_pool
+from verl.trainer.distillation import is_distillation_enabled
 from verl.trainer.ppo.metric_utils import compute_variance_proxy_metrics, process_validation_metrics
 from verl.trainer.ppo.reward import extract_reward
 from verl.trainer.ppo.utils import Role, need_reference_policy, need_reward_model
@@ -62,7 +64,10 @@ from verl_omni.trainer.diffusion.diffusion_metric_utils import (
     compute_throughput_metrics_diffusion,
     compute_timing_metrics_diffusion,
 )
-from verl_omni.trainer.diffusion.diffusion_trainer_utils import worker_group_port_ranges
+from verl_omni.trainer.diffusion.diffusion_trainer_utils import (
+    validate_distillation_config,
+    worker_group_port_ranges,
+)
 from verl_omni.trainer.diffusion.ray_diffusion_trainer import _to_diffusion_worker_tensordict, compute_advantage
 from verl_omni.trainer.diffusion.rollout_correction import (
     apply_bypass_mode_to_diffusion_batch,
@@ -70,11 +75,12 @@ from verl_omni.trainer.diffusion.rollout_correction import (
     compute_rollout_corr_metrics_from_batch,
     rollout_correction_enabled,
 )
+from verl_omni.trainer.diffusion.teacher_manager import DiffusionTeacherManager
 from verl_omni.trainer.diffusion.v1.tq_utils import (
     diffusion_tq_batch_to_dataproto,
     sort_diffusion_tq_keys,
 )
-from verl_omni.workers.engine_workers import ActorRolloutRefWorker
+from verl_omni.workers.engine_workers import ActorRolloutRefWorker, resolve_teacher_infer_micro_batch_size
 from verl_omni.workers.utils.padding import embeds_padding_2_no_padding
 
 logger = logging.getLogger(__name__)
@@ -118,6 +124,11 @@ class PolicyGradientDiffusionTrainerV1(ABC):
         self.parameter_sync_step = config.trainer.v1.get(self.trainer_mode, {}).get("parameter_sync_step", 1)
         self.use_reference_policy = need_reference_policy(config)
         self.use_rm = need_reward_model(config)
+        self.use_teacher_policy = is_distillation_enabled(config.get("distillation"))
+        self.distillation_config = omega_conf_to_dataclass(config.distillation) if self.use_teacher_policy else None
+        validate_distillation_config(config)
+        if self.use_teacher_policy and self.trainer_mode != "sync":
+            raise NotImplementedError("distillation is only supported with trainer_mode='sync'")
         self.replay_buffer = self._build_replay_buffer()
 
         # ref_in_actor: reference policy is the actor without lora applied.
@@ -346,6 +357,11 @@ class PolicyGradientDiffusionTrainerV1(ABC):
             with marked_timer("ref", timing_raw, color="olive"):
                 ref_log_prob = self._compute_ref_log_prob(data)
                 data = data.union(ref_log_prob)
+
+        if self.use_teacher_policy:
+            # score the rollout trajectories with the frozen teacher
+            with marked_timer("teacher", timing_raw, color="olive"):
+                data = data.union(self.teacher_model_manager.compute_prev_sample_mean(data))
 
         with marked_timer("adv", timing_raw, color="brown"):
             data = self._compute_advantage(data)
@@ -615,6 +631,15 @@ class PolicyGradientDiffusionTrainerV1(ABC):
                 self.config.reward.reward_model.n_gpus_per_node = self.config.trainer.n_gpus_per_node
             self.mapping[Role.RewardModel] = "global_pool"
 
+        if self.use_teacher_policy and self.distillation_config.nnodes > 0:
+            if self.distillation_config.n_gpus_per_node <= 0:
+                raise ValueError("config.distillation.n_gpus_per_node must be greater than 0")
+            self.role_worker_mapping[Role.TeacherModel] = ray.remote(ActorRolloutRefWorker)
+            self.mapping[Role.TeacherModel] = "teacher_pool"
+            resource_pool_spec["teacher_pool"] = [
+                self.distillation_config.n_gpus_per_node
+            ] * self.distillation_config.nnodes
+
         self.resource_pool_manager = ResourcePoolManager(resource_pool_spec=resource_pool_spec, mapping=self.mapping)
 
     def _init_colocated_workers(self):
@@ -624,9 +649,26 @@ class PolicyGradientDiffusionTrainerV1(ABC):
         actor_rollout_cls = RayClassWithInitArgs(
             cls=self.role_worker_mapping[actor_role],
             config=self.config.actor_rollout_ref,
+            distillation_config=self.config.get("distillation"),
             role=str(actor_role),
         )
         self.resource_pool_to_cls[actor_rollout_resource_pool][str(actor_role)] = actor_rollout_cls
+
+        # standalone teachers: one sub-pool and worker group per teacher
+        if self.use_teacher_policy and Role.TeacherModel in self.role_worker_mapping:
+            teacher_pool = self.resource_pool_manager.get_resource_pool(Role.TeacherModel)
+            teacher_models = self.distillation_config.teacher_models
+            split_pools = split_resource_pool(teacher_pool, split_size=[t.world_size for t in teacher_models.values()])
+            for key, pool in zip(teacher_models, split_pools, strict=True):
+                self.resource_pool_to_cls[pool] = {
+                    self._teacher_wg_name(key): RayClassWithInitArgs(
+                        self.role_worker_mapping[Role.TeacherModel],
+                        config=self.config.actor_rollout_ref,
+                        distillation_config=self.config.get("distillation"),
+                        role=str(Role.TeacherModel),
+                        teacher_key=key,
+                    )
+                }
 
         all_wg = {}
         wg_kwargs = {"device_name": self.config.trainer.device}
@@ -647,7 +689,28 @@ class PolicyGradientDiffusionTrainerV1(ABC):
             self.ref_policy_wg = self.actor_rollout_wg
         if self.ref_in_actor:
             self.ref_policy_wg = self.actor_rollout_wg
+
+        if self.use_teacher_policy:
+            if Role.TeacherModel in self.role_worker_mapping:
+                teacher_wg = {
+                    key: all_wg[self._teacher_wg_name(key)] for key in self.distillation_config.teacher_models
+                }
+                for wg in teacher_wg.values():
+                    wg.init_model()
+            else:
+                teacher_wg = {key: self.actor_rollout_wg for key in self.distillation_config.teacher_models}
+            self.teacher_model_manager = DiffusionTeacherManager(
+                self.distillation_config,
+                self.config.actor_rollout_ref.model,
+                teacher_wg,
+                infer_micro_batch_size_per_gpu=resolve_teacher_infer_micro_batch_size(self.config.actor_rollout_ref),
+            )
+
         return actor_rollout_resource_pool
+
+    @staticmethod
+    def _teacher_wg_name(key: str) -> str:
+        return f"teacher_{key.replace('/', '_')}"
 
     def _init_online_rollout_stack(self, actor_rollout_resource_pool):
         """Initialize reward loop, LLM server, and checkpoint engine managers."""


### PR DESCRIPTION
### What does this PR do?

Ports the merged diffusion OPD teacher runtime (#325/#427) onto the v1 sync trainer, closing the "OPD still lives on v0" gap tracked in #389. Adds the v1 MOPD recipe, a `V1=1` switch on the teacher e2e smoke, and CPU wiring tests mirroring the v0 suite. `separate_async` + distillation raises `NotImplementedError` until benched (planned follow-up: teacher scheduling in separate_async).

Also bundled: the OPD example recipes now override `actor_rollout_ref.ref.fsdp_config.model_dtype=bfloat16` — teachers derive their engine config from `ref`, whose fp32 default streams 2× parameter bytes per forward under the forward-only CPU offload policy while compute is bf16 either way (FSDP mixed precision). Measured: teacher stage 7.76s → 3.13s standalone (−60%, together with the micro-batch default), 4.35s → ~2.3s colocated; `distill_kl` trajectories under fp32 vs bf16 teachers agree per step over 10 steps (median 0.25%, max 0.85%).

### Why this is not duplicating an existing PR

#389 lists diffusion OPD on v1 as an open gap; `gh pr list --state open --search "v1 distill"` and `--search "OPD"` show no open PR on this path. Claimed on #389 before starting.

### Tests

- CPU (RED verified before implementation): `pytest tests/trainer/diffusion/test_v1_distillation_wiring_on_cpu.py` → 7 passed; regression across v1 + distillation suites → 65 passed.
- E2E smoke matrix (4× RTX PRO 6000): `V1=1 SMOKE={distill,coexistence,mopd,standalone}` + `V1=0 SMOKE=mopd` control → 5/5 PASS; v1 colocated-vs-standalone routing gives identical `distill_kl` to 4 decimals (the #427 equivalence, reproduced on v1).
- Real-model parity, SD3.5-M two-teacher recipe, 100 steps + val each: loss and val-reward curves overlap (final val OCR 0.8505 v0 vs 0.8469 v1, PickScore 0.8015 vs 0.7995); per-stage timings at parity (teacher 2.38 vs 2.33s, update 5.14 vs 4.91s).

![v0 vs v1 curves](https://raw.githubusercontent.com/cr-gao/verl-omni/assets/v1-mopd/v1_mopd_curves.png)

AI assistance (Claude Code) was used for this change; the submitting human has reviewed every changed line and run the tests above.
