### PR TITLE
[model, rollout] feat: add generic Talker RL interface

### DIFF
--- a/docs/contributing/integrating_an_omni_model.md
+++ b/docs/contributing/integrating_an_omni_model.md
@@ -98,7 +98,7 @@ pipeline variants with vLLM-Omni), `get_engine_hf_overrides` (HF config
 overrides like `enable_audio_output: false`), `get_stage_engine_extras`
 (per-stage overrides like `model_arch`).
 
-For a non-text autoregressive policy, also override
+When training an omni model's autoregressive Talker stage, also override
 `postprocess_agent_loop_output`. Put the sampled policy sequence in
 `response_ids`, align `response_mask` and optional `response_logprobs`
 one-to-one, and retain model-native acoustic trajectory and conditioning data
@@ -162,8 +162,9 @@ Key points:
   triggered by `VERL_USE_EXTERNAL_MODULES=verl_omni`.
 - No `stage_configs_path` — the rollout deploy config is auto-generated
   from `pipeline_name` by `vLLMOmniHttpServer`.
-- Use `omni_single_turn_agent` when a rollout adapter must map model-native
-  output to a non-text policy sequence. Standard text-token policies can keep
+- Use `omni_single_turn_agent` only for an omni model's autoregressive Talker
+  stage when its rollout adapter must map model-native output to the Talker
+  policy sequence. Standard text-token stages such as the Thinker can keep
   verl's `single_turn_agent`.
 - No `--config-path/--config-name` — all config comes from CLI overrides
   on `verl_omni`'s `omni_trainer.yaml` defaults.

--- a/docs/contributing/integrating_an_omni_model.md
+++ b/docs/contributing/integrating_an_omni_model.md
@@ -1,6 +1,6 @@
 # How to Add a New Omni Model
 
-Last updated: 08/24/2026.
+Last updated: 08/31/2026.
 
 This guide walks through adding a new omni (multimodal autoregressive) model to
 the verl-omni training framework. It uses the Qwen3-Omni Thinker adapter as a
@@ -60,6 +60,13 @@ adapt each implementation to your model's architecture:
   `module._no_split_modules` to the correct decoder layer class for FSDP.
   This method runs before FSDP wrapping and LoRA injection.
 
+- **`prepare_model_inputs(model_inputs, micro_batch, model_config)`**
+  (optional): Validate model-native trajectory or conditioning data retained
+  by rollout and add it to the actor forward inputs. This is required when the
+  policy token sequence alone cannot reconstruct the exact sampled trajectory.
+  Missing required fields or inconsistent shapes should raise an actionable
+  error; the adapter must not silently reconstruct a different trajectory.
+
 Reference:
 [`verl_omni/pipelines/qwen3_omni/thinker_training_adapter.py`](../../verl_omni/pipelines/qwen3_omni/thinker_training_adapter.py)
 
@@ -86,6 +93,14 @@ Optional overrides: `ensure_pipeline_registered` (register non-standard
 pipeline variants with vLLM-Omni), `get_engine_hf_overrides` (HF config
 overrides like `enable_audio_output: false`), `get_stage_engine_extras`
 (per-stage overrides like `model_arch`).
+
+For a non-text autoregressive policy, also override
+`postprocess_agent_loop_output`. Put the sampled policy sequence in
+`response_ids`, align `response_mask` and optional `response_logprobs`
+one-to-one, and retain model-native acoustic trajectory and conditioning data
+in `extra_fields`. The corresponding training adapter consumes that payload in
+`prepare_model_inputs`. The common contract intentionally does not prescribe a
+codebook count, conditioning source, or model-specific payload keys.
 
 Reference:
 [`verl_omni/pipelines/qwen3_omni/omni_rollout_adapter.py`](../../verl_omni/pipelines/qwen3_omni/omni_rollout_adapter.py)
@@ -129,6 +144,7 @@ python3 -m verl_omni.trainer.main_omni \
     actor_rollout_ref.model.lora_rank=32 \
     actor_rollout_ref.actor.policy_loss.loss_mode=gspo \
     actor_rollout_ref.actor.strategy=fsdp2 \
+    actor_rollout_ref.rollout.agent.default_agent_loop=omni_single_turn_agent \
     +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.output_mode="ar" \
     +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.pipeline_name="your_pipeline_name" \
     trainer.n_gpus_per_node=4 \
@@ -141,6 +157,9 @@ Key points:
   triggered by `VERL_USE_EXTERNAL_MODULES=verl_omni`.
 - No `stage_configs_path` — the rollout deploy config is auto-generated
   from `pipeline_name` by `vLLMOmniHttpServer`.
+- Use `omni_single_turn_agent` when a rollout adapter must map model-native
+  output to a non-text policy sequence. Standard text-token policies can keep
+  verl's `single_turn_agent`.
 - No `--config-path/--config-name` — all config comes from CLI overrides
   on `verl_omni`'s `omni_trainer.yaml` defaults.
 - The `"$@"` at the end lets callers override any field without editing

--- a/docs/contributing/integrating_an_omni_model.md
+++ b/docs/contributing/integrating_an_omni_model.md
@@ -61,11 +61,15 @@ adapt each implementation to your model's architecture:
   This method runs before FSDP wrapping and LoRA injection.
 
 - **`prepare_model_inputs(model_inputs, micro_batch, model_config)`**
-  (optional): Validate model-native trajectory or conditioning data retained
-  by rollout and add it to the actor forward inputs. This is required when the
-  policy token sequence alone cannot reconstruct the exact sampled trajectory.
-  Missing required fields or inconsistent shapes should raise an actionable
-  error; the adapter must not silently reconstruct a different trajectory.
+  (optional): Validate model-native trajectory or conditioning data retained by
+  rollout and add it to the actor forward inputs. Per-sample rollout data starts
+  under a model-defined, namespaced key in `AgentLoopOutput.extra_fields`;
+  `AgentLoopWorker` batches that key into the top level of `micro_batch`. For
+  example, data stored as `output.extra_fields["your_model_replay"]` is consumed
+  as `micro_batch["your_model_replay"]`. This is required when the policy token
+  sequence alone cannot reconstruct the exact sampled trajectory. Missing
+  required fields or inconsistent shapes should raise an actionable error; the
+  adapter must not silently reconstruct a different trajectory.
 
 Reference:
 [`verl_omni/pipelines/qwen3_omni/thinker_training_adapter.py`](../../verl_omni/pipelines/qwen3_omni/thinker_training_adapter.py)
@@ -98,9 +102,10 @@ For a non-text autoregressive policy, also override
 `postprocess_agent_loop_output`. Put the sampled policy sequence in
 `response_ids`, align `response_mask` and optional `response_logprobs`
 one-to-one, and retain model-native acoustic trajectory and conditioning data
-in `extra_fields`. The corresponding training adapter consumes that payload in
-`prepare_model_inputs`. The common contract intentionally does not prescribe a
-codebook count, conditioning source, or model-specific payload keys.
+under a model-defined, namespaced key in `extra_fields`. The corresponding
+training adapter consumes the batched top-level key in `prepare_model_inputs`.
+The common contract intentionally does not prescribe the key name, its nested
+schema, a codebook count, or a conditioning source.
 
 Reference:
 [`verl_omni/pipelines/qwen3_omni/omni_rollout_adapter.py`](../../verl_omni/pipelines/qwen3_omni/omni_rollout_adapter.py)

--- a/tests/agent_loop/test_omni_single_turn_agent_loop_on_cpu.py
+++ b/tests/agent_loop/test_omni_single_turn_agent_loop_on_cpu.py
@@ -17,11 +17,12 @@ from types import SimpleNamespace
 
 import pytest
 import torch
-from verl.experimental.agent_loop.agent_loop import AgentLoopMetrics, AgentLoopOutput
+from verl.experimental.agent_loop.agent_loop import AgentLoopMetrics, AgentLoopOutput, AgentLoopWorker
 from verl.experimental.agent_loop.single_turn_agent_loop import SingleTurnAgentLoop
+from verl.utils import tensordict_utils as tu
 
 from verl_omni.agent_loop.single_turn_agent_loop import OmniSingleTurnAgentLoop
-from verl_omni.pipelines.model_base import OmniModelBase, OmniRolloutPipelineBase
+from verl_omni.pipelines.model_base import OmniRolloutPipelineBase
 
 
 def _output(extra_fields):
@@ -33,6 +34,29 @@ def _output(extra_fields):
         num_turns=2,
         metrics=AgentLoopMetrics(),
         extra_fields=extra_fields,
+    )
+
+
+def _internal_output(replay_payload, *, response_token):
+    prompt_ids = torch.tensor([[10, 11]])
+    response_ids = torch.tensor([[response_token, 0]])
+    input_ids = torch.cat([prompt_ids, response_ids], dim=1)
+    return SimpleNamespace(
+        prompt_ids=prompt_ids,
+        response_ids=response_ids,
+        input_ids=input_ids,
+        position_ids=torch.arange(input_ids.shape[1]).unsqueeze(0),
+        response_mask=torch.tensor([[1, 0]]),
+        attention_mask=torch.tensor([[1, 1, 1, 0]]),
+        response_logprobs=None,
+        routed_experts=None,
+        teacher_logprobs=None,
+        teacher_ids=None,
+        multi_modal_inputs=None,
+        reward_score=None,
+        num_turns=2,
+        metrics=AgentLoopMetrics(),
+        extra_fields={"test_talker_replay": replay_payload},
     )
 
 
@@ -61,8 +85,15 @@ async def test_talker_contract_supports_different_trajectory_and_conditioning_sh
     hidden_states = torch.ones(4, 6)
     upstream_outputs = iter(
         [
-            _output({"rvq_codes": codebooks, "speaker_embedding": torch.ones(5)}),
-            _output({"policy_tokens": [31, 32, 33, 34], "thinker_hidden_states": hidden_states}),
+            _output({"rvq_replay": {"codes": codebooks, "speaker_embedding": torch.ones(5)}}),
+            _output(
+                {
+                    "hidden_state_replay": {
+                        "policy_tokens": [31, 32, 33, 34],
+                        "thinker_hidden_states": hidden_states,
+                    }
+                }
+            ),
         ]
     )
 
@@ -77,7 +108,8 @@ async def test_talker_contract_supports_different_trajectory_and_conditioning_sh
         @classmethod
         def postprocess_agent_loop_output(cls, output, *, tokenizer, response_length):
             del tokenizer
-            output.response_ids = output.extra_fields["rvq_codes"][:response_length, 0].tolist()
+            replay = output.extra_fields["rvq_replay"]
+            output.response_ids = replay["codes"][:response_length, 0].tolist()
             output.response_mask = [1] * len(output.response_ids)
             output.response_logprobs = [-0.2] * len(output.response_ids)
             return output
@@ -86,7 +118,8 @@ async def test_talker_contract_supports_different_trajectory_and_conditioning_sh
         @classmethod
         def postprocess_agent_loop_output(cls, output, *, tokenizer, response_length):
             del tokenizer
-            output.response_ids = output.extra_fields["policy_tokens"][:response_length]
+            replay = output.extra_fields["hidden_state_replay"]
+            output.response_ids = replay["policy_tokens"][:response_length]
             output.response_mask = [1] * len(output.response_ids)
             output.response_logprobs = None
             return output
@@ -101,37 +134,36 @@ async def test_talker_contract_supports_different_trajectory_and_conditioning_sh
     hidden_output = await loop.run({"temperature": 0.8}, raw_prompt=[{"role": "user", "content": "hello"}])
 
     assert rvq_output.response_ids == codebooks[:, 0].tolist()
-    assert rvq_output.extra_fields["rvq_codes"].shape == (3, 8)
+    assert rvq_output.extra_fields["rvq_replay"]["codes"].shape == (3, 8)
     assert hidden_output.response_ids == [31, 32, 33, 34]
-    assert hidden_output.extra_fields["thinker_hidden_states"].shape == (4, 6)
+    assert hidden_output.extra_fields["hidden_state_replay"]["thinker_hidden_states"].shape == (4, 6)
 
-    class RvqTrainingAdapter(OmniModelBase):
-        @classmethod
-        def prepare_model_inputs(cls, model_inputs, micro_batch, model_config):
-            del model_config
-            return {**model_inputs, "rvq_codes": micro_batch["extra_fields"][0]["rvq_codes"]}
 
-    class HiddenStateTrainingAdapter(OmniModelBase):
-        @classmethod
-        def prepare_model_inputs(cls, model_inputs, micro_batch, model_config):
-            del model_config
-            return {
-                **model_inputs,
-                "thinker_hidden_states": micro_batch["extra_fields"][0]["thinker_hidden_states"],
-            }
+def test_agent_loop_batches_model_defined_replay_payload_as_top_level_micro_batch_key():
+    replay_payloads = [
+        {"codes": torch.arange(24, dtype=torch.long).reshape(3, 8), "speaker_embedding": torch.ones(5)},
+        {"codes": torch.arange(32, dtype=torch.long).reshape(4, 8), "speaker_embedding": torch.ones(5) * 2},
+    ]
+    worker = object.__new__(AgentLoopWorker)
+    worker.reward_loop_worker_handles = None
 
-    rvq_inputs = RvqTrainingAdapter.prepare_model_inputs(
-        {"input_ids": torch.ones(1, 3, dtype=torch.long)},
-        {"extra_fields": [rvq_output.extra_fields]},
-        SimpleNamespace(),
+    data = worker._postprocess(
+        [
+            _internal_output(replay_payloads[0], response_token=7),
+            _internal_output(replay_payloads[1], response_token=8),
+        ]
     )
-    hidden_inputs = HiddenStateTrainingAdapter.prepare_model_inputs(
-        {"input_ids": torch.ones(1, 4, dtype=torch.long)},
-        {"extra_fields": [hidden_output.extra_fields]},
-        SimpleNamespace(),
-    )
-    assert rvq_inputs["rvq_codes"].shape == (3, 8)
-    assert hidden_inputs["thinker_hidden_states"].shape == (4, 6)
+
+    assert "extra_fields" not in data.non_tensor_batch
+    assert "test_talker_replay" in data.non_tensor_batch
+    assert data.non_tensor_batch["test_talker_replay"][0]["codes"].shape == (3, 8)
+    assert data.non_tensor_batch["test_talker_replay"][1]["codes"].shape == (4, 8)
+
+    micro_batch = data.to_tensordict()
+    transported_payloads = tu.get(micro_batch, "test_talker_replay")
+    assert len(transported_payloads) == 2
+    assert transported_payloads[0]["speaker_embedding"].tolist() == [1.0] * 5
+    assert transported_payloads[1]["speaker_embedding"].tolist() == [2.0] * 5
 
 
 @pytest.mark.asyncio

--- a/tests/agent_loop/test_omni_single_turn_agent_loop_on_cpu.py
+++ b/tests/agent_loop/test_omni_single_turn_agent_loop_on_cpu.py
@@ -1,0 +1,157 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU contracts for autoregressive omni rollout-to-replay policy output."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from verl.experimental.agent_loop.agent_loop import AgentLoopMetrics, AgentLoopOutput
+from verl.experimental.agent_loop.single_turn_agent_loop import SingleTurnAgentLoop
+
+from verl_omni.agent_loop.single_turn_agent_loop import OmniSingleTurnAgentLoop
+from verl_omni.pipelines.model_base import OmniModelBase, OmniRolloutPipelineBase
+
+
+def _output(extra_fields):
+    return AgentLoopOutput(
+        prompt_ids=[10, 11],
+        response_ids=[1],
+        response_mask=[1],
+        response_logprobs=[-0.1],
+        num_turns=2,
+        metrics=AgentLoopMetrics(),
+        extra_fields=extra_fields,
+    )
+
+
+def test_omni_single_turn_agent_resolves_registered_adapter(monkeypatch):
+    class Adapter(OmniRolloutPipelineBase):
+        @classmethod
+        def build_stage_configs(cls, pipeline_mode="talker"):
+            return []
+
+    monkeypatch.setattr(OmniRolloutPipelineBase, "_registry", {"test_talker": Adapter})
+    config = SimpleNamespace(engine_kwargs={"vllm_omni": {"pipeline_name": "test_talker"}})
+
+    assert OmniSingleTurnAgentLoop._resolve_rollout_adapter(config) is Adapter
+
+    with pytest.raises(ValueError, match="requires a registered"):
+        OmniSingleTurnAgentLoop._resolve_rollout_adapter(
+            SimpleNamespace(engine_kwargs={"vllm_omni": {"pipeline_name": "missing"}})
+        )
+    with pytest.raises(ValueError, match="requires engine_kwargs"):
+        OmniSingleTurnAgentLoop._resolve_rollout_adapter(SimpleNamespace(engine_kwargs={}))
+
+
+@pytest.mark.asyncio
+async def test_talker_contract_supports_different_trajectory_and_conditioning_shapes(monkeypatch):
+    codebooks = torch.arange(24, dtype=torch.long).reshape(3, 8)
+    hidden_states = torch.ones(4, 6)
+    upstream_outputs = iter(
+        [
+            _output({"rvq_codes": codebooks, "speaker_embedding": torch.ones(5)}),
+            _output({"policy_tokens": [31, 32, 33, 34], "thinker_hidden_states": hidden_states}),
+        ]
+    )
+
+    async def upstream_run(_self, sampling_params, **kwargs):
+        assert sampling_params == {"temperature": 0.8}
+        assert kwargs["raw_prompt"][0]["content"] == "hello"
+        return next(upstream_outputs)
+
+    monkeypatch.setattr(SingleTurnAgentLoop, "run", upstream_run)
+
+    class RvqAdapter:
+        @classmethod
+        def postprocess_agent_loop_output(cls, output, *, tokenizer, response_length):
+            del tokenizer
+            output.response_ids = output.extra_fields["rvq_codes"][:response_length, 0].tolist()
+            output.response_mask = [1] * len(output.response_ids)
+            output.response_logprobs = [-0.2] * len(output.response_ids)
+            return output
+
+    class HiddenStateAdapter:
+        @classmethod
+        def postprocess_agent_loop_output(cls, output, *, tokenizer, response_length):
+            del tokenizer
+            output.response_ids = output.extra_fields["policy_tokens"][:response_length]
+            output.response_mask = [1] * len(output.response_ids)
+            output.response_logprobs = None
+            return output
+
+    loop = object.__new__(OmniSingleTurnAgentLoop)
+    loop.response_length = 4
+    loop.tokenizer = SimpleNamespace()
+
+    loop.rollout_adapter = RvqAdapter
+    rvq_output = await loop.run({"temperature": 0.8}, raw_prompt=[{"role": "user", "content": "hello"}])
+    loop.rollout_adapter = HiddenStateAdapter
+    hidden_output = await loop.run({"temperature": 0.8}, raw_prompt=[{"role": "user", "content": "hello"}])
+
+    assert rvq_output.response_ids == codebooks[:, 0].tolist()
+    assert rvq_output.extra_fields["rvq_codes"].shape == (3, 8)
+    assert hidden_output.response_ids == [31, 32, 33, 34]
+    assert hidden_output.extra_fields["thinker_hidden_states"].shape == (4, 6)
+
+    class RvqTrainingAdapter(OmniModelBase):
+        @classmethod
+        def prepare_model_inputs(cls, model_inputs, micro_batch, model_config):
+            del model_config
+            return {**model_inputs, "rvq_codes": micro_batch["extra_fields"][0]["rvq_codes"]}
+
+    class HiddenStateTrainingAdapter(OmniModelBase):
+        @classmethod
+        def prepare_model_inputs(cls, model_inputs, micro_batch, model_config):
+            del model_config
+            return {
+                **model_inputs,
+                "thinker_hidden_states": micro_batch["extra_fields"][0]["thinker_hidden_states"],
+            }
+
+    rvq_inputs = RvqTrainingAdapter.prepare_model_inputs(
+        {"input_ids": torch.ones(1, 3, dtype=torch.long)},
+        {"extra_fields": [rvq_output.extra_fields]},
+        SimpleNamespace(),
+    )
+    hidden_inputs = HiddenStateTrainingAdapter.prepare_model_inputs(
+        {"input_ids": torch.ones(1, 4, dtype=torch.long)},
+        {"extra_fields": [hidden_output.extra_fields]},
+        SimpleNamespace(),
+    )
+    assert rvq_inputs["rvq_codes"].shape == (3, 8)
+    assert hidden_inputs["thinker_hidden_states"].shape == (4, 6)
+
+
+@pytest.mark.asyncio
+async def test_omni_single_turn_agent_rejects_misaligned_policy_output(monkeypatch):
+    async def upstream_run(_self, sampling_params, **kwargs):
+        return _output({"trajectory": torch.ones(2, 2)})
+
+    monkeypatch.setattr(SingleTurnAgentLoop, "run", upstream_run)
+
+    class MisalignedAdapter:
+        @classmethod
+        def postprocess_agent_loop_output(cls, output, *, tokenizer, response_length):
+            output.response_ids = [1, 2]
+            output.response_mask = [1]
+            return output
+
+    loop = object.__new__(OmniSingleTurnAgentLoop)
+    loop.rollout_adapter = MisalignedAdapter
+    loop.response_length = 4
+    loop.tokenizer = SimpleNamespace()
+
+    with pytest.raises(ValueError, match="response_mask must align"):
+        await loop.run({"temperature": 0.8}, raw_prompt=[{"role": "user", "content": "hello"}])

--- a/tests/workers/test_omni_fsdp_engine_on_cpu.py
+++ b/tests/workers/test_omni_fsdp_engine_on_cpu.py
@@ -249,6 +249,9 @@ def test_policy_gradient_prepare_model_inputs_delegates_to_base_engine():
     omni_impl = _get_omni_impl_module()
     engine = object.__new__(omni_impl.OmniFSDPEngine)
     engine.model_config = _make_mock_model_config(trainer_type="policy_gradient")
+    engine.model_adapter_cls = types.SimpleNamespace(
+        prepare_model_inputs=lambda model_inputs, _micro_batch, _model_config: model_inputs
+    )
     engine._trainer_type = "policy_gradient"
     micro_batch = TensorDict({}, batch_size=[0])
 
@@ -269,6 +272,9 @@ def test_direct_preference_prepare_model_inputs_delegates_to_base_engine():
     omni_impl = _get_omni_impl_module()
     engine = object.__new__(omni_impl.OmniFSDPEngine)
     engine.model_config = _make_mock_model_config(trainer_type="direct_preference")
+    engine.model_adapter_cls = types.SimpleNamespace(
+        prepare_model_inputs=lambda model_inputs, _micro_batch, _model_config: model_inputs
+    )
     engine._trainer_type = "direct_preference"
     micro_batch = TensorDict({"input_ids": torch.ones(2, 3, dtype=torch.long)}, batch_size=[])
 
@@ -281,6 +287,32 @@ def test_direct_preference_prepare_model_inputs_delegates_to_base_engine():
 
     mock_base_prepare.assert_called_once_with(micro_batch)
     assert set(model_inputs) == {"input_ids"}
+    assert output_args == {"base": True}
+
+
+def test_prepare_model_inputs_applies_registered_adapter_hook():
+    """The omni engine delegates model-native replay inputs to its adapter."""
+    omni_impl = _get_omni_impl_module()
+    engine = object.__new__(omni_impl.OmniFSDPEngine)
+    engine.model_config = _make_mock_model_config(trainer_type="policy_gradient")
+    engine._trainer_type = "policy_gradient"
+    micro_batch = {"extra_fields": [{"conditioning": torch.ones(2, 3)}]}
+
+    class Adapter:
+        @classmethod
+        def prepare_model_inputs(cls, model_inputs, replay_batch, model_config):
+            assert model_config is engine.model_config
+            return {**model_inputs, "conditioning": replay_batch["extra_fields"][0]["conditioning"]}
+
+    engine.model_adapter_cls = Adapter
+    with patch.object(
+        omni_impl.FSDPEngineWithLMHead,
+        "prepare_model_inputs",
+        return_value=({"input_ids": torch.ones(1, 1, dtype=torch.long)}, {"base": True}),
+    ):
+        model_inputs, output_args = engine.prepare_model_inputs(micro_batch)
+
+    assert model_inputs["conditioning"].shape == (2, 3)
     assert output_args == {"base": True}
 
 

--- a/tests/workers/test_omni_fsdp_engine_on_cpu.py
+++ b/tests/workers/test_omni_fsdp_engine_on_cpu.py
@@ -30,6 +30,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 import torch
 from tensordict import TensorDict
+from tensordict.tensorclass import NonTensorData, NonTensorStack
+from verl.utils import tensordict_utils as tu
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -296,13 +298,22 @@ def test_prepare_model_inputs_applies_registered_adapter_hook():
     engine = object.__new__(omni_impl.OmniFSDPEngine)
     engine.model_config = _make_mock_model_config(trainer_type="policy_gradient")
     engine._trainer_type = "policy_gradient"
-    micro_batch = {"extra_fields": [{"conditioning": torch.ones(2, 3)}]}
+    replay_payloads = [
+        {"conditioning": torch.ones(2, 3)},
+        {"conditioning": torch.ones(2, 3) * 2},
+    ]
+    micro_batch = TensorDict(
+        {"test_talker_replay": NonTensorStack.from_list([NonTensorData(payload) for payload in replay_payloads])},
+        batch_size=[2],
+    )
 
     class Adapter:
         @classmethod
         def prepare_model_inputs(cls, model_inputs, replay_batch, model_config):
             assert model_config is engine.model_config
-            return {**model_inputs, "conditioning": replay_batch["extra_fields"][0]["conditioning"]}
+            payloads = tu.get(replay_batch, "test_talker_replay")
+            conditioning = torch.stack([payload["conditioning"] for payload in payloads])
+            return {**model_inputs, "conditioning": conditioning}
 
     engine.model_adapter_cls = Adapter
     with patch.object(
@@ -312,7 +323,8 @@ def test_prepare_model_inputs_applies_registered_adapter_hook():
     ):
         model_inputs, output_args = engine.prepare_model_inputs(micro_batch)
 
-    assert model_inputs["conditioning"].shape == (2, 3)
+    assert model_inputs["conditioning"].shape == (2, 2, 3)
+    assert model_inputs["conditioning"][1].tolist() == [[2.0] * 3] * 2
     assert output_args == {"base": True}
 
 

--- a/verl_omni/__init__.py
+++ b/verl_omni/__init__.py
@@ -20,8 +20,8 @@ with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), "version/vers
     __version__ = f.read().strip()
 
 
-# Import pipelines / rollout / reward loop / engines to auto-register them
-# Apply model patches and auto-register pipelines / rollout / reward loop / engines
+# Apply model patches and auto-register agent loops / pipelines / rollout / reward loop / engines
+import verl_omni.agent_loop  # noqa: E402, F401
 import verl_omni.models  # noqa: E402, F401
 import verl_omni.pipelines  # noqa: E402, F401
 import verl_omni.reward_loop  # noqa: E402, F401

--- a/verl_omni/agent_loop/__init__.py
+++ b/verl_omni/agent_loop/__init__.py
@@ -23,7 +23,7 @@ from .diffusion_agent_loop_tq import (
     DiffusionAgentLoopWorkerTQ,
     create_diffusion_agent_loop_manager,
 )
-from .single_turn_agent_loop import DiffusionSingleTurnAgentLoop
+from .single_turn_agent_loop import DiffusionSingleTurnAgentLoop, OmniSingleTurnAgentLoop
 
 __all__ = [
     "CompositeAgentLoopWorker",
@@ -32,5 +32,6 @@ __all__ = [
     "DiffusionAgentLoopWorkerTQ",
     "create_diffusion_agent_loop_manager",
     "DiffusionSingleTurnAgentLoop",
+    "OmniSingleTurnAgentLoop",
     "MiniMaxH3DiffusionSingleTurnAgentLoop",
 ]

--- a/verl_omni/agent_loop/single_turn_agent_loop.py
+++ b/verl_omni/agent_loop/single_turn_agent_loop.py
@@ -16,14 +16,73 @@ import os
 from typing import Any
 from uuid import uuid4
 
-from verl.experimental.agent_loop.agent_loop import AgentLoopBase, register
+from verl.experimental.agent_loop.agent_loop import AgentLoopBase, AgentLoopOutput, register
+from verl.experimental.agent_loop.single_turn_agent_loop import SingleTurnAgentLoop
 from verl.utils.profiler import simple_timer
 from verl.utils.tokenizer.chat_template import apply_chat_template as _apply_chat_template
 
 from verl_omni.agent_loop.diffusion_agent_loop import DiffusionAgentLoopOutput
+from verl_omni.pipelines.model_base import OmniRolloutPipelineBase
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
+
+
+@register("omni_single_turn_agent")
+class OmniSingleTurnAgentLoop(SingleTurnAgentLoop):
+    """Single-turn loop for autoregressive omni stages with custom policy tokens."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.rollout_adapter = self._resolve_rollout_adapter(self.rollout_config)
+
+    @staticmethod
+    def _resolve_rollout_adapter(rollout_config):
+        try:
+            pipeline_name = rollout_config.engine_kwargs["vllm_omni"]["pipeline_name"]
+        except (KeyError, TypeError) as error:
+            raise ValueError("omni_single_turn_agent requires engine_kwargs.vllm_omni.pipeline_name.") from error
+
+        adapter = OmniRolloutPipelineBase.get_class(pipeline_name)
+        if adapter is None:
+            raise ValueError(
+                "omni_single_turn_agent requires a registered "
+                f"engine_kwargs.vllm_omni.pipeline_name, got {pipeline_name!r}."
+            )
+        return adapter
+
+    async def run(self, sampling_params: dict[str, Any], **kwargs) -> AgentLoopOutput:
+        """Run the standard flow, then map and validate the model's policy sequence."""
+        output = await super().run(sampling_params, **kwargs)
+        output = self.rollout_adapter.postprocess_agent_loop_output(
+            output,
+            tokenizer=self.tokenizer,
+            response_length=self.response_length,
+        )
+        if not isinstance(output, AgentLoopOutput):
+            raise TypeError(
+                "OmniRolloutPipelineBase.postprocess_agent_loop_output must return an AgentLoopOutput, "
+                f"got {type(output).__name__}."
+            )
+
+        policy_length = len(output.response_ids)
+        if policy_length > self.response_length:
+            raise ValueError(
+                f"Omni policy output has {policy_length} tokens, exceeding response_length={self.response_length}."
+            )
+        if len(output.response_mask) != policy_length:
+            raise ValueError(
+                "Omni policy response_mask must align one-to-one with response_ids, "
+                f"got {len(output.response_mask)} and {policy_length}."
+            )
+        if output.response_logprobs is not None and len(output.response_logprobs) != policy_length:
+            raise ValueError(
+                "Omni policy response_logprobs must align one-to-one with response_ids, "
+                f"got {len(output.response_logprobs)} and {policy_length}."
+            )
+        if not isinstance(output.extra_fields, dict):
+            raise TypeError(f"Omni policy extra_fields must be a dict, got {type(output.extra_fields).__name__}.")
+        return output
 
 
 @register("diffusion_single_turn_agent")

--- a/verl_omni/agent_loop/single_turn_agent_loop.py
+++ b/verl_omni/agent_loop/single_turn_agent_loop.py
@@ -30,7 +30,7 @@ logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
 @register("omni_single_turn_agent")
 class OmniSingleTurnAgentLoop(SingleTurnAgentLoop):
-    """Single-turn loop for autoregressive omni stages with custom policy tokens."""
+    """Single-turn loop for an omni model's autoregressive Talker policy."""
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/verl_omni/pipelines/model_base.py
+++ b/verl_omni/pipelines/model_base.py
@@ -646,6 +646,22 @@ class OmniModelBase(ABC):
 
         return module
 
+    @classmethod
+    def prepare_model_inputs(cls, model_inputs: dict[str, Any], micro_batch, model_config) -> dict[str, Any]:
+        """Add model-native rollout data to an actor replay forward call.
+
+        ``model_inputs`` contains the standard language-model inputs prepared
+        by verl. Talker and other multi-stage policies may also need trajectory
+        or conditioning data retained in the rollout ``extra_fields``. A model
+        adapter can validate those fields in ``micro_batch`` and return the
+        exact inputs required to replay the sampled policy sequence.
+
+        The default keeps the standard autoregressive path unchanged. An
+        adapter that overrides this hook must fail closed when required fields
+        or shapes are missing instead of reconstructing a different trajectory.
+        """
+        return model_inputs
+
 
 class OmniRolloutPipelineBase:
     """Registry for omni model vLLM-Omni pipeline topologies.
@@ -685,6 +701,20 @@ class OmniRolloutPipelineBase:
         topology or external runner configuration.
         """
         return cls._registry.get(model_type)
+
+    @classmethod
+    def postprocess_agent_loop_output(cls, output, *, tokenizer, response_length: int):
+        """Map model-native rollout data to the policy sequence used by RL.
+
+        Adapters for non-text autoregressive stages should put the sampled
+        policy tokens in ``response_ids`` and align ``response_mask`` and
+        optional ``response_logprobs`` one-to-one. Architecture-specific
+        trajectory and conditioning data stays in ``extra_fields`` for
+        :meth:`OmniModelBase.prepare_model_inputs`.
+
+        The default preserves the standard text-token output unchanged.
+        """
+        return output
 
     @classmethod
     @abstractmethod

--- a/verl_omni/pipelines/model_base.py
+++ b/verl_omni/pipelines/model_base.py
@@ -652,9 +652,11 @@ class OmniModelBase(ABC):
 
         ``model_inputs`` contains the standard language-model inputs prepared
         by verl. Talker and other multi-stage policies may also need trajectory
-        or conditioning data retained in the rollout ``extra_fields``. A model
-        adapter can validate those fields in ``micro_batch`` and return the
-        exact inputs required to replay the sampled policy sequence.
+        or conditioning data retained under a model-defined key in the per-sample
+        rollout ``extra_fields``. ``AgentLoopWorker`` batches each such key into
+        the top level of ``micro_batch``. A model adapter can validate its own
+        namespaced payload and return the exact inputs required to replay the
+        sampled policy sequence.
 
         The default keeps the standard autoregressive path unchanged. An
         adapter that overrides this hook must fail closed when required fields
@@ -709,7 +711,9 @@ class OmniRolloutPipelineBase:
         Adapters for non-text autoregressive stages should put the sampled
         policy tokens in ``response_ids`` and align ``response_mask`` and
         optional ``response_logprobs`` one-to-one. Architecture-specific
-        trajectory and conditioning data stays in ``extra_fields`` for
+        trajectory and conditioning data stays under a model-defined,
+        namespaced key in ``extra_fields``. ``AgentLoopWorker`` later exposes
+        that key at the top level of the actor micro-batch for
         :meth:`OmniModelBase.prepare_model_inputs`.
 
         The default preserves the standard text-token output unchanged.

--- a/verl_omni/pipelines/model_base.py
+++ b/verl_omni/pipelines/model_base.py
@@ -651,12 +651,12 @@ class OmniModelBase(ABC):
         """Add model-native rollout data to an actor replay forward call.
 
         ``model_inputs`` contains the standard language-model inputs prepared
-        by verl. Talker and other multi-stage policies may also need trajectory
-        or conditioning data retained under a model-defined key in the per-sample
-        rollout ``extra_fields``. ``AgentLoopWorker`` batches each such key into
-        the top level of ``micro_batch``. A model adapter can validate its own
-        namespaced payload and return the exact inputs required to replay the
-        sampled policy sequence.
+        by verl. A trainable Talker stage may also need trajectory or conditioning
+        data retained under a model-defined key in the per-sample rollout
+        ``extra_fields``. ``AgentLoopWorker`` batches each such key into the top
+        level of ``micro_batch``. A model adapter can validate its own namespaced
+        payload and return the exact inputs required to replay the sampled policy
+        sequence.
 
         The default keeps the standard autoregressive path unchanged. An
         adapter that overrides this hook must fail closed when required fields
@@ -708,12 +708,12 @@ class OmniRolloutPipelineBase:
     def postprocess_agent_loop_output(cls, output, *, tokenizer, response_length: int):
         """Map model-native rollout data to the policy sequence used by RL.
 
-        Adapters for non-text autoregressive stages should put the sampled
-        policy tokens in ``response_ids`` and align ``response_mask`` and
-        optional ``response_logprobs`` one-to-one. Architecture-specific
-        trajectory and conditioning data stays under a model-defined,
-        namespaced key in ``extra_fields``. ``AgentLoopWorker`` later exposes
-        that key at the top level of the actor micro-batch for
+        Adapters for an omni model's autoregressive Talker stage should put the
+        sampled policy tokens in ``response_ids`` and align ``response_mask``
+        and optional ``response_logprobs`` one-to-one. Architecture-specific
+        trajectory and conditioning data stays under a model-defined, namespaced
+        key in ``extra_fields``. ``AgentLoopWorker`` later exposes that key at the
+        top level of the actor micro-batch for
         :meth:`OmniModelBase.prepare_model_inputs`.
 
         The default preserves the standard text-token output unchanged.

--- a/verl_omni/workers/engine/fsdp/omni_impl.py
+++ b/verl_omni/workers/engine/fsdp/omni_impl.py
@@ -43,6 +43,18 @@ logger = logging.getLogger(__name__)
 class OmniFSDPEngine(FSDPEngineWithLMHead):
     """FSDP engine for omni models"""
 
+    def prepare_model_inputs(self, micro_batch):
+        """Prepare standard LM inputs, then add model-native replay fields."""
+        model_inputs, output_args = super().prepare_model_inputs(micro_batch)
+        if not hasattr(self, "model_adapter_cls"):
+            raise RuntimeError("Omni model inputs cannot be prepared before the model adapter is initialized.")
+        model_inputs = self.model_adapter_cls.prepare_model_inputs(model_inputs, micro_batch, self.model_config)
+        if not isinstance(model_inputs, dict):
+            raise TypeError(
+                f"OmniModelBase.prepare_model_inputs must return a dict, got {type(model_inputs).__name__}."
+            )
+        return model_inputs, output_args
+
     def get_per_tensor_param(self, layered_summon=False, base_sync_done=False, **kwargs):
         log_gpu_memory_usage("Before load_fsdp_model_to_gpu", logger=logger)
 
@@ -192,6 +204,7 @@ class OmniFSDPEngine(FSDPEngineWithLMHead):
                 self.model_config.model_stage,
                 self.model_config.get("external_lib"),
             )
+            self.model_adapter_cls = adapter_cls
             module = adapter_cls.configure_model(module, self.model_config)
 
             module.to(torch_dtype)


### PR DESCRIPTION
### What does this PR do?

This PR implements the model-neutral rollout-to-replay contract proposed in RFC #503 and follows the interface-first split requested during review of #428. Rollout adapters map model-native trajectories into aligned `AgentLoopOutput` policy fields, while training adapters turn model-owned replay payloads into the exact actor inputs required to replay the sampled policy trajectory.

The shared API deliberately does not encode Qwen3-TTS assumptions such as 16 codebooks, fixed speaker/text slots, codec-0 offsets, or an external speaker embedding. Each concrete adapter owns a model-defined, namespaced replay key and its nested schema. Qwen3-TTS remains the follow-up concrete implementation in #428; Qwen3-Omni and future Talkers can retain different trajectory and conditioning payloads behind the same lifecycle hooks.

The transport follows verl's existing batching behavior: a per-sample payload stored as `AgentLoopOutput.extra_fields[model_defined_key]` is collected by `AgentLoopWorker` into the top-level non-tensor batch and reaches the actor as `micro_batch[model_defined_key]`.

### API and usage example

A rollout adapter for an omni model's autoregressive Talker stage maps its engine-native output into the policy sequence while retaining model-owned replay data under its own namespaced key:

```python
class MyRolloutAdapter(OmniRolloutPipelineBase):
    @classmethod
    def postprocess_agent_loop_output(cls, output, *, tokenizer, response_length):
        replay = output.extra_fields["my_talker_replay"]
        output.response_ids = replay["policy_tokens"][:response_length]
        output.response_mask = [1] * len(output.response_ids)
        return output
```

After `AgentLoopWorker` batches the samples, the training adapter reads that model-defined key from the top level of `micro_batch`, validates it, and adds the exact replay inputs after standard language-model input preparation:

```python
from verl.utils import tensordict_utils as tu


class MyTrainingAdapter(OmniModelBase):
    @classmethod
    def prepare_model_inputs(cls, model_inputs, micro_batch, model_config):
        replay_payloads = tu.get(micro_batch, "my_talker_replay")
        if replay_payloads is None:
            raise ValueError("Missing my_talker_replay payload required for exact actor replay.")
        trajectories = [payload["trajectory"] for payload in replay_payloads]
        return {**model_inputs, "trajectories": trajectories}
```

Select the Talker loop and the registered rollout adapter through configuration:

```text
actor_rollout_ref.rollout.agent.default_agent_loop=omni_single_turn_agent
+actor_rollout_ref.rollout.engine_kwargs.vllm_omni.pipeline_name=my_talker
```

### Design and code changes

- Add `OmniRolloutPipelineBase.postprocess_agent_loop_output` as an optional boundary for mapping model-native rollout output to aligned policy IDs, masks, and optional rollout log-probabilities while retaining architecture-specific replay data under a model-defined key in `extra_fields`.
- Add `OmniModelBase.prepare_model_inputs` and call it from `OmniFSDPEngine` after standard language-model inputs have been prepared.
- Register `omni_single_turn_agent` for an omni model's autoregressive Talker stage, resolve its rollout adapter from the required `engine_kwargs.vllm_omni.pipeline_name`, and fail closed on unknown adapters, malformed output types, excessive policy length, or token-alignment mismatches.
- Cover two synthetic Talker contracts with different trajectory and conditioning schemas, and verify the real `AgentLoopWorker -> DataProto -> TensorDict` transport exposes the namespaced replay key at the top level of the actor micro-batch.
- Document how an omni model's autoregressive Talker stage opts into the hooks without imposing a shared key name, codebook count, conditioning source, or nested payload schema.
- Leave the default hook implementations as no-ops so existing text-token policy paths remain unchanged.

### Tests

all passed.
