### PR TITLE
[deps] fix: floor flashinfer-python to 0.6.16.post4 to fix TP>=2 import crash

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,9 @@ gpu = [
     "vllm==0.27.0",
     "kernels==0.16.0",
     "liger-kernel",
+    # vllm==0.27.0 pulls in flashinfer-python transitively with no floor; 0.6.16.post3
+    # crashes at import time on any TP>=2 run (see #505). Pin the floor explicitly.
+    "flashinfer-python>=0.6.16.post4",
 ]
 # Training stack (install in step 2).
 # Git commit must match .github/verl_pin.txt (reports as 0.10.0.dev at fefb080).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,8 +63,6 @@ gpu = [
     "vllm==0.27.0",
     "kernels==0.16.0",
     "liger-kernel",
-    # vllm==0.27.0 pulls in flashinfer-python transitively with no floor; 0.6.16.post3
-    # crashes at import time on any TP>=2 run (see #505). Pin the floor explicitly.
     "flashinfer-python>=0.6.16.post4",
 ]
 # Training stack (install in step 2).


### PR DESCRIPTION
## What does this PR do?

Fixes #505: pins `flashinfer-python>=0.6.16.post4` in the `gpu` extra so
`vllm==0.27.0`'s transitive `flashinfer-python` dependency doesn't resolve to
the broken `0.6.16.post3`, which crashes any `TP>=2` GPU run at import time
before training or rollout code executes.

## Root cause and evidence

Found this while independently validating GPU e2e evidence for #502 (a
separate, in-progress PR — unrelated code, this crash happens well upstream
of any reward/training path). Full root-cause discussion is in #505; summary:

- `flashinfer/comm/fd_exchange.py` (in `0.6.16.post3`) evaluates
  `array.array[int]` as a live type hint in a function signature.
  `array.array` never opted into PEP 585 generic subscripting, so this
  raises `TypeError: type 'array.array' is not subscriptable` at import
  time on any CPython that evaluates annotations eagerly.
- This only triggers when vLLM initializes its tensor-parallel CUDA
  communicator and loads flashinfer's custom NCCL all-reduce backend — i.e.
  only with `TP>=2`, which is presumably why single-GPU CI smokes haven't
  hit it.
- Confirmed the fix upstream: `flashinfer-python==0.6.16.post4` adds
  `from __future__ import annotations` to that exact file.
- Confirmed `VLLM_USE_FLASHINFER_ALLREDUCE=0` does **not** work around this
  — `flashinfer_all_reduce.py` imports `flashinfer.comm` unconditionally at
  module load, before any runtime flag is checked. Ruled this out so nobody
  else spends time on that path.
- Not a CUDA-toolkit-version issue: also ruled out the base-image CUDA
  version as a contributing factor before finding the real cause.

## Reproduction / before-after

Before (this repo's own GPU-smoke dependency pins, 2xA10G via Modal,
`.github/actions/gpu-smoke-prepare/action.yml` + `.github/vllm_omni_pin.txt`):

```bash
NUM_GPUS=2 TOTAL_TRAIN_STEPS=2 bash tests/special_e2e/run_dapo_qwen3_omni_thinker_lora_v1_smoke.sh
```

fails in engine-core worker startup; the driver process only surfaces
`RuntimeError: Engine core initialization failed`, the real
`TypeError: type 'array.array' is not subscriptable` traceback is only
visible in per-worker Ray logs under `/tmp/ray/session_*/logs/`.

After pinning `flashinfer-python>=0.6.16.post4` (same environment, same
command): passes cleanly (`RETURNCODE 0`, both training steps complete). See
#502 for the full log this fix was validated against.

## Duplicate-work check

- `gh issue list --repo verl-project/verl-omni --search "flashinfer"` /
  `gh pr list --repo verl-project/verl-omni --search "flashinfer"` — no
  existing issue or PR before #505/this one.

## Test plan

- `pyproject.toml` parses (`tomllib.load`).
- Re-ran the exact repro command above on Modal 2xA10G with this pin applied
  — passes. (Full log referenced in #502's PR description.)
- Did not modify `.github/actions/gpu-smoke-prepare/action.yml` — its
  `uv pip install ".[gpu,dev,audio]"` step picks up this floor automatically
  from `pyproject.toml`, no separate override needed.

## AI usage disclosure

Claude Code found, root-caused, and fixed this while validating GPU e2e
evidence for a separate PR (#502). A human submitter (onepunchmonk) has
reviewed the change and the upstream flashinfer-python source diff cited
above.