### PR TITLE
[doc] chore: document diffusion media output declaration (DiffusionIOSpec)

### DIFF
--- a/docs/contributing/integrating_a_diffusion_model.md
+++ b/docs/contributing/integrating_a_diffusion_model.md
@@ -436,8 +436,54 @@ needs normalized model input must convert locally with
 restore precision discarded at the rollout boundary. Do not multiply uint8 pixels
 by 255 again before PIL, JPEG, or HTTP serialization.
 
+(diffusion-io-spec)=
+### 4.2 Declare the media output contract (`diffusion_io_spec`)
+
+Set a `diffusion_io_spec` class attribute on the registered pipeline so the
+shared `DiffusionStrategy` knows what media your `forward` emits. The strategy
+reads it (via `VllmOmniPipelineBase.get_class(architecture, algorithm)`) when it
+converts the raw pipeline output into the rollout response, so model-specific
+conventions — which tuple position carries audio, what audio sample rate to
+attach — live in the adapter instead of being hardcoded in the shared strategy.
+
+```python
+from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
+
+@VllmOmniPipelineBase.register("MyModelPipeline", algorithm="flow_grpo")
+class MyModelPipelineWithLogProb(MyModelPipeline):
+    # Image-only pipeline:
+    diffusion_io_spec = DiffusionIOSpec(primary=MediaSpec("image"))
+```
+
+- **`primary`** — the main media stream (`MediaSpec("image")` or
+  `MediaSpec("video")`), carried in `responses`.
+- **`auxiliary`** — additional streams in tuple order: `auxiliary[i]` maps to
+  output tuple position `i + 1` (position `0` is the primary). A `forward` that
+  returns `(video, audio)` declares one auxiliary audio stream:
+
+```python
+    diffusion_io_spec = DiffusionIOSpec(
+        primary=MediaSpec("video"),
+        auxiliary=(MediaSpec("audio", sample_rate=32000),),
+    )
+```
+
+- **`MediaSpec.sample_rate`** is the *default* audio sample rate in Hz. If your
+  `forward` attaches a runtime rate through the `rl` rollout metadata, that value
+  takes precedence and the strategy only falls back to this default. Declare the
+  rate your model actually decodes (MiniMax H3 → `32000`, LTX-2 → `24000`).
+- `MediaSpec.fps` is an optional video default; `Modality` is
+  `image | video | audio`.
+- Subclasses inherit the attribute, so a pipeline that subclasses another adapter
+  (e.g. `qwen_image_dual_grpo` extends `qwen_image_flow_grpo`) reuses its
+  `diffusion_io_spec` unless it overrides it.
+
+Every registered diffusion adapter declares one; see
+[`rollout_media.py`](../../verl_omni/pipelines/rollout_media.py) and the
+`test_diffusion_io_spec_on_cpu.py` completeness test.
+
 (request-level-batching)=
-### 4.2 Request-level batching (optional)
+### 4.3 Request-level batching (optional)
 
 To let vLLM-Omni pack multiple requests into one transformer forward
 (`max_num_seqs > 1`), extend the rollout adapter as follows. Reference
@@ -620,6 +666,10 @@ Before opening the PR, confirm every box:
       `model_index.json::_class_name`; the `algorithm=` keyword matches
       the algorithm you are integrating against (e.g. `"flow_grpo"` for
       FlowGRPO).
+- [ ] The registered pipeline declares a `diffusion_io_spec`
+      ([`DiffusionIOSpec`](../../verl_omni/pipelines/rollout_media.py)) whose
+      `primary` modality matches what `forward` emits, plus an `auxiliary`
+      audio stream (with its `sample_rate`) for joint audio/video models.
 - [ ] Scheduler returns latents in fp32 (no `model_output.dtype` cast in `step()`),
       `diffuse()` casts to model dtype before transformer forward and casts
       noise_pred to float32 before `scheduler.step()`

--- a/docs/contributing/integrating_a_stepwise_continuous_batching_model.md
+++ b/docs/contributing/integrating_a_stepwise_continuous_batching_model.md
@@ -441,6 +441,11 @@ The step-execution output must match the full-forward output contract exactly.
 Downstream training code should not need to know which execution mode produced
 the trajectory.
 
+> **Media output contract.** If your `forward` emits joint media such as
+> `(video, audio)`, declare a `diffusion_io_spec` on the pipeline class so the
+> rollout strategy resolves the auxiliary audio stream and its sample rate from
+> the adapter instead of a hardcoded default. See {ref}`diffusion-io-spec`.
+
 ### DiffusionNFT output
 
 DiffusionNFT trains from the final clean latent and the inference timestep


### PR DESCRIPTION
## Summary

Documentation follow-up to **#478** (`[2/N] declare diffusion media outputs`, merged). #478 added the `DiffusionIOSpec` / `MediaSpec` output-declaration contract (each diffusion adapter declares a `diffusion_io_spec` class attribute; the shared `DiffusionStrategy` reads it instead of hardcoding the joint-audio tuple position and a 32 kHz default) but shipped without a contributor-facing doc. This PR documents it.

### Changes (docs only)
- **`docs/contributing/integrating_a_diffusion_model.md`**
  - New subsection **4.2 "Declare the media output contract (`diffusion_io_spec`)"** under *Step 4 — Write `vllm_omni_rollout_adapter.py`*: what `primary` / `auxiliary` mean, the `auxiliary[i]` ↔ output-tuple-position `i+1` mapping, `MediaSpec.sample_rate` as a default overridable by runtime `rl` metadata (MiniMax H3 → 32000, LTX-2 → 24000), and subclass inheritance.
  - New **Final Checklist** item: declare `diffusion_io_spec`.
  - The request-level-batching subsection is renumbered 4.2 → 4.3; its `{ref}` label (`request-level-batching`) is unchanged, so existing links keep working.
- **`docs/contributing/integrating_a_stepwise_continuous_batching_model.md`**
  - Cross-references the new section for joint audio/video models (e.g. MiniMax H3), which declare an auxiliary audio stream + sample rate, via a `{ref}`-style link.

No code changes. Documented strictly against what is on `main` (MediaSpec = `modality` / `sample_rate` / `fps`; `layout` is **not** documented since it is not on main).

## Not a duplicate
- `gh pr list --search "diffusion_io_spec in:body,title"` / `"document diffusion media"` → no other doc PR; only unrelated feature PRs.

## Tests
Docs-only. Validated locally:
- `check_pr_title.py` accepts `[doc] chore: ...`.
- The new `(diffusion-io-spec)=` label + `{ref}`diffusion-io-spec`` follow the repo's existing MyST cross-reference convention (`request-level-batching`).
- `git diff --check` clean.
- The Sphinx build (`doc.yml` → `make html`) will confirm the cross-reference resolves in CI.

## Disclosure
AI assistance (Pi coding agent / OpenAI Codex) was used for this change. A human submitter has reviewed every changed line.
