### PR TITLE
Add V1 sync recipe for Qwen-Image + MixGRPO

### DIFF
--- a/docs/algo/mixgrpo.md
+++ b/docs/algo/mixgrpo.md
@@ -151,6 +151,14 @@ actor_rollout_ref.rollout.algo.sde_type=sde
 The first and third lines pin the cascaded estimator/loss back to
 `flow_grpo`; see [Caveat: cascade vs. validators](#caveat-cascade-vs-validators).
 
+A V1 trainer (TransferQueue + ReplayBuffer, `sync` mode) counterpart is at
+`examples/mixgrpo_trainer/qwen_image/run_qwen_image_ocr_lora_mixgrpo_v1.sh` --
+see [Diffusion V1 training](../start/diffusion_v1.md). The sliding-window
+scheduler depends only on `global_steps` being present on the rollout
+sampling params, which the V1 `DiffusionAgentLoopWorkerTQ` forwards the same
+way the legacy rollout strategy does, so `random` / `progressive` scheduling
+is unchanged under `sync` mode.
+
 
 ## Tuning guide
 

--- a/examples/mixgrpo_trainer/README.md
+++ b/examples/mixgrpo_trainer/README.md
@@ -61,6 +61,22 @@ The NPU script requires the CANN software stack. Before running, set the `ASCEND
 bash examples/mixgrpo_trainer/qwen_image/run_qwen_image_ocr_lora_mixgrpo_npu.sh
 ```
 
+**GPU, V1 trainer (sync mode, 4 GPUs):**
+
+A V1 counterpart is also provided, using `verl_omni.trainer.main_diffusion_v1`
+(TransferQueue + ReplayBuffer, `trainer.v1.trainer_mode=sync`). The MixGRPO
+sliding-window scheduler reads `global_steps` off the rollout sampling
+params; the V1 agent loop worker forwards it the same way the legacy V0
+rollout strategy does, so `sample_strategy=random` / `progressive` behave
+identically to the V0 recipe above. See
+{doc}`Diffusion V1 training <../../docs/start/diffusion_v1>` for setup
+(TransferQueue install, dataset prerequisites) shared with the FlowGRPO V1
+recipes.
+
+```bash
+bash examples/mixgrpo_trainer/qwen_image/run_qwen_image_ocr_lora_mixgrpo_v1.sh
+```
+
 ### MixGRPO Tuning
 
 The default script uses the recommended "reference recipe" (10-step trajectory, 2-step SDE window, random strategy). To tune MixGRPO (e.g. for longer trajectories), adjust these variables in the script:

--- a/examples/mixgrpo_trainer/qwen_image/run_qwen_image_ocr_lora_mixgrpo_v1.sh
+++ b/examples/mixgrpo_trainer/qwen_image/run_qwen_image_ocr_lora_mixgrpo_v1.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Qwen-Image LoRA RL with MixGRPO sliding-window SDE training (V1 trainer:
+# TransferQueue + ReplayBuffer + sync mode).
+#
+# This is the v1 counterpart of run_qwen_image_ocr_lora_mixgrpo.sh. It uses the
+# new `verl_omni.trainer.main_diffusion_v1` entrypoint, which selects
+# `PolicyGradientDiffusionTrainerV1Sync` via `trainer.v1.trainer_mode=sync` and
+# wires verl's `AgentLoopManagerTQ` with `DiffusionAgentLoopWorkerTQ`.
+# TransferQueue is force-enabled inside the runner, so it does not need to be
+# set on the CLI.
+#
+# MixGRPO's sliding-window scheduler reads `global_steps` off
+# `sampling_params.extra_args` (see
+# verl_omni/pipelines/qwen_image_mix_grpo/vllm_omni_rollout_adapter.py). The v1
+# `DiffusionAgentLoopWorkerTQ` forwards `global_steps` from the training batch
+# into `sampling_params` the same way the v0 `vllm_omni_diffusion_strategy`
+# does, so the `random`/`progressive` window scheduler carries over unchanged
+# under `sync` mode.
+#
+# Reference (legacy v0 script):
+# verl-omni/examples/mixgrpo_trainer/qwen_image/run_qwen_image_ocr_lora_mixgrpo.sh
+set -x
+
+# Set WORKSPACE to any writable directory; defaults to $HOME
+WORKSPACE=${WORKSPACE:-$HOME}
+
+ocr_train_path=$WORKSPACE/data/ocr/qwen_image/train.parquet
+ocr_test_path=$WORKSPACE/data/ocr/qwen_image/test.parquet
+
+model_name=Qwen/Qwen-Image
+reward_model_name=Qwen/Qwen3-VL-8B-Instruct
+reward_function_path=verl_omni/utils/reward_score/genrm_ocr.py
+
+NUM_GPUS_ACTOR_ROLLOUT=3
+NUM_GPUS_REWARD=1
+ROLLOUT_TP=1
+REWARD_TP=1
+
+ENGINE=vllm_omni
+REWARD_ENGINE=vllm
+
+python3 -m verl_omni.trainer.main_diffusion_v1 \
+    algorithm.adv_estimator=flow_grpo \
+    data.train_files=$ocr_train_path \
+    data.val_files=$ocr_test_path \
+    data.train_batch_size=32 \
+    data.max_prompt_length=256 \
+    actor_rollout_ref.model.algorithm=mix_grpo \
+    actor_rollout_ref.model.path=$model_name \
+    actor_rollout_ref.model.lora_rank=64 \
+    actor_rollout_ref.model.lora_alpha=128 \
+    actor_rollout_ref.model.target_modules="['to_q','to_k','to_v','to_out.0','add_q_proj','add_k_proj','add_v_proj','to_add_out','img_mlp.net.0.proj','img_mlp.net.2','txt_mlp.net.0.proj','txt_mlp.net.2']" \
+    actor_rollout_ref.actor.optim.lr=3e-4 \
+    actor_rollout_ref.actor.optim.weight_decay=0.0001 \
+    actor_rollout_ref.actor.ppo_mini_batch_size=16 \
+    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=16 \
+    actor_rollout_ref.actor.fsdp_config.param_offload=True \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=True \
+    actor_rollout_ref.actor.fsdp_config.model_dtype=bfloat16 \
+    actor_rollout_ref.actor.diffusion_loss.loss_mode=flow_grpo \
+    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=32 \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=$ROLLOUT_TP \
+    actor_rollout_ref.rollout.name=$ENGINE \
+    actor_rollout_ref.rollout.n=16 \
+    actor_rollout_ref.rollout.agent.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT / ROLLOUT_TP)) \
+    actor_rollout_ref.rollout.load_format=safetensors \
+    actor_rollout_ref.rollout.layered_summon=True \
+    actor_rollout_ref.rollout.pipeline.true_cfg_scale=4.0 \
+    actor_rollout_ref.rollout.pipeline.max_sequence_length=256 \
+    actor_rollout_ref.rollout.algo.sample_strategy=random \
+    actor_rollout_ref.rollout.algo.sde_window_seed=42 \
+    actor_rollout_ref.rollout.algo.sde_window_size=2 \
+    actor_rollout_ref.rollout.algo.sde_window_range="[0,5]" \
+    actor_rollout_ref.rollout.algo.noise_level=1.2 \
+    actor_rollout_ref.rollout.algo.sde_type="sde" \
+    actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=50 \
+    actor_rollout_ref.rollout.val_kwargs.algo.noise_level=0.0 \
+    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=32 \
+    reward.num_workers=$((NUM_GPUS_REWARD / REWARD_TP)) \
+    reward.reward_model.enable=True \
+    reward.reward_model.model_path=$reward_model_name \
+    reward.reward_model.rollout.name=$REWARD_ENGINE \
+    reward.reward_model.enable_resource_pool=True \
+    reward.reward_model.nnodes=1 \
+    reward.reward_model.n_gpus_per_node=$NUM_GPUS_REWARD \
+    reward.reward_model.rollout.tensor_model_parallel_size=$REWARD_TP \
+    reward.custom_reward_function.path=$reward_function_path \
+    reward.custom_reward_function.name=compute_score_ocr \
+    trainer.logger='["console", "wandb"]' \
+    trainer.project_name=mix_grpo \
+    trainer.experiment_name=qwen_image_ocr_lora_mixgrpo_v1 \
+    trainer.log_val_generations=8 \
+    trainer.val_before_train=False \
+    trainer.n_gpus_per_node=$NUM_GPUS_ACTOR_ROLLOUT \
+    trainer.nnodes=1 \
+    trainer.save_freq=30 \
+    trainer.test_freq=30 \
+    trainer.total_epochs=15 \
+    trainer.total_training_steps=150 \
+    trainer.use_v1=true \
+    trainer.v1.trainer_mode=sync "$@"


### PR DESCRIPTION
## Summary

Adds a V1 trainer (TransferQueue + ReplayBuffer, `sync` mode) recipe for Qwen-Image + MixGRPO, mirroring the existing SD3.5 FlowGRPO V1 recipe (`run_sd35_medium_ocr_lora_v1.sh`).

- `examples/mixgrpo_trainer/qwen_image/run_qwen_image_ocr_lora_mixgrpo_v1.sh` — new V1 sync recipe, using `verl_omni.trainer.main_diffusion_v1` with `trainer.use_v1=true trainer.v1.trainer_mode=sync`, keeping the same model, LoRA, reward model, and MixGRPO window settings as the V0 recipe.
- `docs/algo/mixgrpo.md`, `examples/mixgrpo_trainer/README.md` — document the V1 script and link to the shared `docs/start/diffusion_v1.md` guide.

MixGRPO's sliding-window scheduler (`QwenImageMixGRPOPipelineWithLogProb._maybe_make_progressive_window`) depends on `global_steps` being present on the rollout `sampling_params.extra_args`. Confirmed this carries over unchanged under V1: `DiffusionAgentLoopWorkerTQ.generate_sequences` forwards `global_steps` from the training batch into `sampling_params` the same way the legacy `vllm_omni_diffusion_strategy` does for V0, and the pipeline adapter dispatch is registered globally by `algorithm=mix_grpo`, independent of trainer version.

## Test plan

- [x] `bash -n` on the new script
- [ ] GPU smoke run of both V0 and V1 recipes with reduced `total_training_steps`, comparing reward/loss curves (in progress)
- [ ] Confirm `random` and `progressive` `sample_strategy` both behave identically to V0 under `sync` mode

Ref #389