### PR TITLE
[trainer, tests] fix: union colocated reward output into the v1 diffusion trainer batch

### DIFF
--- a/tests/trainer/diffusion/test_v1_colocate_reward_on_cpu.py
+++ b/tests/trainer/diffusion/test_v1_colocate_reward_on_cpu.py
@@ -1,0 +1,68 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU test for the colocated reward-model step of the v1 diffusion trainer."""
+
+import os
+from types import SimpleNamespace
+
+import pytest
+import torch
+from hydra import compose, initialize_config_dir
+from verl import DataProto
+from verl.utils import tensordict_utils as tu
+
+import verl_omni
+
+CONFIG_DIR = os.path.join(os.path.dirname(os.path.abspath(verl_omni.__file__)), "trainer", "config")
+
+
+def compose_cfg(overrides):
+    with initialize_config_dir(config_dir=CONFIG_DIR, version_base=None):
+        return compose(config_name="diffusion_trainer", overrides=overrides)
+
+
+class _Stop(Exception):
+    pass
+
+
+def test_colocate_reward_keeps_trajectory_fields(monkeypatch):
+    from verl_omni.trainer.diffusion.v1.trainer_sync import PolicyGradientDiffusionTrainerV1Sync
+
+    trainer = PolicyGradientDiffusionTrainerV1Sync(compose_cfg(["reward.reward_model.enable=true"]))
+    assert trainer.use_rm
+
+    data = DataProto.from_tensordict(tu.get_tensordict({"all_timesteps": torch.zeros(2, 4)}))
+    reward = DataProto.from_tensordict(tu.get_tensordict({"rm_scores": torch.ones(2, 1)}))
+    trainer.tokenizer = SimpleNamespace(pad_token_id=0)
+    trainer.reward_loop_manager = SimpleNamespace(reward_loop_worker_handles=None)
+    trainer.checkpoint_manager = SimpleNamespace(sleep_replicas=lambda: None, update_weights=lambda step: None)
+    trainer.global_steps = 1
+    monkeypatch.setattr(
+        "verl_omni.trainer.diffusion.v1.trainer_base.diffusion_tq_batch_to_dataproto",
+        lambda meta, pad_token_id: data,
+    )
+    monkeypatch.setattr(trainer, "_compute_reward_colocate", lambda d: reward)
+    captured = {}
+
+    def stop_at_balance(d, metrics):
+        captured["data"] = d
+        raise _Stop
+
+    monkeypatch.setattr(trainer, "_balance_batch", stop_at_balance)
+
+    with pytest.raises(_Stop):
+        trainer._train_sampled_batch({}, {}, object())
+
+    assert "all_timesteps" in captured["data"].batch
+    assert "rm_scores" in captured["data"].batch

--- a/verl_omni/trainer/diffusion/v1/trainer_base.py
+++ b/verl_omni/trainer/diffusion/v1/trainer_base.py
@@ -324,7 +324,7 @@ class PolicyGradientDiffusionTrainerV1(ABC):
         if self.reward_loop_manager.reward_loop_worker_handles is None and self.use_rm:
             with marked_timer("reward", timing_raw, color="yellow"):
                 self.checkpoint_manager.sleep_replicas()
-                data = self._compute_reward_colocate(data)
+                data = data.union(self._compute_reward_colocate(data))
                 self.checkpoint_manager.update_weights(self.global_steps)
 
         data = self._balance_batch(data, metrics=metrics)
@@ -1073,7 +1073,7 @@ class PolicyGradientDiffusionTrainerV1(ABC):
 
             if self.use_rm and self.reward_loop_manager.reward_loop_worker_handles is None:
                 self.checkpoint_manager.sleep_replicas()
-                data = self._compute_reward_colocate(data)
+                data = data.union(self._compute_reward_colocate(data))
                 self.checkpoint_manager.update_weights(self.global_steps)
 
             input_ids = data.batch["prompts"]


### PR DESCRIPTION
### What does this PR do?

The v1 diffusion trainer assigns the reward-only DataProto returned by `_compute_reward_colocate` over the whole batch, in both the train step and `_validate`. The trajectory tensors are dropped and the next stage crashes (`KeyError: 'all_timesteps'` in old_log_prob; `prompts` in validate). The v0 trainer unions the reward output into the batch; this PR does the same in v1. The path was never exercised before: every v1 recipe uses a standalone reward pool, so the colocated branch (`reward_model.enable=true` without `enable_resource_pool`) first ran during OPD scheduler validation on #495's branch.

### Why this is not duplicating an existing PR

No open PR touches the v1 colocated reward path; the bug dates to the v1 port (#296).

### Tests

- CPU (RED first on main): `pytest tests/trainer/diffusion/test_v1_colocate_reward_on_cpu.py` — a stubbed reward step asserts the batch after the reward stage keeps both the trajectory fields and `rm_scores`; fails on main, passes with the fix. v1 suites regression: 93 passed on this head (independently re-verified from a clean archive; main + this test = 1 failed as expected).
- E2E (5× RTX PRO 6000): 12-step SD3.5-M dual-teacher separate_async run with colocated GenRM — crashed at step 1 on main's code path, 12/12 PASS with the fix (blocking reward stage ~10.2s/step, training healthy).

AI assistance (Claude Code) was used for this change; the submitting human has reviewed every changed line and run the tests above.