### PR TITLE
[doc, rollout] fix: restore MoE checkpoint layout before IPC weight reload

### DIFF
--- a/docs/start/install.md
+++ b/docs/start/install.md
@@ -12,7 +12,7 @@ For NVIDIA GPU:
 For Ascend NPU:
 
 * **Python**: Version >= 3.10
-* **CANN**: Version >= 8.5.0
+* **CANN**: Version == 9.1.0
 
 ## Install
 

--- a/verl_omni/workers/rollout/vllm_rollout/npu_utils.py
+++ b/verl_omni/workers/rollout/vllm_rollout/npu_utils.py
@@ -91,6 +91,32 @@ def _skip_diffusers_npu_empty_cache():
 
 
 # ---------------------------------------------------------------------------
+# Restore checkpoint-layout FusedMoE params (reverse of process_weights_after_loading)
+# ---------------------------------------------------------------------------
+
+
+def restore_moe_param_layout(model, hidden_size: int) -> None:
+    """Revert the w13/w2 transpose applied by vllm-ascend's
+    ``process_weights_after_loading`` for ``npu_grouped_matmul``, so IPC
+    ``load_weights`` can write checkpoint-shape weights. NPU-only and idempotent.
+    """
+    from vllm.model_executor.utils import replace_parameter
+
+    for name, param in list(model.named_parameters()):
+        data = param.data
+        if data.ndim != 3:
+            continue
+        if "w2_weight" in name and data.shape[2] == hidden_size:
+            parts = name.split(".")
+            parent_module = model.get_submodule(".".join(parts[:-1]))
+            replace_parameter(parent_module, parts[-1], data.transpose(1, 2).contiguous())
+        elif "w13_weight" in name and data.shape[1] == hidden_size:
+            parts = name.split(".")
+            parent_module = model.get_submodule(".".join(parts[:-1]))
+            replace_parameter(parent_module, parts[-1], data.transpose(1, 2).contiguous())
+
+
+# ---------------------------------------------------------------------------
 # Mixin: NPU-specific overrides for vLLMOmniColocateWorkerExtension
 # ---------------------------------------------------------------------------
 

--- a/verl_omni/workers/rollout/vllm_rollout/utils.py
+++ b/verl_omni/workers/rollout/vllm_rollout/utils.py
@@ -185,6 +185,17 @@ class vLLMOmniColocateWorkerExtension(CustomPipelineWorkerExtension):
                 from verl.utils.vllm.patch import patch_vllm_moe_model_weight_loader
 
                 patch_vllm_moe_model_weight_loader(model)
+
+                # On Ascend, process_weights_after_loading transposes w13/w2 for
+                # fused-MoE compute; revert it so load_weights sees checkpoint-shape
+                # params. The post-load process_weights_after_loading re-transposes.
+                from verl_omni.workers.rollout.vllm_rollout.npu_utils import (
+                    _is_npu_platform,
+                    restore_moe_param_layout,
+                )
+
+                if _is_npu_platform():
+                    restore_moe_param_layout(model, model_config.hf_text_config.hidden_size)
                 receiver.receive_weights(
                     on_bucket_received=lambda weights, *args, **kwargs: model.load_weights(weights)
                 )


### PR DESCRIPTION
### What does this PR do?

Fixes the AR (text) full-weight reload on Ascend NPU by restoring the FusedMoE checkpoint layout before IPC `load_weights`. On NPU, `process_weights_after_loading` transposes `w13_weight` / `w2_weight` for `npu_grouped_matmul`; without pre-reverting to the checkpoint layout, reloading injects checkpoint-shaped params into compute-shaped layout and breaks rollout. This change localizes the revert to the AR full-weight reload path; diffusion and GPU paths are unaffected.

### Checklist Before Starting

- [x] Search for similar PRs: https://github.com/vllm-project/vllm-ascend/pull/13012
- [x] Format the PR title as `[{modules}] {type}: {description}`
  - Title: `[rollout, docs] fix: restore FusedMoE checkpoint layout before IPC weight reload on NPU`

### Test

Validated on Atlas 800T A3 (16 × Ascend 910C) with Qwen3-Omni-30B-A3B-Instruct Thinker:

- wake_up → full-weight IPC sync → resume rollout
- `rollout_corr/log_ppl_diff` ≈ 0 (actor ↔ rollout consistent)
- No parameter-shape errors during reload
- Diffusion pipeline untouched; GPU path unchanged

### API and Usage Example

No breaking API changes. Behavior is unchanged for GPU and diffusion workers.

### Design & Code Changes

- **`verl_omni/workers/rollout/vllm_rollout/npu_utils.py`**: `restore_moe_param_layout(model, hidden_size)` — transposes `w13` / `w2` back to checkpoint layout using `replace_parameter`. NPU-only, idempotent.
- **`verl_omni/workers/rollout/vllm_rollout/utils.py`**: AR full-weight path of `vLLMOmniColocateWorkerExtension.update_weights_from_ipc` calls `restore_moe_param_layout(model, model_config.hf_text_config.hidden_size)` immediately before `receive_weights(... model.load_weights(weights))` when `_is_npu_platform()` is true; relies on post-load `process_weights_after_loading` to re-apply compute layout.
- **`docs/start/install.md`**: updates Ascend dependency to `CANN == 9.1.0` (the previous `>= 8.5.0` is outdated for the current NPU stack).

Limitation: applies only to the NPU AR full-weight reload path. Diffusion path uses a separate wake/sleep mixin and is unaffected. GPU platforms are unaffected.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update the documentation (CANN version).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl-omni/tree/main/.github/workflows): not feasible (requires NPU hardware); validated by real NPU training run instead.
