### PR TITLE
[ci] fix: raise the sanity timeout to 10m and cache pip downloads across CI

### DIFF
--- a/.github/workflows/cpu_unit_tests.yml
+++ b/.github/workflows/cpu_unit_tests.yml
@@ -51,6 +51,11 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: |
+            pyproject.toml
+            .github/vllm_omni_pin.txt
+            .github/verl_pin.txt
       - name: Install dependencies
         run: |
           pip install --extra-index-url https://download.pytorch.org/whl/cpu "https://github.com/vllm-project/vllm/releases/download/v0.28.0/vllm-0.28.0+cpu-cp38-abi3-manylinux_2_34_x86_64.whl"

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -38,6 +38,11 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: |
+            pyproject.toml
+            .github/vllm_omni_pin.txt
+            .github/verl_pin.txt
       - name: Install dependencies
         run: |
           pip install --extra-index-url https://download.pytorch.org/whl/cpu "https://github.com/vllm-project/vllm/releases/download/v0.28.0/vllm-0.28.0+cpu-cp38-abi3-manylinux_2_34_x86_64.whl"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -34,6 +34,10 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: |
+            pyproject.toml
+            .github/verl_pin.txt
       - name: Install the current repository
         run: |
           pip install pre-commit hydra-core

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -29,7 +29,7 @@ jobs:
       github.event_name != 'pull_request' ||
       contains(join(github.event.pull_request.labels.*.name, ','), 'ci')
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 15
     strategy:
       matrix:
         python-version: ["3.12"]
@@ -39,6 +39,12 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: |
+            pyproject.toml
+            .github/vllm_omni_pin.txt
+            .github/verl_pin.txt
+            .github/workflows/sanity.yml
       - name: Verify vLLM-Ascend pin
         run: |
           pin="$(tr -d '[:space:]' < .github/vllm_ascend_pin.txt)"

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -44,7 +44,6 @@ jobs:
             pyproject.toml
             .github/vllm_omni_pin.txt
             .github/verl_pin.txt
-            .github/workflows/sanity.yml
       - name: Verify vLLM-Ascend pin
         run: |
           pin="$(tr -d '[:space:]' < .github/vllm_ascend_pin.txt)"

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -29,7 +29,7 @@ jobs:
       github.event_name != 'pull_request' ||
       contains(join(github.event.pull_request.labels.*.name, ','), 'ci')
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 10
     strategy:
       matrix:
         python-version: ["3.12"]

--- a/.github/workflows/type-coverage-check.yml
+++ b/.github/workflows/type-coverage-check.yml
@@ -33,6 +33,11 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: |
+            pyproject.toml
+            .github/vllm_omni_pin.txt
+            .github/verl_pin.txt
       - name: Install dependencies
         run: |
           pip install --extra-index-url https://download.pytorch.org/whl/cpu "https://github.com/vllm-project/vllm/releases/download/v0.28.0/vllm-0.28.0+cpu-cp38-abi3-manylinux_2_34_x86_64.whl"


### PR DESCRIPTION
### What does this PR do?

Fixes the `sanity` timeout on main after #497 ([run](https://github.com/verl-project/verl-omni/actions/runs/33724207442)): the job budget was 5 minutes — the lowest of any test workflow — while the install step cold-downloads the full 0.28 stack (~1.5–2 GB: vllm+cpu, vllm-omni git deps, `.[dev]`, triton, torch) with no pip cache. The merge commit was cancelled at 5m13s mid-download of the triton wheel on a slow (~2 MB/s) runner; the identical tree passed sanity in 3m57s on a faster one. No code failure — budget vs. install size.

- `sanity` timeout 5 → 10, matching `doc`/`type-coverage-check`.
- pip download caching via `setup-python` in `sanity`, `cpu_unit_tests`, `type-coverage-check`, `doc`, and `pre-commit`. The full-stack workflows share one cache key (`pyproject.toml` + the vllm-omni and verl pins): pip's cache is content-addressed by URL, so a shared key is a safe invalidation hint and avoids five ~2 GB entries against the 10 GB repo cache budget. `pre-commit` (different install set) keeps its own key.

### Checklist Before Starting

- [x] Searched open PRs (`sanity`, `timeout`, `cache`): none touch CI timeouts or caching.

### Test

All five workflows parse (`yaml.safe_load`) and the change is YAML-only; pre-commit passes. The PR's own CI runs validate the cache path end-to-end — the first run is cold-cache by design; the first post-merge main run seeds the repo-wide cache.

> AI assistance (ZCode) was used for this change; every changed line was reviewed by the submitter.
