### PR TITLE
[1/N][omni, rollout, fsdp] feat: support multi-stage AR model training

### DIFF
--- a/docs/api/pipelines.rst
+++ b/docs/api/pipelines.rst
@@ -4,25 +4,32 @@ Pipelines Interface
 Last updated: |today| (API docstrings are auto-generated).
 
 A *pipeline* in VeRL-Omni packages everything needed to plug a particular
-diffusion model architecture into the training loop:
+model architecture into the training loop. Two adapter families are available:
 
-- a **training-side adapter** subclassing
+- autoregressive omni models use a training-side
+  :class:`~verl_omni.pipelines.model_base.OmniModelBase` and an optional
+  rollout-side :class:`~verl_omni.pipelines.model_base.OmniRolloutPipelineBase`;
+- diffusion models use a training-side adapter subclassing
   :class:`~verl_omni.pipelines.model_base.DiffusionModelBase` that handles
   scheduler setup, model-input construction, and the per-step forward /
   reverse-sampling logic used by RL algorithms (e.g. FlowGRPO);
-- an optional **rollout-side adapter** registered via
+- their optional rollout-side adapter is registered via
   :class:`~verl_omni.pipelines.model_base.VllmOmniPipelineBase` that hooks
   into vLLM-Omni's diffusion serving stack to expose log-probabilities.
 
-Adapters are auto-selected by matching the pair
-``(DiffusionModelConfig.architecture, DiffusionModelConfig.algorithm)`` against the
-registered ``(architecture, algorithm)`` key. The architecture is read from the
-model's ``model_index.json``; the algorithm string is taken from the model config's
-``actor_rollout_ref.model.algorithm`` value.
+Autoregressive training adapters are selected by ``(architecture, model_stage)``;
+their rollout adapters are selected by the vLLM-Omni ``pipeline_name``. Diffusion
+adapters are selected by matching
+``(DiffusionModelConfig.architecture, DiffusionModelConfig.algorithm)`` against a
+registered ``(architecture, algorithm)`` key. Diffusion architecture is read from
+``model_index.json`` and the algorithm from
+``actor_rollout_ref.model.algorithm``.
 
 .. autosummary::
    :nosignatures:
 
+   verl_omni.pipelines.model_base.OmniModelBase
+   verl_omni.pipelines.model_base.OmniRolloutPipelineBase
    verl_omni.pipelines.model_base.DiffusionModelBase
    verl_omni.pipelines.model_base.VllmOmniPipelineBase
    verl_omni.pipelines.qwen_image_flow_grpo.QwenImage
@@ -32,6 +39,20 @@ model's ``model_index.json``; the algorithm string is taken from the model confi
 
 Model Base
 ~~~~~~~~~~~~~~~~~
+
+.. autoclass:: verl_omni.pipelines.model_base.OmniModelBase
+   :members: register, get_class, get_class_by_name,
+             register_auto_classes,
+             get_strip_modules, configure_processor, configure_tokenizer,
+             configure_model, prepare_model_inputs
+
+.. autoclass:: verl_omni.pipelines.model_base.OmniRolloutPipelineBase
+   :members: register, get_class,
+             build_stage_configs, rollout_flags, weight_sync_stage_ids,
+             get_pipeline_id, ensure_pipeline_registered, get_engine_hf_overrides,
+             get_stage_engine_extras, prepare_engine_prompt,
+             postprocess_agent_loop_output,
+             combine_engine_outputs
 
 .. autoclass:: verl_omni.pipelines.model_base.DiffusionModelBase
    :members: register, get_class,

--- a/docs/api/pipelines.rst
+++ b/docs/api/pipelines.rst
@@ -48,7 +48,7 @@ Model Base
 
 .. autoclass:: verl_omni.pipelines.model_base.OmniRolloutPipelineBase
    :members: register, get_class,
-             build_stage_configs, rollout_flags, weight_sync_stage_ids,
+             build_stage_configs, rollout_flags, weight_sync_stage_ids, policy_stage_id,
              get_pipeline_id, ensure_pipeline_registered, get_engine_hf_overrides,
              get_stage_engine_extras, prepare_engine_prompt,
              postprocess_agent_loop_output,

--- a/docs/contributing/integrating_an_omni_model.md
+++ b/docs/contributing/integrating_an_omni_model.md
@@ -104,7 +104,9 @@ Optional overrides fall into four groups:
 
 - Pipeline setup: `ensure_pipeline_registered`, `get_engine_hf_overrides`, and
   `get_stage_engine_extras`.
-- Resource behavior: `weight_sync_stage_ids`.
+- Policy and resource behavior: `policy_stage_id` identifies the stage whose
+  sampling parameters and logprobs define the trained policy;
+  `weight_sync_stage_ids` identifies the stages that receive actor weights.
 - Request construction: `prepare_engine_prompt`.
 - Multi-stage output assembly: `combine_engine_outputs`. The AR generation
   strategy derives retained output modalities from stages marked

--- a/docs/contributing/integrating_an_omni_model.md
+++ b/docs/contributing/integrating_an_omni_model.md
@@ -13,10 +13,10 @@ under [`verl_omni/pipelines/`](https://github.com/verl-project/verl-omni/tree/ma
 Decide which **training stage** you want to train and how the model decomposes:
 
 - **Stage-split**: Multi-component omni models (thinker → talker → code2wav)
-  train only the text-understanding head during RL post-training. Other
-  components are stripped before FSDP wrapping to save memory. This is the
-  Qwen3-Omni pattern — the thinker is the autoregressive language model; talker
-  and codec are inference-only.
+  train one selected autoregressive stage during RL post-training. Other
+  components are stripped before FSDP wrapping to save memory. Qwen3-Omni
+  trains the thinker; adapters for other architectures may select a different
+  autoregressive stage.
 - **Encoder-frozen**: Vision/audio encoders are typically frozen during RL
   training (`freeze_vision_tower=True`). The training adapter's
   `get_strip_modules` excludes them from the trainable set if they are separate
@@ -60,6 +60,13 @@ adapt each implementation to your model's architecture:
   `module._no_split_modules` to the correct decoder layer class for FSDP.
   This method runs before FSDP wrapping and LoRA injection.
 
+- **`register_auto_classes()`** (optional): Register classes supplied by an
+  optional model package with the appropriate Transformers Auto APIs. The model
+  config resolves one `(architecture, stage)` adapter before calling this hook;
+  the base implementation is a no-op. Set the adapter's `auto_model_class` when
+  the default `AutoModelForMultimodalLM` loader does not own the architecture;
+  the FSDP engine still owns `from_pretrained`.
+
 - **`prepare_model_inputs(model_inputs, micro_batch, model_config)`**
   (optional): Validate model-native trajectory or conditioning data retained by
   rollout and add it to the actor forward inputs. Per-sample rollout data starts
@@ -93,10 +100,20 @@ and implement:
 - **`get_pipeline_id(pipeline_mode)`**: Return the vLLM-Omni pipeline
   `model_type` string, used when auto-generating the deploy config YAML.
 
-Optional overrides: `ensure_pipeline_registered` (register non-standard
-pipeline variants with vLLM-Omni), `get_engine_hf_overrides` (HF config
-overrides like `enable_audio_output: false`), `get_stage_engine_extras`
-(per-stage overrides like `model_arch`).
+Optional overrides fall into four groups:
+
+- Pipeline setup: `ensure_pipeline_registered`, `get_engine_hf_overrides`, and
+  `get_stage_engine_extras`.
+- Resource behavior: `weight_sync_stage_ids`.
+- Request construction: `prepare_engine_prompt`.
+- Multi-stage output assembly: `combine_engine_outputs`. The AR generation
+  strategy derives retained output modalities from stages marked
+  `final_output` in the pipeline topology.
+
+Their defaults preserve the existing single-output AR behavior. Override only
+the hooks required by the model. A stage-split adapter may, for example, limit
+actor weight synchronization to its trainable stage while retaining outputs
+from both the policy and decoder stages.
 
 When training an omni model's autoregressive Talker stage, also override
 `postprocess_agent_loop_output`. Put the sampled policy sequence in
@@ -234,3 +251,10 @@ model-specific — verify each against your own model's architecture.
   in `configure_tokenizer` and assign it to `tokenizer.chat_template`.
   verl's dataset loader calls `tokenizer.apply_chat_template()` and will
   fail without a template.
+
+- **Actor/rollout probability consistency**: Autoregressive codec policies may
+  combine several codebook embeddings before predicting the selected token.
+  Match actor, reference, rollout, and weight-sync dtypes, then verify selected
+  token log-probabilities before training. Treat numerical comparisons as
+  execution-consistency diagnostics, not evidence of output quality or bitwise
+  agreement between different precision paths.

--- a/docs/contributing/integrating_an_omni_model.md
+++ b/docs/contributing/integrating_an_omni_model.md
@@ -107,11 +107,17 @@ Optional overrides fall into four groups:
 - Policy and resource behavior: `policy_stage_id` identifies the stage whose
   sampling parameters and logprobs define the trained policy;
   `weight_sync_stage_ids` identifies the stages that receive actor weights.
-- Request construction: `prepare_engine_prompt`.
+- Request construction: `prepare_engine_prompt`. When this hook returns a
+  custom prompt, the adapter must include any non-`None`
+  `mm_processor_kwargs`; the shared strategy adds them automatically only to
+  its default prompt.
 - Multi-stage output assembly: override `combine_engine_outputs` to opt into
   retaining outputs from every stage marked `final_output` in the pipeline
   topology. Adapters that keep the default hook preserve the engine's existing
-  single-output behavior.
+  single-output behavior. A custom combiner must also handle abort outputs with
+  empty token IDs and, pending
+  [vllm-omni#6973](https://github.com/vllm-project/vllm-omni/issues/6973), an
+  empty output list.
 
 Their defaults preserve the existing single-output AR behavior. Override only
 the hooks required by the model. A stage-split adapter may, for example, limit

--- a/docs/contributing/integrating_an_omni_model.md
+++ b/docs/contributing/integrating_an_omni_model.md
@@ -108,9 +108,10 @@ Optional overrides fall into four groups:
   sampling parameters and logprobs define the trained policy;
   `weight_sync_stage_ids` identifies the stages that receive actor weights.
 - Request construction: `prepare_engine_prompt`.
-- Multi-stage output assembly: `combine_engine_outputs`. The AR generation
-  strategy derives retained output modalities from stages marked
-  `final_output` in the pipeline topology.
+- Multi-stage output assembly: override `combine_engine_outputs` to opt into
+  retaining outputs from every stage marked `final_output` in the pipeline
+  topology. Adapters that keep the default hook preserve the engine's existing
+  single-output behavior.
 
 Their defaults preserve the existing single-output AR behavior. Override only
 the hooks required by the model. A stage-split adapter may, for example, limit

--- a/tests/trainer/omni/test_main_omni_on_cpu.py
+++ b/tests/trainer/omni/test_main_omni_on_cpu.py
@@ -127,6 +127,34 @@ class TestLoadTokenizerAndProcessor:
         mock_adapter.configure_tokenizer.assert_called_once_with("local:tokenizer-path", model_config)
         mock_adapter.configure_processor.assert_called_once_with(str(tmp_path), model_config)
 
+    def test_config_only_load_registers_known_auto_classes_without_requiring_an_adapter(self, monkeypatch, tmp_path):
+        from types import SimpleNamespace
+
+        from verl_omni.pipelines.model_base import OmniModelBase
+        from verl_omni.workers.config.omni import model as model_config_module
+        from verl_omni.workers.config.omni.model import OmniModelConfig
+
+        mock_adapter = MagicMock()
+        monkeypatch.setattr(OmniModelBase, "peek_class", lambda *_args: mock_adapter)
+        monkeypatch.setattr(model_config_module, "resolve_model_local_dir", lambda path, use_shm=False: str(tmp_path))
+        monkeypatch.setattr(model_config_module, "copy_to_local", lambda path, use_shm=False: str(tmp_path))
+
+        def load_config(*_args, **_kwargs):
+            mock_adapter.register_auto_classes.assert_called_once_with()
+            return SimpleNamespace(tie_word_embeddings=False, architectures=["arch"])
+
+        monkeypatch.setattr(model_config_module.AutoConfig, "from_pretrained", load_config)
+
+        model_config = OmniModelConfig(
+            path=str(tmp_path),
+            architecture="RegisteredArchitecture",
+            model_stage="talker",
+            load_tokenizer=False,
+        )
+
+        assert model_config.tokenizer is None
+        assert model_config.processor is None
+
     def test_ray_task_runner_delegates_omni_model_to_adapter(self, monkeypatch, tmp_path):
         config = OmegaConf.create(
             {

--- a/tests/trainer/omni/test_main_omni_on_cpu.py
+++ b/tests/trainer/omni/test_main_omni_on_cpu.py
@@ -123,6 +123,7 @@ class TestLoadTokenizerAndProcessor:
 
         assert model_config.tokenizer == "tokenizer"
         assert model_config.processor == "processor"
+        mock_adapter.register_auto_classes.assert_called_once_with()
         mock_adapter.configure_tokenizer.assert_called_once_with("local:tokenizer-path", model_config)
         mock_adapter.configure_processor.assert_called_once_with(str(tmp_path), model_config)
 

--- a/tests/workers/rollout/rollout_vllm/test_vllm_omni_deploy_config_on_cpu.py
+++ b/tests/workers/rollout/rollout_vllm/test_vllm_omni_deploy_config_on_cpu.py
@@ -22,11 +22,11 @@ every generated stage so it reaches ``DiffusionParallelConfig``.
 """
 
 import types
-from unittest.mock import MagicMock
 
 import yaml
 from verl.utils.device import get_visible_devices_keyword
 
+from verl_omni.pipelines.model_base import OmniRolloutPipelineBase
 from verl_omni.workers.rollout.vllm_rollout.vllm_omni_ar_strategy import ARStrategy
 
 
@@ -39,14 +39,27 @@ def _run_write_deploy_config(
     fake_self = types.SimpleNamespace(
         config=types.SimpleNamespace(**config_kwargs),
     )
-    adapter = MagicMock()
-    adapter.build_stage_configs.return_value = [types.SimpleNamespace(stage_id=0)]
-    adapter.get_pipeline_id.return_value = "minimax_h3"
-    adapter.get_stage_engine_extras.return_value = {}
+
+    class Adapter(OmniRolloutPipelineBase):
+        @classmethod
+        def build_stage_configs(cls, pipeline_mode="thinker_only"):
+            return [
+                types.SimpleNamespace(
+                    stage_id=0,
+                    final_output=True,
+                    final_output_type="audio",
+                    sampling_constraints={},
+                )
+            ]
+
+        @classmethod
+        def get_pipeline_id(cls, pipeline_mode="thinker_only"):
+            return "minimax_h3"
+
     monkeypatch.setenv(get_visible_devices_keyword(), "0,1,2,3")
 
     engine_kwargs: dict = {}
-    ARStrategy(fake_self)._write_deploy_config(engine_kwargs, "minimax_h3", adapter, "t2av")
+    ARStrategy(fake_self)._write_deploy_config(engine_kwargs, "minimax_h3", Adapter, "t2av")
     with open(engine_kwargs["deploy_config"]) as f:
         return yaml.safe_load(f)
 

--- a/tests/workers/rollout/rollout_vllm/test_vllm_omni_strategy_on_cpu.py
+++ b/tests/workers/rollout/rollout_vllm/test_vllm_omni_strategy_on_cpu.py
@@ -13,12 +13,16 @@
 # limitations under the License.
 
 from argparse import Namespace
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
 import torch
+import yaml
 
+from verl_omni.pipelines.model_base import OmniRolloutPipelineBase
+from verl_omni.pipelines.qwen3_omni.omni_rollout_adapter import Qwen3OmniRolloutAdapter
 from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
 from verl_omni.workers.rollout.vllm_rollout import vllm_omni_ar_strategy as ar_strategy_module
 from verl_omni.workers.rollout.vllm_rollout import vllm_omni_async_server as server_module
@@ -115,6 +119,19 @@ def test_strategies_preserve_platform_worker_extensions():
     assert DiffusionStrategy(server).worker_extension_cls("npu").endswith("vLLMOmniNPUColocateWorkerExtension")
 
 
+def test_optional_rollout_hooks_preserve_existing_ar_defaults():
+    first, final = object(), object()
+
+    assert OmniRolloutPipelineBase.supports_async_chunk is True
+    assert OmniRolloutPipelineBase.weight_sync_stage_ids() is None
+    assert OmniRolloutPipelineBase.prepare_engine_prompt([], None, {}) is None
+    assert OmniRolloutPipelineBase.combine_engine_outputs([final], {}) == (final, {})
+    with pytest.raises(NotImplementedError, match="multiple final outputs"):
+        OmniRolloutPipelineBase.combine_engine_outputs([first, final], {})
+    with pytest.raises(RuntimeError, match="no outputs"):
+        OmniRolloutPipelineBase.combine_engine_outputs([], {})
+
+
 def test_ar_strategy_preserves_prompt_and_sampling_preprocessing():
     processor = SimpleNamespace(dedup_pad_tokens=lambda token_ids: token_ids[:2])
     server = SimpleNamespace(
@@ -195,6 +212,60 @@ def test_ar_strategy_preserves_engine_kwarg_normalization(monkeypatch):
     }
 
 
+@pytest.mark.parametrize(
+    ("timeout_kwargs", "expected"),
+    [
+        ({"stage-init-timeout": 45}, {"stage-init-timeout": 45, "init-timeout": 600}),
+        (
+            {"stage_init_timeout": 45, "init-timeout": 90},
+            {"stage-init-timeout": 45, "init-timeout": 90},
+        ),
+    ],
+)
+def test_ar_strategy_preserves_hyphenated_timeout_kwargs(monkeypatch, timeout_kwargs, expected):
+    monkeypatch.setattr(ar_strategy_module.OmniRolloutPipelineBase, "get_class", lambda pipeline_name: None)
+    strategy = ARStrategy(SimpleNamespace())
+    engine_kwargs = {"pipeline_name": "missing", **timeout_kwargs}
+
+    strategy.preprocess_engine_kwargs(engine_kwargs)
+
+    assert engine_kwargs == expected
+
+
+def test_ar_strategy_honors_adapter_chunking_and_weight_sync_contracts(monkeypatch):
+    class Adapter:
+        supports_async_chunk = False
+
+        @staticmethod
+        def rollout_flags(pipeline_mode):
+            return {0: {"mode": pipeline_mode}}
+
+        @staticmethod
+        def weight_sync_stage_ids(pipeline_mode):
+            assert pipeline_mode == "full"
+            return [1]
+
+        @staticmethod
+        def get_engine_hf_overrides(pipeline_mode):
+            assert pipeline_mode == "full"
+            return {}
+
+    monkeypatch.setattr(ar_strategy_module.OmniRolloutPipelineBase, "get_class", lambda pipeline_name: Adapter)
+    strategy = ARStrategy(SimpleNamespace(_rollout_flags={}))
+    monkeypatch.setattr(strategy, "_write_deploy_config", lambda *args: None)
+
+    with pytest.raises(ValueError, match="requires async_chunk=false"):
+        strategy.preprocess_engine_kwargs({"pipeline_name": "adapter", "pipeline_mode": "full"})
+
+    engine_kwargs = {"pipeline_name": "adapter", "pipeline_mode": "full", "async_chunk": False}
+    strategy.preprocess_engine_kwargs(engine_kwargs)
+
+    assert strategy._rollout_adapter is Adapter
+    assert strategy._weight_sync_stage_ids == [1]
+    assert strategy.server._rollout_flags == {0: {"mode": "full"}}
+    assert engine_kwargs == {"async-chunk": False}
+
+
 def test_ar_strategy_preserves_engine_argument_normalization():
     server = SimpleNamespace(config=SimpleNamespace(logprobs_mode="raw_logprobs"))
     strategy = ARStrategy(server)
@@ -216,6 +287,201 @@ def test_ar_strategy_preserves_engine_argument_normalization():
         "logprobs_mode": "raw_logprobs",
         "compilation_config": {"keep": 1, "nested": {"keep": 2}},
     }
+
+
+def test_ar_strategy_prepares_stage_specific_sampling_params():
+    class Adapter:
+        @staticmethod
+        def prepare_engine_prompt(**kwargs):
+            return {
+                "prompt_token_ids": [1, 1, 1, 1],
+                "additional_information": {"text": ["hello"]},
+            }
+
+    server = SimpleNamespace(
+        model_config=SimpleNamespace(),
+        config=SimpleNamespace(
+            max_model_len=64,
+            prompt_length=16,
+            response_length=8,
+            repetition_penalty=1.0,
+        ),
+        engine=SimpleNamespace(
+            default_sampling_params_list=[ar_strategy_module.SamplingParams(), SimpleNamespace(stage="decoder")]
+        ),
+    )
+    strategy = ARStrategy(server)
+    strategy._rollout_adapter = Adapter
+    strategy._rollout_output_modalities = ["latent", "audio"]
+    strategy._stage_sampling_constraints = {0: {}}
+
+    prompt, params = strategy.preprocess_input(
+        [5, 6],
+        {"temperature": 0.8, "logprobs": True},
+        {},
+        None,
+        None,
+    )
+
+    assert prompt["additional_information"]["max_new_tokens"] == [8]
+    assert len(params) == 2
+    assert params[0].max_tokens == 8
+    assert params[0].temperature == pytest.approx(0.8)
+    assert params[0].logprobs == 0
+    assert params[1].stage == "decoder"
+
+
+@pytest.mark.parametrize(
+    ("adapter_prompt", "message"),
+    [
+        ({"additional_information": {"text": ["hello"]}}, "must contain prompt_token_ids"),
+        ({"prompt_token_ids": "1,2"}, "list of integers"),
+        ([1, 2], "must return a dict or None"),
+    ],
+)
+def test_ar_strategy_rejects_invalid_adapter_prompt(adapter_prompt, message):
+    class Adapter:
+        @staticmethod
+        def prepare_engine_prompt(**kwargs):
+            return adapter_prompt
+
+    server = SimpleNamespace(
+        model_config=SimpleNamespace(),
+        config=SimpleNamespace(max_model_len=64, prompt_length=16, response_length=8),
+    )
+    strategy = ARStrategy(server)
+    strategy._rollout_adapter = Adapter
+
+    with pytest.raises((RuntimeError, TypeError), match=message):
+        strategy.preprocess_input([5, 6], {}, {}, None, None)
+
+
+@pytest.mark.asyncio
+async def test_ar_strategy_retains_requested_stage_outputs_and_targets_weight_sync():
+    policy = SimpleNamespace(outputs=[])
+
+    class Engine:
+        def __init__(self):
+            self.generate_kwargs = None
+            self.rpc_kwargs = None
+
+        async def generate(self, **kwargs):
+            self.generate_kwargs = kwargs
+            yield policy
+
+        async def collective_rpc(self, **kwargs):
+            self.rpc_kwargs = kwargs
+            return "rpc-result"
+
+    class Adapter:
+        @staticmethod
+        def combine_engine_outputs(outputs, prompt):
+            assert outputs == [policy]
+            return policy, {"audio_sample_rate": 24_000}
+
+    server = object.__new__(server_module.vLLMOmniHttpServer)
+    server.engine = Engine()
+    strategy = ARStrategy(server)
+    strategy._rollout_output_modalities = ["latent", "audio"]
+    strategy._rollout_adapter = Adapter
+    strategy._weight_sync_stage_ids = [0]
+    server._generate_strategy = strategy
+
+    result = await strategy.run_generation(
+        {"prompt_token_ids": [1]}, ar_strategy_module.SamplingParams(), "request-0", None, 0
+    )
+    rpc_result = await server.collective_rpc("update_weights_from_ipc", kwargs={"base_sync_done": True})
+
+    assert result is policy
+    assert result._verl_omni_rollout_fields == {"audio_sample_rate": 24_000}
+    assert server.engine.generate_kwargs["output_modalities"] == ["latent", "audio"]
+    assert server.engine.rpc_kwargs["stage_ids"] == [0]
+    assert rpc_result == "rpc-result"
+
+
+def test_ar_strategy_preserves_qwen3_omni_thinker_only_contract():
+    server = SimpleNamespace(
+        config=SimpleNamespace(
+            max_model_len=8,
+            prompt_length=4,
+            response_length=4,
+            repetition_penalty=1.0,
+            logprobs_mode="processed_logprobs",
+        ),
+        model_config=SimpleNamespace(processor=None),
+        global_steps=12,
+    )
+    strategy = ARStrategy(server)
+    strategy._rollout_adapter = Qwen3OmniRolloutAdapter
+    strategy._rollout_output_modalities = None
+
+    engine_args = {"model_stage": "thinker"}
+    strategy.prepare_engine_args(engine_args, Namespace(stage_init_timeout=None, init_timeout=None))
+    assert engine_args["model_stage"] == "thinker"
+
+    prompt, params = strategy.preprocess_input(
+        prompt_ids=[1, 2],
+        sampling_params={"max_new_tokens": 2, "logprobs": True},
+        multi_modal_data={},
+        lora_request=None,
+        negative_prompt_ids=None,
+    )
+    assert prompt == {"prompt_token_ids": [1, 2]}
+    assert isinstance(params, ar_strategy_module.SamplingParams)
+
+    completion = SimpleNamespace(
+        token_ids=[7],
+        logprobs=[{7: SimpleNamespace(logprob=-0.25)}],
+        finish_reason="stop",
+        num_preempted=0,
+    )
+    output = strategy.process_output(
+        SimpleNamespace(request_output=SimpleNamespace(outputs=[completion])),
+        params=params,
+        sampling_params={},
+    )
+    assert output.extra_fields == {"global_steps": 12}
+
+
+def test_ar_strategy_writes_qwen3_omni_thinker_only_deploy_config(monkeypatch):
+    monkeypatch.setattr(ar_strategy_module, "get_visible_devices_keyword", lambda: "CUDA_VISIBLE_DEVICES")
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0,1")
+    server = SimpleNamespace(
+        config=SimpleNamespace(
+            tensor_model_parallel_size=1,
+            text_encoder_tp_size=1,
+            max_model_len=8,
+            max_num_batched_tokens=8,
+        ),
+        _rollout_flags={},
+    )
+    strategy = ARStrategy(server)
+    engine_kwargs = {
+        "pipeline_name": "qwen3_omni_moe",
+        "pipeline_mode": "thinker_only",
+    }
+
+    strategy.preprocess_engine_kwargs(engine_kwargs)
+
+    deploy_path = engine_kwargs["deploy-config"]
+    deploy = yaml.safe_load(Path(deploy_path).read_text(encoding="utf-8"))
+    assert deploy["pipeline"] == Qwen3OmniRolloutAdapter.get_pipeline_id("thinker_only")
+    assert [stage["stage_id"] for stage in deploy["stages"]] == [0]
+    assert strategy._rollout_output_modalities is None
+    server._temp_deploy_ctx.cleanup()
+
+
+def test_ar_strategy_rejects_qwen3_omni_full_multi_output_without_combiner():
+    server = SimpleNamespace(_rollout_flags={})
+    strategy = ARStrategy(server)
+
+    with pytest.raises(ValueError, match="multiple final pipeline outputs"):
+        strategy.preprocess_engine_kwargs(
+            {
+                "pipeline_name": "qwen3_omni_moe",
+                "pipeline_mode": "full",
+            }
+        )
 
 
 def test_diffusion_strategy_preserves_engine_argument_preparation(monkeypatch):

--- a/tests/workers/rollout/rollout_vllm/test_vllm_omni_strategy_on_cpu.py
+++ b/tests/workers/rollout/rollout_vllm/test_vllm_omni_strategy_on_cpu.py
@@ -124,6 +124,7 @@ def test_optional_rollout_hooks_preserve_existing_ar_defaults():
 
     assert OmniRolloutPipelineBase.supports_async_chunk is True
     assert OmniRolloutPipelineBase.weight_sync_stage_ids() is None
+    assert OmniRolloutPipelineBase.policy_stage_id() == 0
     assert OmniRolloutPipelineBase.prepare_engine_prompt([], None, {}) is None
     assert OmniRolloutPipelineBase.combine_engine_outputs([final], {}) == (final, {})
     with pytest.raises(NotImplementedError, match="multiple final outputs"):
@@ -252,7 +253,11 @@ def test_ar_strategy_honors_adapter_chunking_and_weight_sync_contracts(monkeypat
 
     monkeypatch.setattr(ar_strategy_module.OmniRolloutPipelineBase, "get_class", lambda pipeline_name: Adapter)
     strategy = ARStrategy(SimpleNamespace(_rollout_flags={}))
-    monkeypatch.setattr(strategy, "_write_deploy_config", lambda *args: None)
+
+    def write_deploy_config(*args):
+        strategy._weight_sync_stage_ids = Adapter.weight_sync_stage_ids("full")
+
+    monkeypatch.setattr(strategy, "_write_deploy_config", write_deploy_config)
 
     with pytest.raises(ValueError, match="requires async_chunk=false"):
         strategy.preprocess_engine_kwargs({"pipeline_name": "adapter", "pipeline_mode": "full"})
@@ -264,6 +269,89 @@ def test_ar_strategy_honors_adapter_chunking_and_weight_sync_contracts(monkeypat
     assert strategy._weight_sync_stage_ids == [1]
     assert strategy.server._rollout_flags == {0: {"mode": "full"}}
     assert engine_kwargs == {"async-chunk": False}
+
+
+def test_ar_strategy_resolves_nonzero_policy_and_weight_sync_stages(monkeypatch):
+    stages = [
+        SimpleNamespace(stage_id=0, final_output=False, final_output_type=None, sampling_constraints={}),
+        SimpleNamespace(stage_id=1, final_output=True, final_output_type="latent", sampling_constraints={}),
+    ]
+
+    class Adapter(OmniRolloutPipelineBase):
+        @classmethod
+        def build_stage_configs(cls, pipeline_mode="thinker_only"):
+            return stages
+
+        @classmethod
+        def get_pipeline_id(cls, pipeline_mode="thinker_only"):
+            return "test_pipeline"
+
+        @classmethod
+        def policy_stage_id(cls, pipeline_mode="thinker_only"):
+            return 1
+
+        @classmethod
+        def weight_sync_stage_ids(cls, pipeline_mode="thinker_only"):
+            return [1]
+
+    monkeypatch.setattr(ar_strategy_module.OmniRolloutPipelineBase, "get_class", lambda pipeline_name: Adapter)
+    monkeypatch.setattr(ar_strategy_module, "get_visible_devices_keyword", lambda: "CUDA_VISIBLE_DEVICES")
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0,1")
+    server = SimpleNamespace(
+        config=SimpleNamespace(
+            tensor_model_parallel_size=1,
+            text_encoder_tp_size=1,
+            max_model_len=64,
+            max_num_batched_tokens=64,
+        ),
+        _rollout_flags={},
+    )
+    strategy = ARStrategy(server)
+    engine_kwargs = {"pipeline_name": "adapter"}
+
+    strategy.preprocess_engine_kwargs(engine_kwargs)
+
+    assert strategy._policy_stage_id == 1
+    assert strategy._policy_stage_index == 1
+    assert strategy._weight_sync_stage_ids == [1]
+    server._temp_deploy_ctx.cleanup()
+
+
+@pytest.mark.parametrize(
+    ("policy_stage_id", "weight_sync_stage_ids", "error", "message"),
+    [
+        (True, [1], TypeError, "integer stage ID"),
+        (2, [1], ValueError, "unknown stage 2"),
+        (0, [], ValueError, "empty list"),
+        (0, [1, 1], ValueError, "unique stage IDs"),
+        (0, [2], ValueError, "unknown stages"),
+        (0, [True], TypeError, "only integer stage IDs"),
+    ],
+)
+def test_ar_strategy_rejects_invalid_adapter_stage_contracts(
+    monkeypatch, policy_stage_id, weight_sync_stage_ids, error, message
+):
+    class Adapter(OmniRolloutPipelineBase):
+        @classmethod
+        def build_stage_configs(cls, pipeline_mode="thinker_only"):
+            return [
+                SimpleNamespace(stage_id=0, final_output=False, final_output_type=None, sampling_constraints={}),
+                SimpleNamespace(stage_id=1, final_output=True, final_output_type="latent", sampling_constraints={}),
+            ]
+
+        @classmethod
+        def policy_stage_id(cls, pipeline_mode="thinker_only"):
+            return policy_stage_id
+
+        @classmethod
+        def weight_sync_stage_ids(cls, pipeline_mode="thinker_only"):
+            return weight_sync_stage_ids
+
+    monkeypatch.setattr(ar_strategy_module.OmniRolloutPipelineBase, "get_class", lambda pipeline_name: Adapter)
+    strategy = ARStrategy(SimpleNamespace(_rollout_flags={}))
+
+    with pytest.raises(error, match=message):
+        strategy.preprocess_engine_kwargs({"pipeline_name": "adapter"})
 
 
 def test_ar_strategy_preserves_engine_argument_normalization():
@@ -289,7 +377,7 @@ def test_ar_strategy_preserves_engine_argument_normalization():
     }
 
 
-def test_ar_strategy_prepares_stage_specific_sampling_params():
+def test_ar_strategy_prepares_sampling_params_for_nonzero_policy_stage():
     class Adapter:
         @staticmethod
         def prepare_engine_prompt(**kwargs):
@@ -300,6 +388,7 @@ def test_ar_strategy_prepares_stage_specific_sampling_params():
 
     server = SimpleNamespace(
         model_config=SimpleNamespace(),
+        global_steps=0,
         config=SimpleNamespace(
             max_model_len=64,
             prompt_length=16,
@@ -307,13 +396,15 @@ def test_ar_strategy_prepares_stage_specific_sampling_params():
             repetition_penalty=1.0,
         ),
         engine=SimpleNamespace(
-            default_sampling_params_list=[ar_strategy_module.SamplingParams(), SimpleNamespace(stage="decoder")]
+            default_sampling_params_list=[SimpleNamespace(stage="thinker"), ar_strategy_module.SamplingParams()]
         ),
     )
     strategy = ARStrategy(server)
     strategy._rollout_adapter = Adapter
     strategy._rollout_output_modalities = ["latent", "audio"]
-    strategy._stage_sampling_constraints = {0: {}}
+    strategy._policy_stage_id = 1
+    strategy._policy_stage_index = 1
+    strategy._stage_sampling_constraints = {1: {}}
 
     prompt, params = strategy.preprocess_input(
         [5, 6],
@@ -325,10 +416,22 @@ def test_ar_strategy_prepares_stage_specific_sampling_params():
 
     assert prompt["additional_information"]["max_new_tokens"] == [8]
     assert len(params) == 2
-    assert params[0].max_tokens == 8
-    assert params[0].temperature == pytest.approx(0.8)
-    assert params[0].logprobs == 0
-    assert params[1].stage == "decoder"
+    assert params[0].stage == "thinker"
+    assert params[1].max_tokens == 8
+    assert params[1].temperature == pytest.approx(0.8)
+    assert params[1].logprobs == 0
+
+    completion = SimpleNamespace(
+        token_ids=[7],
+        logprobs=[{7: SimpleNamespace(logprob=-0.25)}],
+        finish_reason="stop",
+        num_preempted=0,
+    )
+    final_res = SimpleNamespace(
+        request_output=SimpleNamespace(outputs=[completion]),
+        _verl_omni_rollout_fields={},
+    )
+    assert strategy.process_output(final_res, params, {}).log_probs == [-0.25]
 
 
 @pytest.mark.parametrize(

--- a/tests/workers/rollout/rollout_vllm/test_vllm_omni_strategy_on_cpu.py
+++ b/tests/workers/rollout/rollout_vllm/test_vllm_omni_strategy_on_cpu.py
@@ -318,6 +318,56 @@ def test_ar_strategy_resolves_nonzero_policy_and_weight_sync_stages(monkeypatch)
     server._temp_deploy_ctx.cleanup()
 
 
+def test_ar_strategy_moves_capacity_overrides_to_each_stage(monkeypatch):
+    stages = [
+        SimpleNamespace(stage_id=0, final_output=False, final_output_type=None, sampling_constraints={}),
+        SimpleNamespace(stage_id=1, final_output=True, final_output_type="latent", sampling_constraints={}),
+    ]
+
+    class Adapter(OmniRolloutPipelineBase):
+        @classmethod
+        def build_stage_configs(cls, pipeline_mode="thinker_only"):
+            return stages
+
+        @classmethod
+        def get_pipeline_id(cls, pipeline_mode="thinker_only"):
+            return "test_pipeline"
+
+        @classmethod
+        def get_stage_engine_extras(cls, stage_id, pipeline_mode="thinker_only"):
+            return {"max_model_len": 65536} if stage_id == 1 else {}
+
+    monkeypatch.setattr(ar_strategy_module.OmniRolloutPipelineBase, "get_class", lambda pipeline_name: Adapter)
+    monkeypatch.setattr(ar_strategy_module, "get_visible_devices_keyword", lambda: "CUDA_VISIBLE_DEVICES")
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0,1")
+    server = SimpleNamespace(
+        config=SimpleNamespace(
+            tensor_model_parallel_size=1,
+            text_encoder_tp_size=1,
+            max_model_len=4096,
+            max_num_batched_tokens=8192,
+        ),
+        _rollout_flags={},
+    )
+    strategy = ARStrategy(server)
+    engine_kwargs = {"pipeline_name": "adapter"}
+
+    strategy.preprocess_engine_kwargs(engine_kwargs)
+
+    deploy = yaml.safe_load(Path(engine_kwargs["deploy-config"]).read_text(encoding="utf-8"))
+    assert engine_kwargs["max_model_len"] is None
+    assert engine_kwargs["max_num_batched_tokens"] is None
+    assert deploy["stages"][0]["engine_extras"] == {
+        "max_model_len": 4096,
+        "max_num_batched_tokens": 8192,
+    }
+    assert deploy["stages"][1]["engine_extras"] == {
+        "max_model_len": 65536,
+        "max_num_batched_tokens": 8192,
+    }
+    server._temp_deploy_ctx.cleanup()
+
+
 @pytest.mark.parametrize(
     ("policy_stage_id", "weight_sync_stage_ids", "message"),
     [
@@ -509,7 +559,7 @@ async def test_ar_strategy_retains_requested_stage_outputs_and_targets_weight_sy
     assert strategy._rollout_fields_by_request_id == {"request-0": {"audio_sample_rate": 24_000}}
     assert server.engine.generate_kwargs["output_modalities"] == ["latent", "audio"]
     assert server.engine.rpc_kwargs["stage_ids"] == [0]
-    assert rpc_result == "rpc-result"
+    assert rpc_result is None
 
     output = strategy.process_output(result, ar_strategy_module.SamplingParams(), {})
     assert output.extra_fields == {"global_steps": 3, "audio_sample_rate": 24_000}

--- a/tests/workers/rollout/rollout_vllm/test_vllm_omni_strategy_on_cpu.py
+++ b/tests/workers/rollout/rollout_vllm/test_vllm_omni_strategy_on_cpu.py
@@ -318,19 +318,13 @@ def test_ar_strategy_resolves_nonzero_policy_and_weight_sync_stages(monkeypatch)
 
 
 @pytest.mark.parametrize(
-    ("policy_stage_id", "weight_sync_stage_ids", "error", "message"),
+    ("policy_stage_id", "weight_sync_stage_ids", "message"),
     [
-        (True, [1], TypeError, "integer stage ID"),
-        (2, [1], ValueError, "unknown stage 2"),
-        (0, [], ValueError, "empty list"),
-        (0, [1, 1], ValueError, "unique stage IDs"),
-        (0, [2], ValueError, "unknown stages"),
-        (0, [True], TypeError, "only integer stage IDs"),
+        (2, [1], "unknown stage 2"),
+        (0, [2], "unknown stages"),
     ],
 )
-def test_ar_strategy_rejects_invalid_adapter_stage_contracts(
-    monkeypatch, policy_stage_id, weight_sync_stage_ids, error, message
-):
+def test_ar_strategy_rejects_unknown_adapter_stages(monkeypatch, policy_stage_id, weight_sync_stage_ids, message):
     class Adapter(OmniRolloutPipelineBase):
         @classmethod
         def build_stage_configs(cls, pipeline_mode="thinker_only"):
@@ -350,7 +344,7 @@ def test_ar_strategy_rejects_invalid_adapter_stage_contracts(
     monkeypatch.setattr(ar_strategy_module.OmniRolloutPipelineBase, "get_class", lambda pipeline_name: Adapter)
     strategy = ARStrategy(SimpleNamespace(_rollout_flags={}))
 
-    with pytest.raises(error, match=message):
+    with pytest.raises(ValueError, match=message):
         strategy.preprocess_engine_kwargs({"pipeline_name": "adapter"})
 
 
@@ -421,6 +415,18 @@ def test_ar_strategy_prepares_sampling_params_for_nonzero_policy_stage():
     assert params[1].temperature == pytest.approx(0.8)
     assert params[1].logprobs == 0
 
+    _, next_params = strategy.preprocess_input(
+        [5, 6],
+        {"temperature": 0.2, "logprobs": True},
+        {},
+        None,
+        None,
+    )
+    assert params[0] is next_params[0]
+    assert params[1] is not next_params[1]
+    assert params[1].temperature == pytest.approx(0.8)
+    assert next_params[1].temperature == pytest.approx(0.2)
+
     completion = SimpleNamespace(
         token_ids=[7],
         logprobs=[{7: SimpleNamespace(logprob=-0.25)}],
@@ -428,17 +434,18 @@ def test_ar_strategy_prepares_sampling_params_for_nonzero_policy_stage():
         num_preempted=0,
     )
     final_res = SimpleNamespace(
+        request_id="request-0",
         request_output=SimpleNamespace(outputs=[completion]),
-        _verl_omni_rollout_fields={},
     )
+    strategy._rollout_fields_by_request_id["request-0"] = {}
     assert strategy.process_output(final_res, params, {}).log_probs == [-0.25]
+    assert strategy._rollout_fields_by_request_id == {}
 
 
 @pytest.mark.parametrize(
     ("adapter_prompt", "message"),
     [
         ({"additional_information": {"text": ["hello"]}}, "must contain prompt_token_ids"),
-        ({"prompt_token_ids": "1,2"}, "list of integers"),
         ([1, 2], "must return a dict or None"),
     ],
 )
@@ -461,7 +468,8 @@ def test_ar_strategy_rejects_invalid_adapter_prompt(adapter_prompt, message):
 
 @pytest.mark.asyncio
 async def test_ar_strategy_retains_requested_stage_outputs_and_targets_weight_sync():
-    policy = SimpleNamespace(outputs=[])
+    completion = SimpleNamespace(token_ids=[7], logprobs=None, finish_reason="stop", num_preempted=0)
+    policy = SimpleNamespace(request_id="request-0", outputs=[completion])
 
     class Engine:
         def __init__(self):
@@ -484,6 +492,7 @@ async def test_ar_strategy_retains_requested_stage_outputs_and_targets_weight_sy
 
     server = object.__new__(server_module.vLLMOmniHttpServer)
     server.engine = Engine()
+    server.global_steps = 3
     strategy = ARStrategy(server)
     strategy._rollout_output_modalities = ["latent", "audio"]
     strategy._rollout_adapter = Adapter
@@ -496,10 +505,15 @@ async def test_ar_strategy_retains_requested_stage_outputs_and_targets_weight_sy
     rpc_result = await server.collective_rpc("update_weights_from_ipc", kwargs={"base_sync_done": True})
 
     assert result is policy
-    assert result._verl_omni_rollout_fields == {"audio_sample_rate": 24_000}
+    assert not hasattr(result, "_verl_omni_rollout_fields")
+    assert strategy._rollout_fields_by_request_id == {"request-0": {"audio_sample_rate": 24_000}}
     assert server.engine.generate_kwargs["output_modalities"] == ["latent", "audio"]
     assert server.engine.rpc_kwargs["stage_ids"] == [0]
     assert rpc_result == "rpc-result"
+
+    output = strategy.process_output(result, ar_strategy_module.SamplingParams(), {})
+    assert output.extra_fields == {"global_steps": 3, "audio_sample_rate": 24_000}
+    assert strategy._rollout_fields_by_request_id == {}
 
 
 def test_ar_strategy_preserves_qwen3_omni_thinker_only_contract():
@@ -574,17 +588,31 @@ def test_ar_strategy_writes_qwen3_omni_thinker_only_deploy_config(monkeypatch):
     server._temp_deploy_ctx.cleanup()
 
 
-def test_ar_strategy_rejects_qwen3_omni_full_multi_output_without_combiner():
-    server = SimpleNamespace(_rollout_flags={})
+def test_ar_strategy_preserves_qwen3_omni_full_without_combiner(monkeypatch):
+    monkeypatch.setattr(ar_strategy_module, "get_visible_devices_keyword", lambda: "CUDA_VISIBLE_DEVICES")
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0,1")
+    server = SimpleNamespace(
+        config=SimpleNamespace(
+            tensor_model_parallel_size=1,
+            text_encoder_tp_size=1,
+            max_model_len=8,
+            max_num_batched_tokens=8,
+        ),
+        _rollout_flags={},
+    )
     strategy = ARStrategy(server)
 
-    with pytest.raises(ValueError, match="multiple final pipeline outputs"):
-        strategy.preprocess_engine_kwargs(
-            {
-                "pipeline_name": "qwen3_omni_moe",
-                "pipeline_mode": "full",
-            }
-        )
+    engine_kwargs = {
+        "pipeline_name": "qwen3_omni_moe",
+        "pipeline_mode": "full",
+    }
+    strategy.preprocess_engine_kwargs(engine_kwargs)
+
+    deploy_path = engine_kwargs["deploy-config"]
+    deploy = yaml.safe_load(Path(deploy_path).read_text(encoding="utf-8"))
+    assert [stage["stage_id"] for stage in deploy["stages"]] == [0, 1, 2]
+    assert strategy._rollout_output_modalities is None
+    server._temp_deploy_ctx.cleanup()
 
 
 def test_diffusion_strategy_preserves_engine_argument_preparation(monkeypatch):

--- a/tests/workers/rollout/rollout_vllm/test_vllm_omni_strategy_on_cpu.py
+++ b/tests/workers/rollout/rollout_vllm/test_vllm_omni_strategy_on_cpu.py
@@ -119,18 +119,19 @@ def test_strategies_preserve_platform_worker_extensions():
     assert DiffusionStrategy(server).worker_extension_cls("npu").endswith("vLLMOmniNPUColocateWorkerExtension")
 
 
-def test_optional_rollout_hooks_preserve_existing_ar_defaults():
+@pytest.mark.parametrize("adapter_cls", [OmniRolloutPipelineBase, Qwen3OmniRolloutAdapter])
+def test_optional_rollout_hooks_preserve_existing_ar_defaults(adapter_cls):
     first, final = object(), object()
 
-    assert OmniRolloutPipelineBase.supports_async_chunk is True
-    assert OmniRolloutPipelineBase.weight_sync_stage_ids() is None
-    assert OmniRolloutPipelineBase.policy_stage_id() == 0
-    assert OmniRolloutPipelineBase.prepare_engine_prompt([], None, {}) is None
-    assert OmniRolloutPipelineBase.combine_engine_outputs([final], {}) == (final, {})
+    assert adapter_cls.supports_async_chunk is True
+    assert adapter_cls.weight_sync_stage_ids("full") is None
+    assert adapter_cls.policy_stage_id("full") == 0
+    assert adapter_cls.prepare_engine_prompt([], None, {}) is None
+    assert adapter_cls.combine_engine_outputs([final], {}) == (final, {})
     with pytest.raises(NotImplementedError, match="multiple final outputs"):
-        OmniRolloutPipelineBase.combine_engine_outputs([first, final], {})
+        adapter_cls.combine_engine_outputs([first, final], {})
     with pytest.raises(RuntimeError, match="no outputs"):
-        OmniRolloutPipelineBase.combine_engine_outputs([], {})
+        adapter_cls.combine_engine_outputs([], {})
 
 
 def test_ar_strategy_preserves_prompt_and_sampling_preprocessing():
@@ -311,8 +312,8 @@ def test_ar_strategy_resolves_nonzero_policy_and_weight_sync_stages(monkeypatch)
 
     strategy.preprocess_engine_kwargs(engine_kwargs)
 
-    assert strategy._policy_stage_id == 1
     assert strategy._policy_stage_index == 1
+    assert strategy._policy_sampling_constraints == {}
     assert strategy._weight_sync_stage_ids == [1]
     server._temp_deploy_ctx.cleanup()
 
@@ -396,9 +397,8 @@ def test_ar_strategy_prepares_sampling_params_for_nonzero_policy_stage():
     strategy = ARStrategy(server)
     strategy._rollout_adapter = Adapter
     strategy._rollout_output_modalities = ["latent", "audio"]
-    strategy._policy_stage_id = 1
     strategy._policy_stage_index = 1
-    strategy._stage_sampling_constraints = {1: {}}
+    strategy._policy_sampling_constraints = {}
 
     prompt, params = strategy.preprocess_input(
         [5, 6],

--- a/tests/workers/test_omni_fsdp_engine_on_cpu.py
+++ b/tests/workers/test_omni_fsdp_engine_on_cpu.py
@@ -58,6 +58,7 @@ def _make_mock_model_config(**overrides):
     cfg.model_stage = "thinker"
     cfg.local_path = "/fake/model/path"
     cfg.trust_remote_code = False
+    cfg.external_lib = None
     cfg.use_liger = False
     cfg.use_fused_kernels = False
     cfg.enable_gradient_checkpointing = False
@@ -82,7 +83,6 @@ def _make_mock_model_config(**overrides):
 # ---------------------------------------------------------------------------
 # Isolated module loader
 # ---------------------------------------------------------------------------
-
 
 _omni_impl_cache = None
 
@@ -328,6 +328,26 @@ def test_prepare_model_inputs_applies_registered_adapter_hook():
     assert output_args == {"base": True}
 
 
+def test_weight_sync_casts_floating_dtensor_to_bfloat16():
+    omni_impl = _get_omni_impl_module()
+    tensor = torch.tensor([1.25], dtype=torch.float32)
+
+    synced = omni_impl.OmniFSDPEngine._cast_dtensor_weight_for_sync(tensor)
+
+    assert synced.dtype is torch.bfloat16
+    assert synced.item() == pytest.approx(1.25)
+
+
+def test_weight_sync_keeps_integer_dtensor_buffers():
+    omni_impl = _get_omni_impl_module()
+    tensor = torch.tensor([1, 2], dtype=torch.int64)
+
+    synced = omni_impl.OmniFSDPEngine._cast_dtensor_weight_for_sync(tensor)
+
+    assert synced is tensor
+    assert synced.dtype is torch.int64
+
+
 # ---------------------------------------------------------------------------
 # ``collect_lora_params`` import source
 # ---------------------------------------------------------------------------
@@ -359,8 +379,8 @@ def test_collect_lora_params_import_not_from_verl():
 # ---------------------------------------------------------------------------
 
 
-def test_build_module_uses_auto_model_for_multimodal_lm():
-    """``_build_module`` uses ``AutoModelForMultimodalLM``, not ``AutoModelForCausalLM``."""
+def test_build_module_uses_adapter_selected_auto_model_class():
+    """Adapters select non-default auto model classes without relying on stage names."""
     omni_impl = _get_omni_impl_module()
     assert omni_impl.AutoModelForMultimodalLM is not None
 
@@ -373,19 +393,27 @@ def test_build_module_uses_auto_model_for_multimodal_lm():
     assert "AutoModelForMultimodalLM" in import_names, (
         f"AutoModelForMultimodalLM not imported from transformers; imports: {import_names}"
     )
+    assert "AutoModelForTextToWaveform" not in import_names
     assert "AutoModelForCausalLM" not in import_names, "AutoModelForCausalLM should NOT be imported from transformers"
 
 
-@pytest.mark.parametrize("architecture", ["Qwen3OmniMoeForConditionalGeneration"])
-def test_build_module_calls_adapter_configure_model(architecture):
+@pytest.mark.parametrize(
+    ("architecture", "model_stage"),
+    [
+        ("Qwen3OmniMoeForConditionalGeneration", "thinker"),
+        ("FutureOmniForConditionalGeneration", "talker"),
+    ],
+)
+def test_build_module_calls_adapter_configure_model(architecture, model_stage):
     """Mock ``from_pretrained``; verify ``adapter_cls.configure_model(module, cfg)``."""
     omni_impl = _get_omni_impl_module()
-    model_config = _make_mock_model_config(architecture=architecture)
+    model_config = _make_mock_model_config(architecture=architecture, model_stage=model_stage)
 
     fake_module = MagicMock(spec=torch.nn.Module)
     fake_module.named_parameters.return_value = [("weight", torch.nn.Parameter(torch.randn(2, 2)))]
 
     fake_adapter_cls = MagicMock()
+    fake_adapter_cls.auto_model_class = None
     fake_configured_module = MagicMock(spec=torch.nn.Module)
     fake_configured_module.named_parameters.return_value = [("weight", torch.nn.Parameter(torch.randn(2, 2)))]
     fake_adapter_cls.configure_model.return_value = fake_configured_module
@@ -399,13 +427,15 @@ def test_build_module_calls_adapter_configure_model(architecture):
         patch.object(model_base_mod.OmniModelBase, "get_class_by_name", return_value=fake_adapter_cls) as mock_get_cls,
         patch.object(omni_impl, "get_init_weight_context_manager", return_value=MagicMock()),
         patch.object(omni_impl.warnings, "catch_warnings", return_value=MagicMock()),
-        patch("verl.utils.torch_dtypes.PrecisionType"),
+        patch("verl.utils.torch_dtypes.PrecisionType") as precision_type,
     ):
+        precision_type.to_dtype.side_effect = lambda value: value
         engine = object.__new__(omni_impl.OmniFSDPEngine)
         engine.model_config = model_config
         engine.engine_config = MagicMock()
         engine.engine_config.model_dtype = None
         engine.engine_config.forward_only = False
+        engine.engine_config.strategy = "fsdp2"
         engine.device_mesh = None
 
         result = engine._build_module()
@@ -423,7 +453,80 @@ def test_build_module_calls_adapter_configure_model(architecture):
         )
 
         fake_adapter_cls.configure_model.assert_called_once_with(fake_module, model_config)
+        assert engine.model_adapter_cls is fake_adapter_cls
         assert result is fake_configured_module
+
+
+def test_build_module_calls_adapter_selected_auto_model_loader():
+    omni_impl = _get_omni_impl_module()
+    model_config = _make_mock_model_config(
+        architecture="FutureOmniForConditionalGeneration",
+        model_stage="talker",
+    )
+    loaded_module = MagicMock(spec=torch.nn.Module)
+    loaded_module.named_parameters.return_value = [("weight", torch.nn.Parameter(torch.randn(2, 2)))]
+    configured_module = MagicMock(spec=torch.nn.Module)
+    configured_module.named_parameters.return_value = [("weight", torch.nn.Parameter(torch.randn(2, 2)))]
+    auto_model_cls = MagicMock()
+    auto_model_cls.from_pretrained.return_value = loaded_module
+    adapter_cls = MagicMock()
+    adapter_cls.auto_model_class = auto_model_cls
+    adapter_cls.configure_model.return_value = configured_module
+    model_base_mod = sys.modules["verl_omni.pipelines.model_base"]
+
+    with (
+        patch.object(model_base_mod.OmniModelBase, "get_class_by_name", return_value=adapter_cls),
+        patch.object(omni_impl, "get_init_weight_context_manager", return_value=MagicMock()),
+        patch.object(omni_impl.warnings, "catch_warnings", return_value=MagicMock()),
+        patch("verl.utils.torch_dtypes.PrecisionType") as precision_type,
+    ):
+        precision_type.to_dtype.side_effect = lambda value: value
+        engine = object.__new__(omni_impl.OmniFSDPEngine)
+        engine.model_config = model_config
+        engine.engine_config = MagicMock(model_dtype=None, forward_only=False)
+        engine.engine_config.strategy = "fsdp2"
+        engine.device_mesh = None
+
+        result = engine._build_module()
+
+    auto_model_cls.from_pretrained.assert_called_once_with(
+        pretrained_model_name_or_path=model_config.local_path,
+        torch_dtype=torch.float32,
+        config=model_config.hf_config,
+        trust_remote_code=model_config.trust_remote_code,
+    )
+    adapter_cls.configure_model.assert_called_once_with(loaded_module, model_config)
+    assert result is configured_module
+
+
+def test_build_module_rejects_mixed_frozen_parameters_without_fsdp1_orig_params():
+    omni_impl = _get_omni_impl_module()
+    model_config = _make_mock_model_config()
+    loaded_module = torch.nn.Sequential(torch.nn.Linear(2, 2), torch.nn.Linear(2, 2))
+    configured_module = torch.nn.Sequential(torch.nn.Linear(2, 2), torch.nn.Linear(2, 2))
+    configured_module[0].requires_grad_(False)
+    adapter_cls = MagicMock()
+    adapter_cls.auto_model_class = None
+    adapter_cls.configure_model.return_value = configured_module
+    model_base_mod = sys.modules["verl_omni.pipelines.model_base"]
+
+    with (
+        patch.object(model_base_mod.OmniModelBase, "get_class_by_name", return_value=adapter_cls),
+        patch.object(omni_impl.AutoModelForMultimodalLM, "from_pretrained", return_value=loaded_module),
+        patch.object(omni_impl, "get_init_weight_context_manager", return_value=MagicMock()),
+        patch.object(omni_impl.warnings, "catch_warnings", return_value=MagicMock()),
+        patch("verl.utils.torch_dtypes.PrecisionType") as precision_type,
+    ):
+        precision_type.to_dtype.side_effect = lambda value: value
+        engine = object.__new__(omni_impl.OmniFSDPEngine)
+        engine.model_config = model_config
+        engine.engine_config = MagicMock(model_dtype=None, forward_only=False)
+        engine.engine_config.strategy = "fsdp"
+        engine.engine_config.use_orig_params = False
+        engine.device_mesh = None
+
+        with pytest.raises(ValueError, match="use_orig_params=true"):
+            engine._build_module()
 
 
 @pytest.mark.parametrize("option", ["use_liger", "use_fused_kernels"])

--- a/verl_omni/pipelines/model_base.py
+++ b/verl_omni/pipelines/model_base.py
@@ -513,6 +513,11 @@ class OmniModelBase(ABC):
         )
 
     @classmethod
+    def peek_class(cls, architecture: str, stage: str) -> Optional[type["OmniModelBase"]]:
+        """Return the registered adapter for ``(architecture, stage)`` or ``None``."""
+        return cls._registry.get((architecture, stage))
+
+    @classmethod
     def get_class_by_name(
         cls,
         architecture: str,
@@ -756,6 +761,11 @@ class OmniRolloutPipelineBase:
     def weight_sync_stage_ids(cls, pipeline_mode="thinker_only") -> list[int] | None:
         """Return stages that receive actor weights, or all stages by default."""
         return None
+
+    @classmethod
+    def policy_stage_id(cls, pipeline_mode="thinker_only") -> int:
+        """Return the stage whose sampling parameters and logprobs define the policy."""
+        return 0
 
     @classmethod
     def get_pipeline_id(cls, pipeline_mode: str = "thinker_only") -> str:

--- a/verl_omni/pipelines/model_base.py
+++ b/verl_omni/pipelines/model_base.py
@@ -479,6 +479,7 @@ class OmniModelBase(ABC):
     """
 
     _registry: dict[tuple[str, str], type["OmniModelBase"]] = {}
+    auto_model_class: Any = None
 
     @classmethod
     def register(cls, architecture: str, stage: str = "thinker"):
@@ -545,6 +546,11 @@ class OmniModelBase(ABC):
                 f"stage={stage!r}). Registered: {registered}. "
                 f"Set ``external_lib`` to load your training adapter."
             ) from None
+
+    @classmethod
+    def register_auto_classes(cls) -> None:
+        """Register optional model-package classes with Transformers auto APIs."""
+        return
 
     @classmethod
     @abstractmethod
@@ -615,7 +621,6 @@ class OmniModelBase(ABC):
         Default implementation strips the submodules returned by
         ``get_strip_modules``.  Override to also:
 
-        - Register the model class with ``AutoModelForCausalLM``.
         - Redirect ``forward()`` and embedding accessors to the
           trainable sub-component.
         - Force ``tie_word_embeddings=False`` for FSDP compatibility.
@@ -670,6 +675,7 @@ class OmniRolloutPipelineBase:
     """
 
     _registry: dict[str, type["OmniRolloutPipelineBase"]] = {}
+    supports_async_chunk = True
 
     @classmethod
     def register(cls, model_type: str):
@@ -747,6 +753,11 @@ class OmniRolloutPipelineBase:
         return {}
 
     @classmethod
+    def weight_sync_stage_ids(cls, pipeline_mode="thinker_only") -> list[int] | None:
+        """Return stages that receive actor weights, or all stages by default."""
+        return None
+
+    @classmethod
     def get_pipeline_id(cls, pipeline_mode: str = "thinker_only") -> str:
         """Return the vLLM-Omni pipeline model_type for *pipeline_mode*.
 
@@ -800,3 +811,25 @@ class OmniRolloutPipelineBase:
             dict: Extra key-value pairs merged into the stage's engine args.
         """
         return {}
+
+    @classmethod
+    def prepare_engine_prompt(
+        cls,
+        prompt_ids: list[int],
+        model_config,
+        multi_modal_data: dict,
+        mm_processor_kwargs: Optional[dict] = None,
+    ) -> dict | None:
+        """Build an architecture-specific rollout prompt when required."""
+        return None
+
+    @classmethod
+    def combine_engine_outputs(cls, outputs: list, prompt: dict) -> tuple[Any, dict[str, Any]]:
+        """Select the policy output and collect architecture-specific fields."""
+        if not outputs:
+            raise RuntimeError("The omni rollout engine returned no outputs.")
+        if len(outputs) != 1:
+            raise NotImplementedError(
+                "An omni rollout adapter with multiple final outputs must implement combine_engine_outputs()."
+            )
+        return outputs[0], {}

--- a/verl_omni/pipelines/model_base.py
+++ b/verl_omni/pipelines/model_base.py
@@ -835,7 +835,12 @@ class OmniRolloutPipelineBase:
 
     @classmethod
     def combine_engine_outputs(cls, outputs: list, prompt: dict) -> tuple[Any, dict[str, Any]]:
-        """Select the policy output and collect architecture-specific fields."""
+        """Select the policy output and collect architecture-specific fields.
+
+        Overriding this hook opts an adapter into retaining and assembling
+        multiple final stage outputs. The default preserves single-output AR
+        behavior.
+        """
         if not outputs:
             raise RuntimeError("The omni rollout engine returned no outputs.")
         if len(outputs) != 1:

--- a/verl_omni/workers/config/omni/model.py
+++ b/verl_omni/workers/config/omni/model.py
@@ -170,8 +170,12 @@ class OmniModelConfig(BaseConfig):
         attn_implementation = self.override_config.get("attn_implementation", "flash_attention_2")
         from verl_omni.pipelines.model_base import OmniModelBase
 
-        adapter_cls = OmniModelBase.get_class_by_name(self.architecture, self.model_stage, self.external_lib)
-        adapter_cls.register_auto_classes()
+        if self.load_tokenizer:
+            adapter_cls = OmniModelBase.get_class_by_name(self.architecture, self.model_stage, self.external_lib)
+        else:
+            adapter_cls = OmniModelBase.peek_class(self.architecture, self.model_stage)
+        if adapter_cls is not None:
+            adapter_cls.register_auto_classes()
         self.hf_config = AutoConfig.from_pretrained(
             self.local_hf_config_path,
             trust_remote_code=self.trust_remote_code,

--- a/verl_omni/workers/config/omni/model.py
+++ b/verl_omni/workers/config/omni/model.py
@@ -168,6 +168,10 @@ class OmniModelConfig(BaseConfig):
         # Build hf_config so the FSDP engine can load and wrap the model.
         self.local_hf_config_path = copy_to_local(self.hf_config_path, use_shm=self.use_shm)
         attn_implementation = self.override_config.get("attn_implementation", "flash_attention_2")
+        from verl_omni.pipelines.model_base import OmniModelBase
+
+        adapter_cls = OmniModelBase.get_class_by_name(self.architecture, self.model_stage, self.external_lib)
+        adapter_cls.register_auto_classes()
         self.hf_config = AutoConfig.from_pretrained(
             self.local_hf_config_path,
             trust_remote_code=self.trust_remote_code,
@@ -178,10 +182,7 @@ class OmniModelConfig(BaseConfig):
         self.architectures = getattr(self.hf_config, "architectures", None)
 
         if self.load_tokenizer:
-            from verl_omni.pipelines.model_base import OmniModelBase
-
             self.local_tokenizer_path = copy_to_local(self.tokenizer_path, use_shm=self.use_shm)
-            adapter_cls = OmniModelBase.get_class_by_name(self.architecture, self.model_stage, self.external_lib)
             self.tokenizer = adapter_cls.configure_tokenizer(self.local_tokenizer_path, self)
             self.processor = adapter_cls.configure_processor(self.local_path, self)
 

--- a/verl_omni/workers/engine/fsdp/omni_impl.py
+++ b/verl_omni/workers/engine/fsdp/omni_impl.py
@@ -43,6 +43,12 @@ logger = logging.getLogger(__name__)
 class OmniFSDPEngine(FSDPEngineWithLMHead):
     """FSDP engine for omni models"""
 
+    @staticmethod
+    def _cast_dtensor_weight_for_sync(tensor: torch.Tensor) -> torch.Tensor:
+        if tensor.is_floating_point() and tensor.dtype != torch.bfloat16:
+            return tensor.to(dtype=torch.bfloat16, non_blocking=True)
+        return tensor
+
     def prepare_model_inputs(self, micro_batch):
         """Prepare standard LM inputs, then add model-native replay fields."""
         model_inputs, output_args = super().prepare_model_inputs(micro_batch)
@@ -97,11 +103,10 @@ class OmniFSDPEngine(FSDPEngineWithLMHead):
             per_tensor_param = params.items()
         else:
             device = get_device_id()  # used when fsdp2 set cpu_offload_policy
-            # TODO: cast fp32 to bf16 to reduce weight sync overhead, need more fine-grained control, e.g MoE gate
             per_tensor_param = (
                 (
                     name,
-                    param.to(device, non_blocking=True).full_tensor().to(torch.bfloat16, non_blocking=True)
+                    self._cast_dtensor_weight_for_sync(param.to(device, non_blocking=True).full_tensor())
                     if isinstance(param, DTensor)
                     else param,
                 )
@@ -144,7 +149,7 @@ class OmniFSDPEngine(FSDPEngineWithLMHead):
                 for name, param in params.items():
                     yield (
                         name,
-                        param.to(device, non_blocking=True).full_tensor().to(torch.bfloat16, non_blocking=True)
+                        self._cast_dtensor_weight_for_sync(param.to(device, non_blocking=True).full_tensor())
                         if isinstance(param, DTensor)
                         else param.detach().clone(),
                     )
@@ -171,6 +176,12 @@ class OmniFSDPEngine(FSDPEngineWithLMHead):
 
         self.model_config: OmniModelConfig
         architecture = self.model_config.architecture
+        adapter_cls = OmniModelBase.get_class_by_name(
+            architecture,
+            self.model_config.model_stage,
+            self.model_config.get("external_lib"),
+        )
+        self.model_adapter_cls = adapter_cls
 
         torch_dtype = self.engine_config.model_dtype
 
@@ -192,20 +203,21 @@ class OmniFSDPEngine(FSDPEngineWithLMHead):
         with init_context(), warnings.catch_warnings():
             warnings.simplefilter("ignore")
 
-            module = AutoModelForMultimodalLM.from_pretrained(
+            auto_model_cls = getattr(adapter_cls, "auto_model_class", None) or AutoModelForMultimodalLM
+            module = auto_model_cls.from_pretrained(
                 pretrained_model_name_or_path=self.model_config.local_path,
                 torch_dtype=torch_dtype,
                 config=self.model_config.hf_config,
                 trust_remote_code=self.model_config.trust_remote_code,
             )
-
-            adapter_cls = OmniModelBase.get_class_by_name(
-                architecture,
-                self.model_config.model_stage,
-                self.model_config.get("external_lib"),
-            )
-            self.model_adapter_cls = adapter_cls
             module = adapter_cls.configure_model(module, self.model_config)
+
+            if self.engine_config.strategy == "fsdp" and not self.engine_config.use_orig_params:
+                trainability = {parameter.requires_grad for parameter in module.parameters()}
+                if len(trainability) > 1:
+                    raise ValueError(
+                        "FSDP1 requires use_orig_params=true when a model adapter freezes only part of the model."
+                    )
 
             module.to(torch_dtype)
 

--- a/verl_omni/workers/rollout/vllm_rollout/vllm_omni_ar_strategy.py
+++ b/verl_omni/workers/rollout/vllm_rollout/vllm_omni_ar_strategy.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import copy
 import json
 import logging
 import os
@@ -56,6 +57,14 @@ class ARStrategy(OmniStrategyBase):
     rollout_config_cls = RolloutConfig
     model_config_cls = OmniModelConfig
 
+    def __init__(self, server: Any) -> None:
+        super().__init__(server)
+        self._rollout_adapter: type[OmniRolloutPipelineBase] | None = None
+        self._pipeline_mode = "thinker_only"
+        self._rollout_output_modalities: list[str] | None = None
+        self._weight_sync_stage_ids: list[int] | None = None
+        self._stage_sampling_constraints: dict[int, dict[str, Any]] = {}
+
     def validate_configs(self) -> None:
         if self.server.config.max_model_len is None:
             self.server.config.max_model_len = self.server.config.prompt_length + self.server.config.response_length
@@ -74,13 +83,23 @@ class ARStrategy(OmniStrategyBase):
         engine_kwargs.pop("custom_pipeline", None)
         # TODO (mike): drop this later. It should be inferred from the model config.
         pipeline_name = engine_kwargs.pop("pipeline_name", None)
-        pipeline_mode = engine_kwargs.pop("pipeline_mode", "thinker_only")
+        self._pipeline_mode = engine_kwargs.pop("pipeline_mode", "thinker_only")
 
         adapter_cls = OmniRolloutPipelineBase.get_class(pipeline_name)
         if adapter_cls is not None:
-            self._write_deploy_config(engine_kwargs, pipeline_name, adapter_cls, pipeline_mode)
-            self.server._rollout_flags = adapter_cls.rollout_flags(pipeline_mode=pipeline_mode)
-            adapter_overrides = adapter_cls.get_engine_hf_overrides(pipeline_mode=pipeline_mode)
+            async_chunk = engine_kwargs.get("async_chunk", engine_kwargs.get("async-chunk", True))
+            if not isinstance(async_chunk, bool):
+                raise TypeError(f"async_chunk must be a boolean, got {type(async_chunk).__name__}.")
+            if async_chunk and not adapter_cls.supports_async_chunk:
+                raise ValueError(
+                    f"{adapter_cls.__name__} requires async_chunk=false because chunked stage outputs "
+                    "cannot be replayed by its actor adapter."
+                )
+            self._rollout_adapter = adapter_cls
+            self._write_deploy_config(engine_kwargs, pipeline_name, adapter_cls, self._pipeline_mode)
+            self.server._rollout_flags = adapter_cls.rollout_flags(pipeline_mode=self._pipeline_mode)
+            self._weight_sync_stage_ids = adapter_cls.weight_sync_stage_ids(pipeline_mode=self._pipeline_mode)
+            adapter_overrides = adapter_cls.get_engine_hf_overrides(pipeline_mode=self._pipeline_mode)
             if adapter_overrides:
                 hf_overrides = engine_kwargs.get("hf_overrides", {})
                 if isinstance(hf_overrides, str):
@@ -111,12 +130,42 @@ class ARStrategy(OmniStrategyBase):
         adapter_cls.ensure_pipeline_registered(pipeline_mode)
         stages = adapter_cls.build_stage_configs(pipeline_mode=pipeline_mode)
         pipeline_id = adapter_cls.get_pipeline_id(pipeline_mode)
+        final_output_types = [stage.final_output_type for stage in stages if stage.final_output]
+        self._rollout_output_modalities = (
+            list(dict.fromkeys(final_output_types)) if len(final_output_types) > 1 else None
+        )
+        adapter_combiner = getattr(adapter_cls.combine_engine_outputs, "__func__", adapter_cls.combine_engine_outputs)
+        default_combiner = getattr(
+            OmniRolloutPipelineBase.combine_engine_outputs,
+            "__func__",
+            OmniRolloutPipelineBase.combine_engine_outputs,
+        )
+        if self._rollout_output_modalities is not None and adapter_combiner is default_combiner:
+            raise ValueError(
+                f"{adapter_cls.__name__} exposes multiple final pipeline outputs but does not implement "
+                "combine_engine_outputs(); refusing to guess which output contains policy token IDs."
+            )
+        self._stage_sampling_constraints = {stage.stage_id: dict(stage.sampling_constraints) for stage in stages}
+        stage_extras = {
+            stage.stage_id: dict(adapter_cls.get_stage_engine_extras(stage.stage_id, pipeline_mode=pipeline_mode))
+            for stage in stages
+        }
+        capacity_fields = ("max_model_len", "max_num_batched_tokens")
+        if any(field in extras for extras in stage_extras.values() for field in capacity_fields):
+            for extras in stage_extras.values():
+                for field in capacity_fields:
+                    extras.setdefault(field, getattr(self.server.config, field))
+            for field in capacity_fields:
+                engine_kwargs[field] = None
 
         device_control_env = get_visible_devices_keyword()
         visible_devices = os.environ.get(device_control_env, "")
         tp_size = self.server.config.tensor_model_parallel_size
 
         deploy_dict: dict[str, object] = {"pipeline": pipeline_id}
+        async_chunk = engine_kwargs.get("async_chunk", engine_kwargs.get("async-chunk"))
+        if async_chunk is not None:
+            deploy_dict["async_chunk"] = async_chunk
 
         if visible_devices:
             device_count = len([device for device in visible_devices.split(",") if device.strip()])
@@ -128,7 +177,7 @@ class ARStrategy(OmniStrategyBase):
                     "devices": devices,
                     "tensor_parallel_size": tp_size,
                     "text_encoder_tp_size": getattr(self.server.config, "text_encoder_tp_size", 1),
-                    "engine_extras": adapter_cls.get_stage_engine_extras(stage_id, pipeline_mode=pipeline_mode),
+                    "engine_extras": stage_extras[stage_id],
                 }
                 for stage_id in stage_ids
             ]
@@ -151,6 +200,10 @@ class ARStrategy(OmniStrategyBase):
         engine_kwargs["deploy_config"] = deploy_path
 
     def prepare_engine_args(self, engine_args: dict[str, Any], args: Namespace) -> None:
+        if self._rollout_output_modalities is not None:
+            # The generated per-stage deploy config owns model_stage for
+            # multi-output pipelines.
+            engine_args["model_stage"] = None
         for timeout_key in ("stage_init_timeout", "init_timeout"):
             timeout_value = getattr(args, timeout_key, None)
             if timeout_value is not None:
@@ -158,6 +211,11 @@ class ARStrategy(OmniStrategyBase):
         engine_args["logprobs_mode"] = getattr(self.server.config, "logprobs_mode", "processed_logprobs")
         if isinstance(engine_args.get("compilation_config"), dict):
             engine_args["compilation_config"] = _drop_none_mapping_values(engine_args["compilation_config"])
+
+    def collective_rpc_stage_ids(self, method: Any) -> list[int] | None:
+        if method in {"set_pending_lora_peft_config", "update_weights_from_ipc"}:
+            return self._weight_sync_stage_ids
+        return None
 
     def preprocess_input(
         self,
@@ -170,15 +228,38 @@ class ARStrategy(OmniStrategyBase):
         mm_processor_kwargs: Optional[dict[str, Any]] = None,
         extra_prompt_ids: Optional[dict[str, list[int]]] = None,
         negative_extra_prompt_ids: Optional[dict[str, list[int]]] = None,
-    ) -> tuple[dict[str, Any], SamplingParams]:
+    ) -> tuple[dict[str, Any], SamplingParams | list[Any]]:
         if multi_modal_data:
             processor = getattr(self.server.model_config, "processor", None)
             if processor is not None and hasattr(processor, "dedup_pad_tokens"):
                 prompt_ids = processor.dedup_pad_tokens(prompt_ids)
-        max_possible_tokens = self.server.config.max_model_len - len(prompt_ids)
+
+        prompt = None
+        adapter_prepared_prompt = False
+        if self._rollout_adapter is not None:
+            prompt = self._rollout_adapter.prepare_engine_prompt(
+                prompt_ids=prompt_ids,
+                model_config=self.server.model_config,
+                multi_modal_data=multi_modal_data,
+                mm_processor_kwargs=mm_processor_kwargs,
+            )
+            adapter_prepared_prompt = prompt is not None
+        if prompt is not None:
+            if not isinstance(prompt, dict):
+                raise TypeError(f"An omni rollout adapter must return a dict or None, got {type(prompt).__name__}.")
+            if "prompt_token_ids" not in prompt:
+                raise RuntimeError("An adapter-prepared omni prompt must contain prompt_token_ids.")
+            effective_prompt_ids = prompt["prompt_token_ids"]
+            if not isinstance(effective_prompt_ids, list) or any(
+                isinstance(token_id, bool) or not isinstance(token_id, int) for token_id in effective_prompt_ids
+            ):
+                raise TypeError("An adapter-prepared omni prompt must contain prompt_token_ids as a list of integers.")
+        else:
+            effective_prompt_ids = prompt_ids
+        max_possible_tokens = self.server.config.max_model_len - len(effective_prompt_ids)
         if max_possible_tokens <= 0:
             raise ValueError(
-                f"Prompt length ({len(prompt_ids)}) meets or exceeds the model's maximum context length "
+                f"Prompt length ({len(effective_prompt_ids)}) meets or exceeds the model's maximum context length "
                 f"({self.server.config.max_model_len}), leaving no space for generation."
             )
 
@@ -189,7 +270,7 @@ class ARStrategy(OmniStrategyBase):
         else:
             max_tokens = min(
                 self.server.config.response_length,
-                self.server.config.prompt_length + self.server.config.response_length - len(prompt_ids),
+                self.server.config.prompt_length + self.server.config.response_length - len(effective_prompt_ids),
             )
         max_tokens = max(0, min(max_tokens, max_possible_tokens))
 
@@ -201,13 +282,26 @@ class ARStrategy(OmniStrategyBase):
         else:
             sampling_params["logprobs"] = None
         sampling_params.setdefault("repetition_penalty", getattr(self.server.config, "repetition_penalty", 1.0))
-        params = SamplingParams(max_tokens=max_tokens, **sampling_params)
+        policy_params = SamplingParams(max_tokens=max_tokens, **sampling_params)
+        if self._rollout_output_modalities is not None:
+            params = copy.deepcopy(self.server.engine.default_sampling_params_list)
+            if len(params) <= 1:
+                raise RuntimeError("A multi-output omni rollout requires per-stage sampling parameters.")
+            constrained = self._stage_sampling_constraints[0]
+            for field in {"max_tokens", *sampling_params} - constrained.keys():
+                setattr(params[0], field, getattr(policy_params, field))
+        else:
+            params = policy_params
 
-        prompt = {"prompt_token_ids": prompt_ids}
+        if prompt is None:
+            prompt = {"prompt_token_ids": prompt_ids}
+        additional_information = prompt.get("additional_information")
+        if isinstance(additional_information, dict):
+            additional_information.setdefault("max_new_tokens", [max_tokens])
         if multi_modal_data:
-            prompt["multi_modal_data"] = multi_modal_data
-        if mm_processor_kwargs:
-            prompt["mm_processor_kwargs"] = mm_processor_kwargs
+            prompt.setdefault("multi_modal_data", multi_modal_data)
+        if mm_processor_kwargs and not adapter_prepared_prompt:
+            prompt.setdefault("mm_processor_kwargs", mm_processor_kwargs)
         return prompt, params
 
     async def run_generation(
@@ -218,17 +312,34 @@ class ARStrategy(OmniStrategyBase):
         lora_request: Optional[LoRARequest],
         priority: int,
     ) -> Any:
-        return await self._collect_last_output(
-            self.server.engine.generate(
-                prompt=prompt,
-                sampling_params_list=params,
-                request_id=request_id,
-                lora_request=lora_request,
-                priority=priority,
-            )
+        generate_kwargs = dict(
+            prompt=prompt,
+            sampling_params_list=params,
+            request_id=request_id,
+            lora_request=lora_request,
+            priority=priority,
         )
+        if self._rollout_output_modalities is not None:
+            generate_kwargs["output_modalities"] = self._rollout_output_modalities
+        generator = self.server.engine.generate(**generate_kwargs)
+        if self._rollout_output_modalities is None:
+            return await self._collect_last_output(generator)
 
-    def process_output(self, final_res: Any, params: SamplingParams, sampling_params: dict[str, Any]) -> TokenOutput:
+        outputs = []
+        async for output in generator:
+            outputs.append(output)
+        if self._rollout_adapter is None:
+            raise RuntimeError("Retaining multiple stage outputs requires a registered rollout adapter.")
+        final_res, rollout_fields = self._rollout_adapter.combine_engine_outputs(outputs, prompt)
+        final_res._verl_omni_rollout_fields = rollout_fields
+        return final_res
+
+    def process_output(
+        self,
+        final_res: Any,
+        params: SamplingParams | list[Any],
+        sampling_params: dict[str, Any],
+    ) -> TokenOutput:
         if final_res is None:
             raise RuntimeError("AR mode: vLLM-Omni engine yielded no output for the prompt.")
 
@@ -237,9 +348,12 @@ class ARStrategy(OmniStrategyBase):
             raise RuntimeError("AR mode expects outputs with token IDs, but got None or empty.")
 
         extra_fields = {"global_steps": self.server.global_steps}
+        if self._rollout_output_modalities is not None:
+            extra_fields.update(final_res._verl_omni_rollout_fields)
         token_ids = req_output.outputs[0].token_ids
         log_probs = None
-        if params.logprobs is not None:
+        policy_params = params[0] if isinstance(params, list) else params
+        if policy_params.logprobs is not None:
             log_probs = [
                 logprobs[token_ids[index]].logprob for index, logprobs in enumerate(req_output.outputs[0].logprobs)
             ]

--- a/verl_omni/workers/rollout/vllm_rollout/vllm_omni_ar_strategy.py
+++ b/verl_omni/workers/rollout/vllm_rollout/vllm_omni_ar_strategy.py
@@ -64,6 +64,8 @@ class ARStrategy(OmniStrategyBase):
         self._rollout_output_modalities: list[str] | None = None
         self._weight_sync_stage_ids: list[int] | None = None
         self._stage_sampling_constraints: dict[int, dict[str, Any]] = {}
+        self._policy_stage_id = 0
+        self._policy_stage_index = 0
 
     def validate_configs(self) -> None:
         if self.server.config.max_model_len is None:
@@ -98,7 +100,6 @@ class ARStrategy(OmniStrategyBase):
             self._rollout_adapter = adapter_cls
             self._write_deploy_config(engine_kwargs, pipeline_name, adapter_cls, self._pipeline_mode)
             self.server._rollout_flags = adapter_cls.rollout_flags(pipeline_mode=self._pipeline_mode)
-            self._weight_sync_stage_ids = adapter_cls.weight_sync_stage_ids(pipeline_mode=self._pipeline_mode)
             adapter_overrides = adapter_cls.get_engine_hf_overrides(pipeline_mode=self._pipeline_mode)
             if adapter_overrides:
                 hf_overrides = engine_kwargs.get("hf_overrides", {})
@@ -129,6 +130,37 @@ class ARStrategy(OmniStrategyBase):
         """Write a deploy config YAML from the adapter's stage topology."""
         adapter_cls.ensure_pipeline_registered(pipeline_mode)
         stages = adapter_cls.build_stage_configs(pipeline_mode=pipeline_mode)
+        stage_ids = [stage.stage_id for stage in stages]
+        policy_stage_id = adapter_cls.policy_stage_id(pipeline_mode=pipeline_mode)
+        if isinstance(policy_stage_id, bool) or not isinstance(policy_stage_id, int):
+            raise TypeError(f"{adapter_cls.__name__}.policy_stage_id() must return an integer stage ID.")
+        if policy_stage_id not in stage_ids:
+            raise ValueError(
+                f"{adapter_cls.__name__}.policy_stage_id() returned unknown stage {policy_stage_id}; "
+                f"available stages are {stage_ids}."
+            )
+        self._policy_stage_id = policy_stage_id
+        self._policy_stage_index = stage_ids.index(policy_stage_id)
+
+        weight_sync_stage_ids = adapter_cls.weight_sync_stage_ids(pipeline_mode=pipeline_mode)
+        if weight_sync_stage_ids is not None:
+            if not isinstance(weight_sync_stage_ids, list):
+                raise TypeError(f"{adapter_cls.__name__}.weight_sync_stage_ids() must return a list or None.")
+            if not weight_sync_stage_ids:
+                raise ValueError(f"{adapter_cls.__name__}.weight_sync_stage_ids() must not return an empty list.")
+            if any(isinstance(stage_id, bool) or not isinstance(stage_id, int) for stage_id in weight_sync_stage_ids):
+                raise TypeError(f"{adapter_cls.__name__}.weight_sync_stage_ids() must contain only integer stage IDs.")
+            if len(weight_sync_stage_ids) != len(set(weight_sync_stage_ids)):
+                raise ValueError(f"{adapter_cls.__name__}.weight_sync_stage_ids() must contain unique stage IDs.")
+            unknown_stage_ids = sorted(set(weight_sync_stage_ids) - set(stage_ids))
+            if unknown_stage_ids:
+                raise ValueError(
+                    f"{adapter_cls.__name__}.weight_sync_stage_ids() returned unknown stages {unknown_stage_ids}; "
+                    f"available stages are {stage_ids}."
+                )
+            weight_sync_stage_ids = list(weight_sync_stage_ids)
+        self._weight_sync_stage_ids = weight_sync_stage_ids
+
         pipeline_id = adapter_cls.get_pipeline_id(pipeline_mode)
         final_output_types = [stage.final_output_type for stage in stages if stage.final_output]
         self._rollout_output_modalities = (
@@ -285,11 +317,11 @@ class ARStrategy(OmniStrategyBase):
         policy_params = SamplingParams(max_tokens=max_tokens, **sampling_params)
         if self._rollout_output_modalities is not None:
             params = copy.deepcopy(self.server.engine.default_sampling_params_list)
-            if len(params) <= 1:
+            if len(params) <= 1 or self._policy_stage_index >= len(params):
                 raise RuntimeError("A multi-output omni rollout requires per-stage sampling parameters.")
-            constrained = self._stage_sampling_constraints[0]
+            constrained = self._stage_sampling_constraints[self._policy_stage_id]
             for field in {"max_tokens", *sampling_params} - constrained.keys():
-                setattr(params[0], field, getattr(policy_params, field))
+                setattr(params[self._policy_stage_index], field, getattr(policy_params, field))
         else:
             params = policy_params
 
@@ -352,7 +384,7 @@ class ARStrategy(OmniStrategyBase):
             extra_fields.update(final_res._verl_omni_rollout_fields)
         token_ids = req_output.outputs[0].token_ids
         log_probs = None
-        policy_params = params[0] if isinstance(params, list) else params
+        policy_params = params[self._policy_stage_index] if isinstance(params, list) else params
         if policy_params.logprobs is not None:
             log_probs = [
                 logprobs[token_ids[index]].logprob for index, logprobs in enumerate(req_output.outputs[0].logprobs)

--- a/verl_omni/workers/rollout/vllm_rollout/vllm_omni_ar_strategy.py
+++ b/verl_omni/workers/rollout/vllm_rollout/vllm_omni_ar_strategy.py
@@ -60,14 +60,11 @@ class ARStrategy(OmniStrategyBase):
     def __init__(self, server: Any) -> None:
         super().__init__(server)
         self._rollout_adapter: type[OmniRolloutPipelineBase] | None = None
-        self._pipeline_mode = "thinker_only"
         self._rollout_output_modalities: list[str] | None = None
         self._weight_sync_stage_ids: list[int] | None = None
-        self._stage_sampling_constraints: dict[int, dict[str, Any]] = {}
-        self._default_stage_sampling_params: tuple[Any, ...] | None = None
         self._rollout_fields_by_request_id: dict[str, dict[str, Any]] = {}
-        self._policy_stage_id = 0
         self._policy_stage_index = 0
+        self._policy_sampling_constraints: dict[str, Any] = {}
 
     def validate_configs(self) -> None:
         if self.server.config.max_model_len is None:
@@ -87,7 +84,7 @@ class ARStrategy(OmniStrategyBase):
         engine_kwargs.pop("custom_pipeline", None)
         # TODO (mike): drop this later. It should be inferred from the model config.
         pipeline_name = engine_kwargs.pop("pipeline_name", None)
-        self._pipeline_mode = engine_kwargs.pop("pipeline_mode", "thinker_only")
+        pipeline_mode = engine_kwargs.pop("pipeline_mode", "thinker_only")
 
         adapter_cls = OmniRolloutPipelineBase.get_class(pipeline_name)
         if adapter_cls is not None:
@@ -100,9 +97,9 @@ class ARStrategy(OmniStrategyBase):
                     "cannot be replayed by its actor adapter."
                 )
             self._rollout_adapter = adapter_cls
-            self._write_deploy_config(engine_kwargs, pipeline_name, adapter_cls, self._pipeline_mode)
-            self.server._rollout_flags = adapter_cls.rollout_flags(pipeline_mode=self._pipeline_mode)
-            adapter_overrides = adapter_cls.get_engine_hf_overrides(pipeline_mode=self._pipeline_mode)
+            self._write_deploy_config(engine_kwargs, pipeline_name, adapter_cls, pipeline_mode)
+            self.server._rollout_flags = adapter_cls.rollout_flags(pipeline_mode=pipeline_mode)
+            adapter_overrides = adapter_cls.get_engine_hf_overrides(pipeline_mode=pipeline_mode)
             if adapter_overrides:
                 hf_overrides = engine_kwargs.get("hf_overrides", {})
                 if isinstance(hf_overrides, str):
@@ -139,8 +136,8 @@ class ARStrategy(OmniStrategyBase):
                 f"{adapter_cls.__name__}.policy_stage_id() returned unknown stage {policy_stage_id}; "
                 f"available stages are {stage_ids}."
             )
-        self._policy_stage_id = policy_stage_id
         self._policy_stage_index = stage_ids.index(policy_stage_id)
+        self._policy_sampling_constraints = dict(stages[self._policy_stage_index].sampling_constraints)
 
         weight_sync_stage_ids = adapter_cls.weight_sync_stage_ids(pipeline_mode=pipeline_mode)
         if weight_sync_stage_ids is not None:
@@ -165,7 +162,6 @@ class ARStrategy(OmniStrategyBase):
             if len(final_output_types) > 1 and adapter_combiner is not default_combiner
             else None
         )
-        self._stage_sampling_constraints = {stage.stage_id: dict(stage.sampling_constraints) for stage in stages}
         stage_extras = {
             stage.stage_id: dict(adapter_cls.get_stage_engine_extras(stage.stage_id, pipeline_mode=pipeline_mode))
             for stage in stages
@@ -300,18 +296,14 @@ class ARStrategy(OmniStrategyBase):
         sampling_params.setdefault("repetition_penalty", getattr(self.server.config, "repetition_penalty", 1.0))
         policy_params = SamplingParams(max_tokens=max_tokens, **sampling_params)
         if self._rollout_output_modalities is not None:
-            if self._default_stage_sampling_params is None:
-                self._default_stage_sampling_params = tuple(
-                    copy.deepcopy(self.server.engine.default_sampling_params_list)
-                )
-            if len(self._default_stage_sampling_params) <= 1 or self._policy_stage_index >= len(
-                self._default_stage_sampling_params
+            default_stage_sampling_params = self.server.engine.default_sampling_params_list
+            if len(default_stage_sampling_params) <= 1 or self._policy_stage_index >= len(
+                default_stage_sampling_params
             ):
                 raise RuntimeError("A multi-output omni rollout requires per-stage sampling parameters.")
-            params = list(self._default_stage_sampling_params)
+            params = list(default_stage_sampling_params)
             params[self._policy_stage_index] = copy.copy(params[self._policy_stage_index])
-            constrained = self._stage_sampling_constraints[self._policy_stage_id]
-            for field in {"max_tokens", *sampling_params} - constrained.keys():
+            for field in {"max_tokens", *sampling_params} - self._policy_sampling_constraints.keys():
                 setattr(params[self._policy_stage_index], field, getattr(policy_params, field))
         else:
             params = policy_params

--- a/verl_omni/workers/rollout/vllm_rollout/vllm_omni_ar_strategy.py
+++ b/verl_omni/workers/rollout/vllm_rollout/vllm_omni_ar_strategy.py
@@ -64,6 +64,8 @@ class ARStrategy(OmniStrategyBase):
         self._rollout_output_modalities: list[str] | None = None
         self._weight_sync_stage_ids: list[int] | None = None
         self._stage_sampling_constraints: dict[int, dict[str, Any]] = {}
+        self._default_stage_sampling_params: tuple[Any, ...] | None = None
+        self._rollout_fields_by_request_id: dict[str, dict[str, Any]] = {}
         self._policy_stage_id = 0
         self._policy_stage_index = 0
 
@@ -132,8 +134,6 @@ class ARStrategy(OmniStrategyBase):
         stages = adapter_cls.build_stage_configs(pipeline_mode=pipeline_mode)
         stage_ids = [stage.stage_id for stage in stages]
         policy_stage_id = adapter_cls.policy_stage_id(pipeline_mode=pipeline_mode)
-        if isinstance(policy_stage_id, bool) or not isinstance(policy_stage_id, int):
-            raise TypeError(f"{adapter_cls.__name__}.policy_stage_id() must return an integer stage ID.")
         if policy_stage_id not in stage_ids:
             raise ValueError(
                 f"{adapter_cls.__name__}.policy_stage_id() returned unknown stage {policy_stage_id}; "
@@ -144,39 +144,27 @@ class ARStrategy(OmniStrategyBase):
 
         weight_sync_stage_ids = adapter_cls.weight_sync_stage_ids(pipeline_mode=pipeline_mode)
         if weight_sync_stage_ids is not None:
-            if not isinstance(weight_sync_stage_ids, list):
-                raise TypeError(f"{adapter_cls.__name__}.weight_sync_stage_ids() must return a list or None.")
-            if not weight_sync_stage_ids:
-                raise ValueError(f"{adapter_cls.__name__}.weight_sync_stage_ids() must not return an empty list.")
-            if any(isinstance(stage_id, bool) or not isinstance(stage_id, int) for stage_id in weight_sync_stage_ids):
-                raise TypeError(f"{adapter_cls.__name__}.weight_sync_stage_ids() must contain only integer stage IDs.")
-            if len(weight_sync_stage_ids) != len(set(weight_sync_stage_ids)):
-                raise ValueError(f"{adapter_cls.__name__}.weight_sync_stage_ids() must contain unique stage IDs.")
             unknown_stage_ids = sorted(set(weight_sync_stage_ids) - set(stage_ids))
             if unknown_stage_ids:
                 raise ValueError(
                     f"{adapter_cls.__name__}.weight_sync_stage_ids() returned unknown stages {unknown_stage_ids}; "
                     f"available stages are {stage_ids}."
                 )
-            weight_sync_stage_ids = list(weight_sync_stage_ids)
         self._weight_sync_stage_ids = weight_sync_stage_ids
 
         pipeline_id = adapter_cls.get_pipeline_id(pipeline_mode)
         final_output_types = [stage.final_output_type for stage in stages if stage.final_output]
-        self._rollout_output_modalities = (
-            list(dict.fromkeys(final_output_types)) if len(final_output_types) > 1 else None
-        )
         adapter_combiner = getattr(adapter_cls.combine_engine_outputs, "__func__", adapter_cls.combine_engine_outputs)
         default_combiner = getattr(
             OmniRolloutPipelineBase.combine_engine_outputs,
             "__func__",
             OmniRolloutPipelineBase.combine_engine_outputs,
         )
-        if self._rollout_output_modalities is not None and adapter_combiner is default_combiner:
-            raise ValueError(
-                f"{adapter_cls.__name__} exposes multiple final pipeline outputs but does not implement "
-                "combine_engine_outputs(); refusing to guess which output contains policy token IDs."
-            )
+        self._rollout_output_modalities = (
+            list(dict.fromkeys(final_output_types))
+            if len(final_output_types) > 1 and adapter_combiner is not default_combiner
+            else None
+        )
         self._stage_sampling_constraints = {stage.stage_id: dict(stage.sampling_constraints) for stage in stages}
         stage_extras = {
             stage.stage_id: dict(adapter_cls.get_stage_engine_extras(stage.stage_id, pipeline_mode=pipeline_mode))
@@ -282,10 +270,6 @@ class ARStrategy(OmniStrategyBase):
             if "prompt_token_ids" not in prompt:
                 raise RuntimeError("An adapter-prepared omni prompt must contain prompt_token_ids.")
             effective_prompt_ids = prompt["prompt_token_ids"]
-            if not isinstance(effective_prompt_ids, list) or any(
-                isinstance(token_id, bool) or not isinstance(token_id, int) for token_id in effective_prompt_ids
-            ):
-                raise TypeError("An adapter-prepared omni prompt must contain prompt_token_ids as a list of integers.")
         else:
             effective_prompt_ids = prompt_ids
         max_possible_tokens = self.server.config.max_model_len - len(effective_prompt_ids)
@@ -316,9 +300,16 @@ class ARStrategy(OmniStrategyBase):
         sampling_params.setdefault("repetition_penalty", getattr(self.server.config, "repetition_penalty", 1.0))
         policy_params = SamplingParams(max_tokens=max_tokens, **sampling_params)
         if self._rollout_output_modalities is not None:
-            params = copy.deepcopy(self.server.engine.default_sampling_params_list)
-            if len(params) <= 1 or self._policy_stage_index >= len(params):
+            if self._default_stage_sampling_params is None:
+                self._default_stage_sampling_params = tuple(
+                    copy.deepcopy(self.server.engine.default_sampling_params_list)
+                )
+            if len(self._default_stage_sampling_params) <= 1 or self._policy_stage_index >= len(
+                self._default_stage_sampling_params
+            ):
                 raise RuntimeError("A multi-output omni rollout requires per-stage sampling parameters.")
+            params = list(self._default_stage_sampling_params)
+            params[self._policy_stage_index] = copy.copy(params[self._policy_stage_index])
             constrained = self._stage_sampling_constraints[self._policy_stage_id]
             for field in {"max_tokens", *sampling_params} - constrained.keys():
                 setattr(params[self._policy_stage_index], field, getattr(policy_params, field))
@@ -363,7 +354,7 @@ class ARStrategy(OmniStrategyBase):
         if self._rollout_adapter is None:
             raise RuntimeError("Retaining multiple stage outputs requires a registered rollout adapter.")
         final_res, rollout_fields = self._rollout_adapter.combine_engine_outputs(outputs, prompt)
-        final_res._verl_omni_rollout_fields = rollout_fields
+        self._rollout_fields_by_request_id[request_id] = rollout_fields
         return final_res
 
     def process_output(
@@ -375,13 +366,20 @@ class ARStrategy(OmniStrategyBase):
         if final_res is None:
             raise RuntimeError("AR mode: vLLM-Omni engine yielded no output for the prompt.")
 
+        rollout_fields = {}
+        if self._rollout_output_modalities is not None:
+            request_id = final_res.request_id
+            try:
+                rollout_fields = self._rollout_fields_by_request_id.pop(request_id)
+            except KeyError:
+                raise RuntimeError(f"Missing retained rollout fields for request {request_id!r}.") from None
+
         req_output = getattr(final_res, "request_output", None) or final_res
         if not req_output.outputs:
             raise RuntimeError("AR mode expects outputs with token IDs, but got None or empty.")
 
         extra_fields = {"global_steps": self.server.global_steps}
-        if self._rollout_output_modalities is not None:
-            extra_fields.update(final_res._verl_omni_rollout_fields)
+        extra_fields.update(rollout_fields)
         token_ids = req_output.outputs[0].token_ids
         log_probs = None
         policy_params = params[self._policy_stage_index] if isinstance(params, list) else params

--- a/verl_omni/workers/rollout/vllm_rollout/vllm_omni_async_server.py
+++ b/verl_omni/workers/rollout/vllm_rollout/vllm_omni_async_server.py
@@ -191,6 +191,22 @@ class vLLMOmniHttpServer(vLLMHttpServer):
         # TODO (mike): support multi node
         raise NotImplementedError("vLLM-Omni headless mode is not implemented yet.")
 
+    async def collective_rpc(
+        self,
+        method: Any,
+        timeout: float | None = None,
+        args: tuple = (),
+        kwargs: dict[str, Any] | None = None,
+    ):
+        """Dispatch a shared RPC to the stages selected by the active strategy."""
+        return await self.engine.collective_rpc(
+            method=method,
+            timeout=timeout,
+            args=args,
+            kwargs=kwargs,
+            stage_ids=self._generate_strategy.collective_rpc_stage_ids(method),
+        )
+
     # -----------------------------------------------------------------------
     # wake_up hook: Omni does not restore KV cache on wake-up
     # -----------------------------------------------------------------------

--- a/verl_omni/workers/rollout/vllm_rollout/vllm_omni_async_server.py
+++ b/verl_omni/workers/rollout/vllm_rollout/vllm_omni_async_server.py
@@ -199,7 +199,7 @@ class vLLMOmniHttpServer(vLLMHttpServer):
         kwargs: dict[str, Any] | None = None,
     ):
         """Dispatch a shared RPC to the stages selected by the active strategy."""
-        return await self.engine.collective_rpc(
+        await self.engine.collective_rpc(
             method=method,
             timeout=timeout,
             args=args,

--- a/verl_omni/workers/rollout/vllm_rollout/vllm_omni_strategy_base.py
+++ b/verl_omni/workers/rollout/vllm_rollout/vllm_omni_strategy_base.py
@@ -56,8 +56,8 @@ class OmniStrategyBase(ABC):
     * optionally override the concrete hooks (:meth:`init_config`,
       :meth:`init_model_config`, :meth:`validate_configs`, :meth:`post_init`,
       :meth:`apply_quantization`, :meth:`override_generation_config`,
-      :meth:`preprocess_engine_kwargs`) when the mode needs behavior beyond the
-      shared defaults.
+      :meth:`preprocess_engine_kwargs`, :meth:`collective_rpc_stage_ids`) when
+      the mode needs behavior beyond the shared defaults.
 
     The two concrete subclasses are
     :class:`~verl_omni.workers.rollout.vllm_rollout.vllm_omni_ar_strategy.ARStrategy`
@@ -154,6 +154,14 @@ class OmniStrategyBase(ABC):
             engine_kwargs: The engine keyword-argument dict, mutated in place.
         """
         engine_kwargs.pop("output_mode", None)
+
+    def collective_rpc_stage_ids(self, method: Any) -> list[int] | None:
+        """Return pipeline stages targeted by a shared collective RPC.
+
+        ``None`` preserves the engine default of broadcasting to every stage.
+        AR adapters can narrow actor weight synchronization to trainable stages.
+        """
+        return None
 
     @abstractmethod
     def prepare_engine_args(self, engine_args: dict[str, Any], args: Namespace) -> None:


### PR DESCRIPTION
### What does this PR do?

This PR adds model-neutral extension points for staged autoregressive omni pipelines:

- adapter-selected Transformers auto-model registration and loading;
- stage-aware prompt construction, sampling parameters, output retention, and output assembly;
- stage-selective weight synchronization and async-server collective RPC;
- FSDP handling for partially frozen models and integer DTensor buffers.


### Checklist Before Starting

- [x] Search for similar PRs. Queries: [staged AR hooks](https://github.com/verl-project/verl-omni/pulls?q=is%3Apr+is%3Aopen+staged+AR+hooks), [adapter hooks](https://github.com/verl-project/verl-omni/pulls?q=is%3Apr+is%3Aopen+adapter+hooks), and [issue 428 references](https://github.com/verl-project/verl-omni/pulls?q=is%3Apr+is%3Aopen+428+in%3Abody).
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)

### Test

```bash
python -m pytest --noconftest -q \
  tests/trainer/omni/test_main_omni_on_cpu.py \
  tests/workers/test_omni_fsdp_engine_on_cpu.py \
  tests/workers/rollout/rollout_vllm/test_vllm_omni_strategy_on_cpu.py \
  tests/pipelines/test_qwen3_omni_thinker_adapter_on_cpu.py
# all passed

```


### API and Usage Example

Adapters keep the existing defaults and override only the behavior required by their pipeline:

```python
class MyRolloutAdapter(OmniRolloutPipelineBase):
    @classmethod
    def weight_sync_stage_ids(cls, pipeline_mode):
        return [0]

    @classmethod
    def prepare_engine_prompt(cls, prompt, *, stage_id, pipeline_mode):
        return prompt

    @classmethod
    def combine_engine_outputs(cls, outputs, *, pipeline_mode):
        return outputs[-1]
```

### Design & Code Changes

- Keep default adapter behavior compatible with existing single-output AR pipelines.
- Let a model adapter select its Transformers auto-model class without moving `from_pretrained` ownership out of the FSDP engine.
- Preserve integer DTensor buffers during FSDP2 synchronization while casting floating DTensor weights to BF16 for rollout synchronization.
- Expose stage-local request and sampling hooks, retain declared final outputs, and fail closed when a multi-stage adapter does not define a valid assembly.
- Allow adapters to move capacity limits into per-stage engine extras; once any stage overrides a capacity field, materialize both capacity fields for every stage and suppress the conflicting top-level values.
- Route collective RPC to all stages by default, with an explicit adapter hook for trainable-stage-only weight synchronization.
- Document the public extension contract and cover default and custom behavior with CPU tests.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update the documentation.
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl-omni/tree/main/.github/workflows) to cover all the code.
