### PR TITLE
[doc, recipe] chore: document MiniMax H3 training support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It originated from the multi-modal generation RL effort in `verl`, and now has a
 
 ## News 🔥
 - **[2026-08]** **[DiffusionOPD](docs/algo/diffusion_opd.md)** (on-policy distillation, including multi-teacher MOPD) is now supported.
-- **[2026-09]** 🔥 **MiniMax-H3** now supports T2VA, FL2VA, and Ref2VA with both [FlowGRPO](examples/flowgrpo_trainer/minimax_h3/README.md) and [DiffusionNFT](examples/diffusionnft_trainer/minimax_h3/README.md).
+- **[2026-08]** 🔥 **MiniMax-H3** now supports T2VA, FL2VA, and Ref2VA with both [FlowGRPO](examples/flowgrpo_trainer/minimax_h3/README.md) and [DiffusionNFT](examples/diffusionnft_trainer/minimax_h3/README.md).
 - **[2026-08]** 🎉 We have released [v0.2.0](https://github.com/verl-project/verl-omni/releases/tag/v0.2.0) for faster diffusion rl and more stable Qwen3-Omni multimodal training. Blog: [VeRL-Omni v0.2.0](https://verl-project.github.io/posts/2026-08-17-verl-omni-v0-2-0/)
 - **[2026-08]** [LTX2.3](examples/flowgrpo_trainer/ltx2/README.md) text-to-video+audio model is now supported with FlowGRPO.
 - **[2026-07]** Team-proposed algorithm [FlowGRPO with DiNa-LRM](https://verl-omni.readthedocs.io/en/latest/examples/flowgrpo_trainer_sd35_drm.html) is available. Training skips VAE decoding by scoring clean diffusion latents directly for faster and more resource-efficient model alignment.

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Visit our [documentation](https://verl-omni.readthedocs.io/en/latest/index.html)
   <tr>
     <td rowspan="2"><b>MiniMax-H3</b></td>
     <td rowspan="2">Diffusion generator</td>
-    <td rowspan="2">Any → Video + Audio<br>(T2VA / FL2VA / Ref2VA)</td>
+    <td rowspan="2">Any → Video + Audio</td>
     <td>DiffusionNFT</td>
     <td>✅</td>
   </tr>

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Visit our [documentation](https://verl-omni.readthedocs.io/en/latest/index.html)
   <tr>
     <td rowspan="2"><b>MiniMax-H3</b></td>
     <td rowspan="2">Diffusion generator</td>
-    <td rowspan="2">Text / Image / Multimodal references → Video + Audio<br>(T2VA / FL2VA / Ref2VA)</td>
+    <td rowspan="2">Any → Video + Audio<br>(T2VA / FL2VA / Ref2VA)</td>
     <td>DiffusionNFT</td>
     <td>✅</td>
   </tr>

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It originated from the multi-modal generation RL effort in `verl`, and now has a
 
 ## News 🔥
 - **[2026-08]** **[DiffusionOPD](docs/algo/diffusion_opd.md)** (on-policy distillation, including multi-teacher MOPD) is now supported.
-- **[2026-08]** 🔥 **[MiniMax-H3](examples/diffusionnft_trainer/minimax_h3/README.md)** T2VA and FL2VA is now supported with DiffusionNFT. Doc: [MiniMax-H3 DiffusionNFT Training](examples/diffusionnft_trainer/minimax_h3/README.md)
+- **[2026-09]** 🔥 **MiniMax-H3** now supports T2VA, FL2VA, and Ref2VA with both [FlowGRPO](examples/flowgrpo_trainer/minimax_h3/README.md) and [DiffusionNFT](examples/diffusionnft_trainer/minimax_h3/README.md).
 - **[2026-08]** 🎉 We have released [v0.2.0](https://github.com/verl-project/verl-omni/releases/tag/v0.2.0) for faster diffusion rl and more stable Qwen3-Omni multimodal training. Blog: [VeRL-Omni v0.2.0](https://verl-project.github.io/posts/2026-08-17-verl-omni-v0-2-0/)
 - **[2026-08]** [LTX2.3](examples/flowgrpo_trainer/ltx2/README.md) text-to-video+audio model is now supported with FlowGRPO.
 - **[2026-07]** Team-proposed algorithm [FlowGRPO with DiNa-LRM](https://verl-omni.readthedocs.io/en/latest/examples/flowgrpo_trainer_sd35_drm.html) is available. Training skips VAE decoding by scoring clean diffusion latents directly for faster and more resource-efficient model alignment.
@@ -131,13 +131,13 @@ Visit our [documentation](https://verl-omni.readthedocs.io/en/latest/index.html)
   <tr>
     <td rowspan="2"><b>MiniMax-H3</b></td>
     <td rowspan="2">Diffusion generator</td>
-    <td rowspan="2">Any → Video + Audio</td>
+    <td rowspan="2">Text / Image / Multimodal references → Video + Audio<br>(T2VA / FL2VA / Ref2VA)</td>
     <td>DiffusionNFT</td>
     <td>✅</td>
   </tr>
   <tr>
     <td>FlowGRPO</td>
-    <td>WIP</td>
+    <td>✅</td>
   </tr>
   <tr>
     <td><b>Boogu-Image</b></td>

--- a/examples/diffusionnft_trainer/README.md
+++ b/examples/diffusionnft_trainer/README.md
@@ -1,16 +1,21 @@
 # DiffusionNFT Trainer
 
-Last updated: 06/30/2026
+Last updated: 09/04/2026
 
 This example shows how to post-train `Qwen-Image` with DiffusionNFT on an OCR-style image generation task using `vllm-omni` rollout and a visual generative reward model (`Qwen3-VL-8B-Instruct` in this example).
 
 DiffusionNFT is a direct-preference / forward-process algorithm. Unlike PPO-style FlowGRPO training, this example trains from final clean latents and uses an `old` LoRA adapter as the rollout policy while updating the `default` adapter.
 
-A MiniMax H3 text-to-audio-video recipe is also available at
-[`minimax_h3/run_minimax_h3_t2va_lora.sh`](minimax_h3/run_minimax_h3_t2va_lora.sh).
-It uses the dedicated token-ID-native H3 AgentLoop; see the
-[MiniMax H3 recipe README](minimax_h3/README.md) for model staging, data preparation,
-and launch instructions.
+MiniMax H3 DiffusionNFT recipes support text-to-audio-video (T2VA), first-frame
+image-to-audio-video (FL2VA), and multimodal reference-to-audio-video (Ref2VA):
+
+- [`minimax_h3/run_minimax_h3_t2va_lora.sh`](minimax_h3/run_minimax_h3_t2va_lora.sh)
+- [`minimax_h3/run_minimax_h3_fl2va_lora.sh`](minimax_h3/run_minimax_h3_fl2va_lora.sh)
+- [`minimax_h3/run_minimax_h3_ref2va_lora.sh`](minimax_h3/run_minimax_h3_ref2va_lora.sh)
+
+They use the dedicated token-ID-native H3 AgentLoop; see the
+[MiniMax H3 recipe README](minimax_h3/README.md) for model staging, data
+preparation, and launch instructions.
 
 For the full installation guide, see [Installation](../../docs/start/install.md). For implementation details on adding or extending direct-preference diffusion algorithms, see `docs/contributing/integrating_a_new_direct_preference_algorithm_for_diffusion_model.md`.
 

--- a/examples/diffusionnft_trainer/minimax_h3/README.md
+++ b/examples/diffusionnft_trainer/minimax_h3/README.md
@@ -1,11 +1,12 @@
-# MiniMax-H3 text-to-audio-video DiffusionNFT training
+# MiniMax H3 T2VA, FL2VA, and Ref2VA DiffusionNFT
 
-Last updated: 09/01/2026
+Last updated: 09/04/2026
 
-This recipe trains a rank-64 MiniMax H3 LoRA with online DiffusionNFT for
-text-to-audio-video (T2VA). A Diffusers transformer is trained with FSDP2 while
-vLLM-Omni generates joint video and audio rollouts. CLAP and ImageBind provide
-the default multi-reward (audio-video alignment).
+These recipes train rank-64 MiniMax H3 LoRA adapters with online DiffusionNFT
+for text-to-audio-video (T2VA), first-frame image-to-audio-video (FL2VA), and
+reference-to-audio-video (Ref2VA) generation. A Diffusers transformer is
+trained with FSDP2 while vLLM-Omni generates joint video and audio rollouts.
+CLAP and ImageBind provide the default multi-reward (audio-video alignment).
 
 A ready-made FL2VA first-frame dataset built with the data pipeline below is
 published at https://huggingface.co/datasets/zyfenghit/dancegrpo-t2av


### PR DESCRIPTION
## Summary

- announce that MiniMax H3 supports T2VA, FL2VA, and Ref2VA with both FlowGRPO and DiffusionNFT
- mark MiniMax H3 FlowGRPO as supported in the repository capability matrix
- update the DiffusionNFT landing page and MiniMax H3 recipe introduction so all six launcher paths are discoverable

## Duplicate-work check

This does not duplicate an open PR. Searches for `MiniMax H3 README capabilities` and `MiniMax H3 FlowGRPO DiffusionNFT` returned no open pull requests in `verl-project/verl-omni`. The implementation work is already merged; this PR only updates the now-stale capability documentation after the Ref2VA support landed.

## Testing

- `git diff --check` — passed
- `.venv/bin/python tests/special_sanity/check_docs_time_info.py` — passed
- `.venv/bin/python tests/special_sanity/check_example_docs_symlinks.py` — passed (15 example README pages)
- verified that the T2VA, FL2VA, and Ref2VA GPU launcher paths exist for both FlowGRPO and DiffusionNFT

## AI assistance

AI assistance (pi coding agent) was used to inspect the existing documentation, prepare the edits, and run the checks. The human submitter reviewed every changed line and can explain and defend the change end-to-end.
