### PR TITLE
[BREAKING][diffusion, trainer, tests, doc] fix: drop the silent FA-to-native/SDPA fallback (#516)

### DIFF
--- a/docs/start/flowgrpo_quickstart.md
+++ b/docs/start/flowgrpo_quickstart.md
@@ -150,7 +150,7 @@ If rollout OOM persists after increasing `ROLLOUT_TP`, reduce memory-heavy rollo
 
 | Error | Fix | What it changes |
 | --- | --- | --- |
-| `Attention backend mismatch` | Pair backends: FA3 actor with `FLASH_ATTN_3_HUB` (or `FLASH_ATTN` / `FLASH_ATTN_HUB`); native/`_native_npu` with `TORCH_SDPA` | Actor `attn_backend=_flash_3_varlen_hub` must use a FA rollout backend. Default is `FLASH_ATTN_3_HUB` for kernels FA3 train/rollout consistency. If FA3 deps are missing, both actor and rollout fall back to native/SDPA automatically. |
+| `Attention backend mismatch` | Pair backends: FA3 actor with `FLASH_ATTN_3_HUB` (or `FLASH_ATTN` / `FLASH_ATTN_HUB`); native/`_native_npu` with `TORCH_SDPA` | Actor `attn_backend=_flash_3_varlen_hub` must use a FA rollout backend. Default is `FLASH_ATTN_3_HUB` for kernels FA3 train/rollout consistency. Missing FA3 deps fail fast; install them or switch to native/`TORCH_SDPA` explicitly. |
 
 ## Wandb logging
 

--- a/docs/start/install.md
+++ b/docs/start/install.md
@@ -95,7 +95,7 @@ actor_rollout_ref.rollout.rollout_attn_backend=FLASH_ATTN_3_HUB
 `FLASH_ATTN_3_HUB` is provided by vLLM-Omni (`kernels-community/flash-attn3`). The legacy
 `FLASH_ATTN` rollout path still uses local FA packages (`fa3-fwd` / `flash-attn`).
 
-If FA3 deps are missing at runtime, training falls back to native/SDPA automatically. NPU recipes override with `actor_rollout_ref.model.attn_backend=_native_npu`.
+If FA deps are missing or broken at runtime, requesting an FA2/FA3 backend fails fast instead of silently downgrading to native/SDPA. Fix the install or select `native` / `TORCH_SDPA` explicitly. NPU recipes override with `actor_rollout_ref.model.attn_backend=_native_npu`.
 
 On older GPUs, prefer FA2 over the FA3 default — both use the same `kernels` Hub path, so nothing extra to install:
 

--- a/examples/flowgrpo_trainer/README.md
+++ b/examples/flowgrpo_trainer/README.md
@@ -50,8 +50,8 @@ bash examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_lora.sh
 ```
 
 GPU training defaults to matched kernels FA3 in config (`attn_backend: _flash_3_varlen_hub`;
-`rollout_attn_backend: FLASH_ATTN_3_HUB`). Training falls back to native/SDPA if FA3 deps
-are unavailable.
+`rollout_attn_backend: FLASH_ATTN_3_HUB`). Missing FA3 deps fail fast; install them or
+switch to native/`TORCH_SDPA` explicitly.
 
 Optional KL loss tuning:
 

--- a/tests/nightly/qwen_image_flowgrpo/run.py
+++ b/tests/nightly/qwen_image_flowgrpo/run.py
@@ -34,7 +34,6 @@ _FORWARDED_ENV_NAMES = {
     "CUBLAS_WORKSPACE_CONFIG",
     "DEBUG_METRICS_JSONL",
     "NIGHTLY_DETERMINISTIC_SEED",
-    "NIGHTLY_REQUIRE_FA3",
     "NIGHTLY_ATTN_BACKEND",
     "NIGHTLY_ROLLOUT_ATTN_BACKEND",
     "PYTHONHASHSEED",
@@ -73,36 +72,8 @@ def _patch_ray_init() -> None:
     ray.init = ray_init_with_debug_hooks
 
 
-def _patch_require_fa3() -> None:
-    """Disable FA3→SDPA fallback for nightly runs that require deterministic FA3."""
-    if os.environ.get("NIGHTLY_REQUIRE_FA3", "0") != "1":
-        return
-
-    import verl_omni.utils.diffusion_attention as diffusion_attention
-
-    if getattr(diffusion_attention.fallback_fa_if_unavailable, "__nightly_require_fa3__", False):
-        return
-
-    def fallback_fa_if_unavailable_or_raise(config) -> None:
-        attn_backend = config.actor_rollout_ref.model.get("attn_backend", diffusion_attention.ACTOR_FA3_BACKEND)
-        if attn_backend != diffusion_attention.ACTOR_FA3_BACKEND:
-            return
-        if diffusion_attention.fa_available():
-            return
-        raise RuntimeError(
-            "FA3 is required for nightly but unavailable: "
-            f"actor_kernels={diffusion_attention.actor_fa_available()}, "
-            f"rollout_fa={diffusion_attention.rollout_fa_available()}. "
-            "Install pinned kernels and fa3-fwd, and use a supported GPU (SM 8.x)."
-        )
-
-    fallback_fa_if_unavailable_or_raise.__nightly_require_fa3__ = True
-    diffusion_attention.fallback_fa_if_unavailable = fallback_fa_if_unavailable_or_raise
-
-
 def main() -> None:
     install_debug_hooks.install_debug_hooks()
-    _patch_require_fa3()
     _patch_ray_init()
     runpy.run_module("verl_omni.trainer.main_diffusion", run_name="__main__", alter_sys=True)
 

--- a/tests/utils/test_diffusion_attention_on_cpu.py
+++ b/tests/utils/test_diffusion_attention_on_cpu.py
@@ -13,12 +13,14 @@
 # limitations under the License.
 
 import logging
+import sys
 
+import pytest
 from omegaconf import OmegaConf
 
 from tests.utils.smoke_attention import resolve_smoke_attention_backends
-from verl_omni.utils.diffusion_attention import fallback_fa_if_unavailable, validate_attention_consistency
-from verl_omni.workers.config.diffusion import DiffusionRolloutConfig
+from verl_omni.utils.diffusion_attention import validate_attention_consistency
+from verl_omni.workers.config.diffusion import DiffusionModelConfig, DiffusionRolloutConfig
 
 
 def test_rollout_config_builds_structured_vllm_omni_attention_config():
@@ -90,19 +92,18 @@ def test_native_actor_rejects_flash_attn_3_hub():
         raise AssertionError("expected ValueError")
 
 
-def test_fallback_hub_fa3_without_kernels_sets_sdpa(monkeypatch):
-    monkeypatch.setattr("verl_omni.utils.diffusion_attention.actor_fa_available", lambda: False)
-    config = OmegaConf.create(
-        {
-            "actor_rollout_ref": {
-                "model": {"attn_backend": "_flash_3_varlen_hub"},
-                "rollout": {"rollout_attn_backend": "FLASH_ATTN_3_HUB"},
-            }
-        }
-    )
-    fallback_fa_if_unavailable(config)
-    assert config.actor_rollout_ref.model.attn_backend == "native"
-    assert config.actor_rollout_ref.rollout.rollout_attn_backend == "TORCH_SDPA"
+@pytest.mark.parametrize("attn_backend", ["flash_varlen_hub", "_flash_3_varlen_hub"])
+def test_fa_actor_backend_without_kernels_raises(monkeypatch, tmp_path, attn_backend):
+    monkeypatch.setitem(sys.modules, "kernels", None)
+    with pytest.raises(ImportError, match="requires `kernels` package"):
+        DiffusionModelConfig(
+            path=str(tmp_path),
+            architecture="StableDiffusion3Pipeline",
+            algorithm="flow_grpo",
+            attn_backend=attn_backend,
+            load_tokenizer=False,
+            transformer_config={},
+        )
 
 
 def test_fa2_actor_allows_flash_attn():
@@ -117,21 +118,6 @@ def test_fa2_actor_allows_flash_attn():
             }
         )
     )
-
-
-def test_fallback_fa2_without_kernels_sets_sdpa(monkeypatch):
-    monkeypatch.setattr("verl_omni.utils.diffusion_attention.actor_fa_available", lambda: False)
-    config = OmegaConf.create(
-        {
-            "actor_rollout_ref": {
-                "model": {"attn_backend": "flash_varlen_hub"},
-                "rollout": {"rollout_attn_backend": "FLASH_ATTN_HUB"},
-            }
-        }
-    )
-    fallback_fa_if_unavailable(config)
-    assert config.actor_rollout_ref.model.attn_backend == "native"
-    assert config.actor_rollout_ref.rollout.rollout_attn_backend == "TORCH_SDPA"
 
 
 def test_resolve_smoke_attention_backends_prefers_local_fa(monkeypatch):

--- a/verl_omni/trainer/main_diffusion.py
+++ b/verl_omni/trainer/main_diffusion.py
@@ -31,7 +31,7 @@ from verl_omni.trainer.diffusion.ray_diffusion_trainer import (
     validate_separate_config,
 )
 from verl_omni.utils.config import validate_config
-from verl_omni.utils.diffusion_attention import fallback_fa_if_unavailable, validate_attention_consistency
+from verl_omni.utils.diffusion_attention import validate_attention_consistency
 
 
 def _count_controller_capture_ranges(profile_steps: list[int], profile_continuous_steps: bool) -> int:
@@ -65,7 +65,6 @@ def main(config):
     auto_set_device(config)
     OmegaConf.resolve(config)
     validate_config(config)
-    fallback_fa_if_unavailable(config)
     validate_attention_consistency(config)
     run_diffusion(config)
 

--- a/verl_omni/trainer/main_diffusion_v1.py
+++ b/verl_omni/trainer/main_diffusion_v1.py
@@ -25,7 +25,7 @@ from verl.utils.device import auto_set_device, is_cuda_available
 from verl.utils.import_utils import load_class_from_fqn
 
 from verl_omni.utils.config import validate_config
-from verl_omni.utils.diffusion_attention import fallback_fa_if_unavailable, validate_attention_consistency
+from verl_omni.utils.diffusion_attention import validate_attention_consistency
 
 logger = logging.getLogger(__name__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "INFO"))
@@ -140,7 +140,6 @@ def main(config):
     auto_set_device(config)
     OmegaConf.resolve(config)
     validate_config(config)
-    fallback_fa_if_unavailable(config)
     validate_attention_consistency(config)
 
     if config.trainer.get("use_v1", False):

--- a/verl_omni/utils/diffusion_attention.py
+++ b/verl_omni/utils/diffusion_attention.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""FA2/FA3 availability checks and fallback for matched actor/rollout attention."""
+"""FA2/FA3 availability checks and validation for matched actor/rollout attention."""
 
 from __future__ import annotations
 
@@ -28,7 +28,6 @@ ROLLOUT_SDPA_BACKEND = "TORCH_SDPA"
 
 # Keep in sync with vllm-omni diffusion attention backends for FA train/rollout pairs.
 FA_ROLLOUT_BACKENDS = ("FLASH_ATTN", "FLASH_ATTN_HUB", "FLASH_ATTN_3_HUB")
-KERNELS_HUB_ROLLOUT_BACKENDS = ("FLASH_ATTN_HUB", "FLASH_ATTN_3_HUB")
 ACTOR_BACKENDS = (ACTOR_FA2_BACKEND, ACTOR_FA3_BACKEND, ACTOR_NATIVE_BACKEND, "_native_npu")
 ROLLOUT_BACKENDS = FA_ROLLOUT_BACKENDS + (ROLLOUT_SDPA_BACKEND,)
 
@@ -64,38 +63,8 @@ def fa_available() -> bool:
     return actor_fa_available() and rollout_fa_available()
 
 
-# TODO (mike): drop this fallback and raise instead — a silent FA-to-native downgrade hides a broken kernels stack.
-def fallback_fa_if_unavailable(config: Any) -> None:
-    """Downgrade explicit FA2/FA3 settings to native/SDPA when deps are missing."""
-    attn_backend = config.actor_rollout_ref.model.get("attn_backend", ACTOR_FA3_BACKEND)
-    if attn_backend not in (ACTOR_FA2_BACKEND, ACTOR_FA3_BACKEND):
-        return
-
-    rollout_backend = config.actor_rollout_ref.rollout.get("rollout_attn_backend")
-    if rollout_backend in KERNELS_HUB_ROLLOUT_BACKENDS:
-        if actor_fa_available():
-            return
-    elif fa_available():
-        return
-
-    logger.warning(
-        "FA2/FA3 requested but unavailable for matched actor+rollout (kernels=%s, rollout_fa=%s); "
-        "falling back to actor=%s, rollout=%s.",
-        actor_fa_available(),
-        rollout_fa_available(),
-        ACTOR_NATIVE_BACKEND,
-        ROLLOUT_SDPA_BACKEND,
-    )
-    config.actor_rollout_ref.model.attn_backend = ACTOR_NATIVE_BACKEND
-    if rollout_backend in FA_ROLLOUT_BACKENDS:
-        config.actor_rollout_ref.rollout.rollout_attn_backend = ROLLOUT_SDPA_BACKEND
-
-
 def validate_attention_consistency(config: Any) -> None:
     """Validate that rollout and training attention backends match.
-
-    Called after ``fallback_fa_if_unavailable`` so any FA→native downgrade
-    has already updated both config fields.
 
     Rules:
         - If the training engine is VeOmni, skip validation.


### PR DESCRIPTION
### What does this PR do?

Closes #516.

Requesting an FA backend (`attn_backend=flash_varlen_hub` / `_flash_3_varlen_hub` + a `FLASH_ATTN*` rollout backend) on an environment where the kernels stack is missing or broken did not fail — `fallback_fa_if_unavailable` silently rewrote the config to native actor / SDPA rollout with a single `logger.warning`, so a broken install (e.g. `kernels==0.14.1` on torch 2.13 / CUDA 13) kept producing green-looking runs on degraded attention. PR #497 kept the downgrade deliberately and marked the helper for removal (`TODO (mike)`); #244 carried it through the FA2 rename.

This PR drops the fallback entirely, per the issue discussion: an explicitly requested backend is now honored verbatim, and the existing fail-fast paths handle unavailability —

- `DiffusionModelConfig.__post_init__` raises `ImportError` when `kernels` cannot be imported, for both FA2 and FA3 actor backends (`verl_omni/workers/config/diffusion/model.py`);
- the FSDP model load wraps `set_attention_backend` failures in a `RuntimeError` stating the backend cannot be downgraded (`verl_omni/workers/engine/fsdp/diffusers_impl.py`);
- a kernels package that is installed but broken surfaces its real load error instead of being masked.

`validate_attention_consistency` still runs in both trainer entrypoints and still rejects mismatched train/rollout pairs.

### Checklist Before Starting

- [x] Search for similar PRs:
  - Issue read: https://github.com/verl-project/verl-omni/issues/516
  - `gh pr list --state open --search "516 in:body"` → only unrelated hits (#314 draft LingBot T2V, #459 L3 nightly script pin)
  - `gh pr list --state open --search "fa3 fallback in:title,body"` and `"attn_backend"` → same two unrelated PRs; nothing addresses the product-code fallback.
- [x] Title formatted `[BREAKING][{modules}] {type}: {description}`; modules checked against `tests/special_sanity/check_pr_title.py`.

### Test

CPU tests (conda env `verl-omni-py312`, macOS — no GPU locally), run on top of current `main` (post-#244):

```
python -m pytest -q --asyncio-mode=auto \
  tests/utils/test_diffusion_attention_on_cpu.py \
  tests/utils/test_diffusion_attention_validation_on_cpu.py \
  tests/trainer/diffusion/test_separate_trainer_on_cpu.py \
  tests/trainer/diffusion/test_distillation_trainer_wiring_on_cpu.py \
  tests/trainer/diffusion/test_controller_nsys_profiler_on_cpu.py \
  tests/pipelines/test_image_edit_interface_on_cpu.py
→ 68 passed, 20 warnings in 14.17s   (warnings are pre-existing optional-engine noise)
```

The trainer tests import `verl_omni.trainer.main_diffusion`, so both edited entrypoints are exercised on import/wiring. The new `test_fa_actor_backend_without_kernels_raises` is parametrized over both FA2 (`flash_varlen_hub`) and FA3 (`_flash_3_varlen_hub`): with `kernels` unimportable (`sys.modules["kernels"] = None`), constructing `DiffusionModelConfig` raises `ImportError`.

`pre-commit` ran at commit time — all hooks passed (ruff, ruff-format, mypy, autogen-trainer-cfg, docs-time, docstrings, license, device-api, dataproto, structure, naming, compileall).

Not run locally (no GPU): the nightly/e2e shell regressions. Their behavior is unchanged in kind — they pre-flight `fa_available()` and set backends explicitly before launch.

### API and Usage Example

**[BREAKING]** `verl_omni.utils.diffusion_attention.fallback_fa_if_unavailable` is deleted (called `fallback_fa3_if_unavailable` before #244). Configs are no longer rewritten; environments that were silently training on native/SDPA after the downgrade will now fail loudly until the kernels install is fixed or the backend is set explicitly:

```bash
# fail fast (default): keep FA, fix the install
actor_rollout_ref.model.attn_backend=_flash_3_varlen_hub   # or flash_varlen_hub (FA2)
actor_rollout_ref.rollout.rollout_attn_backend=FLASH_ATTN_3_HUB

# opt out explicitly instead of relying on a silent downgrade
actor_rollout_ref.model.attn_backend=native
actor_rollout_ref.rollout.rollout_attn_backend=TORCH_SDPA
```

### Design & Code Changes

- `verl_omni/utils/diffusion_attention.py` — delete `fallback_fa_if_unavailable`, the `TODO (mike)` marker, and the now-orphaned `KERNELS_HUB_ROLLOUT_BACKENDS` constant; docstrings updated. Availability helpers (`fa_available` etc.) stay — smoke/e2e/nightly scripts use them for their own pre-flight checks.
- `verl_omni/trainer/main_diffusion.py`, `main_diffusion_v1.py` — drop the fallback call/import; startup keeps `validate_config` → `validate_attention_consistency`.
- `tests/nightly/qwen_image_flowgrpo/run.py` — remove `_patch_require_fa3`, which monkeypatched the (now deleted) fallback to raise under `NIGHTLY_REQUIRE_FA3=1`. Redundant twice over: the wrapper shell script already hard-aborts when `fa_available()` is false before launching, and missing kernels now fail natively. The unused env-var forwarding entry is gone; the shell export stays (`env_metadata.py` still records it).
- `tests/utils/test_diffusion_attention_on_cpu.py` — replace the two downgrade tests (FA3 + FA2, from #244) with the parametrized fail-fast test.
- `docs/start/install.md`, `docs/start/flowgrpo_quickstart.md`, `examples/flowgrpo_trainer/README.md` — the spots promising "falls back automatically" now state the fail-fast behavior.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md).
- [x] pre-commit checks applied (all hooks passed at commit time).
- [x] Documentation updated (install.md, flowgrpo_quickstart.md, example README).
- [x] Unit test added/updated in the CPU workflow (`tests/utils/test_diffusion_attention_on_cpu.py`).

### Disclosures

- **AI assistance was used**: implemented, tested, and drafted by ZCode (agent) from the user's direction ("drop the entire fallback"); rebased onto main after #244's FA2 rename. The human submitter (@zhtmike) has reviewed and can defend every changed line end-to-end.
- Related upstream companion (kernels pin for torch 2.13 / CUDA 13): to be cross-linked from #516 once filed in vllm-omni.
