### PR TITLE
[diffusion, rollout, reward, data, recipe] feat: add FLUX.1-dev DanceGRPO training

### DIFF
--- a/docs/examples/flux1/dancegrpo_trainer_flux1.md
+++ b/docs/examples/flux1/dancegrpo_trainer_flux1.md
@@ -1,0 +1,1 @@
+../../../examples/dancegrpo_trainer/flux1/README.md

--- a/docs/index.md
+++ b/docs/index.md
@@ -73,6 +73,7 @@ examples/flowgrpo_trainer.md
 examples/flowdppo_trainer.md
 examples/dpo_trainer.md
 examples/dancegrpo_trainer.md
+examples/flux1/dancegrpo_trainer_flux1.md
 examples/diffusionnft_trainer.md
 examples/grpoguard_trainer.md
 examples/gspo_trainer.md

--- a/examples/dancegrpo_trainer/flux1/README.md
+++ b/examples/dancegrpo_trainer/flux1/README.md
@@ -1,0 +1,102 @@
+# FLUX.1-dev DanceGRPO
+
+Last updated: 09/07/2026
+
+This directory contains an Ascend NPU-only launcher for full-parameter
+FLUX.1-dev DanceGRPO training with HPSv2 reward. Its default configuration uses:
+720x720 images, 16 denoising steps, rollout `guidance_scale=3.5`, actor
+`guidance_scale=1.0`, 0.3 DanceSDE noise, and a random 60% subset after dropping
+the final transition.
+
+FLUX.1-dev uses a distilled guidance embedding. This adapter does not run a
+negative-prompt CFG branch and deliberately has no `true_cfg_scale` option.
+The rollout and actor guidance values are intentionally different; they keep
+their existing `guidance_scale` config names because their locations already
+distinguish sampling from actor log-probability recomputation.
+
+## Prepare prompts
+
+Prompt files are not included. Supply two UTF-8 text files with one prompt per
+line so the train/test boundary is explicit and reviewable. Public sources you
+can evaluate include the [HPSv2 project and HPD benchmark](https://github.com/tgxs002/HPSv2)
+and the [DanceGRPO reference implementation](https://github.com/XueZeyue/DanceGRPO).
+
+Convert the files to the same chat-style parquet schema used by the other
+DanceGRPO examples:
+
+```bash
+python3 examples/dancegrpo_trainer/flux1/dataprocess/prepare_prompts.py \
+  --train-path /path/to/train.txt \
+  --test-path /path/to/test.txt \
+  --output-dir "${WORKSPACE:-$HOME}/data/hpsv2"
+```
+
+When `--output-dir` is omitted, the processor writes `train.parquet` and
+`test.parquet` to `~/data/hpsv2`, matching the launcher's default paths. The
+processor never downloads, embeds, randomly splits, or copies prompt text into
+this repository.
+
+## Prepare FLUX.1-dev and HPSv2
+
+Install the HPSv2 dependency on top of the standard verl-omni environment. The
+following version has been validated with this recipe:
+
+```bash
+pip install open_clip_torch==3.3.0
+```
+
+Prepare a local diffusers-format
+[FLUX.1-dev](https://huggingface.co/black-forest-labs/FLUX.1-dev) checkpoint and
+download these HPSv2.1 files:
+
+- [`HPS_v2.1_compressed.pt`](https://huggingface.co/xswu/HPSv2/tree/main)
+- [`open_clip_pytorch_model.bin`](https://huggingface.co/laion/CLIP-ViT-H-14-laion2B-s32B-b79K/tree/main)
+
+Only use checkpoints you trust: the HPSv2 loader uses PyTorch checkpoint
+deserialization for compatibility with the published weights.
+
+## Run with HPSv2
+
+From the repository root:
+
+```bash
+export MODEL_NAME=/path/to/FLUX.1-dev
+export HPSV2_PRETRAINED_PATH=/path/to/open_clip_pytorch_model.bin
+export CUSTOM_REWARD_MODEL_PATH=/path/to/HPS_v2.1_compressed.pt
+
+bash examples/dancegrpo_trainer/flux1/run_flux1_dev_dancegrpo_fullparam.sh
+```
+
+## Validate with one training step
+
+Use the same model, reward checkpoints, and prepared parquet files, but limit
+the launcher to one step:
+
+```bash
+TOTAL_TRAINING_STEPS=1 \
+EXPERIMENT_NAME=flux1_dev_fullparam_hpsv2_smoke \
+bash examples/dancegrpo_trainer/flux1/run_flux1_dev_dancegrpo_fullparam.sh
+```
+
+A successful smoke run reaches `training/global_step:1` and reports
+`critic/hpsv2_raw/mean`, `rollout_corr/logprob_abs_diff_mean`, `actor/loss`,
+and `timing_s/step`. This exercises rollout generation, HPSv2 scoring, Actor
+log-probability recomputation and update, and weight synchronization.
+
+By default, the launcher reads `$WORKSPACE/data/hpsv2/train.parquet` and
+`$WORKSPACE/data/hpsv2/test.parquet`, where `WORKSPACE` defaults to `$HOME`.
+Set `TRAIN_FILES_PATH` and `VAL_FILES_PATH` to override these locations.
+
+HPSv2 defaults to two CPU-resident reward workers (`REWARD_NUM_WORKERS=2` and
+`REWARD_DEVICE=cpu`). The OpenCLIP model and both checkpoints are loaded on
+CPU, so reward scoring does not consume rollout NPU memory. Synchronous scorer
+calls run through the reward manager's executor, and HPSv2 uses autocast during
+inference. To opt into NPU
+scoring, set `REWARD_DEVICE=npu:0` explicitly. This is not the default because
+verl RewardLoopWorkers do not reserve Ray accelerator resources; an explicit
+NPU scorer can therefore contend with actor and rollout allocations.
+
+The launcher defaults to eight NPUs and full-parameter training
+(`model.lora_rank=0`). Hardware and batch settings can be overridden with
+`ASCEND_RT_VISIBLE_DEVICES`, `NUM_GPUS`, `ROLLOUT_TP`, `TRAIN_BATCH_SIZE`,
+`ROLLOUT_N`, `REWARD_NUM_WORKERS`, `TRAIN_FILES_PATH`, and `VAL_FILES_PATH`.

--- a/examples/dancegrpo_trainer/flux1/dataprocess/prepare_prompts.py
+++ b/examples/dancegrpo_trainer/flux1/dataprocess/prepare_prompts.py
@@ -1,0 +1,83 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Convert explicit train/test text prompt files to verl-omni parquet data."""
+
+import argparse
+import os
+
+import pandas as pd
+from verl.utils.hdfs_io import copy, makedirs
+
+
+def _load_prompts(path: str) -> list[str]:
+    with open(path, encoding="utf-8") as prompt_file:
+        prompts = [line.strip() for line in prompt_file if line.strip()]
+    if not prompts:
+        raise ValueError(f"No non-empty prompts found in {path}")
+    return prompts
+
+
+def _make_record(prompt: str, split: str, index: int) -> dict:
+    return {
+        "data_source": "dance_grpo/flux1",
+        "prompt": [
+            {"role": "system", "content": ""},
+            {"role": "user", "content": prompt},
+        ],
+        "negative_prompt": [
+            {"role": "system", "content": ""},
+            {"role": "user", "content": " "},
+        ],
+        "ability": "t2i",
+        "reward_model": {"style": "model", "ground_truth": prompt},
+        "extra_info": {"split": split, "index": index},
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--train-path", required=True, help="UTF-8 text file with one training prompt per line")
+    parser.add_argument("--test-path", required=True, help="UTF-8 text file with one validation prompt per line")
+    parser.add_argument(
+        "--output-dir",
+        default="~/data/hpsv2",
+        help="Directory for train.parquet and test.parquet (default: ~/data/hpsv2)",
+    )
+    parser.add_argument("--hdfs-dir", default=None, help="Optional HDFS destination")
+    args = parser.parse_args()
+
+    train_path = os.path.abspath(os.path.expanduser(args.train_path))
+    test_path = os.path.abspath(os.path.expanduser(args.test_path))
+    output_dir = os.path.abspath(os.path.expanduser(args.output_dir))
+    train_prompts = _load_prompts(train_path)
+    test_prompts = _load_prompts(test_path)
+
+    os.makedirs(output_dir, exist_ok=True)
+    outputs = {
+        "train": (train_prompts, os.path.join(output_dir, "train.parquet")),
+        "test": (test_prompts, os.path.join(output_dir, "test.parquet")),
+    }
+    for split, (prompts, output_path) in outputs.items():
+        records = [_make_record(prompt, split, index) for index, prompt in enumerate(prompts)]
+        pd.DataFrame(records).to_parquet(output_path, index=False)
+        print(f"{split}: {len(records)} records -> {output_path}")
+
+    if args.hdfs_dir:
+        makedirs(args.hdfs_dir)
+        copy(src=output_dir, dst=args.hdfs_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/dancegrpo_trainer/flux1/run_flux1_dev_dancegrpo_fullparam.sh
+++ b/examples/dancegrpo_trainer/flux1/run_flux1_dev_dancegrpo_fullparam.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# FLUX.1-dev full-parameter DanceGRPO recipe with HPSv2 reward.
+set -euo pipefail
+
+if ! npu-smi info >/dev/null 2>&1; then
+    echo "Error: this recipe requires Ascend NPUs." >&2
+    exit 1
+fi
+
+WORKSPACE=${WORKSPACE:-$HOME}
+TRAIN_FILES_PATH=${TRAIN_FILES_PATH:-$WORKSPACE/data/hpsv2/train.parquet}
+VAL_FILES_PATH=${VAL_FILES_PATH:-$WORKSPACE/data/hpsv2/test.parquet}
+
+: "${MODEL_NAME:?Set MODEL_NAME to a local FLUX.1-dev diffusers checkpoint}"
+: "${CUSTOM_REWARD_MODEL_PATH:?Set CUSTOM_REWARD_MODEL_PATH to HPS_v2.1_compressed.pt}"
+: "${HPSV2_PRETRAINED_PATH:?Set HPSV2_PRETRAINED_PATH to open_clip_pytorch_model.bin}"
+
+REWARD_FUNCTION_PATH=verl_omni/utils/reward_score/hpsv2_reward.py
+REWARD_FUNCTION_NAME=compute_score_hpsv2
+# RewardLoopWorkers do not reserve Ray accelerator resources. Keep the HPSv2
+# scorers on CPU while using two workers for scoring throughput. Accelerator
+# use must be an explicit override.
+REWARD_NUM_WORKERS=${REWARD_NUM_WORKERS:-2}
+REWARD_DEVICE=${REWARD_DEVICE:-cpu}
+ROLLOUT_TP=${ROLLOUT_TP:-2}
+TRAIN_BATCH_SIZE=${TRAIN_BATCH_SIZE:-16}
+ROLLOUT_GPU_MEMORY_UTILIZATION=${ROLLOUT_GPU_MEMORY_UTILIZATION:-0.4}
+ACTOR_MODEL_DTYPE=${ACTOR_MODEL_DTYPE:-fp32}
+EXPERIMENT_NAME=${EXPERIMENT_NAME:-flux1_dev_fullparam_hpsv2}
+
+export CUSTOM_REWARD_MODEL_PATH HPSV2_PRETRAINED_PATH REWARD_DEVICE
+
+export ASCEND_RT_VISIBLE_DEVICES=${ASCEND_RT_VISIBLE_DEVICES:-0,1,2,3,4,5,6,7}
+export MULTI_STREAM_MEMORY_REUSE=${MULTI_STREAM_MEMORY_REUSE:-2}
+export RAY_memory_usage_threshold=${RAY_memory_usage_threshold:-1.0}
+
+NUM_GPUS=${NUM_GPUS:-8}
+ROLLOUT_N=${ROLLOUT_N:-12}
+TOTAL_TRAINING_STEPS=${TOTAL_TRAINING_STEPS:-150}
+SAVE_FREQ=${SAVE_FREQ:-1000000000}
+MAX_CKPT_KEEP=${MAX_CKPT_KEEP:-1}
+PROJECT_NAME=${PROJECT_NAME:-dance_grpo}
+CUSTOM_CHAT_TEMPLATE='{% for message in messages %}{% if message['\''role'\''] == '\''user'\'' %}{{ message['\''content'\''] }}{% endif %}{% endfor %}'
+
+if (( NUM_GPUS % ROLLOUT_TP != 0 )); then
+    echo "Error: NUM_GPUS ($NUM_GPUS) must be divisible by ROLLOUT_TP ($ROLLOUT_TP)." >&2
+    exit 1
+fi
+
+python3 -m verl_omni.trainer.main_diffusion \
+    trainer.device=npu \
+    trainer.nnodes=1 \
+    trainer.n_gpus_per_node=$NUM_GPUS \
+    trainer.total_training_steps=$TOTAL_TRAINING_STEPS \
+    trainer.total_epochs=1 \
+    trainer.val_before_train=false \
+    trainer.test_freq=-1 \
+    trainer.save_freq=$SAVE_FREQ \
+    trainer.max_actor_ckpt_to_keep=$MAX_CKPT_KEEP \
+    trainer.logger='["console", "tensorboard"]' \
+    trainer.project_name=$PROJECT_NAME \
+    trainer.experiment_name=$EXPERIMENT_NAME \
+    algorithm.adv_estimator=dance_grpo \
+    algorithm.rollout_correction.bypass_mode=false \
+    actor_rollout_ref.model.path=$MODEL_NAME \
+    actor_rollout_ref.model.algorithm=dance_grpo \
+    actor_rollout_ref.model.custom_chat_template="\"$CUSTOM_CHAT_TEMPLATE\"" \
+    'actor_rollout_ref.model.extra_tokenizers={clip: {path: tokenizer, max_length: 77}, t5: {path: tokenizer_2, max_length: 256}}' \
+    actor_rollout_ref.model.lora_rank=0 \
+    actor_rollout_ref.model.attn_backend=native \
+    actor_rollout_ref.model.enable_gradient_checkpointing=true \
+    actor_rollout_ref.model.pipeline.guidance_scale=1.0 \
+    actor_rollout_ref.actor.diffusion_loss.loss_mode=dance_grpo \
+    actor_rollout_ref.actor.diffusion_loss.clip_ratio=1e-4 \
+    actor_rollout_ref.actor.diffusion_loss.adv_clip_max=5.0 \
+    actor_rollout_ref.actor.optim.optimizer=AdamW \
+    actor_rollout_ref.actor.optim.lr=1e-5 \
+    actor_rollout_ref.actor.optim.weight_decay=1e-4 \
+    actor_rollout_ref.actor.optim.lr_scheduler_type=constant \
+    actor_rollout_ref.actor.optim.lr_warmup_steps=0 \
+    actor_rollout_ref.actor.optim.lr_warmup_steps_ratio=0.0 \
+    actor_rollout_ref.actor.optim.clip_grad=1.0 \
+    actor_rollout_ref.actor.ppo_epochs=1 \
+    actor_rollout_ref.actor.shuffle=false \
+    actor_rollout_ref.actor.data_loader_seed=42 \
+    actor_rollout_ref.actor.ppo_mini_batch_size=4 \
+    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=1 \
+    actor_rollout_ref.actor.fsdp_config.fsdp_size=$NUM_GPUS \
+    actor_rollout_ref.actor.fsdp_config.model_dtype=$ACTOR_MODEL_DTYPE \
+    actor_rollout_ref.actor.fsdp_config.dtype=bfloat16 \
+    actor_rollout_ref.actor.fsdp_config.param_offload=true \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=true \
+    actor_rollout_ref.actor.fsdp_config.ulysses_sequence_parallel_size=1 \
+    actor_rollout_ref.actor.fsdp_config.forward_prefetch=true \
+    actor_rollout_ref.rollout.name=vllm_omni \
+    actor_rollout_ref.rollout.rollout_attn_backend=TORCH_SDPA \
+    actor_rollout_ref.rollout.n=$ROLLOUT_N \
+    actor_rollout_ref.rollout.seed=42 \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=$ROLLOUT_TP \
+    actor_rollout_ref.rollout.agent.num_workers=$((NUM_GPUS / ROLLOUT_TP)) \
+    actor_rollout_ref.rollout.layered_summon=true \
+    +actor_rollout_ref.rollout.enable_sleep_mode=true \
+    actor_rollout_ref.rollout.free_cache_engine=true \
+    actor_rollout_ref.rollout.calculate_log_probs=true \
+    actor_rollout_ref.rollout.gpu_memory_utilization=$ROLLOUT_GPU_MEMORY_UTILIZATION \
+    actor_rollout_ref.rollout.max_num_seqs=4 \
+    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=1 \
+    actor_rollout_ref.rollout.pipeline.height=720 \
+    actor_rollout_ref.rollout.pipeline.width=720 \
+    actor_rollout_ref.rollout.pipeline.num_inference_steps=16 \
+    actor_rollout_ref.rollout.pipeline.guidance_scale=3.5 \
+    actor_rollout_ref.rollout.pipeline.max_sequence_length=256 \
+    actor_rollout_ref.rollout.max_prompt_embed_length=256 \
+    actor_rollout_ref.rollout.algo.sde_type=dance_sde \
+    actor_rollout_ref.rollout.algo.noise_level=0.3 \
+    actor_rollout_ref.rollout.algo.sde_window_size=null \
+    actor_rollout_ref.rollout.algo.sde_window_range=null \
+    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=1 \
+    data.train_files=$TRAIN_FILES_PATH \
+    data.val_files=$VAL_FILES_PATH \
+    data.train_batch_size=$TRAIN_BATCH_SIZE \
+    data.max_prompt_length=256 \
+    data.shuffle=true \
+    data.seed=1223627 \
+    data.dataloader_num_workers=4 \
+    reward.num_workers=$REWARD_NUM_WORKERS \
+    reward.reward_model.enable=false \
+    reward.custom_reward_function.path=$REWARD_FUNCTION_PATH \
+    reward.custom_reward_function.name=$REWARD_FUNCTION_NAME \
+    "$@"

--- a/tests/pipelines/test_flux_dance_grpo_on_cpu.py
+++ b/tests/pipelines/test_flux_dance_grpo_on_cpu.py
@@ -1,0 +1,183 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+import torch
+
+from verl_omni.pipelines.flux_dance_grpo.common import select_dance_grpo_transitions
+from verl_omni.pipelines.flux_dance_grpo.diffusers_training_adapter import FluxDanceGRPO
+from verl_omni.pipelines.flux_dance_grpo.vllm_omni_rollout_adapter import (
+    FluxDanceGRPOPipelineWithLogProb,
+    _extract_extra_prompt_ids,
+    _normalize_window_range,
+    _pad_token_ids,
+    _sample_sde_windows,
+)
+
+
+class _PipelineConfig(dict):
+    """Minimal Hydra-like mapping with attribute access for adapter tests."""
+
+    __getattr__ = dict.__getitem__
+
+
+def test_select_transitions_drops_last_and_keeps_gathered_fields_aligned() -> None:
+    current = torch.arange(10, dtype=torch.float32).reshape(2, 5, 1)
+    next_latents = current + 100
+    timesteps = current.squeeze(-1) + 200
+    log_probs = current.squeeze(-1) + 300
+    generators = [torch.Generator().manual_seed(7), torch.Generator().manual_seed(11)]
+
+    selected_current, selected_next, selected_timesteps, selected_log_probs = select_dance_grpo_transitions(
+        current,
+        next_latents,
+        timesteps,
+        log_probs,
+        strategy="random_subset",
+        fraction=0.5,
+        drop_last=True,
+        generator=generators,
+    )
+
+    assert selected_current.shape == (2, 2, 1)
+    torch.testing.assert_close(selected_next, selected_current + 100)
+    torch.testing.assert_close(selected_timesteps, selected_current.squeeze(-1) + 200)
+    torch.testing.assert_close(selected_log_probs, selected_current.squeeze(-1) + 300)
+    assert 4 not in selected_current[0, :, 0].tolist()
+    assert 9 not in selected_current[1, :, 0].tolist()
+
+
+def test_select_transitions_validates_fraction_and_generator_count() -> None:
+    latents = torch.zeros(2, 3, 1)
+    timesteps = torch.zeros(2, 3)
+    log_probs = torch.zeros(2, 3)
+
+    with pytest.raises(ValueError, match="fraction must be in"):
+        select_dance_grpo_transitions(latents, latents, timesteps, log_probs, fraction=0.0)
+    with pytest.raises(ValueError, match="expected 2 transition generators"):
+        select_dance_grpo_transitions(
+            latents,
+            latents,
+            timesteps,
+            log_probs,
+            strategy="random_subset",
+            generator=[torch.Generator()],
+        )
+
+
+def test_normalize_and_sample_sde_windows() -> None:
+    assert _normalize_window_range(None, 16) == (0, 16)
+    assert _normalize_window_range("[2, 12]", 16) == (2, 12)
+    assert _sample_sde_windows(
+        window_size=None,
+        window_range=None,
+        num_steps=16,
+        batch_size=2,
+        generators=None,
+        device=torch.device("cpu"),
+    ) == [(0, 16), (0, 16)]
+
+    generators = [torch.Generator().manual_seed(3), torch.Generator().manual_seed(5)]
+    windows = _sample_sde_windows(
+        window_size=4,
+        window_range=(2, 12),
+        num_steps=16,
+        batch_size=2,
+        generators=generators,
+        device=torch.device("cpu"),
+    )
+    assert all(2 <= start < end <= 12 and end - start == 4 for start, end in windows)
+
+    with pytest.raises(ValueError, match="invalid sde_window_size"):
+        _sample_sde_windows(
+            window_size=11,
+            window_range=(2, 12),
+            num_steps=16,
+            batch_size=1,
+            generators=None,
+            device=torch.device("cpu"),
+        )
+
+
+def test_pad_token_ids_truncates_and_pads() -> None:
+    padded = _pad_token_ids(
+        [[1, 2], [3, 4, 5, 6]],
+        max_length=3,
+        pad_token_id=0,
+        device=torch.device("cpu"),
+    )
+
+    assert padded.dtype == torch.long
+    assert padded.tolist() == [[1, 2, 0], [3, 4, 5]]
+
+
+def test_extra_prompt_ids_require_both_configured_tokenizers() -> None:
+    with pytest.raises(ValueError, match=r"extra_tokenizers\.clip and \.t5"):
+        _extract_extra_prompt_ids([{"extra_prompt_ids": {"clip": [1, 2]}}])
+    with pytest.raises(TypeError, match=r"extra_prompt_ids\['t5'\]"):
+        _extract_extra_prompt_ids([{"extra_prompt_ids": {"clip": [1, 2], "t5": "invalid"}}])
+
+
+def test_rollout_and_actor_use_identical_non_dyadic_sigma_schedule() -> None:
+    rollout = object.__new__(FluxDanceGRPOPipelineWithLogProb)
+    rollout.device = torch.device("cpu")
+    rollout.scheduler = SimpleNamespace(set_timesteps=MagicMock(), timesteps=torch.empty(0))
+    FluxDanceGRPOPipelineWithLogProb._set_timesteps(rollout, num_steps=20, shift=3.0)
+    rollout_sigmas = rollout.scheduler.set_timesteps.call_args.kwargs["sigmas"]
+
+    actor_scheduler = SimpleNamespace(set_timesteps=MagicMock())
+    model_config = SimpleNamespace(pipeline=_PipelineConfig(num_inference_steps=20, shift=3.0))
+    FluxDanceGRPO.set_timesteps(actor_scheduler, model_config, "cpu")
+    actor_sigmas = actor_scheduler.set_timesteps.call_args.kwargs["sigmas"]
+
+    np.testing.assert_array_equal(rollout_sigmas, actor_sigmas)
+
+
+class _GuidanceModule:
+    config = SimpleNamespace(guidance_embeds=True)
+
+    @staticmethod
+    def parameters():
+        return iter(())
+
+
+def test_actor_missing_guidance_scale_defaults_to_one() -> None:
+    latents = torch.zeros(2, 1, 3, 4)
+    timesteps = torch.full((2, 1), 500.0)
+    prompt_embeds = torch.zeros(2, 5, 4)
+    micro_batch = {
+        "text_ids": torch.zeros(5, 3),
+        "image_ids": torch.zeros(3, 3),
+        "pooled_prompt_embeds": torch.zeros(2, 4),
+    }
+
+    model_inputs, negative_inputs = FluxDanceGRPO.prepare_model_inputs(
+        _GuidanceModule(),
+        SimpleNamespace(pipeline={}),
+        latents,
+        timesteps,
+        prompt_embeds,
+        torch.ones(2, 5),
+        torch.empty(0),
+        torch.empty(0),
+        micro_batch,
+        0,
+    )
+
+    assert negative_inputs is None
+    torch.testing.assert_close(model_inputs["guidance"], torch.ones(2))

--- a/tests/utils/reward_score/test_hpsv2_reward_on_cpu.py
+++ b/tests/utils/reward_score/test_hpsv2_reward_on_cpu.py
@@ -1,0 +1,66 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pytest
+import torch
+from PIL import Image
+
+from verl_omni.utils.reward_score.hpsv2_reward import _to_rgb_image
+
+
+def test_to_rgb_image_converts_tensor_and_pil_inputs() -> None:
+    tensor = torch.tensor(
+        [
+            [[0.0, 1.0], [0.5, 0.25]],
+            [[1.0, 0.0], [0.5, 0.25]],
+            [[0.0, 0.5], [1.0, 0.25]],
+        ]
+    )
+    converted_tensor = _to_rgb_image(tensor)
+    converted_pil = _to_rgb_image(Image.new("RGBA", (2, 1), (1, 2, 3, 4)))
+
+    assert converted_tensor.mode == "RGB"
+    assert converted_tensor.size == (2, 2)
+    assert converted_tensor.getpixel((0, 0)) == (0, 255, 0)
+    assert converted_pil.mode == "RGB"
+    assert converted_pil.getpixel((0, 0)) == (1, 2, 3)
+
+
+def test_to_rgb_image_accepts_singleton_batch_and_grayscale() -> None:
+    image = _to_rgb_image(np.array([[[0.0, 1.0], [0.5, 0.25]]], dtype=np.float32))
+
+    assert image.mode == "RGB"
+    assert image.size == (2, 2)
+    assert np.asarray(image).tolist() == [
+        [[0, 0, 0], [255, 255, 255]],
+        [[128, 128, 128], [64, 64, 64]],
+    ]
+
+
+@pytest.mark.parametrize(
+    ("value", "message"),
+    [
+        (object(), "Unsupported image type"),
+        (np.zeros((2, 1, 1, 3)), "scores one image per call"),
+        (np.zeros((2, 2, 2, 2, 2)), "Expected an HxW"),
+        (np.zeros((2, 2, 2)), "Expected 1, 3, or 4 image channels"),
+        (np.array([[np.nan]], dtype=np.float32), "non-finite"),
+        (np.array([[-1.0]], dtype=np.float32), r"must be in \[0, 1\] or \[0, 255\]"),
+        (np.array([[256.0]], dtype=np.float32), r"must be in \[0, 1\] or \[0, 255\]"),
+    ],
+)
+def test_to_rgb_image_rejects_invalid_inputs(value, message) -> None:
+    with pytest.raises((TypeError, ValueError), match=message):
+        _to_rgb_image(value)

--- a/verl_omni/pipelines/__init__.py
+++ b/verl_omni/pipelines/__init__.py
@@ -15,6 +15,7 @@
 from . import (
     bagel_flow_grpo,
     boogu_image_flow_grpo,
+    flux_dance_grpo,
     ltx2_flow_grpo,
     minimax_h3_diffusion_nft,
     minimax_h3_flow_grpo,
@@ -31,6 +32,7 @@ from . import (
 )
 from .bagel_flow_grpo import *  # noqa: F401, F403
 from .boogu_image_flow_grpo import *  # noqa: F401, F403
+from .flux_dance_grpo import *  # noqa: F401, F403
 from .ltx2_flow_grpo import *  # noqa: F401, F403
 from .minimax_h3_diffusion_nft import *  # noqa: F401, F403
 from .minimax_h3_flow_grpo import *  # noqa: F401, F403
@@ -60,3 +62,4 @@ __all__ += list(qwen_image_dpo.__all__)
 __all__ += list(qwen_image_dual_grpo.__all__)
 __all__ += list(qwen_image_edit_flow_grpo.__all__)
 __all__ += list(boogu_image_flow_grpo.__all__)
+__all__ += list(flux_dance_grpo.__all__)

--- a/verl_omni/pipelines/flux_dance_grpo/__init__.py
+++ b/verl_omni/pipelines/flux_dance_grpo/__init__.py
@@ -1,0 +1,18 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .diffusers_training_adapter import FluxDanceGRPO
+from .vllm_omni_rollout_adapter import FluxDanceGRPOPipelineWithLogProb
+
+__all__ = ["FluxDanceGRPO", "FluxDanceGRPOPipelineWithLogProb"]

--- a/verl_omni/pipelines/flux_dance_grpo/common.py
+++ b/verl_omni/pipelines/flux_dance_grpo/common.py
@@ -1,0 +1,99 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared FLUX DanceGRPO rollout utilities."""
+
+from typing import Optional
+
+import torch
+
+from verl_omni.pipelines.wan22_dance_grpo.common import sd3_time_shift  # noqa: F401
+
+
+def predict_original_sample(
+    sample: torch.Tensor, model_output: torch.Tensor, sigma: torch.Tensor | float
+) -> torch.Tensor:
+    """Return FLUX's clean latent prediction ``x0 = x_t - sigma * v``."""
+    if sample.shape != model_output.shape:
+        raise ValueError(f"sample/model_output shapes differ: {tuple(sample.shape)} vs {tuple(model_output.shape)}")
+    sigma_tensor = torch.as_tensor(sigma, device=sample.device, dtype=sample.dtype)
+    return sample - sigma_tensor * model_output.to(dtype=sample.dtype)
+
+
+def select_dance_grpo_transitions(
+    current_latents: torch.Tensor,
+    next_latents: torch.Tensor,
+    timesteps: torch.Tensor,
+    log_probs: torch.Tensor,
+    *,
+    strategy: str = "continuous",
+    fraction: float = 1.0,
+    drop_last: bool = False,
+    generator: Optional[torch.Generator | list[torch.Generator]] = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Select aligned transitions after the chronological rollout completes."""
+    if strategy not in {"continuous", "random_subset"}:
+        raise ValueError(f"unknown timestep selection strategy: {strategy!r}")
+    if not 0 < fraction <= 1:
+        raise ValueError(f"timestep fraction must be in (0, 1], got {fraction}")
+    if current_latents.ndim < 3 or next_latents.ndim != current_latents.ndim:
+        raise ValueError("current_latents and next_latents must have matching [B,T,...] shapes")
+    if current_latents.shape != next_latents.shape:
+        raise ValueError(
+            f"current/next latent shapes differ: {tuple(current_latents.shape)} vs {tuple(next_latents.shape)}"
+        )
+    if timesteps.ndim != 2 or timesteps.shape != current_latents.shape[:2]:
+        raise ValueError(
+            f"timesteps must match latent [B,T]={tuple(current_latents.shape[:2])}, got {tuple(timesteps.shape)}"
+        )
+    if log_probs.ndim < 2 or log_probs.shape[:2] != timesteps.shape:
+        raise ValueError(f"log_probs first dimensions must be {tuple(timesteps.shape)}, got {tuple(log_probs.shape)}")
+
+    if drop_last:
+        if timesteps.shape[1] <= 1:
+            raise ValueError("cannot drop the last transition when T <= 1")
+        current_latents = current_latents[:, :-1]
+        next_latents = next_latents[:, :-1]
+        timesteps = timesteps[:, :-1]
+        log_probs = log_probs[:, :-1]
+
+    batch_size, num_transitions = timesteps.shape
+    if strategy == "continuous":
+        return current_latents, next_latents, timesteps, log_probs
+
+    num_selected = max(1, int(num_transitions * fraction))
+    if isinstance(generator, list) and len(generator) != batch_size:
+        raise ValueError(f"expected {batch_size} transition generators, got {len(generator)}")
+    indices = torch.stack(
+        [
+            torch.randperm(
+                num_transitions,
+                device=timesteps.device,
+                generator=generator[row] if isinstance(generator, list) else generator,
+            )[:num_selected]
+            for row in range(batch_size)
+        ],
+        dim=0,
+    )
+
+    def _gather(value: torch.Tensor) -> torch.Tensor:
+        gather_index = indices.view(batch_size, num_selected, *([1] * (value.ndim - 2)))
+        return torch.gather(value, 1, gather_index.expand(-1, -1, *value.shape[2:]))
+
+    return (
+        _gather(current_latents),
+        _gather(next_latents),
+        _gather(timesteps),
+        _gather(log_probs),
+    )

--- a/verl_omni/pipelines/flux_dance_grpo/diffusers_training_adapter.py
+++ b/verl_omni/pipelines/flux_dance_grpo/diffusers_training_adapter.py
@@ -1,0 +1,299 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+FLUX training-side adapter for diffusers-based diffusion RL (DanceGRPO).
+
+Implements the :class:`DiffusionModelBase` interface for FLUX.1-dev,
+handling packed 2D latents, dual T5+CLIP prompt encoding, text/image position
+IDs, guidance embedding, and SDE-based log-probability computation.
+"""
+
+from typing import Optional
+
+import numpy as np
+import torch
+from diffusers.models.transformers.transformer_flux import FluxTransformer2DModel
+from tensordict import TensorDict
+from verl.utils.device import get_device_name
+
+from verl_omni.pipelines.model_base import DiffusionModelBase
+from verl_omni.pipelines.schedulers import FlowMatchSDEDiscreteScheduler
+from verl_omni.workers.config import DiffusionModelConfig
+
+from .common import sd3_time_shift
+
+__all__ = ["FluxDanceGRPO"]
+
+
+@DiffusionModelBase.register("FluxPipeline", algorithm="dance_grpo")
+class FluxDanceGRPO(DiffusionModelBase):
+    """Training adapter for the FLUX.1-dev diffusion model with DanceGRPO.
+
+    Implements the :class:`~verl_omni.pipelines.model_base.DiffusionModelBase`
+    interface for ``FluxPipeline`` architecture, providing scheduler
+    configuration, model-input construction, and the forward/sampling step
+    used during DanceGRPO RL training.
+
+    Registered under ``("FluxPipeline", "dance_grpo")``.
+
+    At 720x720 resolution, packed latents have shape ``(B, 2025, 64)``.
+    """
+
+    # ------------------------------------------------------------------
+    # Scheduler
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def build_scheduler(cls, model_config: DiffusionModelConfig):
+        """Build and configure the SDE scheduler for FLUX DanceGRPO.
+
+        Loads the scheduler configuration from the model's ``scheduler``
+        subfolder via ``from_pretrained``.
+
+        Uses ``FlowMatchSDEDiscreteScheduler`` with the ``dance_sde`` SDE variant.
+
+        Args:
+            model_config: Configuration for the diffusion model.
+
+        Returns:
+            Configured scheduler with timesteps set.
+        """
+        model_path = model_config.local_path
+        if model_path is None:
+            raise ValueError("FLUX DanceGRPO requires model_config.local_path")
+        scheduler = FlowMatchSDEDiscreteScheduler.from_pretrained(
+            pretrained_model_name_or_path=model_path,
+            subfolder="scheduler",
+        )
+        # Explicit shifted sigmas are supplied below, so neutralise the
+        # scheduler's own shifting to prevent a second transformation.
+        if getattr(scheduler.config, "use_dynamic_shifting", False):
+            scheduler.register_to_config(use_dynamic_shifting=False)
+        if getattr(scheduler, "shift", 1.0) != 1.0:
+            scheduler.register_to_config(shift=1.0)
+            scheduler.set_shift(1.0)
+        if scheduler.shift != 1.0:
+            raise RuntimeError(f"FLUX actor scheduler shift must be 1.0, got {scheduler.shift}")
+
+        cls.set_timesteps(scheduler, model_config, get_device_name())
+        return scheduler
+
+    @classmethod
+    def set_timesteps(
+        cls,
+        scheduler: FlowMatchSDEDiscreteScheduler,
+        model_config: DiffusionModelConfig,
+        device: str,
+    ):
+        """Configure timesteps with DanceGRPO-style shifted sigmas.
+
+        Produces a sigma schedule via ``sd3_time_shift(shift, linspace(1,0,N+1))``
+        and trims to *N* entries for denoising.
+
+        Args:
+            scheduler: The scheduler whose timesteps will be set.
+            model_config: Configuration providing ``num_inference_steps``.
+            device: Target device string.
+        """
+        num_inference_steps = model_config.pipeline.num_inference_steps
+        shift = model_config.pipeline.get("shift", 3.0)
+
+        sigmas_np = np.linspace(1.0, 0.0, num_inference_steps + 1)
+        sigmas_t = sd3_time_shift(shift, torch.from_numpy(sigmas_np).float())
+        sigmas = sigmas_t[:num_inference_steps].numpy()
+        scheduler.set_timesteps(num_inference_steps, device=device, sigmas=sigmas)
+
+    # ------------------------------------------------------------------
+    # Model inputs
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def prepare_model_inputs(
+        cls,
+        module: FluxTransformer2DModel,
+        model_config: DiffusionModelConfig,
+        latents: torch.Tensor,
+        timesteps: torch.Tensor,
+        prompt_embeds: torch.Tensor,
+        prompt_embeds_mask: torch.Tensor,
+        negative_prompt_embeds: torch.Tensor,
+        negative_prompt_embeds_mask: torch.Tensor,
+        micro_batch: TensorDict,
+        step: int,
+    ) -> tuple[dict, Optional[dict]]:
+        """Build FLUX-specific inputs for the transformer forward pass.
+
+        FLUX requires the following inputs beyond the standard latent/timestep:
+            - ``txt_ids``: text position IDs of shape ``(B, seq_len, 3)``.
+            - ``img_ids``: image position IDs of shape ``(patches, 3)``.
+            - ``pooled_projections``: CLIP pooled text embedding ``(B, 768)``.
+            - ``guidance``: guidance scale embedding broadcast to ``(B,)``.
+            - ``joint_attention_kwargs``: optional cross-attention kwargs.
+            - ``return_dict``: always ``False`` (returns tuple).
+
+        Timesteps are divided by 1000 before being passed to the transformer,
+        matching the standard FLUX convention.
+
+        Args:
+            module: The FLUX transformer module.
+            model_config: Configuration providing guidance scale and other settings.
+            latents: Full latent trajectory ``(B, T, patches, C)``.
+            timesteps: Full timestep tensor ``(B, T)`` (integer, 0-1000 range).
+            prompt_embeds: T5 encoder_hidden_states ``(B, L, 4096)``.
+            prompt_embeds_mask: Attention mask for *prompt_embeds*.
+            negative_prompt_embeds: Unused; FLUX.1-dev uses distilled guidance embeddings.
+            negative_prompt_embeds_mask: Unused; kept for the shared adapter interface.
+            micro_batch: Micro-batch metadata containing:
+                - ``text_ids``: text position IDs.
+                - ``image_ids``: image position IDs.
+                - ``pooled_prompt_embeds``: CLIP pooled embedding.
+            step: Current denoising step index.
+
+        Returns:
+            tuple[dict, dict]: ``(model_inputs, negative_model_inputs)`` dicts
+                ready to be unpacked into the FLUX transformer ``__call__``.
+        """
+        del prompt_embeds_mask, negative_prompt_embeds, negative_prompt_embeds_mask
+
+        # Slice to current denoising step (step index within the trajectory)
+        model_dtype = prompt_embeds.dtype
+        try:
+            model_dtype = next(module.parameters()).dtype
+        except (AttributeError, StopIteration):
+            pass
+        hidden_states = latents[:, step].to(dtype=model_dtype)  # (B, patches, C)
+
+        # FLUX transformer expects timesteps in [0, 1] range (divided by 1000)
+        timestep = timesteps[:, step].float() / 1000.0
+
+        device = hidden_states.device
+        dtype = hidden_states.dtype
+        prompt_embeds = prompt_embeds.to(device=device, dtype=dtype)
+
+        def _shared_position_ids(name: str, expected_length: int) -> torch.Tensor:
+            ids = micro_batch.get(name, None)
+            if ids is None:
+                raise KeyError(f"FLUX actor requires rollout field {name!r}")
+            if ids.ndim == 2:
+                shared = ids
+            elif ids.ndim == 3:
+                if ids.shape[0] != hidden_states.shape[0]:
+                    raise ValueError(f"{name} batch {ids.shape[0]} != latent batch {hidden_states.shape[0]}")
+                shared = ids[0]
+                if ids.shape[0] > 1 and not torch.equal(ids, shared.unsqueeze(0).expand_as(ids)):
+                    raise ValueError(f"{name} must be identical across a FLUX micro-batch")
+            else:
+                raise ValueError(f"{name} must be [L,3] or [B,L,3], got {tuple(ids.shape)}")
+            if shared.shape != (expected_length, 3):
+                raise ValueError(f"{name} expected {(expected_length, 3)}, got {tuple(shared.shape)}")
+            return shared.to(device=device, dtype=dtype)
+
+        text_ids = _shared_position_ids("text_ids", prompt_embeds.shape[1])
+        image_ids = _shared_position_ids("image_ids", hidden_states.shape[1])
+
+        pooled_prompt_embeds = micro_batch.get("pooled_prompt_embeds", None)
+        if pooled_prompt_embeds is None:
+            raise KeyError("FLUX actor requires pooled_prompt_embeds from rollout CLIP encoding")
+        pooled_prompt_embeds = pooled_prompt_embeds.to(device=device, dtype=dtype)
+
+        # FLUX.1-dev encodes distilled guidance directly in the transformer.
+        guidance_scale = model_config.pipeline.get("guidance_scale", None)
+        if guidance_scale is None:
+            guidance_scale = 1.0
+        guidance = None
+        if getattr(module.config, "guidance_embeds", False):
+            guidance = torch.full(
+                (hidden_states.shape[0],),
+                float(guidance_scale),
+                device=hidden_states.device,
+                dtype=torch.float32,
+            )
+
+        # Canonical FLUX prompt encoding does not pass a T5 attention mask.
+        model_inputs = {
+            "hidden_states": hidden_states,
+            "timestep": timestep,
+            "encoder_hidden_states": prompt_embeds,
+            "pooled_projections": pooled_prompt_embeds,
+            "txt_ids": text_ids,
+            "img_ids": image_ids,
+            "guidance": guidance,
+            "joint_attention_kwargs": None,
+            "return_dict": False,
+        }
+
+        return model_inputs, None
+
+    # ------------------------------------------------------------------
+    # Forward + sample previous step
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def forward_and_sample_previous_step(
+        cls,
+        module: FluxTransformer2DModel,
+        scheduler: FlowMatchSDEDiscreteScheduler,
+        model_config: DiffusionModelConfig,
+        model_inputs: dict[str, torch.Tensor],
+        negative_model_inputs: Optional[dict[str, torch.Tensor]],
+        scheduler_inputs: Optional[TensorDict | dict[str, torch.Tensor]],
+        step: int,
+    ):
+        """Run the FLUX transformer and sample the previous denoising step.
+
+        Used by DanceGRPO which requires log-probabilities for reversed sampling.
+
+        Args:
+            module: The FLUX transformer module.
+            scheduler: Scheduler used to sample the previous step and compute
+                log-probabilities.
+            model_config: Configuration providing guidance scale, noise level,
+                and SDE type.
+            model_inputs: Positive-prompt inputs for the transformer forward.
+            negative_model_inputs: Unused; kept for the shared adapter interface.
+            scheduler_inputs: Must contain ``"all_latents"`` and ``"all_timesteps"``.
+            step: Current denoising step index.
+
+        Returns:
+            tuple: ``(log_prob, prev_sample_mean, std_dev_t, sqrt_dt)``.
+        """
+        del negative_model_inputs
+        if scheduler_inputs is None:
+            raise ValueError("FLUX DanceGRPO requires scheduler inputs from rollout")
+        latents = scheduler_inputs["all_latents"]
+        next_latents = scheduler_inputs.get("all_next_latents", None)
+        if next_latents is None:
+            raise KeyError("FLUX DanceGRPO requires all_next_latents for explicit transition pairing")
+        if next_latents.shape != latents.shape:
+            raise ValueError(
+                f"all_next_latents shape {tuple(next_latents.shape)} != all_latents {tuple(latents.shape)}"
+            )
+        timesteps = scheduler_inputs["all_timesteps"]
+
+        noise_pred = module(**model_inputs)[0]
+
+        # Sample previous step via SDE scheduler
+        _, log_prob, prev_sample_mean, std_dev_t, sqrt_dt = scheduler.sample_previous_step(
+            sample=latents[:, step].float(),
+            model_output=noise_pred.float(),
+            timestep=timesteps[:, step],
+            noise_level=model_config.algo.noise_level,
+            prev_sample=next_latents[:, step].float(),
+            sde_type=model_config.algo.sde_type,
+            return_logprobs=True,
+            return_sqrt_dt=True,
+        )
+
+        return log_prob, prev_sample_mean, std_dev_t, sqrt_dt

--- a/verl_omni/pipelines/flux_dance_grpo/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/flux_dance_grpo/vllm_omni_rollout_adapter.py
@@ -1,0 +1,514 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""FLUX.1-dev rollout adapter for DanceGRPO.
+
+The adapter follows the request-batch and per-text-encoder token-id contracts
+of the current verl-omni SD3 adapter. CLIP/T5 run only in rollout; the actor
+receives fixed-size embeddings and trains the complete FLUX transformer.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+from typing import Any
+
+import numpy as np
+import torch
+from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
+from vllm_omni.diffusion.distributed.utils import get_local_device
+from vllm_omni.diffusion.forward_context import set_forward_context_denoise_step_idx
+from vllm_omni.diffusion.models.flux import pipeline_flux
+from vllm_omni.diffusion.models.flux.pipeline_flux import FluxPipeline
+from vllm_omni.diffusion.request import DUMMY_DIFFUSION_REQUEST_ID, OmniDiffusionRequest
+from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
+
+from verl_omni.pipelines.diffusion_rollout_output import rollout_output, wrap_rollout_postprocessor
+from verl_omni.pipelines.model_base import VllmOmniPipelineBase
+from verl_omni.pipelines.request_batch import split_diffusion_output_by_request
+from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
+from verl_omni.pipelines.schedulers import FlowMatchSDEDiscreteScheduler
+from verl_omni.pipelines.wan22_dance_grpo.common import seed_from_prompt_ids
+
+from .common import predict_original_sample, sd3_time_shift, select_dance_grpo_transitions
+
+__all__ = ["FluxDanceGRPOPipelineWithLogProb"]
+
+FLUX_CLIP_TOKENS_KEY = "clip"
+FLUX_T5_TOKENS_KEY = "t5"
+FLUX_ENCODER_TOKEN_KEYS = (FLUX_CLIP_TOKENS_KEY, FLUX_T5_TOKENS_KEY)
+
+_FLUX_POST_PROCESS_FACTORY = pipeline_flux.get_flux_post_process_func
+
+
+def get_rollout_post_process_func(od_config):
+    """Postprocess generated images while preserving rollout metadata."""
+    return wrap_rollout_postprocessor(_FLUX_POST_PROCESS_FACTORY(od_config))
+
+
+pipeline_flux.get_flux_post_process_func = get_rollout_post_process_func
+
+
+def _coalesce_not_none(value, default):
+    return default if value is None else value
+
+
+def _to_token_list(value: Any) -> list[int] | None:
+    if value is None:
+        return None
+    if isinstance(value, torch.Tensor):
+        return [int(item) for item in value.tolist()]
+    if isinstance(value, list):
+        return [int(item) for item in value]
+    return None
+
+
+def _extract_extra_prompt_ids(prompts: list[Any]) -> dict[str, list[list[int]]] | None:
+    """Return CLIP/T5 token ids produced by the latest agent loop."""
+    if not prompts:
+        return None
+    per_prompt: list[dict[str, Any]] = []
+    for prompt in prompts:
+        if not isinstance(prompt, dict) or not prompt.get("extra_prompt_ids"):
+            return None
+        per_prompt.append(prompt["extra_prompt_ids"])
+
+    for index, extra in enumerate(per_prompt):
+        missing = [key for key in FLUX_ENCODER_TOKEN_KEYS if key not in extra]
+        if missing:
+            raise ValueError(
+                f"FLUX request {index} is missing extra_prompt_ids entries {missing}. "
+                "Configure actor_rollout_ref.model.extra_tokenizers.clip and .t5."
+            )
+        for key in FLUX_ENCODER_TOKEN_KEYS:
+            if _to_token_list(extra[key]) is None:
+                raise TypeError(f"extra_prompt_ids[{key!r}] must be a list or tensor of token ids")
+    return {key: [_to_token_list(extra[key]) for extra in per_prompt] for key in FLUX_ENCODER_TOKEN_KEYS}
+
+
+def _extract_text_prompts(prompts: list[Any]) -> list[str] | None:
+    values = [prompt if isinstance(prompt, str) else (prompt.get("prompt") or "") for prompt in prompts]
+    return values if any(values) else None
+
+
+def _pad_token_ids(
+    ids_list: list[list[int]],
+    *,
+    max_length: int,
+    pad_token_id: int,
+    device: torch.device,
+) -> torch.Tensor:
+    rows = []
+    for ids in ids_list:
+        ids = ids[:max_length]
+        rows.append(ids + [pad_token_id] * (max_length - len(ids)))
+    return torch.tensor(rows, dtype=torch.long, device=device)
+
+
+def _normalize_window_range(value: list[int] | tuple[int, int] | str | None, num_steps: int) -> tuple[int, int]:
+    if value is None:
+        return 0, num_steps
+    if isinstance(value, str):
+        value = ast.literal_eval(value)
+    if len(value) != 2:
+        raise ValueError("sde_window_range must contain exactly [start, end]")
+    return int(value[0]), int(value[1])
+
+
+def _sample_sde_windows(
+    *,
+    window_size: int | None,
+    window_range: list[int] | tuple[int, int] | str | None,
+    num_steps: int,
+    batch_size: int,
+    generators: torch.Generator | list[torch.Generator] | None,
+    device: torch.device,
+) -> list[tuple[int, int]]:
+    if window_size is None:
+        return [(0, num_steps)] * batch_size
+    window_size = int(window_size)
+    start, end = _normalize_window_range(window_range, num_steps)
+    if window_size <= 0 or start < 0 or end > num_steps or start + window_size > end:
+        raise ValueError(
+            f"invalid sde_window_size={window_size}, sde_window_range={(start, end)}, num_steps={num_steps}"
+        )
+    high = end - window_size + 1
+
+    def sample_one(generator: torch.Generator | None) -> tuple[int, int]:
+        selected = int(torch.randint(start, high, (1,), device=device, generator=generator).item())
+        return selected, selected + window_size
+
+    if isinstance(generators, list):
+        if len(generators) != batch_size:
+            raise ValueError(f"expected {batch_size} generators, got {len(generators)}")
+        return [sample_one(generator) for generator in generators]
+    sampled = sample_one(generators)
+    return [sampled] * batch_size
+
+
+@VllmOmniPipelineBase.register("FluxPipeline", algorithm="dance_grpo")
+class FluxDanceGRPOPipelineWithLogProb(FluxPipeline):
+    """FLUX.1-dev generation plus aligned DanceGRPO transition capture."""
+
+    supports_request_batch = True
+    diffusion_io_spec = DiffusionIOSpec(primary=MediaSpec("image"))
+
+    def __init__(self, *, od_config: OmniDiffusionConfig, prefix: str = ""):
+        super().__init__(od_config=od_config, prefix=prefix)
+        # ``interrupt`` is a read-only property on the vllm_omni FluxPipeline
+        # backed by ``_interrupt``, which FluxPipeline only initialises inside
+        # ``__call__``. This adapter drives generation via ``diffuse()`` instead,
+        # so initialise the flag here (mirrors the wan22_dance_grpo adapter).
+        self._interrupt = False
+        self.device = get_local_device()
+        model = od_config.model
+        scheduler = FlowMatchSDEDiscreteScheduler.from_pretrained(
+            model,
+            subfolder="scheduler",
+            local_files_only=os.path.exists(model),
+        )
+        # We pass an already shifted sigma schedule. Keep the scheduler itself
+        # at identity shift so rollout and actor cannot double-shift.
+        if getattr(scheduler.config, "use_dynamic_shifting", False):
+            scheduler.register_to_config(use_dynamic_shifting=False)
+        if getattr(scheduler, "shift", 1.0) != 1.0:
+            scheduler.register_to_config(shift=1.0)
+            scheduler.set_shift(1.0)
+        if scheduler.shift != 1.0:
+            raise RuntimeError(f"FLUX rollout scheduler shift must be 1.0, got {scheduler.shift}")
+        self.scheduler = scheduler
+
+    def encode_prompt_from_token_ids(
+        self,
+        *,
+        clip_prompt_ids: list[list[int]],
+        t5_prompt_ids: list[list[int]],
+        max_sequence_length: int,
+        num_images_per_prompt: int,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Canonical FLUX CLIP pooled + T5 sequence encoding from fixed ids."""
+        if len(clip_prompt_ids) != len(t5_prompt_ids):
+            raise ValueError("CLIP and T5 prompt batches must have the same size")
+        batch_size = len(clip_prompt_ids)
+        clip_ids = _pad_token_ids(
+            clip_prompt_ids,
+            max_length=self.tokenizer_max_length,
+            pad_token_id=self.tokenizer.pad_token_id,
+            device=self.device,
+        )
+        pooled_prompt_embeds = self.text_encoder(clip_ids, output_hidden_states=False).pooler_output
+        pooled_prompt_embeds = pooled_prompt_embeds.to(device=self.device, dtype=self.text_encoder.dtype)
+
+        t5_ids = _pad_token_ids(
+            t5_prompt_ids,
+            max_length=max_sequence_length,
+            pad_token_id=self.tokenizer_2.pad_token_id,
+            device=self.device,
+        )
+        prompt_embeds = self.text_encoder_2(t5_ids)[0]
+        prompt_embeds = prompt_embeds.to(device=self.device, dtype=self.text_encoder_2.dtype)
+
+        prompt_embeds = prompt_embeds.repeat(1, num_images_per_prompt, 1).view(
+            batch_size * num_images_per_prompt, max_sequence_length, -1
+        )
+        pooled_prompt_embeds = pooled_prompt_embeds.repeat(1, num_images_per_prompt).view(
+            batch_size * num_images_per_prompt, -1
+        )
+        text_ids = torch.zeros(
+            max_sequence_length,
+            3,
+            device=self.device,
+            dtype=prompt_embeds.dtype,
+        )
+        return prompt_embeds, pooled_prompt_embeds, text_ids
+
+    def _set_timesteps(self, *, num_steps: int, shift: float) -> torch.Tensor:
+        sigmas_np = np.linspace(1.0, 0.0, num_steps + 1)
+        shifted = sd3_time_shift(shift, torch.from_numpy(sigmas_np).float())
+        self.scheduler.set_timesteps(
+            num_steps,
+            device=self.device,
+            sigmas=shifted[:num_steps].cpu().numpy(),
+        )
+        return self.scheduler.timesteps
+
+    def diffuse(
+        self,
+        *,
+        latents: torch.Tensor,
+        timesteps: torch.Tensor,
+        prompt_embeds: torch.Tensor,
+        pooled_prompt_embeds: torch.Tensor,
+        text_ids: torch.Tensor,
+        image_ids: torch.Tensor,
+        guidance_scale: float,
+        noise_level: float,
+        sde_type: str,
+        generators: torch.Generator | list[torch.Generator] | None,
+        windows: list[tuple[int, int]],
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Run chronological diffusion and collect selected explicit pairs."""
+        batch_size = latents.shape[0]
+        if len(windows) != batch_size:
+            raise ValueError(f"expected {batch_size} SDE windows, got {len(windows)}")
+        if len({end - start for start, end in windows}) != 1:
+            raise ValueError("all packed SDE windows must have the same length")
+
+        current_rows: list[list[torch.Tensor]] = [[] for _ in range(batch_size)]
+        next_rows: list[list[torch.Tensor]] = [[] for _ in range(batch_size)]
+        log_prob_rows: list[list[torch.Tensor]] = [[] for _ in range(batch_size)]
+        timestep_rows: list[list[torch.Tensor]] = [[] for _ in range(batch_size)]
+        pred_original_sample: torch.Tensor | None = None
+        model_dtype = self.od_config.dtype
+        self.scheduler.set_begin_index(0)
+
+        for step_index, timestep_value in enumerate(timesteps):
+            if self.interrupt:
+                continue
+            self._current_timestep = timestep_value
+            set_forward_context_denoise_step_idx(step_index)
+            current_sample = latents.float()
+            timestep = timestep_value.expand(batch_size).to(device=self.device, dtype=model_dtype)
+
+            guidance = None
+            if getattr(self.transformer, "guidance_embeds", False):
+                guidance = torch.full((batch_size,), guidance_scale, device=self.device, dtype=torch.float32)
+
+            noise_pred = self.transformer(
+                hidden_states=latents.to(model_dtype),
+                timestep=timestep / 1000.0,
+                encoder_hidden_states=prompt_embeds,
+                pooled_projections=pooled_prompt_embeds,
+                txt_ids=text_ids,
+                img_ids=image_ids,
+                guidance=guidance,
+                joint_attention_kwargs=None,
+                return_dict=False,
+            )[0]
+
+            sigma_index = self.scheduler.index_for_timestep(timestep_value)
+            sigma = self.scheduler.sigmas[sigma_index].to(device=current_sample.device, dtype=current_sample.dtype)
+            pred_original_sample = predict_original_sample(current_sample, noise_pred.float(), sigma)
+
+            levels = [float(noise_level) if start <= step_index < end else 0.0 for start, end in windows]
+            step_noise: float | torch.Tensor
+            if all(level == levels[0] for level in levels):
+                step_noise = levels[0]
+            else:
+                step_noise = torch.tensor(levels, device=self.device, dtype=torch.float32).view(batch_size, 1, 1)
+
+            has_active_row = any(start <= step_index < end for start, end in windows)
+            latents, log_prob, _, _ = self.scheduler.step(
+                noise_pred.float(),
+                timestep_value,
+                current_sample,
+                generator=generators,
+                noise_level=step_noise,
+                sde_type=sde_type,
+                return_logprobs=has_active_row,
+                return_dict=False,
+            )
+            if has_active_row and log_prob is None:
+                raise RuntimeError("DanceGRPO scheduler did not return rollout log-probabilities")
+
+            for row, (start, end) in enumerate(windows):
+                if start <= step_index < end:
+                    if log_prob is None:
+                        raise RuntimeError("active DanceGRPO transition is missing a rollout log-probability")
+                    current_rows[row].append(current_sample[row].detach().clone())
+                    next_rows[row].append(latents[row].detach().float().clone())
+                    log_prob_rows[row].append(log_prob[row].detach().float().clone())
+                    timestep_rows[row].append(timestep_value.detach().float().clone())
+
+        if pred_original_sample is None or any(not row for row in current_rows):
+            raise RuntimeError("FLUX rollout collected no DanceGRPO transitions")
+        return (
+            torch.stack([torch.stack(row) for row in current_rows]),
+            torch.stack([torch.stack(row) for row in next_rows]),
+            torch.stack([torch.stack(row) for row in log_prob_rows]),
+            torch.stack([torch.stack(row) for row in timestep_rows]),
+            pred_original_sample,
+        )
+
+    @torch.no_grad()
+    def forward(
+        self,
+        req: OmniDiffusionRequest | DiffusionRequestBatch,
+        *,
+        height: int | None = None,
+        width: int | None = None,
+        num_inference_steps: int = 16,
+        guidance_scale: float = 3.5,
+        output_type: str = "image",
+        init_same_noise: bool = True,
+        **kwargs: Any,
+    ) -> DiffusionOutput | list[DiffusionOutput]:
+        request_batch = req if isinstance(req, DiffusionRequestBatch) else DiffusionRequestBatch(requests=[req])
+        return_batch = isinstance(req, DiffusionRequestBatch)
+        if all(request.request_id == DUMMY_DIFFUSION_REQUEST_ID for request in request_batch.requests):
+            outputs = [DiffusionOutput(output=None) for _ in range(request_batch.num_reqs)]
+            return outputs if return_batch else outputs[0]
+        prompts = request_batch.prompts or []
+        extra_prompt_ids = _extract_extra_prompt_ids(prompts)
+        text_prompts = _extract_text_prompts(prompts)
+
+        if extra_prompt_ids is None and text_prompts is None:
+            if any(
+                request.request_id != DUMMY_DIFFUSION_REQUEST_ID
+                and isinstance(prompt, dict)
+                and prompt.get("prompt_token_ids") is not None
+                for request, prompt in zip(request_batch.requests, prompts, strict=False)
+            ):
+                raise ValueError(
+                    "FLUX received only the generic prompt_token_ids. Configure "
+                    "actor_rollout_ref.model.extra_tokenizers.clip={path: tokenizer, max_length: 77} "
+                    "and .t5={path: tokenizer_2, max_length: 512}."
+                )
+            outputs = [DiffusionOutput(output=None) for _ in range(request_batch.num_reqs)]
+            return outputs if return_batch else outputs[0]
+
+        sampling = request_batch.sampling_params_list[0]
+        extra_args = sampling.extra_args or {}
+        height = sampling.height or height or self.default_sample_size * self.vae_scale_factor
+        width = sampling.width or width or self.default_sample_size * self.vae_scale_factor
+        num_steps = sampling.num_inference_steps or num_inference_steps
+        max_sequence_length = sampling.max_sequence_length or 512
+        if sampling.guidance_scale_provided:
+            guidance_scale = sampling.guidance_scale
+        output_type = sampling.output_type or extra_args.get("output_type") or output_type
+        if output_type not in ("image", "latent"):
+            raise ValueError(f"FLUX DanceGRPO output_type must be 'image' or 'latent', got {output_type!r}")
+        num_outputs = sampling.num_outputs_per_prompt if sampling.num_outputs_per_prompt > 0 else 1
+        self._guidance_scale = guidance_scale
+        self._interrupt = False
+
+        shift = float(_coalesce_not_none(extra_args.get("shift"), kwargs.get("shift", 3.0)))
+        noise_level = float(_coalesce_not_none(extra_args.get("noise_level"), kwargs.get("noise_level", 1.0)))
+        sde_type = _coalesce_not_none(extra_args.get("sde_type"), kwargs.get("sde_type", "dance_sde"))
+        window_size = _coalesce_not_none(extra_args.get("sde_window_size"), kwargs.get("sde_window_size"))
+        window_range = _coalesce_not_none(extra_args.get("sde_window_range"), kwargs.get("sde_window_range"))
+        strategy = _coalesce_not_none(
+            extra_args.get("timestep_sample_strategy"), kwargs.get("timestep_sample_strategy", "random_subset")
+        )
+        fraction = float(_coalesce_not_none(extra_args.get("timestep_fraction"), kwargs.get("timestep_fraction", 0.6)))
+        drop_last = bool(
+            _coalesce_not_none(extra_args.get("drop_last_transition"), kwargs.get("drop_last_transition", True))
+        )
+        if strategy == "random_subset" and window_size is not None:
+            raise ValueError("random_subset requires the full trajectory; unset sde_window_size")
+
+        if extra_prompt_ids is not None:
+            prompt_embeds, pooled_prompt_embeds, text_ids = self.encode_prompt_from_token_ids(
+                clip_prompt_ids=extra_prompt_ids[FLUX_CLIP_TOKENS_KEY],
+                t5_prompt_ids=extra_prompt_ids[FLUX_T5_TOKENS_KEY],
+                max_sequence_length=max_sequence_length,
+                num_images_per_prompt=num_outputs,
+            )
+        else:
+            prompt_embeds, pooled_prompt_embeds, text_ids = self.encode_prompt(
+                prompt=text_prompts,
+                prompt_2=None,
+                num_images_per_prompt=num_outputs,
+                max_sequence_length=max_sequence_length,
+            )
+        prompt_embeds_mask = torch.ones(prompt_embeds.shape[:2], device=self.device, dtype=torch.long)
+
+        for request in request_batch.requests:
+            params = request.sampling_params
+            if params.generator is None and params.seed is not None:
+                params.generator = torch.Generator(device=self.device).manual_seed(params.seed)
+        generators = request_batch.collate_request_generators(num_outputs, None)
+        initial_generators = generators
+        if init_same_noise and extra_prompt_ids is not None:
+            global_steps = extra_args.get("global_steps")
+            # Repeated generations of one prompt start from the same noise,
+            # matching MindSpeed-MM. Keep the request-specific generators for
+            # SDE updates so the trajectories do not become identical.
+            initial_generators = [
+                torch.Generator(device=self.device).manual_seed(seed_from_prompt_ids(ids, global_steps))
+                for ids in extra_prompt_ids[FLUX_T5_TOKENS_KEY]
+                for _ in range(num_outputs)
+            ]
+        latents = request_batch.collate_request_tensors("latents", None)
+        num_channels_latents = self.transformer.in_channels // 4
+        latents, image_ids = self.prepare_latents(
+            prompt_embeds.shape[0],
+            num_channels_latents,
+            height,
+            width,
+            prompt_embeds.dtype,
+            self.device,
+            initial_generators,
+            latents,
+        )
+
+        timesteps = self._set_timesteps(num_steps=num_steps, shift=shift)
+        self._num_timesteps = len(timesteps)
+        windows = _sample_sde_windows(
+            window_size=window_size,
+            window_range=window_range,
+            num_steps=len(timesteps),
+            batch_size=latents.shape[0],
+            generators=generators,
+            device=self.device,
+        )
+        current, next_latents, log_probs, selected_timesteps, pred_original = self.diffuse(
+            latents=latents,
+            timesteps=timesteps,
+            prompt_embeds=prompt_embeds,
+            pooled_prompt_embeds=pooled_prompt_embeds,
+            text_ids=text_ids,
+            image_ids=image_ids,
+            guidance_scale=guidance_scale,
+            noise_level=noise_level,
+            sde_type=sde_type,
+            generators=generators,
+            windows=windows,
+        )
+        current, next_latents, selected_timesteps, log_probs = select_dance_grpo_transitions(
+            current,
+            next_latents,
+            selected_timesteps,
+            log_probs,
+            strategy=strategy,
+            fraction=fraction,
+            drop_last=drop_last,
+            generator=generators,
+        )
+
+        self._current_timestep = None
+        if output_type == "latent":
+            output = pred_original
+        else:
+            clean = self._unpack_latents(pred_original, height, width, self.vae_scale_factor)
+            clean = (clean / self.vae.config.scaling_factor) + self.vae.config.shift_factor
+            output = self.vae.decode(clean.to(self.vae.dtype), return_dict=False)[0]
+
+        batch_size = prompt_embeds.shape[0]
+        result = rollout_output(
+            media=output,
+            trajectory_latents=current,
+            trajectory_log_probs=log_probs,
+            trajectory_timesteps=selected_timesteps,
+            prompt_embeddings={
+                "prompt_embeds": prompt_embeds,
+                "prompt_embeds_mask": prompt_embeds_mask,
+                "pooled_prompt_embeds": pooled_prompt_embeds,
+                "text_ids": text_ids.unsqueeze(0).expand(batch_size, -1, -1),
+                "image_ids": image_ids.unsqueeze(0).expand(batch_size, -1, -1),
+            },
+            rl={"all_next_latents": next_latents},
+            to_cpu=True,
+        )
+        outputs = split_diffusion_output_by_request(
+            result,
+            request_batch,
+            num_outputs_per_prompt=num_outputs,
+        )
+        return outputs if return_batch else outputs[0]

--- a/verl_omni/utils/reward_score/hpsv2_reward.py
+++ b/verl_omni/utils/reward_score/hpsv2_reward.py
@@ -1,0 +1,173 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""HPSv2.1 reward scorer backed by ``open_clip_torch``.
+
+The score follows the HPSv2 convention used by MindSpeed-MM: the diagonal of
+``image_features @ text_features.T``. Advantage normalization remains in the
+trainer and no additional logit or reward scaling is applied here.
+
+Required environment variables:
+
+- ``HPSV2_PRETRAINED_PATH``: OpenCLIP ViT-H-14 pretrained checkpoint.
+- ``CUSTOM_REWARD_MODEL_PATH``: HPS-v2.1 reward checkpoint.
+
+Optional environment variable:
+
+- ``REWARD_DEVICE``: inference device, default ``cpu``. ``HPSV2_DEVICE`` is
+  accepted as a backward-compatible fallback.
+"""
+
+import logging
+import os
+import threading
+from typing import Any
+
+import numpy as np
+import torch
+from PIL import Image
+
+logger = logging.getLogger(__name__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "INFO"))
+
+_load_lock = threading.Lock()
+_scorer = None
+_scorer_key: tuple[str, str, str] | None = None
+
+
+def _required_file(env_name: str) -> str:
+    path = os.getenv(env_name)
+    if not path:
+        raise ValueError(f"{env_name} must point to an HPSv2.1 checkpoint file")
+    if not os.path.isfile(path):
+        raise FileNotFoundError(f"{env_name} is not a file: {path}")
+    return path
+
+
+def _resolve_device(device: str | torch.device | None) -> torch.device:
+    if device is not None:
+        return torch.device(device)
+    configured = os.getenv("REWARD_DEVICE") or os.getenv("HPSV2_DEVICE") or "cpu"
+    return torch.device(configured)
+
+
+class _HPSv2Scorer:
+    """One OpenCLIP scorer instance owned by one RewardLoopWorker process."""
+
+    def __init__(self, pretrained_path: str, reward_checkpoint_path: str, device: torch.device):
+        try:
+            import open_clip
+        except ImportError as exc:
+            raise ImportError("HPSv2 reward requires `pip install open_clip_torch`") from exc
+
+        model, _, preprocess = open_clip.create_model_and_transforms(
+            "ViT-H-14",
+            pretrained=pretrained_path,
+            precision="amp",
+            device="cpu",
+            jit=False,
+            output_dict=True,
+        )
+        checkpoint = torch.load(reward_checkpoint_path, map_location="cpu", weights_only=False)
+        state_dict = checkpoint.get("state_dict", checkpoint)
+        model.load_state_dict(state_dict, strict=True)
+        self.model = model.to(device).eval()
+        self.preprocess = preprocess
+        self.tokenizer = open_clip.get_tokenizer("ViT-H-14")
+        self.device = device
+        logger.info("HPSv2.1 scorer loaded on %s", device)
+
+    def score(self, image: Image.Image, prompt: str) -> float:
+        image_input = self.preprocess(image).unsqueeze(0).to(self.device)
+        text_input = self.tokenizer([prompt]).to(self.device)
+        with torch.inference_mode(), torch.autocast(device_type=self.device.type):
+            output = self.model(image_input, text_input)
+            raw_score = torch.diagonal(output["image_features"] @ output["text_features"].T)
+        return float(raw_score.item())
+
+
+def _get_hpsv2_scorer(device: str | torch.device | None = None) -> _HPSv2Scorer:
+    """Load exactly one configured scorer in each RewardLoopWorker process."""
+    global _scorer, _scorer_key
+
+    pretrained_path = _required_file("HPSV2_PRETRAINED_PATH")
+    reward_checkpoint_path = _required_file("CUSTOM_REWARD_MODEL_PATH")
+    resolved_device = _resolve_device(device)
+    scorer_key = (pretrained_path, reward_checkpoint_path, str(resolved_device))
+
+    if _scorer is not None:
+        if _scorer_key != scorer_key:
+            raise RuntimeError(f"HPSv2 scorer is already loaded with {_scorer_key}, cannot switch to {scorer_key}")
+        return _scorer
+
+    with _load_lock:
+        if _scorer is None:
+            if resolved_device.type != "cpu":
+                logger.warning(
+                    "HPSv2 is using %s from a RewardLoopWorker that does not reserve Ray accelerator resources.",
+                    resolved_device,
+                )
+            loaded_scorer = _HPSv2Scorer(pretrained_path, reward_checkpoint_path, resolved_device)
+            _scorer_key = scorer_key
+            _scorer = loaded_scorer
+        elif _scorer_key != scorer_key:
+            raise RuntimeError(f"HPSv2 scorer is already loaded with {_scorer_key}, cannot switch to {scorer_key}")
+        return _scorer
+
+
+def _to_rgb_image(value: Image.Image | np.ndarray | torch.Tensor) -> Image.Image:
+    if isinstance(value, Image.Image):
+        return value.convert("RGB")
+    if isinstance(value, torch.Tensor):
+        value = value.detach().cpu().numpy()
+    if not isinstance(value, np.ndarray):
+        raise TypeError(f"Unsupported image type: {type(value).__name__}")
+
+    array = value
+    if array.ndim == 4:
+        if array.shape[0] != 1:
+            raise ValueError(f"HPSv2 scores one image per call, got batch shape {tuple(array.shape)}")
+        array = array[0]
+    if array.ndim == 3 and array.shape[0] in (1, 3, 4):
+        array = np.moveaxis(array, 0, -1)
+    if array.ndim not in (2, 3):
+        raise ValueError(f"Expected an HxW, HxWxC, or CxHxW image, got shape {tuple(array.shape)}")
+    if array.ndim == 3 and array.shape[-1] not in (1, 3, 4):
+        raise ValueError(f"Expected 1, 3, or 4 image channels, got shape {tuple(array.shape)}")
+    if not np.isfinite(array).all():
+        raise ValueError("Image contains non-finite values")
+
+    array = array.astype(np.float32, copy=False)
+    minimum = float(array.min())
+    maximum = float(array.max())
+    if minimum < 0 or maximum > 255:
+        raise ValueError(f"Image values must be in [0, 1] or [0, 255], got [{minimum}, {maximum}]")
+    if maximum <= 1:
+        array = array * 255
+    array = np.rint(array).astype(np.uint8)
+    if array.ndim == 3 and array.shape[-1] == 1:
+        array = array[..., 0]
+    return Image.fromarray(array).convert("RGB")
+
+
+def compute_score_hpsv2(
+    solution_image: Image.Image | np.ndarray | torch.Tensor,
+    ground_truth: Any = None,
+    **_: Any,
+) -> dict[str, float]:
+    """Score one generated image using the VisualRewardManager contract."""
+    scorer = _get_hpsv2_scorer()
+    prompt = "" if ground_truth is None else str(ground_truth)
+    score = scorer.score(_to_rgb_image(solution_image), prompt)
+    return {"score": score, "hpsv2_raw": score}


### PR DESCRIPTION
## PR description

### What does this PR do?

Add an end-to-end, full-parameter FLUX.1-dev DanceGRPO training path to verl-omni, using vLLM-Omni for rollout, the existing diffusion trainer for Actor updates, and HPSv2.1 as the default reward.

The implementation:

- adds a FLUX.1-dev rollout adapter that preserves separate CLIP and T5 prompt token IDs, performs FLUX-native prompt encoding, applies the shifted DanceSDE schedule, and returns explicit current/next latent pairs with rollout log-probabilities;
- adds a diffusers-based Actor adapter that reconstructs the same FLUX inputs and transition schedule for DanceGRPO policy updates;
- reuses the existing DanceGRPO trainer, diffusion configuration contracts, scheduler utilities, and rollout/Actor interfaces instead of adding FLUX-specific branches to `ray_diffusion_trainer` or introducing new trainer configuration fields;
- adds an HPSv2.1 custom reward scorer with lazy per-worker loading and CPU inference by default;
- adds explicit train/test prompt conversion to the standard chat-style parquet schema;
- adds an Ascend NPU full-parameter launcher and documentation for model, data, and HPSv2 checkpoint paths;
- adds CPU tests for transition selection, SDE windows, token handling, rollout/Actor schedule alignment, Actor guidance defaults, and HPSv2 image conversion.

The default recipe uses 720×720 images, 16 denoising steps, rollout guidance `3.5`, Actor guidance `1.0`, scheduler shift `3.0`, DanceSDE noise `0.3`, and a random 60% transition subset after dropping the final transition.

This PR is intentionally limited to FLUX.1-dev full-parameter DanceGRPO training with HPSv2.1. HPSv3 and a FLUX LoRA recipe are out of scope. The provided launcher is Ascend NPU-only.

### Relationship to existing work and non-duplication

Related issue/PR: None.

### Test

Pre-commit checks for the PR-owned files and generated trainer configuration:

```bash
PR_TITLE='[diffusion, rollout, reward, data, recipe] feat: add FLUX.1-dev DanceGRPO training' \
python tests/special_sanity/check_pr_title.py

pre-commit run ruff --files <changed-files>
pre-commit run ruff-format --files <changed-files>
pre-commit run mypy --files <changed-files>
pre-commit run autogen-trainer-cfg --all-files

bash -n examples/dancegrpo_trainer/flux1/run_flux1_dev_dancegrpo_fullparam.sh

python -m compileall -q \
  examples/dancegrpo_trainer/flux1/dataprocess/prepare_prompts.py \
  verl_omni/pipelines/flux_dance_grpo \
  verl_omni/utils/reward_score/hpsv2_reward.py

git diff --check
```

Result: all commands above passed. The proposed title passed the repository title validator.

CPU tests added by this PR:

```bash
python -m pytest -q \
  tests/pipelines/test_flux_dance_grpo_on_cpu.py \
  tests/utils/reward_score/test_hpsv2_reward_on_cpu.py
```

These tests cover aligned transition gathering with `drop_last` and fractional sampling, SDE window normalization/sampling, token padding and required CLIP/T5 `extra_tokenizers` data, exact rollout/Actor schedule equality for 20 denoising steps, the Actor guidance default, and supported/invalid HPSv2 image inputs. The full CPU test suite completed successfully: `1128 passed, 0 failed` in `49.39s` with exit code `0`.

The example also documents a complementary real-weight, one-step end-to-end validation command:

```bash
TOTAL_TRAINING_STEPS=1 \
EXPERIMENT_NAME=flux1_dev_fullparam_hpsv2_smoke \
bash examples/dancegrpo_trainer/flux1/run_flux1_dev_dancegrpo_fullparam.sh
```

A successful smoke run reaches `training/global_step:1` and reports `critic/hpsv2_raw/mean`, `rollout_corr/logprob_abs_diff_mean`, `actor/loss`, and `timing_s/step`.

Real-weight Ascend validation:

- Eight Ascend Atlas A3 NPUs, 720×720 output, 16 denoising steps, full-parameter Actor training, and HPSv2.1 reward.
- `open_clip_torch==3.3.0` successfully loaded the OpenCLIP and HPSv2.1 checkpoints, and the reward workers produced HPSv2 scores during training.

#### Training results: first 100 comparison steps

The table reports arithmetic means for each displayed interval. Reward is the mean raw HPSv2 score per training step. The vLLM 0.24.0 workload normalization is explained below the table.

| Steps | MindSpeed-MM reward | MindSpeed-MM time (s/step) | verl-omni / vLLM 0.24.0 reward | verl-omni / vLLM 0.24.0 normalized time (s/step) | verl-omni / vLLM 0.27.1.dev0 reward | verl-omni / vLLM 0.27.1.dev0 time (s/step) | verl-omni / vLLM 0.28.0 reward | verl-omni / vLLM 0.28.0 time (s/step) |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 1–10 | 0.304355 | 397.30 | 0.309064 | 295.94 | 0.310482 | 321.05 | Testing | Testing |
| 11–20 | 0.301006 | 404.34 | 0.311398 | 295.55 | 0.310261 | 320.07 | Testing | Testing |
| 21–30 | 0.317296 | 410.92 | 0.315434 | 297.71 | 0.312007 | 318.30 | Testing | Testing |
| 31–40 | 0.320794 | 292.78 | 0.314099 | 299.57 | 0.308585 | 319.68 | Testing | Testing |
| 41–50 | 0.321875 | 289.46 | 0.316091 | 293.72 | 0.311293 | 322.52 | Testing | Testing |
| 51–60 | 0.320441 | 279.06 | 0.323983 | 294.91 | 0.317975 | 323.81 | Testing | Testing |
| 61–70 | 0.325590 | 277.56 | 0.336245 | 295.83 | 0.327611 | 321.19 | Testing | Testing |
| 71–80 | 0.330947 | 277.46 | 0.326705 | 293.39 | 0.317322 | 320.30 | Testing | Testing |
| 81–90 | 0.329360 | 277.57 | 0.331612 | 293.25 | 0.330849 | 321.25 | Testing | Testing |
| 91–100 | 0.338033 | 277.77 | 0.333782 | 291.15 | 0.329052 | 321.01 | Testing | Testing |

Metric sources and runtime versions:

- MindSpeed-MM: `gathered_hps_reward_mean` and tqdm `step_time` from the original training log.
- verl-omni / vLLM 0.24.0: `critic/hpsv2_raw/mean` and `timing_s/step`; the source tree pins `vllm==0.24.0`, `vllm-omni==0.24.0`, and vLLM-Omni commit `fe478a95ab39e80085da06e3401c3ed471898a57`.
- verl-omni / vLLM 0.27.1.dev0: `critic/hpsv2_raw/mean` and `timing_s/step`; the log reports vLLM commit `4bdc8a788` and vLLM-Omni commit `444485650`.
- verl-omni / vLLM 0.28.0: the current dependency set pins `vllm==0.28.0`, `vllm-omni==0.28.0rc1`, and vLLM-Omni commit `ded8934626aaad1a3e816c3a1d9d742efc012d93`; testing is in progress.

<img width="1584" height="944" alt="flux1_reward_ma5_first120" src="https://github.com/user-attachments/assets/2a1fe9c8-ac1e-417a-a37c-6693f8329827" />

Over the equivalent first 100 comparison steps, the observed mean HPSv2 rewards are `0.321841` for vLLM 0.24.0, `0.320970` for MindSpeed-MM, and `0.317544` for vLLM 0.27.1.dev0. The workload-normalized mean step time is `295.10` seconds for vLLM 0.24.0 and `320.92` seconds for vLLM 0.27.1.dev0, making the observed vLLM 0.24.0 result approximately 8.0% lower.

### API and Usage Example

Install the validated HPSv2 dependency on top of the standard verl-omni environment:

```bash
pip install open_clip_torch==3.3.0
```

Prepare explicit train and validation prompt files. The default output is `~/data/hpsv2`, which matches `$WORKSPACE/data/hpsv2` when `WORKSPACE` uses its default value of `$HOME`:

```bash
python3 examples/dancegrpo_trainer/flux1/dataprocess/prepare_prompts.py \
  --train-path /path/to/train.txt \
  --test-path /path/to/test.txt \
  --output-dir "${WORKSPACE:-$HOME}/data/hpsv2"
```

Launch training from the repository root with explicit model and reward-checkpoint paths:

```bash
export WORKSPACE=/path/to/workspace
export MODEL_NAME=/path/to/FLUX.1-dev
export HPSV2_PRETRAINED_PATH=/path/to/open_clip_pytorch_model.bin
export CUSTOM_REWARD_MODEL_PATH=/path/to/HPS_v2.1_compressed.pt

bash examples/dancegrpo_trainer/flux1/run_flux1_dev_dancegrpo_fullparam.sh
```

The launcher reads `$WORKSPACE/data/hpsv2/train.parquet` and `$WORKSPACE/data/hpsv2/test.parquet` by default. `TRAIN_FILES_PATH` and `VAL_FILES_PATH` can override those locations. Missing model or HPSv2 checkpoint variables fail immediately instead of falling back to machine-specific paths.

HPSv2 scoring defaults to two CPU-resident reward workers. Set `REWARD_DEVICE` explicitly only when a different scoring device is intended.

### Design & Code Changes

1. **Reuse the existing trainer and configuration contracts:** FLUX registers through the same diffusion model/rollout discovery path used by existing models. This PR does not modify `ray_diffusion_trainer` or add FLUX-only trainer config fields.
2. **FLUX-native conditioning:** transport separate CLIP and T5 token IDs and reuse the official FLUX prompt-embedding, packed-latent, rotary-position, and VAE conventions from diffusers and pinned vLLM-Omni.
3. **Aligned DanceGRPO rollout:** extend the vLLM-Omni FLUX pipeline with shifted sigmas, per-prompt DanceSDE windows, explicit transition pairing, log-probability capture, and deterministic initial-noise grouping.
4. **Aligned Actor replay:** rebuild the same FLUX transformer inputs on the training side and evaluate the stored transition under the Actor policy without a negative-prompt CFG branch. The Actor guidance default is `1.0`, matching the recipe's Actor/rollout split (`1.0`/`3.5`).
5. **Shared schedule behavior:** reuse Wan2.2's existing `sd3_time_shift` utility. Both rollout and Actor construct the base schedule with NumPy `linspace`, then apply the same float32 shift, so exact timestep lookup remains stable for non-dyadic step counts such as 20.
6. **HPSv2.1 reward integration:** lazily load one OpenCLIP scorer per reward worker, validate checkpoint paths, normalize supported image representations, and return both the standard score and raw HPSv2 metric.
7. **Reproducible recipe and data boundary:** keep train/test prompts explicit, write the existing parquet schema, require local model/checkpoint paths, and expose only operational overrides through environment variables.
8. **Fail-fast optional rollout import:** when `vllm-omni` is unavailable, export a raise-on-use placeholder instead of silently leaking `None` through `__all__`.

This change is larger than the preferred 500-line guideline because rollout trajectory capture, Actor replay, reward scoring, pipeline registration, prompt preparation, the launcher, and their CPU tests are required together to form a runnable and reviewable training path. Splitting any of these pieces into an independently merged PR would leave incomplete FLUX support that cannot be validated end to end. The implementation minimizes shared-framework changes: ten of the eleven changed files are feature-specific additions; the only shared-file change is a three-line pipeline export.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md).
- [x] Synchronize the branch with upstream `main` at `03655dc`; merge commit `ee61dbd` completed without conflicts.
- [x] Run Ruff, Ruff format, mypy, generated-config verification, Shell syntax, Python compilation, and diff checks for the PR-owned changes.
- [x] Add the FLUX recipe documentation without changing the existing Wan2.2 DanceGRPO README.
- [x] Add CPU tests for the new FLUX DanceGRPO helpers/contracts and HPSv2 image conversion.
- [x] Run the full CPU test suite in the project environment: `1128 passed, 0 failed` in `49.39s` with exit code `0`.
- [x] Document the one-step real-weight validation command and expected metrics in the FLUX example.
- [ ] Complete and report current-pin vLLM 0.28.0 real-weight Ascend validation.
- [x] Record the Ascend Atlas A3 hardware used for the experiments.
- [x] Attach any test evidence/screenshots required for review.

### AI assistance and accountability

AI assistance (OpenAI Codex) was used to inspect, revise, validate, and document this change. Before requesting review, the human submitter will review every changed line, rerun the relevant checks in the project environment, and be prepared to explain and maintain the implementation.