### PR TITLE
[ci, misc] fix: make the train extra resolvable with the verl pin

### DIFF
--- a/.github/workflows/cpu_unit_tests.yml
+++ b/.github/workflows/cpu_unit_tests.yml
@@ -11,6 +11,7 @@ on:
       - "pyproject.toml"
       - .github/workflows/cpu_unit_tests.yml
       - .github/vllm_omni_pin.txt
+      - .github/verl_pin.txt
   pull_request:
     branches:
       - main
@@ -22,6 +23,7 @@ on:
       - "pyproject.toml"
       - .github/workflows/cpu_unit_tests.yml
       - .github/vllm_omni_pin.txt
+      - .github/verl_pin.txt
 
 # Cancel jobs on the same ref if a new one is triggered
 concurrency:
@@ -64,6 +66,10 @@ jobs:
           pip install --no-deps "verl @ git+https://github.com/verl-project/verl.git@$(cat .github/verl_pin.txt)"
           pip install ".[dev]"
           pip install --no-deps -e .
+      - name: Verify the documented train install resolves
+        run: |
+          pip install uv
+          uv pip install --dry-run --python "$(command -v python)" -e ".[train]"
       - name: Run CPU unit tests
         run: |
           echo '[pytest]' > pytest.ini

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -13,6 +13,8 @@ on:
       - "docs/**"
       # Example READMEs are the Sphinx sources via git symlinks under docs/examples/.
       - "examples/**"
+      - .github/verl_pin.txt
+      - .github/vllm_omni_pin.txt
       - .github/workflows/doc.yml
 
 concurrency:

--- a/.github/workflows/gpu_smoke.yml
+++ b/.github/workflows/gpu_smoke.yml
@@ -15,6 +15,7 @@ on:
       - "pyproject.toml"
       - .github/workflows/gpu_smoke.yml
       - .github/vllm_omni_pin.txt
+      - .github/verl_pin.txt
       - .github/actions/gpu-smoke-prepare/**
       - .github/actions/gpu-smoke-upload-logs/**
   pull_request:
@@ -32,6 +33,7 @@ on:
       - "pyproject.toml"
       - .github/workflows/gpu_smoke.yml
       - .github/vllm_omni_pin.txt
+      - .github/verl_pin.txt
       - .github/actions/gpu-smoke-prepare/**
       - .github/actions/gpu-smoke-upload-logs/**
 

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -13,6 +13,8 @@ on:
     paths:
       - "**/*.py"
       - .github/vllm_ascend_pin.txt
+      - .github/vllm_omni_pin.txt
+      - .github/verl_pin.txt
       - .github/workflows/sanity.yml
       - "tests/special_sanity/**"
 

--- a/.github/workflows/type-coverage-check.yml
+++ b/.github/workflows/type-coverage-check.yml
@@ -8,6 +8,8 @@ on:
     types: [labeled]
     paths:
       - "**/*.py"
+      - .github/verl_pin.txt
+      - .github/vllm_omni_pin.txt
       - .github/workflows/type-coverage-check.yml
 
 concurrency:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -194,4 +194,5 @@ verl_omni = [
 override-dependencies = [
     "accelerate>=1.14.0",
     "kernels==0.16.0",
+    "transformers>=5.13.0,<=5.14.1",
 ]


### PR DESCRIPTION
### What does this PR do?

Closes #531.

The documented `uv pip install -e ".[train]"` has been unsatisfiable since #497: PR #497 raised verl-omni's transformers floor to `>=5.13.0` (load-bearing — transformers 5.10–5.12 crash at `import vllm` with kernels 0.16.0, see 48bc073a), but the `train` extra's verl pin (`fefb080`) declares `transformers>=5.5.3,!=5.6.0,<5.11` in its `setup.py`. The ranges are disjoint, so uv reports the requirements unsatisfiable for anyone following docs/start/install.md. Upstream verl main still carries the `<5.11` cap as of 2026-09-04.

No CI surface caught this because every workflow installs verl `--no-deps`; the `[train]` extra was only ever resolved end-to-end by end users.

This PR:

- adds the validated transformers window (`>=5.13.0,<=5.14.1`) to the existing `[tool.uv] override-dependencies` table — the same mechanism pyproject already uses for `accelerate` and `kernels`, and one `uv pip install -e .` does respect (verified empirically);
- adds a `cpu_unit_tests` step that runs `uv pip install --dry-run -e ".[train]"` so the documented command is resolved in CI from now on;
- lists `.github/verl_pin.txt` and `.github/vllm_omni_pin.txt` in the path filters of every workflow that installs from them (`sanity`, `gpu_smoke`, `doc`, `type-coverage-check`; `cpu_unit_tests` got `verl_pin`, `l3_nightly` already had both). The vllm-omni gap was the bigger one: its git pin lives only in the pin file (the pyproject `vllm-omni` extra points at the PyPI `0.28.0rc1` baseline), so a code-free re-pin previously triggered zero path-filtered workflows.

Known limitation (pre-existing, unchanged): the override applies to the documented clone + `uv pip install -e .` flow. `uv pip install verl-omni[train]` run outside the repo (non-editable, from PyPI) does not read a dependency's `[tool.uv]` table and remains unresolvable, as does plain `pip install -e ".[train]"` — pip has no override mechanism. The formal fix would be upstream verl relaxing its `<5.11` cap (their cap tracks their own vllm-0.24/sglang stack, not an API break at 5.13+); worth filing separately.

### Checklist Before Starting

- [x] Search for similar PRs:
  - `gh pr list --repo verl-project/verl-omni --state open --search "531 in:body"` → no open PR (only closed false positives)
  - `gh pr list --repo verl-project/verl-omni --state open` scanned in full → #530 (FA fallback), #515 (install.md GPU/NPU split — different scope, doesn't touch the conflict) and others; none addresses the resolution failure
  - Issue #531 read with comments (one `cc: @zhtmike`)
- [x] Title formatted `[ci, misc] fix: ...`; modules checked against `tests/special_sanity/check_pr_title.py` (`ci` official, `misc` official, `fix` valid type)

### Test

Reproduced first, then verified the fix (conda env `verl-omni-py312`, uv 0.12.9, macOS — resolution-only work, no GPU needed):

```bash
# before the fix — exact error from the issue:
uv pip install --dry-run -e ".[train]"
# × No solution found ... verl==0.10.0.dev0 depends on transformers<5.11 ...
#   verl-omni==0.2.0rc1 depends on transformers>=5.13.0,<=5.14.1 ... unsatisfiable

# after the fix:
uv pip install --dry-run -e ".[train]"          # Resolved 129 packages
uv pip install --dry-run -e ".[train,dev]"      # Resolved 129 packages (AGENTS.md flow)
# cold resolution from a bare interpreter (conda base, nothing preinstalled):
uv pip install --dry-run --python <base python3> -e ".[train]"
#   Resolved 129 packages → transformers==5.14.1, verl==0.10.0.dev0 (git fefb080),
#   verl-omni editable
# gpu extra for the Linux target platform (macOS fails on liger-kernel→triton
# having no macOS wheels — pre-existing, unrelated):
uv pip install --dry-run -e ".[gpu]" --torch-backend=auto --python-platform x86_64-unknown-linux-gnu
#   Resolved 246 packages → kernels==0.16.0, liger-kernel==0.8.2

pre-commit run --files <the six changed files>   # all hooks passed/skipped (no .py changes)
python tests/special_sanity/check_docs_time_info.py  # passed (docs untouched)
# all 12 workflow YAMLs parse (yaml.safe_load); pyproject parses (tomllib)
```

The new CI step runs the same dry-run command on ubuntu-latest with the runner's setup-python 3.12.

Not run locally (macOS, no GPU): the CPU unit-test suite and GPU smokes — both run in CI on this PR (pyproject.toml is in their path filters).

### API and Usage Example

No API change. The documented install works again as written:

```bash
git clone https://github.com/verl-project/verl-omni.git && cd verl-omni
uv venv --python 3.12 --seed && source .venv/bin/activate
uv pip install -e ".[gpu]" --torch-backend=auto
uv pip install "vllm-omni @ git+https://github.com/vllm-project/vllm-omni.git@$(cat .github/vllm_omni_pin.txt)"
uv pip install -e ".[train]"   # ← was failing with the #531 error, now resolves
```

### Design & Code Changes

- `pyproject.toml` (+1 line): `"transformers>=5.13.0,<=5.14.1"` in `[tool.uv] override-dependencies`, matching the declared range in `[project].dependencies` exactly.
- `.github/workflows/cpu_unit_tests.yml`: new "Verify the documented train install resolves" step (`pip install uv` + the dry-run), and `.github/verl_pin.txt` added to both path-trigger blocks.
- `.github/workflows/{sanity,gpu_smoke,doc,type-coverage-check}.yml`: pin-file path entries — `verl_pin.txt` everywhere it was missing; `vllm_omni_pin.txt` in the three workflows that install the vllm-omni git pin but didn't list it. `pre-commit.yml` has no paths filter and `gpu_smoke_verl_latest.yml` is dispatch-only (installs verl `@main`), so neither needs an entry.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md).
- [x] pre-commit checks applied (all hooks passed on the changed files at commit time).
- [x] Documentation: not updated — the documented commands themselves are what was broken; they now work verbatim, and plain `pip` was never a documented path.
- [x] Unit test added to the CI workflow (the new resolution-guard step).

### Disclosures

- **AI assistance was used**: implemented, verified, and drafted by ZCode (agent) from the user's direction, including the three review rounds requested by the user (comment cleanup, other-workflow pin coverage, dropping the docs change). The human submitter (@zhtmike) has reviewed every changed line and can defend the change end-to-end.
- Follow-up worth filing separately: an upstream verl PR relaxing the `transformers<5.11` cap would make the override unnecessary and also fix non-editable/PyPI installs of `verl-omni[train]`.
