### PR TITLE
[trainer, cfg, tests] fix: abort on a sustained non-finite grad_norm streak

### DIFF
--- a/tests/trainer/diffusion/test_nonfinite_grad_streak_on_cpu.py
+++ b/tests/trainer/diffusion/test_nonfinite_grad_streak_on_cpu.py
@@ -1,0 +1,56 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU tests for the non-finite grad_norm streak tracker (verl-project/verl-omni#388, item A3)."""
+
+import math
+
+import pytest
+
+from verl_omni.trainer.diffusion.diffusion_trainer_utils import track_nonfinite_grad_streak
+
+
+class TestTrackNonfiniteGradStreak:
+    def test_finite_grad_norm_resets_streak(self):
+        assert track_nonfinite_grad_streak(streak=3, grad_norm=1.5, max_consecutive=5) == 0
+
+    def test_none_grad_norm_resets_streak(self):
+        assert track_nonfinite_grad_streak(streak=3, grad_norm=None, max_consecutive=5) == 0
+
+    def test_non_finite_grad_norm_increments_streak(self):
+        assert track_nonfinite_grad_streak(streak=0, grad_norm=float("nan"), max_consecutive=5) == 1
+        assert track_nonfinite_grad_streak(streak=1, grad_norm=float("inf"), max_consecutive=5) == 2
+
+    def test_disabled_threshold_never_raises(self):
+        streak = 0
+        for _ in range(100):
+            streak = track_nonfinite_grad_streak(streak, math.nan, max_consecutive=0)
+        assert streak == 100
+
+    def test_raises_once_streak_exceeds_threshold(self):
+        streak = 0
+        for _ in range(3):
+            streak = track_nonfinite_grad_streak(streak, math.nan, max_consecutive=3)
+        assert streak == 3
+        with pytest.raises(RuntimeError, match="non-finite"):
+            track_nonfinite_grad_streak(streak, math.nan, max_consecutive=3)
+
+    def test_intervening_finite_step_prevents_abort(self):
+        streak = 0
+        for _ in range(3):
+            streak = track_nonfinite_grad_streak(streak, math.nan, max_consecutive=3)
+        streak = track_nonfinite_grad_streak(streak, 2.0, max_consecutive=3)
+        assert streak == 0
+        for _ in range(3):
+            streak = track_nonfinite_grad_streak(streak, math.nan, max_consecutive=3)
+        assert streak == 3

--- a/tests/trainer/diffusion/test_nonfinite_grad_streak_on_cpu.py
+++ b/tests/trainer/diffusion/test_nonfinite_grad_streak_on_cpu.py
@@ -37,20 +37,20 @@ class TestTrackNonfiniteGradStreak:
             streak = track_nonfinite_grad_streak(streak, math.nan, max_consecutive=0)
         assert streak == 100
 
-    def test_raises_once_streak_exceeds_threshold(self):
+    def test_raises_once_streak_reaches_threshold(self):
         streak = 0
-        for _ in range(3):
+        for _ in range(2):
             streak = track_nonfinite_grad_streak(streak, math.nan, max_consecutive=3)
-        assert streak == 3
+        assert streak == 2
         with pytest.raises(RuntimeError, match="non-finite"):
             track_nonfinite_grad_streak(streak, math.nan, max_consecutive=3)
 
     def test_intervening_finite_step_prevents_abort(self):
         streak = 0
-        for _ in range(3):
+        for _ in range(2):
             streak = track_nonfinite_grad_streak(streak, math.nan, max_consecutive=3)
         streak = track_nonfinite_grad_streak(streak, 2.0, max_consecutive=3)
         assert streak == 0
-        for _ in range(3):
+        for _ in range(2):
             streak = track_nonfinite_grad_streak(streak, math.nan, max_consecutive=3)
-        assert streak == 3
+        assert streak == 2

--- a/verl_omni/trainer/config/_generated_diffusion_trainer.yaml
+++ b/verl_omni/trainer/config/_generated_diffusion_trainer.yaml
@@ -534,6 +534,7 @@ trainer:
   nnodes: 1
   n_gpus_per_node: 8
   save_freq: -1
+  max_consecutive_nonfinite_grad_steps: 0
   esi_redundant_time: 0
   resume_mode: auto
   resume_from_path: null

--- a/verl_omni/trainer/config/_generated_diffusion_veomni_trainer.yaml
+++ b/verl_omni/trainer/config/_generated_diffusion_veomni_trainer.yaml
@@ -575,6 +575,7 @@ trainer:
   nnodes: 1
   n_gpus_per_node: 8
   save_freq: -1
+  max_consecutive_nonfinite_grad_steps: 0
   esi_redundant_time: 0
   resume_mode: auto
   resume_from_path: null

--- a/verl_omni/trainer/config/diffusion_trainer.yaml
+++ b/verl_omni/trainer/config/diffusion_trainer.yaml
@@ -173,6 +173,9 @@ trainer:
   # Save frequency (by iteration) for model checkpoints
   save_freq: -1
 
+  # Abort after this many consecutive non-finite grad_norm steps. <= 0 disables the abort.
+  max_consecutive_nonfinite_grad_steps: 0
+
   # ESI refers to the elastic server instance used during training, similar to the training plan. For example,
   # if you purchase 10 hours of computing power, the ESI will automatically shut down after 10 hours of training.
   # To ensure a checkpoint is saved before ESI shuts down, the system will start saving a checkpoint in advance.

--- a/verl_omni/trainer/diffusion/diffusion_trainer_utils.py
+++ b/verl_omni/trainer/diffusion/diffusion_trainer_utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Shared helpers for diffusion Ray trainers."""
 
+import math
 from collections.abc import Sequence
 from typing import Any, Optional
 
@@ -64,6 +65,20 @@ def worker_group_port_ranges(master_port_range: Optional[Sequence[int]], num_gro
             f"trainer.ray_master_port_range={master_port_range} has fewer ports than worker groups ({num_groups})."
         )
     return [[lo + i * stride, hi if i == num_groups - 1 else lo + (i + 1) * stride] for i in range(num_groups)]
+
+
+def track_nonfinite_grad_streak(streak: int, grad_norm: Optional[float], max_consecutive: int) -> int:
+    """Update the consecutive-non-finite-gradient streak, raising past ``max_consecutive`` (<= 0 disables)."""
+    if grad_norm is None or math.isfinite(grad_norm):
+        return 0
+    streak += 1
+    if max_consecutive > 0 and streak > max_consecutive:
+        raise RuntimeError(
+            f"grad_norm has been non-finite for {streak} consecutive optimizer steps "
+            f"(trainer.max_consecutive_nonfinite_grad_steps={max_consecutive}); aborting instead of "
+            "continuing to silently skip optimizer steps."
+        )
+    return streak
 
 
 def validate_distillation_config(config) -> None:

--- a/verl_omni/trainer/diffusion/diffusion_trainer_utils.py
+++ b/verl_omni/trainer/diffusion/diffusion_trainer_utils.py
@@ -72,7 +72,7 @@ def track_nonfinite_grad_streak(streak: int, grad_norm: Optional[float], max_con
     if grad_norm is None or math.isfinite(grad_norm):
         return 0
     streak += 1
-    if max_consecutive > 0 and streak > max_consecutive:
+    if max_consecutive > 0 and streak >= max_consecutive:
         raise RuntimeError(
             f"grad_norm has been non-finite for {streak} consecutive optimizer steps "
             f"(trainer.max_consecutive_nonfinite_grad_steps={max_consecutive}); aborting instead of "

--- a/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
+++ b/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
@@ -71,6 +71,7 @@ from verl_omni.trainer.diffusion.diffusion_trainer_utils import (
     NoOpCheckpointManager,
     _to_diffusion_worker_tensordict,
     old_policy_decay,
+    track_nonfinite_grad_streak,
     validate_distillation_config,
     worker_group_port_ranges,
 )
@@ -1233,6 +1234,7 @@ class PolicyGradientRayTrainer(BaseRayDiffusionTrainer):
         self.global_steps += 1
         last_val_metrics = None
         self.max_steps_duration = 0
+        self._nonfinite_grad_streak = 0
 
         # Profiler step state machine. Mirrors verl/trainer/ppo/ray_trainer.py.
         prev_step_profile = False
@@ -1469,6 +1471,12 @@ class PolicyGradientRayTrainer(BaseRayDiffusionTrainer):
                 # compute variance proxy metrics
                 gradient_norm = metrics.get("actor/grad_norm", None)
                 metrics.update(compute_variance_proxy_metrics(batch=batch, gradient_norm=gradient_norm))
+                self._nonfinite_grad_streak = track_nonfinite_grad_streak(
+                    self._nonfinite_grad_streak,
+                    gradient_norm,
+                    self.config.trainer.get("max_consecutive_nonfinite_grad_steps", 0),
+                )
+                metrics["train/nonfinite_grad_steps"] = self._nonfinite_grad_streak
 
                 logger.log(data=metrics, step=self.global_steps)
 
@@ -1677,6 +1685,7 @@ class DirectPreferenceRayTrainer(BaseRayDiffusionTrainer):
         self.global_steps += 1
         last_val_metrics = None
         self.max_steps_duration = 0
+        self._nonfinite_grad_streak = 0
 
         # Profiler step state machine. Mirrors verl/trainer/ppo/ray_trainer.py.
         prev_step_profile = False
@@ -1877,9 +1886,15 @@ class DirectPreferenceRayTrainer(BaseRayDiffusionTrainer):
                 )
                 metrics.update(compute_timing_metrics_diffusion(timing_raw=timing_raw, num_images=num_images))
                 metrics.update(compute_throughput_metrics_diffusion(batch=batch, timing_raw=timing_raw, n_gpus=n_gpus))
+                gradient_norm = metrics.get("actor/grad_norm", None)
                 if "advantages" in batch.batch:
-                    gradient_norm = metrics.get("actor/grad_norm", None)
                     metrics.update(compute_variance_proxy_metrics(batch=batch, gradient_norm=gradient_norm))
+                self._nonfinite_grad_streak = track_nonfinite_grad_streak(
+                    self._nonfinite_grad_streak,
+                    gradient_norm,
+                    self.config.trainer.get("max_consecutive_nonfinite_grad_steps", 0),
+                )
+                metrics["train/nonfinite_grad_steps"] = self._nonfinite_grad_streak
 
                 logger.log(data=metrics, step=self.global_steps)
 

--- a/verl_omni/trainer/diffusion/v1/trainer_base.py
+++ b/verl_omni/trainer/diffusion/v1/trainer_base.py
@@ -65,6 +65,7 @@ from verl_omni.trainer.diffusion.diffusion_metric_utils import (
     compute_timing_metrics_diffusion,
 )
 from verl_omni.trainer.diffusion.diffusion_trainer_utils import (
+    track_nonfinite_grad_streak,
     validate_distillation_config,
     worker_group_port_ranges,
 )
@@ -141,6 +142,7 @@ class PolicyGradientDiffusionTrainerV1(ABC):
         self.global_steps = 0
         # Local update index within the parameter-sync cycle.
         self.local_trigger_step = 0
+        self._nonfinite_grad_streak = 0
 
     def _build_replay_buffer(self) -> ReplayBuffer:
         sampler_config = self.config.trainer.v1.sampler
@@ -1317,9 +1319,15 @@ class PolicyGradientDiffusionTrainerV1(ABC):
             for key in keys:
                 reward_extra_infos_dict[key] = [info.get(key) for info in infos]
         metrics.update(compute_reward_extra_metrics_diffusion(reward_extra_infos_dict))
+        gradient_norm = metrics.get("actor/grad_norm", None)
         if "advantages" in data.batch:
-            gradient_norm = metrics.get("actor/grad_norm", None)
             metrics.update(compute_variance_proxy_metrics(batch=data, gradient_norm=gradient_norm))
+        self._nonfinite_grad_streak = track_nonfinite_grad_streak(
+            self._nonfinite_grad_streak,
+            gradient_norm,
+            self.config.trainer.get("max_consecutive_nonfinite_grad_steps", 0),
+        )
+        metrics["train/nonfinite_grad_steps"] = self._nonfinite_grad_streak
 
         # off-policy staleness metrics (model-version units)
         non_padding = np.array([not tag.get("is_padding", False) for tag in batch_meta.tags], dtype=bool)

--- a/verl_omni/workers/engine/fsdp/diffusers_impl.py
+++ b/verl_omni/workers/engine/fsdp/diffusers_impl.py
@@ -667,7 +667,7 @@ class DiffusersFSDPEngine(LoRAAdapterMixin, BaseEngine, ABC):
 
         # if grad_norm is not finite, skip the update
         if not torch.isfinite(grad_norm):
-            print(f"WARN: grad_norm is not finite: {grad_norm}")
+            logger.error("grad_norm is not finite: %s; skipping this optimizer step.", grad_norm)
             self.optimizer.zero_grad()
         else:
             self.optimizer.step()

--- a/verl_omni/workers/engine/veomni/diffusion_impl.py
+++ b/verl_omni/workers/engine/veomni/diffusion_impl.py
@@ -519,7 +519,7 @@ class VeOmniDiffusionEngine(BaseEngine):
             grad_norm = grad_norm.full_tensor()
 
         if not torch.isfinite(grad_norm):
-            logger.warning("grad_norm is not finite: %s", grad_norm)
+            logger.error("grad_norm is not finite: %s; skipping this optimizer step.", grad_norm)
             self.optimizer.zero_grad()
         else:
             self.optimizer.step()


### PR DESCRIPTION
## Summary

Item A3 of #388's fail-fast checklist. Both the FSDP and VeOmni diffusion engines (`workers/engine/fsdp/diffusers_impl.py`, `workers/engine/veomni/diffusion_impl.py`) silently skip the optimizer step and only `print`/`logger.warning` on a non-finite `grad_norm`. If a run gets stuck producing non-finite gradients, every subsequent optimizer step is silently skipped forever — the run keeps burning GPU time with no visible failure signal, which is exactly the silent-fallback pattern #388 was filed to eliminate.

## What changed

- Added `track_nonfinite_grad_streak()` (`verl_omni/trainer/diffusion/diffusion_trainer_utils.py`), a small pure function that tracks the consecutive non-finite-`grad_norm` streak and raises once a configurable threshold is exceeded.
- Wired it into both training loops that already read `metrics.get("actor/grad_norm")`: `v1/trainer_base.py` (`_compute_metrics`) and `ray_diffusion_trainer.py` (`PolicyGradientRayTrainer.fit` and `DirectPreferenceRayTrainer.fit`). Each now exports `train/nonfinite_grad_steps` and aborts past the threshold.
- Added `trainer.max_consecutive_nonfinite_grad_steps` (default `0` = disabled, preserving current behavior) to `diffusion_trainer.yaml`; regenerated the derived `_generated_diffusion_trainer.yaml` / `_generated_diffusion_veomni_trainer.yaml`.
- Bumped both engines' silent `logger.warning`/`print` to `logger.error`.
- Added `tests/trainer/diffusion/test_nonfinite_grad_streak_on_cpu.py`.

## Why this is not duplicate work

Checked before starting:

```bash
gh issue view 388 --repo verl-project/verl-omni --comments
gh pr list --repo verl-project/verl-omni --search "grad_norm" --state all
gh pr list --repo verl-project/verl-omni --search "nonfinite" --state all
gh pr list --repo verl-project/verl-omni --search "diffusion_impl.py" --state all
```

The three PRs already merged against #388 (#443, #429, #497) do not touch `workers/engine/veomni/diffusion_impl.py` or `workers/engine/fsdp/diffusers_impl.py` — confirmed by diffing their changed-file lists. #429's own branch name (`wenzhe/fail-fast-a5-a8`) explicitly scopes it to items A5/A8, not A3. `main` still has the bare `logger.warning`/`print` with no counter as of this PR.

## Test plan

Ran on a Modal A10G GPU box (this dev machine cannot install the GPU-only `vllm-omni` wheel), following `docs/start/install.md`:

```bash
uv pip install -e ".[gpu]" --torch-backend=auto
uv pip install "vllm-omni @ git+https://github.com/vllm-project/vllm-omni.git@$(cat .github/vllm_omni_pin.txt)"
uv pip install -e ".[train,dev]"

python -m pytest -q tests/trainer/diffusion/test_nonfinite_grad_streak_on_cpu.py \
  tests/trainer/diffusion/test_diffusion_teacher_manager_on_cpu.py \
  tests/trainer/diffusion/test_diffusion_core_algos_on_cpu.py
# 44 passed

python -m pytest -q tests/trainer/diffusion
# 311 passed
```

Also ran `ruff check` / `ruff format --check` locally on every changed `.py` file (clean) and `git diff --check` (clean). Did not run `pre-commit` itself (not available on this dev machine) or `scripts/generate_trainer_config.sh` on the GPU box — the generated YAML diffs were produced locally via that script and match the field addition.

## AI assistance disclosure

- [x] This PR was developed with AI assistance (Claude). The submitting human reviewed the change end-to-end and can defend it.

- [x] A manual human reviewer (onepunchmonk) has reviewed the changes before marking them ready for review.