### PR TITLE
[omni, rollout, tests] fix: normalize interleaved audio-video prompts before rollout

### DIFF
--- a/tests/pipelines/test_qwen3_omni_interleaved_dedup_on_cpu.py
+++ b/tests/pipelines/test_qwen3_omni_interleaved_dedup_on_cpu.py
@@ -1,0 +1,68 @@
+# Copyright 2026 verl-omni contributors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import pytest
+
+from verl_omni.pipelines.qwen3_omni.thinker_training_adapter import _collapse_interleaved_audio_video_tokens
+
+
+def tokenizer(**overrides):
+    names = ("vision_start", "audio_start", "video_pad", "audio_pad", "audio_end", "vision_end")
+    mapping = {f"<|{name}|>": i for i, name in enumerate(names, 101)}
+    mapping.update(overrides)
+    return SimpleNamespace(unk_token_id=0, convert_tokens_to_ids=lambda tok: mapping.get(tok, 0))
+
+
+SPAN = [101, 102, 103, 103, 104, 104, 103, 104, 105, 106]
+RAW = [101, 103, 106]
+
+
+@pytest.mark.parametrize("prefix,suffix", [([], []), ([7, 7], [8, 8]), ([1, 2, 3], [4, 5, 6])])
+def test_complete_interleaved_span_preserves_surrounding_tokens(prefix, suffix):
+    original = prefix + SPAN + suffix
+    saved = original.copy()
+    actual = _collapse_interleaved_audio_video_tokens(original, tokenizer())
+    assert actual == prefix + RAW + suffix
+    assert original == saved
+    assert _collapse_interleaved_audio_video_tokens(actual, tokenizer()) == actual
+
+
+def test_multiple_media_and_history_keep_order():
+    original = [7] + SPAN + [8, 9, 10] + SPAN + [11]
+    assert _collapse_interleaved_audio_video_tokens(original, tokenizer()) == [7] + RAW + [8, 9, 10] + RAW + [11]
+
+
+@pytest.mark.parametrize(
+    "tokens",
+    [
+        [],
+        [7, 7, 8],
+        RAW,
+        [101, 103, 103, 106],
+        [102, 104, 104, 105],
+        SPAN[:-1],
+        SPAN[:-2],
+        [101, 102, 103, 7, 104, 105, 106],
+        [101, 102, 103, 105, 106],
+        [101, 102, 104, 105, 106],
+        [101, 102, 105, 106],
+        [101, 102, 103, 104, 106, 105],
+    ],
+)
+def test_non_interleaved_or_malformed_span_is_unchanged(tokens):
+    assert _collapse_interleaved_audio_video_tokens(tokens, tokenizer()) == tokens
+
+
+@pytest.mark.parametrize("value", [None, 0, 101])
+def test_unknown_or_aliased_special_token_is_unchanged(value):
+    assert _collapse_interleaved_audio_video_tokens(SPAN, tokenizer(**{"<|audio_end|>": value})) == SPAN

--- a/tests/pipelines/test_qwen3_omni_interleaved_dedup_on_cpu.py
+++ b/tests/pipelines/test_qwen3_omni_interleaved_dedup_on_cpu.py
@@ -15,12 +15,23 @@ import pytest
 
 from verl_omni.pipelines.qwen3_omni.thinker_training_adapter import _collapse_interleaved_audio_video_tokens
 
+TOKEN_ATTRS = (
+    "vision_bos_token",
+    "audio_bos_token",
+    "video_token",
+    "audio_token",
+    "audio_eos_token",
+    "vision_eos_token",
+)
 
-def tokenizer(**overrides):
-    names = ("vision_start", "audio_start", "video_pad", "audio_pad", "audio_end", "vision_end")
-    mapping = {f"<|{name}|>": i for i, name in enumerate(names, 101)}
+
+def processor(**overrides):
+    # Deliberately not the default HF strings: the processor owns these names.
+    tokens = {attr: f"custom_{attr}" for attr in TOKEN_ATTRS}
+    mapping = {token: i for i, token in enumerate(tokens.values(), 101)}
     mapping.update(overrides)
-    return SimpleNamespace(unk_token_id=0, convert_tokens_to_ids=lambda tok: mapping.get(tok, 0))
+    tokenizer = SimpleNamespace(unk_token_id=0, convert_tokens_to_ids=lambda tok: mapping.get(tok, 0))
+    return SimpleNamespace(tokenizer=tokenizer, **tokens)
 
 
 SPAN = [101, 102, 103, 103, 104, 104, 103, 104, 105, 106]
@@ -31,15 +42,15 @@ RAW = [101, 103, 106]
 def test_complete_interleaved_span_preserves_surrounding_tokens(prefix, suffix):
     original = prefix + SPAN + suffix
     saved = original.copy()
-    actual = _collapse_interleaved_audio_video_tokens(original, tokenizer())
+    actual = _collapse_interleaved_audio_video_tokens(original, processor())
     assert actual == prefix + RAW + suffix
     assert original == saved
-    assert _collapse_interleaved_audio_video_tokens(actual, tokenizer()) == actual
+    assert _collapse_interleaved_audio_video_tokens(actual, processor()) == actual
 
 
 def test_multiple_media_and_history_keep_order():
     original = [7] + SPAN + [8, 9, 10] + SPAN + [11]
-    assert _collapse_interleaved_audio_video_tokens(original, tokenizer()) == [7] + RAW + [8, 9, 10] + RAW + [11]
+    assert _collapse_interleaved_audio_video_tokens(original, processor()) == [7] + RAW + [8, 9, 10] + RAW + [11]
 
 
 @pytest.mark.parametrize(
@@ -60,9 +71,27 @@ def test_multiple_media_and_history_keep_order():
     ],
 )
 def test_non_interleaved_or_malformed_span_is_unchanged(tokens):
-    assert _collapse_interleaved_audio_video_tokens(tokens, tokenizer()) == tokens
+    assert _collapse_interleaved_audio_video_tokens(tokens, processor()) == tokens
 
 
 @pytest.mark.parametrize("value", [None, 0, 101])
 def test_unknown_or_aliased_special_token_is_unchanged(value):
-    assert _collapse_interleaved_audio_video_tokens(SPAN, tokenizer(**{"<|audio_end|>": value})) == SPAN
+    assert _collapse_interleaved_audio_video_tokens(SPAN, processor(custom_audio_eos_token=value)) == SPAN
+
+
+@pytest.mark.parametrize("attr", ["tokenizer", *TOKEN_ATTRS])
+def test_missing_processor_attribute_is_unchanged(attr):
+    proc = processor()
+    delattr(proc, attr)
+    assert _collapse_interleaved_audio_video_tokens(SPAN, proc) == SPAN
+
+
+@pytest.mark.parametrize("error", [TypeError, ValueError])
+def test_unresolvable_processor_token_is_unchanged(error):
+    proc = processor()
+
+    def convert(token):
+        raise error(token)
+
+    proc.tokenizer.convert_tokens_to_ids = convert
+    assert _collapse_interleaved_audio_video_tokens(SPAN, proc) == SPAN

--- a/tests/pipelines/test_qwen3_omni_thinker_adapter_on_cpu.py
+++ b/tests/pipelines/test_qwen3_omni_thinker_adapter_on_cpu.py
@@ -41,7 +41,8 @@ def _has_lora(module: nn.Module) -> bool:
     return hasattr(module, "lora_A") and hasattr(module, "lora_B")
 
 
-def test_configure_processor_binds_multimodal_pad_dedup(monkeypatch):
+@pytest.mark.parametrize("token_prefix", ["", "custom_"])
+def test_configure_processor_binds_multimodal_pad_dedup(monkeypatch, token_prefix):
     """The V1 processor path must collapse image, video, and audio pad runs."""
     pytest.importorskip("transformers")
     _require_version("transformers", "5.0.0")
@@ -52,16 +53,25 @@ def test_configure_processor_binds_multimodal_pad_dedup(monkeypatch):
         "<|image_pad|>": 101,
         "<|video_pad|>": 102,
         "<|audio_pad|>": 103,
+        "<|vision_start|>": 104,
+        "<|audio_start|>": 105,
+        "<|audio_end|>": 106,
+        "<|vision_end|>": 107,
     }
+    token_ids = {token_prefix + token: tid for token, tid in token_ids.items()}
     tokenizer = SimpleNamespace(
         unk_token_id=0,
         convert_tokens_to_ids=lambda token: token_ids.get(token, 0),
     )
     processor = SimpleNamespace(
         tokenizer=tokenizer,
-        image_token="<|image_pad|>",
-        video_token="<|video_pad|>",
-        audio_token="<|audio_pad|>",
+        image_token=token_prefix + "<|image_pad|>",
+        video_token=token_prefix + "<|video_pad|>",
+        audio_token=token_prefix + "<|audio_pad|>",
+        vision_bos_token=token_prefix + "<|vision_start|>",
+        audio_bos_token=token_prefix + "<|audio_start|>",
+        audio_eos_token=token_prefix + "<|audio_end|>",
+        vision_eos_token=token_prefix + "<|vision_end|>",
     )
     config = SimpleNamespace(
         thinker_config=SimpleNamespace(vision_config=SimpleNamespace(spatial_merge_size=2)),
@@ -89,6 +99,17 @@ def test_configure_processor_binds_multimodal_pad_dedup(monkeypatch):
         7,
         7,
     ]
+
+    # Exercise the bound production entry point, not only the collapse helper.
+    # Image/audio runs outside the span must still undergo ordinary run-dedup.
+    span = [104, 105, 102, 102, 103, 103, 102, 103, 106, 107]
+    raw = [104, 102, 107]
+    original = [7, 7, 101, 101] + span + [8] + span + [103, 103, 9, 9]
+    saved = original.copy()
+    expected = [7, 7, 101] + raw + [8] + raw + [103, 9, 9]
+    assert configured.dedup_pad_tokens(original) == expected
+    assert configured.dedup_pad_tokens(expected) == expected
+    assert original == saved
 
 
 def test_v1_adapter_forwards_qwen3_omni_audio_lengths_to_rope(monkeypatch):

--- a/verl_omni/pipelines/qwen3_omni/thinker_training_adapter.py
+++ b/verl_omni/pipelines/qwen3_omni/thinker_training_adapter.py
@@ -31,6 +31,39 @@ from verl_omni.pipelines.model_base import OmniModelBase
 logger = logging.getLogger(__name__)
 
 
+def _collapse_interleaved_audio_video_tokens(prompt_ids: list[int], tokenizer) -> list[int]:
+    """Restore each complete HF audio-in-video span to one raw video placeholder.
+
+    vLLM-Omni re-expands the video placeholder into both modalities. Merely
+    deduplicating each pad run leaves the original audio runs and wrappers in
+    the prompt. Only recognize complete spans containing both pad types and
+    no text; ordinary audio, video, and surrounding conversation stay intact.
+    """
+    token_names = ("vision_start", "audio_start", "video_pad", "audio_pad", "audio_end", "vision_end")
+    ids = [tokenizer.convert_tokens_to_ids(f"<|{name}|>") for name in token_names]
+    if any(tid is None or tid == getattr(tokenizer, "unk_token_id", None) for tid in ids):
+        return prompt_ids
+    if len(set(ids)) != len(ids):
+        return prompt_ids
+    vision_start, audio_start, video_pad, audio_pad, audio_end, vision_end = ids
+    result = []
+    i = 0
+    while i < len(prompt_ids):
+        if prompt_ids[i : i + 2] == [vision_start, audio_start]:
+            j = i + 2
+            seen = set()
+            while j < len(prompt_ids) and prompt_ids[j] in (video_pad, audio_pad):
+                seen.add(prompt_ids[j])
+                j += 1
+            if seen == {video_pad, audio_pad} and prompt_ids[j : j + 2] == [audio_end, vision_end]:
+                result.extend((vision_start, video_pad, vision_end))
+                i = j + 2
+                continue
+        result.append(prompt_ids[i])
+        i += 1
+    return result
+
+
 @OmniModelBase.register("Qwen3OmniMoeForConditionalGeneration", stage="thinker")
 class Qwen3OmniThinkerAdapter(OmniModelBase):
     """Thinker-stage training adapter for Qwen3-Omni.
@@ -118,6 +151,7 @@ class Qwen3OmniThinkerAdapter(OmniModelBase):
             tokenizer = getattr(self, "tokenizer", None)
             if tokenizer is None:
                 return prompt_ids
+            prompt_ids = _collapse_interleaved_audio_video_tokens(prompt_ids, tokenizer)
             pad_ids: set[int] = set()
             for tok_attr in ("image_token", "video_token", "audio_token"):
                 tok = getattr(self, tok_attr, None)

--- a/verl_omni/pipelines/qwen3_omni/thinker_training_adapter.py
+++ b/verl_omni/pipelines/qwen3_omni/thinker_training_adapter.py
@@ -31,7 +31,7 @@ from verl_omni.pipelines.model_base import OmniModelBase
 logger = logging.getLogger(__name__)
 
 
-def _collapse_interleaved_audio_video_tokens(prompt_ids: list[int], tokenizer) -> list[int]:
+def _collapse_interleaved_audio_video_tokens(prompt_ids: list[int], processor) -> list[int]:
     """Restore each complete HF audio-in-video span to one raw video placeholder.
 
     vLLM-Omni re-expands the video placeholder into both modalities. Merely
@@ -39,8 +39,24 @@ def _collapse_interleaved_audio_video_tokens(prompt_ids: list[int], tokenizer) -
     the prompt. Only recognize complete spans containing both pad types and
     no text; ordinary audio, video, and surrounding conversation stay intact.
     """
-    token_names = ("vision_start", "audio_start", "video_pad", "audio_pad", "audio_end", "vision_end")
-    ids = [tokenizer.convert_tokens_to_ids(f"<|{name}|>") for name in token_names]
+    tokenizer = getattr(processor, "tokenizer", None)
+    if tokenizer is None:
+        return prompt_ids
+    token_attrs = (
+        "vision_bos_token",
+        "audio_bos_token",
+        "video_token",
+        "audio_token",
+        "audio_eos_token",
+        "vision_eos_token",
+    )
+    tokens = [getattr(processor, attr, None) for attr in token_attrs]
+    if any(token is None for token in tokens):
+        return prompt_ids
+    try:
+        ids = [tokenizer.convert_tokens_to_ids(token) for token in tokens]
+    except (TypeError, ValueError):
+        return prompt_ids
     if any(tid is None or tid == getattr(tokenizer, "unk_token_id", None) for tid in ids):
         return prompt_ids
     if len(set(ids)) != len(ids):
@@ -112,6 +128,11 @@ class Qwen3OmniThinkerAdapter(OmniModelBase):
 
         Returns:
             The configured processor with RoPE and dedup helpers bound.
+
+        Note:
+            Interleaved audio-video normalization is installed on this V1
+            adapter path only. The deprecated ``models.transformers.
+            qwen3_omni_thinker`` hf_processor fallback is unchanged.
         """
         import types
 
@@ -151,7 +172,7 @@ class Qwen3OmniThinkerAdapter(OmniModelBase):
             tokenizer = getattr(self, "tokenizer", None)
             if tokenizer is None:
                 return prompt_ids
-            prompt_ids = _collapse_interleaved_audio_video_tokens(prompt_ids, tokenizer)
+            prompt_ids = _collapse_interleaved_audio_video_tokens(prompt_ids, self)
             pad_ids: set[int] = set()
             for tok_attr in ("image_token", "video_token", "audio_token"):
                 tok = getattr(self, tok_attr, None)


### PR DESCRIPTION
## What does this PR do?

**This PR fixes a rollout prompt-consistency bug in Qwen3-Omni: incomplete audio-video normalization leaves extra tokens after vLLM-Omni re-expansion, causing rollout to use different prompt IDs from those retained by the agent loop. Fix incomplete normalization of Qwen3-Omni interleaved audio-video prompts before vLLM-Omni rollout.**

The existing `dedup_pad_tokens` collapses consecutive runs of each modality's pad token. For an HF-expanded audio-in-video span, that leaves multiple interleaved video/audio pads and the original audio boundary tokens. When vLLM-Omni expands the video placeholder into the full audio-video sequence, the remaining tokens cause a different prompt from the one retained by the agent loop. **This prompt mismatch may lead to training–inference inconsistency between vLLM-Omni rollout and the RL actor, as they may compute token probabilities conditioned on different prompt sequences.**

This change recognizes a complete span of the form:

```text
<|vision_start|><|audio_start|>[video/audio pads]<|audio_end|><|vision_end|>
```

and restores it to:

```text
<|vision_start|><|video_pad|><|vision_end|>
```

Both audio and video pads must be present, and no other tokens may occur inside the span. Existing pad-run deduplication then handles the other modality cases as before.

**Scope: this PR fixes only the V1 `Qwen3OmniThinkerAdapter.configure_processor` path. The deprecated `verl_omni/models/transformers/qwen3_omni_thinker.py` `hf_processor` fallback is unchanged and can still retain the original interleaved-span mismatch.** This scope is also documented in the adapter docstring.

### Additional experimental CPU entry validation

A separate local harness exercised the real `SingleTurnAgentLoop`, Continuous Token builder, HF processor, `OmniStrategyBase.generate`, `ARStrategy`, and pinned vLLM-Omni multimodal processor. It used deterministic synthetic decoded media, with a processor-only engine fixture returning a fixed answer instead of running a model forward.

Public processor assets: `Qwen/Qwen3-Omni-30B-A3B-Instruct`, revision `26291f793822fb6be9555850f06dfe95f2d7e695`. Input: four 64×64 RGB frames at 1 FPS and four seconds of 16 kHz synthetic audio.

| Case | HF reference audio/video pads | Before | After |
|---|---:|---:|---:|
| Audio only | 52 / 0 | 52 / 0 | 52 / 0 |
| Video only | 0 / 8 | 0 / 8 | 0 / 8 |
| Interleaved audio-video | 52 / 8 | 54 / 9 | 52 / 8 |
| Two interleaved items | 104 / 16 | 108 / 18 | 104 / 16 |
| Interleaved media with conversation history | 52 / 8 | 54 / 9 | 52 / 8 |

After the fix, the full prompt IDs—not only pad counts—matched the HF reference in all tested cases. An additional separate-audio-plus-video case and processor-only cache hits also preserved the full IDs. These are separate harness measurements, not claims that the new helper unit tests run the whole stack.

## Relationship to existing work

- Related to #445, specifically P15: the broader token-ID double-expansion issue and the existing dedup workaround are already known. This PR does not claim to discover that general issue.
- Related to #416: the NextQA recipe enables audio-in-video. The diff reviewed for that PR does not include this interleaved-span normalization; this PR does not duplicate its dataset extraction or recipe changes.
- Searches checked: [interleaved](https://github.com/verl-project/verl-omni/issues?q=interleaved), [dedup](https://github.com/verl-project/verl-omni/issues?q=dedup), and [use_audio_in_video](https://github.com/verl-project/verl-omni/issues?q=use_audio_in_video). No identical interleaved-span fix was found in the reviewed results as of 2026-09-05.

## Design and code changes

- Add a private normalization helper in the Qwen3-Omni Thinker training adapter and call it before the existing run deduplication.
- Preserve surrounding text and media order; do not mutate the caller's list.
- Leave incomplete spans, spans containing text, unknown special-token IDs, and aliased special-token IDs unchanged by this helper.
- Resolve all six span tokens from the processor bos/eos/pad attributes instead of a hardcoded token-string table.
- Add 28 helper regression cases covering valid/multiple spans, history, idempotence, non-mutation, malformed inputs, missing attributes, conversion errors, and unknown/aliased IDs.
- Extend `test_configure_processor_binds_multimodal_pad_dedup` through the bound `processor.dedup_pad_tokens` entry with both default and deliberately renamed token strings.

## Tests run

```bash
python -m pytest -q \
  tests/pipelines/test_qwen3_omni_interleaved_dedup_on_cpu.py \
  tests/pipelines/test_qwen3_omni_thinker_adapter_on_cpu.py
```

Result after the review revision: **35 passed**, no cases deselected (28 helper cases plus 7 adapter cases).

The configured-processor test verifies interleaved collapse and ordinary pad-run deduplication in the same prompt, multiple media items, idempotence, and preservation of the input list. It runs with both default and renamed token strings.

As a separate negative control, replacing the collapse helper with an in-memory no-op made both configured-processor cases fail. This confirms the tests reject a disconnected collapse call; no source files were changed by the negative control.

```bash
python -m ruff check \
  verl_omni/pipelines/qwen3_omni/thinker_training_adapter.py \
  tests/pipelines/test_qwen3_omni_interleaved_dedup_on_cpu.py \
  tests/pipelines/test_qwen3_omni_thinker_adapter_on_cpu.py
python -m ruff format --check \
  verl_omni/pipelines/qwen3_omni/thinker_training_adapter.py \
  tests/pipelines/test_qwen3_omni_interleaved_dedup_on_cpu.py \
  tests/pipelines/test_qwen3_omni_thinker_adapter_on_cpu.py
git diff --check
```

All three checks passed. The CPU test files match the existing `tests/**/*_on_cpu.py` collection rule. Full-repository pre-commit/CI has not been run locally.



