### PR TITLE
[diffusion, fsdp, cfg, recipe, tests] fix: support merged LoRA weight sync in the diffusers FSDP engine

### DIFF
--- a/examples/flowgrpo_trainer/bagel/README.md
+++ b/examples/flowgrpo_trainer/bagel/README.md
@@ -1,6 +1,6 @@
 # BAGEL-7B-MoT FlowGRPO training
 
-Last updated: 07/06/2026
+Last updated: 09/07/2026
 
 [BAGEL-7B-MoT](https://github.com/ByteDance-Seed/BAGEL) is a
 Mixture-of-Transformers model supporting both image understanding and
@@ -135,6 +135,7 @@ wrapper replacement but simply has ``requires_grad=False`` set by the
 | Architecture | Auto-detected | Explicit: ``+actor_rollout_ref.model.architecture=OmniBagelForConditionalGeneration`` |
 | Deploy config | Not needed | ``bagel_deploy_config.yaml`` (single-stage topology) |
 | LoRA targets | ``*_proj`` layers | ``*_proj`` + ``*_moe_gen`` (MoT dual-pathway) |
+| LoRA weight sync | Adapter tensors | Merged full weights (``lora.merge=True``): the rollout engine's fused MoT layout cannot bind ``*_moe_gen`` adapters |
 | FSDP prefixes | ``transformer_blocks.`` | ``layers.`` |
 | CFG | Standard true CFG | 3-branch (gen / text-uncond / img-uncond) with global renormalisation |
 | Timestep convention | ``t / 1000`` | Raw sigma with SD3-style shift of 3.0 |

--- a/examples/flowgrpo_trainer/bagel/run_bagel_ocr_lora.sh
+++ b/examples/flowgrpo_trainer/bagel/run_bagel_ocr_lora.sh
@@ -41,6 +41,7 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.model.lora_rank=64 \
     actor_rollout_ref.model.lora_alpha=128 \
     actor_rollout_ref.model.lora_dtype=float32 \
+    actor_rollout_ref.model.lora.merge=True \
     actor_rollout_ref.model.target_modules="['q_proj_moe_gen','k_proj_moe_gen','v_proj_moe_gen','o_proj_moe_gen','mlp_moe_gen.gate_proj','mlp_moe_gen.up_proj','mlp_moe_gen.down_proj']" \
     actor_rollout_ref.model.fsdp_layer_prefixes="['layers.']" \
     actor_rollout_ref.actor.optim.lr=1e-4 \

--- a/examples/flowgrpo_trainer/bagel/run_bagel_ocr_lora_npu.sh
+++ b/examples/flowgrpo_trainer/bagel/run_bagel_ocr_lora_npu.sh
@@ -5,6 +5,11 @@
 #       --model_path ~/models/ByteDance-Seed/BAGEL-7B-MoT \
 #       --input_dir ~/data/ocr \
 #       --output_dir ~/data/ocr/bagel
+#
+# NOTE: on vllm-omni >= 0.24 BAGEL LoRA requires merged weight sync
+# (actor_rollout_ref.model.lora.merge=True) — adapter sync silently binds zero
+# modules on the fused MoT layout and reward stays flat. Merged sync is not yet
+# validated on NPU, so it is not enabled here.
 set -x
 export VERL_DATAPROTO_SERIALIZATION_METHOD=numpy
 ASCEND_HOME_PATH=${ASCEND_HOME_PATH:-/usr/local/Ascend/cann-9.0.0}
@@ -31,6 +36,7 @@ ENGINE=vllm_omni
 REWARD_ENGINE=vllm
 
 
+echo "WARNING: BAGEL LoRA on vllm-omni >= 0.24 needs actor_rollout_ref.model.lora.merge=True (NPU validation pending); reward may stay flat without it" >&2
 python3 -m verl_omni.trainer.main_diffusion \
     trainer.device=npu \
     data.train_files=$ocr_train_path \

--- a/examples/flowgrpo_trainer/bagel/run_bagel_pickscore_lora.sh
+++ b/examples/flowgrpo_trainer/bagel/run_bagel_pickscore_lora.sh
@@ -43,6 +43,7 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.model.lora_rank=64 \
     actor_rollout_ref.model.lora_alpha=128 \
     actor_rollout_ref.model.lora_dtype=float32 \
+    actor_rollout_ref.model.lora.merge=True \
     actor_rollout_ref.model.target_modules="['q_proj_moe_gen','k_proj_moe_gen','v_proj_moe_gen','o_proj_moe_gen','mlp_moe_gen.gate_proj','mlp_moe_gen.up_proj','mlp_moe_gen.down_proj']" \
     actor_rollout_ref.model.fsdp_layer_prefixes="['layers.']" \
     actor_rollout_ref.actor.optim.lr=1e-4 \

--- a/tests/workers/test_diffusers_fsdp_merged_lora_on_cpu.py
+++ b/tests/workers/test_diffusers_fsdp_merged_lora_on_cpu.py
@@ -1,0 +1,188 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU checks for merged-LoRA weight export in the diffusers FSDP engine."""
+
+from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+import verl_omni.workers.engine.fsdp.diffusers_impl as diffusers_impl
+from verl_omni.workers.config.diffusion import DiffusionModelConfig
+from verl_omni.workers.engine.fsdp.diffusers_impl import PPODiffusersFSDPEngine
+
+
+class _ToyModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.proj = torch.nn.Linear(4, 4, bias=False)
+        # Carrying a ``peft_config`` is all ``get_per_tensor_param`` needs to
+        # take the LoRA branch.
+        self.peft_config = {"default": SimpleNamespace(to_dict=lambda: {"r": 8})}
+
+
+def _make_engine(module, lora_config: dict) -> PPODiffusersFSDPEngine:
+    engine = object.__new__(PPODiffusersFSDPEngine)
+    engine.module = module
+    engine._is_offload_param = False
+    engine._uses_fsdp2_cpu_offload_policy = False
+    # DiffusionModelConfig.__post_init__ does I/O; set the fields under test directly.
+    model_config = object.__new__(DiffusionModelConfig)
+    object.__setattr__(model_config, "lora", lora_config)
+    object.__setattr__(model_config, "fsdp_layer_prefixes", ["layers."])
+    engine.model_config = model_config
+    return engine
+
+
+def _patch_sync_helpers(monkeypatch, merged_context=None):
+    monkeypatch.setattr(diffusers_impl, "log_gpu_memory_usage", MagicMock())
+    monkeypatch.setattr(diffusers_impl, "load_fsdp_model_to_gpu", MagicMock())
+    monkeypatch.setattr(diffusers_impl, "offload_fsdp_model_to_cpu", MagicMock())
+    monkeypatch.setattr(diffusers_impl, "get_device_id", lambda: torch.device("cpu"))
+    if merged_context is not None:
+        monkeypatch.setattr(diffusers_impl, "merged_lora_context", merged_context)
+
+
+def _passthrough_names(monkeypatch):
+    monkeypatch.setattr(diffusers_impl, "normalize_peft_param_name", lambda state: state)
+    monkeypatch.setattr(diffusers_impl, "convert_weight_keys", lambda state, model: state)
+
+
+def test_merge_branch_streams_full_weights_without_peft_config(monkeypatch):
+    module = _ToyModel()
+
+    @contextmanager
+    def merged_context(actor, backup_adapters):
+        assert actor is module
+        assert backup_adapters
+        yield
+
+    _patch_sync_helpers(monkeypatch, merged_context)
+    _passthrough_names(monkeypatch)
+    collect = MagicMock(return_value={})
+    monkeypatch.setattr(diffusers_impl, "collect_lora_params", collect)
+
+    engine = _make_engine(module, lora_config={"merge": True})
+    params, peft_config = engine.get_per_tensor_param(layered_summon=False, base_sync_done=True)
+
+    weights = dict(params)
+    assert peft_config is None  # routes the rollout to the full-weight branch
+    assert set(weights) == {"transformer.proj.weight"}
+    torch.testing.assert_close(weights["transformer.proj.weight"], module.proj.weight)
+    collect.assert_not_called()  # merge mode bypasses the adapter path entirely
+
+
+def test_merged_weights_materialized_and_actor_restored(monkeypatch):
+    pytest.importorskip("peft")
+    from peft import LoraConfig, get_peft_model
+
+    class _Base(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.proj = torch.nn.Linear(4, 4, bias=False)
+
+    torch.manual_seed(0)
+    peft_model = get_peft_model(_Base(), LoraConfig(r=8, lora_alpha=16, target_modules=["proj"]))
+    wrapped = peft_model.base_model.model.proj
+    base_weight = wrapped.base_layer.weight.detach().clone()
+    with torch.no_grad():
+        # Default zero-init lora_B would merge to a no-op; make the delta visible.
+        wrapped.lora_B["default"].weight.fill_(1.0)
+
+    @contextmanager
+    def peft_merge_context(actor, backup_adapters):
+        # Stand-in for verl's FSDP-dependent merged_lora_context: per-layer
+        # merge/unmerge, the same mechanism verl's fsdp_merge_unmerge uses.
+        from peft.tuners.lora import LoraLayer
+
+        assert backup_adapters
+        with torch.no_grad():
+            for layer in actor.modules():
+                if isinstance(layer, LoraLayer):
+                    layer.merge()
+        try:
+            yield
+        finally:
+            with torch.no_grad():
+                for layer in actor.modules():
+                    if isinstance(layer, LoraLayer):
+                        layer.unmerge()
+
+    _patch_sync_helpers(monkeypatch, peft_merge_context)
+    # Real normalize_peft_param_name / convert_weight_keys: exercises the actual
+    # name cleaning (strips peft wrappers, drops lora_* keys) end to end.
+
+    engine = _make_engine(peft_model, lora_config={"merge": True})
+    weights = dict(engine._merged_lora_per_tensor_param())
+
+    assert set(weights) == {"transformer.proj.weight"}
+    expected = base_weight + (16 / 8) * (wrapped.lora_B["default"].weight @ wrapped.lora_A["default"].weight)
+    torch.testing.assert_close(weights["transformer.proj.weight"], expected)
+    # The actor must come back unmerged once the stream is consumed.
+    torch.testing.assert_close(wrapped.base_layer.weight, base_weight)
+
+
+def test_merged_stream_offloads_on_finally(monkeypatch):
+    _patch_sync_helpers(
+        monkeypatch,
+        merged_context=MagicMock(),
+    )
+    _passthrough_names(monkeypatch)
+
+    engine = _make_engine(_ToyModel(), lora_config={"merge": True})
+    engine._is_offload_param = True
+    list(engine._merged_lora_per_tensor_param())
+    diffusers_impl.offload_fsdp_model_to_cpu.assert_called_once_with(engine.module)
+
+
+def test_merged_stream_skips_offload_when_disabled(monkeypatch):
+    _patch_sync_helpers(
+        monkeypatch,
+        merged_context=MagicMock(),
+    )
+    _passthrough_names(monkeypatch)
+
+    engine = _make_engine(_ToyModel(), lora_config={"merge": True})
+    list(engine._merged_lora_per_tensor_param())
+    diffusers_impl.offload_fsdp_model_to_cpu.assert_not_called()
+
+
+def test_adapter_branch_unchanged_when_merge_disabled(monkeypatch):
+    module = _ToyModel()
+    adapter_weight = torch.zeros(8, 4)
+
+    _patch_sync_helpers(monkeypatch)
+    monkeypatch.setattr(diffusers_impl, "convert_weight_keys", lambda state, model: state)
+    collect = MagicMock(
+        return_value={"layers.0.self_attn.q_proj_moe_gen.lora_A.weight": adapter_weight},
+    )
+    monkeypatch.setattr(diffusers_impl, "collect_lora_params", collect)
+
+    engine = _make_engine(module, lora_config={})
+    params, peft_config = engine.get_per_tensor_param(layered_summon=True, base_sync_done=True)
+
+    weights = dict(params)
+    assert peft_config == {"r": 8}  # still routed to the rollout's add_lora branch
+    assert set(weights) == {"transformer.layers.0.self_attn.q_proj_moe_gen.lora_A.weight"}
+    torch.testing.assert_close(weights["transformer.layers.0.self_attn.q_proj_moe_gen.lora_A.weight"], adapter_weight)
+    collect.assert_called_once_with(
+        module=module,
+        layered_summon=True,
+        base_sync_done=True,
+        is_diffusers=True,
+        adapter_name="default",
+        layer_prefixes=["layers."],
+    )

--- a/tests/workers/test_diffusers_fsdp_merged_lora_on_cpu.py
+++ b/tests/workers/test_diffusers_fsdp_merged_lora_on_cpu.py
@@ -135,6 +135,21 @@ def test_merged_weights_materialized_and_actor_restored(monkeypatch):
     torch.testing.assert_close(wrapped.base_layer.weight, base_weight)
 
 
+def test_merge_branch_rejects_named_adapter(monkeypatch):
+    module = _ToyModel()
+
+    _patch_sync_helpers(monkeypatch)
+    _passthrough_names(monkeypatch)
+    monkeypatch.setattr(diffusers_impl, "merged_lora_context", MagicMock())
+
+    engine = _make_engine(module, lora_config={"merge": True})
+    with pytest.raises(ValueError, match="rollout_adapter='old'"):
+        engine.get_per_tensor_param(base_sync_done=True, adapter_name="old")
+    # "default" is what the weight-sync call sites pass and must stay accepted.
+    _, peft_config = engine.get_per_tensor_param(base_sync_done=True, adapter_name="default")
+    assert peft_config is None
+
+
 def test_merged_stream_offloads_on_finally(monkeypatch):
     _patch_sync_helpers(
         monkeypatch,

--- a/verl_omni/trainer/config/_generated_diffusion_trainer.yaml
+++ b/verl_omni/trainer/config/_generated_diffusion_trainer.yaml
@@ -315,6 +315,8 @@ actor_rollout_ref:
     target_modules: all-linear
     target_parameters: null
     exclude_modules: null
+    lora:
+      merge: false
     lora_adapter_path: null
     policy_state_adapters:
     - default

--- a/verl_omni/trainer/config/_generated_diffusion_veomni_trainer.yaml
+++ b/verl_omni/trainer/config/_generated_diffusion_veomni_trainer.yaml
@@ -356,6 +356,8 @@ actor_rollout_ref:
     target_modules: all-linear
     target_parameters: null
     exclude_modules: null
+    lora:
+      merge: false
     lora_adapter_path: null
     policy_state_adapters:
     - default

--- a/verl_omni/trainer/config/diffusion/model/diffusion_model.yaml
+++ b/verl_omni/trainer/config/diffusion/model/diffusion_model.yaml
@@ -63,6 +63,12 @@ target_parameters: null
 # Exclude modules from LoRA adaptation
 exclude_modules: null
 
+# LoRA (Low-Rank Adaptation) configuration
+lora:
+
+  # whether to merge LoRA into base weights before transferring to vllm_omni
+  merge: False
+
 # Path to pre-trained LoRA adapter to load for continued training
 lora_adapter_path: null
 

--- a/verl_omni/workers/engine/fsdp/diffusers_impl.py
+++ b/verl_omni/workers/engine/fsdp/diffusers_impl.py
@@ -46,6 +46,8 @@ from verl.utils.fsdp_utils import (
     init_fn,
     load_fsdp_model_to_gpu,
     load_fsdp_optimizer,
+    merged_lora_context,
+    normalize_peft_param_name,
     offload_fsdp_model_to_cpu,
     offload_fsdp_optimizer,
 )
@@ -772,20 +774,28 @@ class DiffusersFSDPEngine(LoRAAdapterMixin, BaseEngine, ABC):
         log_gpu_memory_usage("After load_fsdp_model_to_gpu", logger=logger)
 
         peft_config = None
+        merge_lora = self.model_config.lora.get("merge", False)
 
         peft_model = getattr(self.module, "_fsdp_wrapped_module", self.module)
         if hasattr(peft_model, "peft_config"):  # LoRA
-            peft_config = peft_model.peft_config.get("default", None)
-            adapter_ctx = self.use_adapter(adapter_name) if adapter_name is not None else nullcontext()
-            with adapter_ctx:
-                params = collect_lora_params(
-                    module=self.module,
-                    layered_summon=layered_summon,
-                    base_sync_done=base_sync_done,
-                    is_diffusers=True,
-                    adapter_name=adapter_name or "default",
-                    layer_prefixes=self.model_config.fsdp_layer_prefixes,
-                )
+            if not merge_lora:
+                peft_config = peft_model.peft_config.get("default", None)
+                adapter_ctx = self.use_adapter(adapter_name) if adapter_name is not None else nullcontext()
+                with adapter_ctx:
+                    params = collect_lora_params(
+                        module=self.module,
+                        layered_summon=layered_summon,
+                        base_sync_done=base_sync_done,
+                        is_diffusers=True,
+                        adapter_name=adapter_name or "default",
+                        layer_prefixes=self.model_config.fsdp_layer_prefixes,
+                    )
+            else:  # merge lora
+                # state_dict() aliases the live parameter storage and merged_lora_context
+                # restores the un-merged base weights on exit, so tensors must be
+                # materialized while the context is still open (inside the generator).
+                # Materializing after exit silently sends base weights without adapters.
+                return self._merged_lora_per_tensor_param(), None
         else:
             params = self.module.state_dict()
 
@@ -815,6 +825,39 @@ class DiffusersFSDPEngine(LoRAAdapterMixin, BaseEngine, ABC):
         per_tensor_param = ((f"transformer.{name}", tensor) for name, tensor in per_tensor_param)
         peft_config_dict = peft_config.to_dict() if peft_config is not None else None
         return per_tensor_param, peft_config_dict
+
+    def _merged_lora_per_tensor_param(self):
+        """Stream merged (base + LoRA) weights for rollout weight sync.
+
+        ``state_dict()`` returns tensors that alias the live FSDP parameter
+        storage, and ``merged_lora_context`` restores the un-merged base
+        weights when it exits. The context therefore must stay open until the
+        consumer has materialized every tensor: ``DTensor.full_tensor()``
+        produces a copy, so yielded tensors remain valid after the restore.
+        Consuming a state_dict captured inside the context after the context
+        has exited would silently send base weights without the adapters.
+
+        Names carry the ``transformer.`` prefix, matching the non-merge export path above.
+        """
+        device = get_device_id()
+        try:
+            with merged_lora_context(self.module, backup_adapters=True):
+                params = normalize_peft_param_name(self.module.state_dict())
+                params = convert_weight_keys(params, getattr(self.module, "_fsdp_wrapped_module", self.module))
+                for name, param in params.items():
+                    yield (
+                        f"transformer.{name}",
+                        param.to(device, non_blocking=True).full_tensor().to(torch.bfloat16, non_blocking=True)
+                        if isinstance(param, DTensor)
+                        # clone: plain tensors also alias module storage, and bucketed
+                        # senders may flush after the restore has already run
+                        else param.detach().clone(),
+                    )
+        finally:
+            log_gpu_memory_usage("Before offload_fsdp_model_to_cpu", logger=logger)
+            if self._is_offload_param:
+                offload_fsdp_model_to_cpu(self.module)
+            log_gpu_memory_usage("After offload_fsdp_model_to_cpu", logger=logger)
 
     def _run_forward_backward_batch(
         self,

--- a/verl_omni/workers/engine/fsdp/diffusers_impl.py
+++ b/verl_omni/workers/engine/fsdp/diffusers_impl.py
@@ -791,6 +791,14 @@ class DiffusersFSDPEngine(LoRAAdapterMixin, BaseEngine, ABC):
                         layer_prefixes=self.model_config.fsdp_layer_prefixes,
                     )
             else:  # merge lora
+                if adapter_name not in (None, "default"):
+                    # merged_lora_context merges the active ("default") adapter only;
+                    # silently exporting it for a named rollout_adapter would sync the
+                    # wrong policy.
+                    raise ValueError(
+                        f"model.lora.merge=True exports the active 'default' adapter only; "
+                        f"got rollout_adapter={adapter_name!r}."
+                    )
                 # state_dict() aliases the live parameter storage and merged_lora_context
                 # restores the un-merged base weights on exit, so tensors must be
                 # materialized while the context is still open (inside the generator).


### PR DESCRIPTION
### What does this PR do?

Fixes #552.

BAGEL-7B-MoT LoRA FlowGRPO silently trains nothing on vllm-omni >= 0.24: the MoT kernel
rework fused the `*_moe_gen` image-expert projections into containers whose weights the
fused Triton GEMM reads directly, so the rollout's `DiffusionLoRAManager` binds **zero
modules** per `add_lora` — rollouts keep sampling the frozen base policy (flat reward
while `grad_norm`/KL explode; reproduction matrix and wandb evidence in #552). The
engine-side acceptance of such no-op adapters is tracked upstream in
vllm-project/vllm-omni#7190 (vLLM core raises where the diffusion manager stays silent).

The fix ports the merged-LoRA weight sync that verl core (`transformer_impl`) and the
omni engine already ship, and that `engine_workers.update_weights` has documented all
along: with `model.lora.merge=True`, the diffusers FSDP engine exports **fully merged
weights with `peft_config=None`**, routing the sync through the proven full-weight path
(`pipeline.load_weights` fused remap) instead of `add_lora`. Convergence was validated
on 4×H800 (issue #552): reward 0.815 → 0.844 (peak 0.855), validation 0.8318 → 0.8402,
`grad_norm`/KL back to healthy levels, throughput parity (−0.5% vs the same-env
baseline; `update_weights` 6.8 s → 13.0 s, ~1.3% of a 470 s step).

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here:
  - https://github.com/verl-project/verl-omni/pulls?q=is%3Aopen+bagel+lora+in%3Atitle%2Cbody — no open PR addresses the LoRA weight-sync regression. The closest open PR, #544 (`[vllm_omni] fix: fix bagel at v0.2.0`), is an unrelated attention-backend argument rename on `release/v0.2.0`.
  - https://github.com/verl-project/verl-omni/pulls?q=is%3Aopen+552+in%3Abody — none reference issue #552.
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `[diffusion, fsdp, cfg, recipe, tests] fix: ...` — all modules are in the validator set.
  - Not `[BREAKING]`: the `lora` dict field already existed on `DiffusionModelConfig`; declaring the node only removes the need for the hydra `+` prefix. Compat of the old `+actor_rollout_ref.model.lora.merge=True` form is hydra-version-dependent: on hydra-core 1.3.6 it still works (`lora` is an open `dict[str, Any]`, so `+` is a legal dict append/override — verified via `scripts/print_cfg.py`), while older hydra raises a loud one-line `OverrideError` at parse suggesting `++` or dropping the `+`. Either way the failure is immediate and self-explanatory; the in-repo scripts use the bare form.

### Test

Bagel LoRA training on pickscore

<img width="1829" height="569" alt="螢幕截圖 2026-09-07 下午1 52 26" src="https://github.com/user-attachments/assets/03e49ede-08d9-4393-aedb-1c952a1c8916" />
<img width="618" height="298" alt="螢幕截圖 2026-09-07 下午1 52 41" src="https://github.com/user-attachments/assets/8fe7c8c3-bd54-48c6-a313-b7e941a4abb0" />

CPU unit tests (macOS, conda env with the repo's dev extras; CI-equivalent invocation;
counts updated for the review-fix head `a1faabf9`):

```console
$ TORCH_COMPILE_DISABLE=1 TORCHINDUCTOR_DISABLE=1 pytest tests/workers -o python_files='*_on_cpu.py' --asyncio-mode=auto -q
164 passed, 20 warnings in 11.67s

$ TORCH_COMPILE_DISABLE=1 TORCHINDUCTOR_DISABLE=1 pytest tests/workers/test_diffusers_fsdp_merged_lora_on_cpu.py -q --asyncio-mode=auto
6 passed, 20 warnings in 11.35s
```

The new tests cover: merge-branch dispatch (`peft_config=None`, `transformer.`-prefixed
full weights, adapter path bypassed), merged weights materialized inside the merge
context with the actor restored afterwards (real peft merge math on a toy module),
offload-on-`finally`, the non-merge adapter path unchanged, and the named-adapter
rejection under merge mode (see review follow-ups).

Pre-commit (also ran as part of both commits):

```console
$ pre-commit run --files <all changed files>
ruff / ruff format / mypy / autogen-trainer-cfg / docs / license / device-api / dataproto / structure / naming / compileall
All Passed (12/12)
```

Config composition (no hydra `+` prefix needed after the schema change):

```console
$ python3 scripts/print_cfg.py --cfg job --config-name=diffusion_trainer.yaml \
    'actor_rollout_ref.model.lora.merge=True' | grep -A1 '^    lora:'
    lora:
      merge: true
```

GPU convergence is not CI-testable here; it is validated by the experiments recorded in
issue #552 (reproduction matrix isolating the vllm-omni 0.22→0.24 bump, fix-vs-baseline
wandb signatures, and the throughput table).

### API and Usage Example

New config key `actor_rollout_ref.model.lora.merge` (mirrors the omni trainer's
`omni_model.yaml` node; required for BAGEL LoRA on vllm-omni >= 0.24):

```bash
# examples/flowgrpo_trainer/bagel/run_bagel_pickscore_lora.sh (updated in this PR)
actor_rollout_ref.model.lora.merge=True \
```

### Design & Code Changes

- `verl_omni/workers/engine/fsdp/diffusers_impl.py`
  - `get_per_tensor_param`: `merge_lora` branch mirroring verl core's
    `transformer_impl.py` — early-returns the merged stream with `peft_config=None`.
  - `_merged_lora_per_tensor_param`: verbatim port of verl core's implementation
    (merge context with `backup_adapters=True`, name normalization, bf16 DTensor
    staging, offload in `finally`). The single delta is the inline
    `f"transformer.{name}"` prefix, matching this engine's existing export contract
    (`get_per_tensor_param` prefixes every non-merge path the same way); a one-line
    docstring note flags it.
- `verl_omni/trainer/config/diffusion/model/diffusion_model.yaml`: declare the `lora:`
  node (`merge: False`), comment aligned with `omni_model.yaml` / verl core's
  `hf_model.yaml`; regenerated `_generated_diffusion_trainer.yaml` and
  `_generated_diffusion_veomni_trainer.yaml` via `scripts/generate_trainer_config.sh`.
- `examples/flowgrpo_trainer/bagel/run_bagel_pickscore_lora.sh`,
  `run_bagel_ocr_lora.sh`: enable `actor_rollout_ref.model.lora.merge=True` (both target
  `*_moe_gen` modules and are affected identically). The NPU LoRA recipe is left
  unchanged (merged sync not yet validated on NPU).
- `examples/flowgrpo_trainer/bagel/README.md`: one-line note + table row.
- `tests/workers/test_diffusers_fsdp_merged_lora_on_cpu.py`: new, 6 CPU tests.

Review follow-ups (`a1faabf9`):

- **Named rollout adapters under merge mode** (review thread): `rollout_adapter="old"` is
  legal config (`DiffusionRolloutConfig` validates `{"default", "old"}`) but
  `merged_lora_context` merges only the active `default` adapter — the merge branch now
  raises an actionable `ValueError` for `adapter_name not in (None, "default")` instead
  of silently syncing the wrong policy, with a regression test.
- **NPU recipe**: `run_bagel_ocr_lora_npu.sh` carries a header note + runtime warning
  that BAGEL LoRA on vllm-omni >= 0.24 requires `lora.merge=True`; the flag stays off
  there until merged sync is validated on NPU.
- **Mid-stream abort restore timing**: intentionally unchanged — identical exposure in
  the verl-core implementation this ports; possible follow-up is closing the generator
  at the `engine_workers.py` call site.
- Upstream no-op detection: vllm-project/vllm-omni#7190 (fix PR vllm-project/vllm-omni#7193).

Alternatives considered and rejected (details in #552): a MiniMax-H3-style name mapper
cannot reach the four attention gen experts and would yield a silently partial policy;
engine-side weight-delta surgery saves ~1.3% step time but adds TP/dtype/revert-sensitive
machinery with the same silent-stale-weight failure class. The proper adapter-side fix
lives upstream (vllm-project/vllm-omni#7190).

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always` — all hooks passed (and re-ran during both commits).
- [x] Add / Update the documentation. — `diffusion_model.yaml` schema comment, BAGEL recipe README.
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl-omni/tree/main/.github/workflows) to cover all the code. — 6 new `*_on_cpu.py` tests collected by the CPU job. GPU-side learning assertions are out of scope here; the engine-side no-op detection that would have caught this class is proposed upstream in vllm-project/vllm-omni#7190.

---

**AI-assistance disclosure:** this change was prepared with AI assistance (ZCode); the
root-cause analysis, alternatives assessment, and all code/tests above were produced in
that session. The human submitter has reviewed every changed line, ran the CPU tests and
pre-commit locally, and performed the GPU convergence validation referenced in #552.
