### PR TITLE
[6/N][BREAKING][diffusion, rollout, trainer, reward, tests] feat: add named media artifact path

### DIFF
--- a/docs/contributing/diffusion_media_artifacts.md
+++ b/docs/contributing/diffusion_media_artifacts.md
@@ -1,6 +1,6 @@
 # Named diffusion media artifacts
 
-Last updated: 09/07/2026.
+Last updated: 09/08/2026.
 
 All registered in-tree diffusion adapters emit named media. The strategy,
 agent loops, rewards and V0/V1 exporters consume declarations rather than
@@ -9,11 +9,15 @@ The public `generate(**kwargs)` RPC is unchanged.
 
 ## Contract
 
-`pipelines/rollout_artifacts.py` defines:
+`pipelines/rollout_media.py` retains `MediaSpec` and `DiffusionIOSpec`:
 
-- `ArtifactSpec(modality, representation, layout, sample_rate=None, fps=None)`.
+- `MediaSpec(modality, representation, layout, sample_rate=None, fps=None)`.
   Modality is `image`, `video` or `audio`; representation is `latent` or
   `decoded`. **The tensor owns its dtype**, not the configuration.
+- `DiffusionIOSpec(artifacts=...)` maps available artifact names to `MediaSpec`.
+
+`pipelines/rollout_artifacts.py` defines:
+
 - `MediaArtifact(spec, data, context="")`: one sample, with no implicit request
   batch dimension. Context records the pipeline/request for downstream errors.
 - `validate_artifacts`: checks returned versus expected names, duplicates,
@@ -36,13 +40,12 @@ packed layout are distinct facts.
 Each adapter declares available names next to its implementation:
 
 ```python
-from verl_omni.pipelines.rollout_artifacts import ArtifactSpec
-from verl_omni.pipelines.rollout_media import DiffusionIOSpec
+from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
 
 class MyPipeline(...):
     diffusion_io_spec = DiffusionIOSpec(artifacts={
-        "image_preview": ArtifactSpec("image", "decoded", "CHW"),
-        "image_latent": ArtifactSpec("image", "latent", "LC"),
+        "image_preview": MediaSpec("image", "decoded", "CHW"),
+        "image_latent": MediaSpec("image", "latent", "LC"),
     })
 ```
 

--- a/docs/contributing/diffusion_media_artifacts.md
+++ b/docs/contributing/diffusion_media_artifacts.md
@@ -2,123 +2,207 @@
 
 Last updated: 09/07/2026.
 
-This is the first working slice of RFC #403 PR6, not the completed all-adapter
-migration. MiniMax H3 **DiffusionNFT** emits named artifacts. Other adapters
-(including H3 FlowGRPO) still use the primary/auxiliary contract and its legacy
-consumer paths. GPU verification is required before completing that migration.
+All registered in-tree diffusion adapters emit named media. The strategy,
+agent loops, rewards and V0/V1 exporters consume declarations rather than
+identifying images, videos or latents from tensor rank or channel size.
+The public `generate(**kwargs)` RPC is unchanged.
 
-## Runtime contract
+## Contract
 
-`verl_omni/pipelines/rollout_artifacts.py` defines:
+`pipelines/rollout_artifacts.py` defines:
 
-- `ArtifactSpec(modality, representation, layout, sample_rate=None, fps=None)`:
-  a per-request declaration. Representation is `latent` or `decoded`; latent is
-  not a modality. There is no configurable dtype: the tensor owns its dtype.
-- `MediaArtifact(spec, data)`: **one sample**, without an implicit batch axis.
-- `validate_artifacts(items, specs, primary=..., context=..., requested=...)`:
-  checks returned versus declared names, duplicate/missing/unexpected/requested
-  artifacts, metadata, rank, channel axes and dtype, then normalizes decoded axes.
+- `ArtifactSpec(modality, representation, layout, sample_rate=None, fps=None)`.
+  Modality is `image`, `video` or `audio`; representation is `latent` or
+  `decoded`. **The tensor owns its dtype**, not the configuration.
+- `MediaArtifact(spec, data, context="")`: one sample, with no implicit request
+  batch dimension. Context records the pipeline/request for downstream errors.
+- `validate_artifacts`: checks returned versus expected names, duplicates,
+  requested-but-absent outputs, declarations, rank, channels and dtype before
+  normalizing decoded axes.
 
-Decoded image/video must already be uint8 `[0,255]`; decoded audio is a floating
-waveform with a positive sample rate. Decoded layouts normalize to `CHW`, `TCHW`
-and `CT`. Image `HWC`, video `CTHW`/`THWC`, and mono audio `T` are accepted **only
-when explicitly declared**. Model-native latent axes (including packed `LC` or
-H3 audio `CLT`) remain unchanged, as do their floating dtype and storage.
+Decoded visual data is uint8 `[0,255]`. Audio is a floating waveform with a
+positive sample rate. Decoded video requires positive finite FPS. Canonical
+layouts are image `CHW`, video `TCHW` and audio `CT`. Conversion from an explicitly
+declared `HWC`, `CTHW`, `THWC` or mono `T` is supported at the adapter boundary;
+consumers do not identify axes by looking for a dimension of size 3.
 
-An adapter constructs expected specs separately from its returned named items:
+Native/packed latents retain their axes, floating dtype and values. Do not
+reinterpret a packed sequence as image channels or normalize a training latent
+into a decoded-video layout. A codec's VAE input layout and the final sampler's
+packed layout are distinct facts.
+
+### Available outputs versus requested outputs
+
+Each adapter declares available names next to its implementation:
 
 ```python
-specs = {
-    "video_preview": ArtifactSpec("video", "decoded", "THWC", fps=24),
-    "video_latent": ArtifactSpec("video", "latent", "CTHW"),
-}
-items = [
-    ("video_preview", MediaArtifact(specs["video_preview"], decoded_video)),
-    ("video_latent", MediaArtifact(specs["video_latent"], native_video_latent)),
-]
-output = with_media_artifacts(
+from verl_omni.pipelines.rollout_artifacts import ArtifactSpec
+from verl_omni.pipelines.rollout_media import DiffusionIOSpec
+
+class MyPipeline(...):
+    diffusion_io_spec = DiffusionIOSpec(artifacts={
+        "image_preview": ArtifactSpec("image", "decoded", "CHW"),
+        "image_latent": ArtifactSpec("image", "latent", "LC"),
+    })
+```
+
+The runtime packet declares the outputs actually emitted and explicit `primary`,
+`preview` and `audio` selectors. `preview=None` means no preview was produced;
+export skips it, never substitutes `responses` or latent tensors. A non-null
+selector naming a missing artifact is an error.
+
+The current visual adapters select a native primary for `output_type=latent`
+and a decoded primary for `image`/`pt`/`np`/`pil`/`both`. These format spellings
+are compatibility inputs, not separate tensor-layout contracts.
+
+To require previews with a latent primary, configure the names explicitly:
+
+```bash
++actor_rollout_ref.rollout.pipeline.output_type=latent \
+actor_rollout_ref.rollout.pipeline.requested_outputs='[image_preview]'
+```
+
+For audiovisual scoring, request `video_preview` and `audio` as appropriate.
+The setting is mirrored to validation and model pipeline configs; validation can
+override its own list. Unknown/duplicate requests fail before generation when
+an adapter declaration is available. Packed request batches take the union of
+all requests' requirements, not just those of the first request.
+
+Requested names express **required availability**, not an exclusive output set.
+Qwen/SD3/Boogu/Wan can avoid preview decoding when it is not requested and the
+primary is latent. LTX decodes its joint pair when either decoded stream is
+required. Pinned H3 and Bagel forwards still decode; no selective-decoding
+optimization is claimed for those models.
+
+## Implementing an adapter
+
+`pipelines/diffusion_rollout_output.py` separates algorithm data from media:
+
+1. Construct native trajectory fields and `prompt_embeddings` / `rl` groups
+   with `rollout_output` or `with_rollout_data`.
+2. Attach media with `with_visual_artifacts` (batched VAE visuals and native
+   latents), `with_batched_media_artifacts` (explicit B-prefixed streams), or
+   `with_media_artifacts` (one sample).
+3. Ensure the engine's postprocessor preserves the named envelope. Use
+   `wrap_rollout_postprocessor` for a media-only upstream processor; do not run
+   VAE normalization/PIL conversion on already-canonical artifacts a second time.
+
+For example, after an image sampler returns packed `BLC` latents and its VAE
+returns floating `BCHW` pixels in `[-1,1]`:
+
+```python
+return with_visual_artifacts(
     rollout_output_with_training_data,
-    artifacts=items,
-    specs=specs,
-    primary="video_latent",
-    preview="video_preview",
-    context=f"pipeline=MyPipeline/my_algorithm, request_id={request_id}",
+    decoded=vae_pixels,          # None only when no preview is requested
+    latents=final_packed_latents,
+    latent_layout="LC",
+    decoded_layout="CHW",
+    pixel_range="minus_one_one",
+    output_type=output_type,
+    requested=requested_outputs,
+    context=f"pipeline=MyPipeline, request_id={request_id}",
 )
 ```
 
-`with_media_artifacts` lives in `pipelines/diffusion_rollout_output.py`. Its
-`primary` selects the temporary legacy `responses` projection; `preview` is the
-explicit decoded dump/W&B selection; optional `audio` selects the temporary
-legacy audio projection. All artifacts remain available regardless of primary
-selection. No consumer may replace a missing named preview with latent data.
+`pixel_range` is an adapter-owned fact, not detected from dtype or extrema.
+`zero_one` and `uint8` are also supported. Capture final latents **before** VAE
+casts/unpacking/normalization; never substitute the last saved SDE transition.
+Algorithm-owned `latents_clean`, trajectories, reference latents and replay
+fields keep their existing representations. Internal engine warmup is not a
+serving response: Qwen step hooks and LTX still execute decoder warmup but
+return no media packet for the reserved dummy request. Real nonfinite pixels
+continue to fail validation.
 
-The existing sampling `extra_args` can carry `requested_outputs` for validation.
-This initial slice checks requested names, but **does not skip decoding or
-transferring unrequested outputs**: the pinned H3 forward always decodes. It does
-not claim a selective-decoding optimization.
+Raw condition media and engine-prepared views are not aliases. In particular,
+Qwen-Image-Edit encodes the raw `multi_modal_data.image` view whose processor
+grid matches the already-tokenized placeholders; the engine's separately resized
+`additional_information.condition_images` must not be compared against it or
+substituted for it. VAE condition tensors/sizes use their own explicit fields.
 
-## Engine and training transport
+Request batching uses an explicit leading batch axis for payload samples,
+trajectory fields and the two training groups. Other metadata, including the
+artifact declaration, remains shared. A mismatched leading size is an error,
+not a signal to guess that a training tensor was shared.
 
-The pinned vllm-omni formatter retains only selected payload keys in its public
-multimodal output. The adapter therefore puts the complete named tensor mapping
-under one modality-keyed `payload` entry, with `media_artifacts` declarations and
-selectors in `metadata`. The engine's native formatter is exercised in CPU tests;
-no installed upstream package is patched.
+## Engine and TensorDict transport
 
-`DiffusionStrategy` validates and restores the mapping, exposes
-`DiffusionOutput.artifacts`, `primary_artifact`, `preview_artifact`, and projects
-only the explicitly selected primary to `diffusion_output`. Algorithm-owned
-`rl`, prompt embeddings and trajectory fields remain separate and unchanged.
+The pinned formatter does not put every visual tensor in `multimodal_output`.
+The adapter packs all named tensors under one modality-keyed payload entry,
+with declarations/selectors in `metadata.media_artifacts`. Batched helpers use
+an explicit list of per-sample mappings so request splitting cannot slice a
+latent's native axes accidentally.
 
-At the agent-loop boundary, tensors become ordinary fields named
-`media_artifact__<name>`. Tensor-free spec dictionaries and selectors travel in
-non-tensor metadata. Both ordinary batching and TransferQueue preserve them;
-scorers reconstruct per-sample artifacts from those fields. This avoids hiding
-large tensor payloads inside non-tensor object arrays.
+`DiffusionStrategy` combines complementary `multimodal_output` and `images`
+sources and rejects conflicting data/dtypes. A tensor-only `images` fallback
+requires an explicit `final_output_type` matching the named primary. Unlabelled
+legacy tensor/tuple results are rejected; the strategy does not guess a tuple's
+roles, select the first media key or cast floats into pixels.
 
-Migrated consumers:
+`DiffusionOutput` exposes `artifacts`, `primary_artifact` and `preview_artifact`.
+The temporary `diffusion_output` / `DataProto.responses` view is a projection of
+that named primary. Training fields and the audio projection remain for their
+existing consumers; retaining a projection does not add another interpretation.
 
-- V0/V1 rollout dumps and validation/W&B select the declared preview, even when
-  `responses` contains floating latents. Named previews bypass rank/channel-count
-  layout inference, carry their FPS to video export, and honor max-sample limits.
-- CLAP selects the decoded `audio` artifact and its rate.
-- ImageBind selects `audio` and `video_preview`, rather than interpreting the
-  primary response as a video. The legacy branch remains for unmigrated adapters.
-- The SD3 latent HTTP client accepts a declared `image_latent` in native `CHW`
-  layout. It rejects other model layouts rather than coercing packed latents into
-  the SD3 protocol. No SD3 producer migration is claimed in this slice.
+At the agent-loop boundary, tensors become `media_artifact__<name>` fields.
+`media_artifact_specs`, `primary_artifact`, `preview_artifact` and
+`media_artifact_context` are tensor-free metadata. Ordinary batching and
+TransferQueue preserve these fields, including an explicitly absent preview.
+Both reward managers reconstruct artifacts and validate that `responses` really
+matches the declared primary, including decoded floating audio. They do not
+infer its representation from a global training configuration.
 
-Schema/representation/layout/selector errors fail synchronously. Filesystem,
-FFmpeg and W&B failures retain the best-effort reporting behavior from PR4.
+## Consumers and failure policy
 
-## MiniMax H3 NFT evidence and limits
+- CLAP selects decoded `audio` and its actual rate.
+- ImageBind selects decoded `video_preview` and/or `audio` according to its mode.
+- Image scorers/frame samplers use the selected decoded preview and canonical
+  CHW/TCHW axes. The standalone tensor API requires an explicit media kind.
+- SD3 latent HTTP scoring selects `image_latent` and requires native `CHW`;
+  it does not accept packed `LC` by guessing that a dimension equals 16.
+- V0/V1 rollout dumps, validation and W&B select decoded previews, preserve
+  artifact FPS (including fractional rates), and never reinterpret latent data.
 
-The adapter declares four artifacts: `video_preview`, `audio`, `video_latent`,
-and `audio_latent`. Its declarations follow the **pinned source**, not tensor
-channel-size heuristics:
+Schema, selection, primary-projection and metadata errors fail before scoring or
+best-effort I/O. `ArtifactContractError` is fatal even for an optional weighted
+sub-reward. Encoder/filesystem/W&B failures still warn/skip or record the existing
+per-sample fallback. V1 permits only one pending dump, skips with a warning when
+it is busy, and copies only retained previews/audio so row views do not pin a
+whole batch or unused training latents in the background queue.
 
-| Artifact | Pinned source at `ded893462` | Per-sample input layout |
-| --- | --- | --- |
-| video preview | `_prepare_minimax_h3_video_output` in `pipeline_minimax_h3.py` emits uint8 NTHWC | THWC |
-| decoded audio | `MiniMaxH3AudioVAE.decode_latent` in `vae.py` returns NCT | CT |
-| video latent | `minimax_h3_patchify_video_latent` in `packed_tokens.py` requires NCTHW | CTHW, unchanged |
-| audio latent | `minimax_h3_pack_audio_latent` in `packed_tokens.py` requires CLT | CLT, unchanged |
+## Layout evidence and GPU checks
 
-Existing packed `latents_clean` and reference/replay tensors are not renamed or
-repacked. CPU tests cover the real H3 postprocessor/formatter, Ref2VA replay
-metadata and both transport paths. **These are not full-weight GPU layout or
-quality verification.**
+The adapters and pinned VAE/postprocessor code establish these distinct layouts:
 
-## Before PR6 is ready
+| Family | Final sampling artifact (per sample) | VAE input | Decoded visual before canonical boundary |
+| --- | --- | --- | --- |
+| Qwen image / edit / DPO / NFT / dual / mix | packed `LC` | `NCTHW`, image T=1 | `NCHW` after selecting the image frame |
+| SD3, Boogu | `CHW` | `NCHW` | `NCHW` |
+| Bagel | packed `LC` | `NCHW` after unpatchifying | RGB PIL image |
+| Wan | `CTHW` | `NCTHW` | `NCTHW` |
+| LTX | video `CTHW`, audio `CTF` | `NCTHW` / `NCTF` | `NTCHW` from `VideoProcessor(..., output_type="pt")` |
+| H3 NFT / FlowGRPO | video `CTHW`, audio `CLT` | `NCTHW` / `CLT` | uint8 `NTHWC` from `_prepare_minimax_h3_video_output` |
 
-- [ ] Verify H3 NFT T2VA/FL2VA/Ref2VA on GPU with decoded export and latent-primary scoring.
-- [ ] Migrate H3 FlowGRPO, LTX, Wan, Qwen variants, SD3, Boogu and Bagel using their actual postprocessor outputs.
-- [ ] GPU-verify every decoded layout, including request batching and step execution.
-- [ ] Replace the legacy `DiffusionIOSpec.primary/auxiliary` declarations once every producer uses named artifacts.
-- [ ] Remove remaining tuple/shape/representation fallback branches and legacy projections only after their consumers migrate.
-- [ ] Add selective preview decoding/transfer if a model can actually honor requested outputs.
-- [ ] Stress-test video dump queue memory/backpressure; CPU unit tests do not establish that property.
+H3 and LTX decoded audio is `NCT` at their decoder boundary. H3 uses 32000 Hz;
+LTX reads the vocoder's actual `output_sampling_rate` (BWE checkpoints can be
+48000 Hz, not the old 24000 Hz default).
 
-The live implementation and tests, not this checklist, are the source of truth
-for what is complete. See `test_rollout_artifacts_on_cpu.py`,
-`test_media_artifact_transport_on_cpu.py` and `test_artifact_preview_dump_on_cpu.py`.
+Reproducible GPU checks live under `tests/special_e2e/`:
+
+- `check_diffusion_vae_layouts.py --models-json <case-to-local-path.json> --output <report.json>`
+  loads actual VAE implementations/local weights, records implementation class,
+  parameter count and input/output shapes, and validates canonical conversion.
+- `check_named_diffusion_rollout.py --model <path> --architecture <name> --algorithm <name> --output-dir <dir>`
+  exercises the real engine through production request lowering and output
+  parsing; `--num-requests` and `--step-execution` cover the two batching modes.
+  `--require-request-batch` additionally checks that producer context contains
+  every request ID from a real packed forward. Use `--tokenizer-path` for model
+  layouts such as Boogu's `processor/`, and `--deploy-config` with BAGEL's
+  single-stage deployment recipe rather than its default two-stage AR pipeline.
+- Existing training recipes cover actor updates, ordinary agent loops and V1/TQ.
+  V1 requires **both** `trainer.use_v1=True` and `transfer_queue.enable=True`;
+  invoking `main_diffusion_v1` alone can fall back to V0.
+
+Set `CUDA_VISIBLE_DEVICES` explicitly and do not stop unrelated Ray/GPU jobs.
+Tiny-model plumbing, real-VAE layout verification and full-model training quality
+are different evidence. Record the exact checkpoint, pin, mode and result in the
+PR; a CPU pass or a VAE-only probe is not an end-to-end training pass.

--- a/docs/contributing/diffusion_media_artifacts.md
+++ b/docs/contributing/diffusion_media_artifacts.md
@@ -1,0 +1,124 @@
+# Named diffusion media artifacts
+
+Last updated: 09/07/2026.
+
+This is the first working slice of RFC #403 PR6, not the completed all-adapter
+migration. MiniMax H3 **DiffusionNFT** emits named artifacts. Other adapters
+(including H3 FlowGRPO) still use the primary/auxiliary contract and its legacy
+consumer paths. GPU verification is required before completing that migration.
+
+## Runtime contract
+
+`verl_omni/pipelines/rollout_artifacts.py` defines:
+
+- `ArtifactSpec(modality, representation, layout, sample_rate=None, fps=None)`:
+  a per-request declaration. Representation is `latent` or `decoded`; latent is
+  not a modality. There is no configurable dtype: the tensor owns its dtype.
+- `MediaArtifact(spec, data)`: **one sample**, without an implicit batch axis.
+- `validate_artifacts(items, specs, primary=..., context=..., requested=...)`:
+  checks returned versus declared names, duplicate/missing/unexpected/requested
+  artifacts, metadata, rank, channel axes and dtype, then normalizes decoded axes.
+
+Decoded image/video must already be uint8 `[0,255]`; decoded audio is a floating
+waveform with a positive sample rate. Decoded layouts normalize to `CHW`, `TCHW`
+and `CT`. Image `HWC`, video `CTHW`/`THWC`, and mono audio `T` are accepted **only
+when explicitly declared**. Model-native latent axes (including packed `LC` or
+H3 audio `CLT`) remain unchanged, as do their floating dtype and storage.
+
+An adapter constructs expected specs separately from its returned named items:
+
+```python
+specs = {
+    "video_preview": ArtifactSpec("video", "decoded", "THWC", fps=24),
+    "video_latent": ArtifactSpec("video", "latent", "CTHW"),
+}
+items = [
+    ("video_preview", MediaArtifact(specs["video_preview"], decoded_video)),
+    ("video_latent", MediaArtifact(specs["video_latent"], native_video_latent)),
+]
+output = with_media_artifacts(
+    rollout_output_with_training_data,
+    artifacts=items,
+    specs=specs,
+    primary="video_latent",
+    preview="video_preview",
+    context=f"pipeline=MyPipeline/my_algorithm, request_id={request_id}",
+)
+```
+
+`with_media_artifacts` lives in `pipelines/diffusion_rollout_output.py`. Its
+`primary` selects the temporary legacy `responses` projection; `preview` is the
+explicit decoded dump/W&B selection; optional `audio` selects the temporary
+legacy audio projection. All artifacts remain available regardless of primary
+selection. No consumer may replace a missing named preview with latent data.
+
+The existing sampling `extra_args` can carry `requested_outputs` for validation.
+This initial slice checks requested names, but **does not skip decoding or
+transferring unrequested outputs**: the pinned H3 forward always decodes. It does
+not claim a selective-decoding optimization.
+
+## Engine and training transport
+
+The pinned vllm-omni formatter retains only selected payload keys in its public
+multimodal output. The adapter therefore puts the complete named tensor mapping
+under one modality-keyed `payload` entry, with `media_artifacts` declarations and
+selectors in `metadata`. The engine's native formatter is exercised in CPU tests;
+no installed upstream package is patched.
+
+`DiffusionStrategy` validates and restores the mapping, exposes
+`DiffusionOutput.artifacts`, `primary_artifact`, `preview_artifact`, and projects
+only the explicitly selected primary to `diffusion_output`. Algorithm-owned
+`rl`, prompt embeddings and trajectory fields remain separate and unchanged.
+
+At the agent-loop boundary, tensors become ordinary fields named
+`media_artifact__<name>`. Tensor-free spec dictionaries and selectors travel in
+non-tensor metadata. Both ordinary batching and TransferQueue preserve them;
+scorers reconstruct per-sample artifacts from those fields. This avoids hiding
+large tensor payloads inside non-tensor object arrays.
+
+Migrated consumers:
+
+- V0/V1 rollout dumps and validation/W&B select the declared preview, even when
+  `responses` contains floating latents. Named previews bypass rank/channel-count
+  layout inference, carry their FPS to video export, and honor max-sample limits.
+- CLAP selects the decoded `audio` artifact and its rate.
+- ImageBind selects `audio` and `video_preview`, rather than interpreting the
+  primary response as a video. The legacy branch remains for unmigrated adapters.
+- The SD3 latent HTTP client accepts a declared `image_latent` in native `CHW`
+  layout. It rejects other model layouts rather than coercing packed latents into
+  the SD3 protocol. No SD3 producer migration is claimed in this slice.
+
+Schema/representation/layout/selector errors fail synchronously. Filesystem,
+FFmpeg and W&B failures retain the best-effort reporting behavior from PR4.
+
+## MiniMax H3 NFT evidence and limits
+
+The adapter declares four artifacts: `video_preview`, `audio`, `video_latent`,
+and `audio_latent`. Its declarations follow the **pinned source**, not tensor
+channel-size heuristics:
+
+| Artifact | Pinned source at `ded893462` | Per-sample input layout |
+| --- | --- | --- |
+| video preview | `_prepare_minimax_h3_video_output` in `pipeline_minimax_h3.py` emits uint8 NTHWC | THWC |
+| decoded audio | `MiniMaxH3AudioVAE.decode_latent` in `vae.py` returns NCT | CT |
+| video latent | `minimax_h3_patchify_video_latent` in `packed_tokens.py` requires NCTHW | CTHW, unchanged |
+| audio latent | `minimax_h3_pack_audio_latent` in `packed_tokens.py` requires CLT | CLT, unchanged |
+
+Existing packed `latents_clean` and reference/replay tensors are not renamed or
+repacked. CPU tests cover the real H3 postprocessor/formatter, Ref2VA replay
+metadata and both transport paths. **These are not full-weight GPU layout or
+quality verification.**
+
+## Before PR6 is ready
+
+- [ ] Verify H3 NFT T2VA/FL2VA/Ref2VA on GPU with decoded export and latent-primary scoring.
+- [ ] Migrate H3 FlowGRPO, LTX, Wan, Qwen variants, SD3, Boogu and Bagel using their actual postprocessor outputs.
+- [ ] GPU-verify every decoded layout, including request batching and step execution.
+- [ ] Replace the legacy `DiffusionIOSpec.primary/auxiliary` declarations once every producer uses named artifacts.
+- [ ] Remove remaining tuple/shape/representation fallback branches and legacy projections only after their consumers migrate.
+- [ ] Add selective preview decoding/transfer if a model can actually honor requested outputs.
+- [ ] Stress-test video dump queue memory/backpressure; CPU unit tests do not establish that property.
+
+The live implementation and tests, not this checklist, are the source of truth
+for what is complete. See `test_rollout_artifacts_on_cpu.py`,
+`test_media_artifact_transport_on_cpu.py` and `test_artifact_preview_dump_on_cpu.py`.

--- a/docs/contributing/diffusion_media_artifacts.md
+++ b/docs/contributing/diffusion_media_artifacts.md
@@ -1,6 +1,6 @@
 # Named diffusion media artifacts
 
-Last updated: 09/08/2026.
+Last updated: 09/10/2026.
 
 All registered in-tree diffusion adapters emit named media. The strategy,
 agent loops, rewards and V0/V1 exporters consume declarations rather than
@@ -72,7 +72,7 @@ an adapter declaration is available. Packed request batches take the union of
 all requests' requirements, not just those of the first request.
 
 Requested names express **required availability**, not an exclusive output set.
-Qwen/SD3/Boogu/Wan can avoid preview decoding when it is not requested and the
+Qwen/SD3/FLUX/Boogu/Wan can avoid preview decoding when it is not requested and the
 primary is latent. LTX decodes its joint pair when either decoded stream is
 required. Pinned H3 and Bagel forwards still decode; no selective-decoding
 optimization is claimed for those models.
@@ -180,6 +180,7 @@ The adapters and pinned VAE/postprocessor code establish these distinct layouts:
 | --- | --- | --- | --- |
 | Qwen image / edit / DPO / NFT / dual / mix | packed `LC` | `NCTHW`, image T=1 | `NCHW` after selecting the image frame |
 | SD3, Boogu | `CHW` | `NCHW` | `NCHW` |
+| FLUX DanceGRPO | packed `LC` | `NCHW` after unpacking | `NCHW` |
 | Bagel | packed `LC` | `NCHW` after unpatchifying | RGB PIL image |
 | Wan | `CTHW` | `NCTHW` | `NCTHW` |
 | LTX | video `CTHW`, audio `CTF` | `NCTHW` / `NCTF` | `NTCHW` from `VideoProcessor(..., output_type="pt")` |
@@ -188,6 +189,11 @@ The adapters and pinned VAE/postprocessor code establish these distinct layouts:
 H3 and LTX decoded audio is `NCT` at their decoder boundary. H3 uses 32000 Hz;
 LTX reads the vocoder's actual `output_sampling_rate` (BWE checkpoints can be
 48000 Hz, not the old 24000 Hz default).
+
+FLUX DanceGRPO was aligned when rebasing onto the newer main branch. Its pinned
+packing/unpacking, named outputs, per-request splitting and optional preview
+union are CPU-tested with mocked encoders/denoising/VAE. Real FLUX VAE and GPU
+rollout validation remain pending; the earlier GPU matrix does not cover it.
 
 Reproducible GPU checks live under `tests/special_e2e/`:
 

--- a/docs/contributing/integrating_a_diffusion_model.md
+++ b/docs/contributing/integrating_a_diffusion_model.md
@@ -1,6 +1,6 @@
 # How to Integrate a New Diffusion Model for FlowGRPO Training
 
-Last updated: 09/07/2026.
+Last updated: 09/08/2026.
 
 This guide walks you through everything required to integrate a new diffusion
 model into VeRL-Omni so it can be trained end-to-end with the **FlowGRPO**
@@ -457,18 +457,19 @@ outputs, batching, transport and fail-fast validation.
 
 Set `diffusion_io_spec` to the named outputs your adapter can produce. The
 strategy resolves it by `(architecture, algorithm)` and checks returned names,
-modality, representation and layout against it. The positional `primary` /
-`auxiliary` declaration and `MediaSpec` API have been replaced:
+modality, representation and layout against it. `DiffusionIOSpec` and `MediaSpec`
+retain their names and import location. The positional `primary` / `auxiliary`
+declaration is replaced by named artifacts, with `representation` and `layout`
+added to `MediaSpec`:
 
 ```python
-from verl_omni.pipelines.rollout_media import DiffusionIOSpec
-from verl_omni.pipelines.rollout_artifacts import ArtifactSpec
+from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
 
 @VllmOmniPipelineBase.register("MyModelPipeline", algorithm="flow_grpo")
 class MyModelPipelineWithLogProb(MyModelPipeline):
     diffusion_io_spec = DiffusionIOSpec(artifacts={
-        "image_preview": ArtifactSpec("image", "decoded", "CHW"),
-        "image_latent": ArtifactSpec("image", "latent", "LC"),
+        "image_preview": MediaSpec("image", "decoded", "CHW"),
+        "image_latent": MediaSpec("image", "latent", "LC"),
     })
 ```
 

--- a/docs/contributing/integrating_a_diffusion_model.md
+++ b/docs/contributing/integrating_a_diffusion_model.md
@@ -442,9 +442,10 @@ by 255 again before PIL, JPEG, or HTTP serialization.
 Set a `diffusion_io_spec` class attribute on the registered pipeline so the
 shared `DiffusionStrategy` knows what media your `forward` emits. The strategy
 reads it (via `VllmOmniPipelineBase.get_class(architecture, algorithm)`) when it
-converts the raw pipeline output into the rollout response, so model-specific
-conventions — which tuple position carries audio, what audio sample rate to
-attach — live in the adapter instead of being hardcoded in the shared strategy.
+converts the raw pipeline output into the rollout response. The primary modality
+and default audio sample rate come from the adapter.
+The current transport supports a single primary output or a `(visual, audio)`
+tuple; it does not support arbitrary auxiliary streams.
 
 ```python
 from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
@@ -457,9 +458,10 @@ class MyModelPipelineWithLogProb(MyModelPipeline):
 
 - **`primary`** — the main media stream (`MediaSpec("image")` or
   `MediaSpec("video")`), carried in `responses`.
-- **`auxiliary`** — additional streams in tuple order: `auxiliary[i]` maps to
-  output tuple position `i + 1` (position `0` is the primary). A `forward` that
-  returns `(video, audio)` declares one auxiliary audio stream:
+- **`auxiliary`** — either empty or one audio stream at tuple position `1`
+  (position `0` is the primary visual output). Other auxiliary declarations and
+  extra tuple elements are rejected, not silently discarded. A `forward` that
+  returns `(video, audio)` declares:
 
 ```python
     diffusion_io_spec = DiffusionIOSpec(
@@ -472,8 +474,10 @@ class MyModelPipelineWithLogProb(MyModelPipeline):
   `forward` attaches a runtime rate through the `rl` rollout metadata, that value
   takes precedence and the strategy only falls back to this default. Declare the
   rate your model actually decodes (MiniMax H3 → `32000`, LTX-2 → `24000`).
-- `MediaSpec.fps` is an optional video default; `Modality` is
-  `image | video | audio`.
+- `MediaSpec.fps` is an optional declaration; current exporters still use
+  `trainer.video_fps`, not this field. `Modality` is `image | video | audio`.
+- The strategy propagates the primary modality as `media_kind`. Runtime metadata
+  may repeat the same value, but a conflicting modality raises an error.
 - Subclasses inherit the attribute, so a pipeline that subclasses another adapter
   (e.g. `qwen_image_dual_grpo` extends `qwen_image_flow_grpo`) reuses its
   `diffusion_io_spec` unless it overrides it.

--- a/docs/contributing/integrating_a_diffusion_model.md
+++ b/docs/contributing/integrating_a_diffusion_model.md
@@ -104,8 +104,9 @@ expects pre-tokenised input on every request.
 
 ### Single text encoder (Qwen-Image and similar)
 
-One tokenizer, one text encoder. The agent loop sends `prompt_token_ids`; your
-rollout adapter overrides `encode_prompt` to accept `prompt_ids=` (and an
+One tokenizer, one text encoder. The agent loop sends `prompt_ids` to the server;
+the diffusion prompt keeps that canonical spelling. Your rollout adapter overrides
+`encode_prompt` to accept `prompt_ids=` (and an
 optional attention mask) and runs the text encoder directly — see
 [`qwen_image_flow_grpo/common.py`](../../verl_omni/pipelines/qwen_image_flow_grpo/common.py).
 
@@ -137,12 +138,21 @@ t5:   {path: tokenizer_3, max_length: 256}   # feeds T5; align max_length with p
 **Rollout transport**
 
 [`vLLMOmniHttpServer`](../../verl_omni/workers/rollout/vllm_rollout/vllm_omni_async_server.py)
-forwards `extra_prompt_ids` / `negative_extra_prompt_ids` on the diffusion
-custom prompt dict alongside `prompt_token_ids`.
+places `extra_prompt_ids` / `negative_extra_prompt_ids` inside the diffusion
+prompt's `extra_args`, alongside the top-level canonical `prompt_ids`. Media and
+`mm_processor_kwargs` stay at the top level: the pinned MiniMax/Bagel runtime reads
+them there, even though upstream's `OmniCustomPrompt` TypedDict omits those fields.
+The server never duplicates media into `extra_args`.
+
+Multistage rollout whose first stage is AR still needs vLLM's `prompt_token_ids`
+at that entrance. `prompt_ids_from_payload` is the sole shared adapter bridge for
+that spelling and rejects conflicting IDs. The public Ray keyword API and AR
+strategy are unchanged. Historical condition-image aliases are accepted only by
+the conflict-checking compatibility parser, not emitted on the new wire path.
 
 **Rollout adapter behaviour**
 
-Read `req.prompts[0]["extra_prompt_ids"]`, pad each id list to the encoder's
+Read `req.prompts[0]["extra_args"]["extra_prompt_ids"]`, pad each id list to the encoder's
 fixed length using **that tokenizer's** `pad_token_id` (SD3 CLIP-L and CLIP-G
 use different pad tokens even though they share a vocab), run the text
 encoders on `input_ids`, and concatenate embeddings exactly as the upstream
@@ -659,7 +669,7 @@ third model demands the same code, then unify.
 Before opening the PR, confirm every box:
 
 - [ ] Prompt tokenisation follows [Prompt Tokenisation](#prompt-tokenisation-agent-loop--rollout):
-      single-encoder models use `prompt_token_ids` only; multi-encoder models
+      single-encoder diffusion prompts use `prompt_ids`; multi-encoder models
       configure `extra_tokenizers` and a token-id-native rollout encoder
       (no decode-and-re-encode in the pipeline).
 - [ ] `verl_omni/pipelines/<model>_flow_grpo/` contains `__init__.py`,

--- a/docs/contributing/integrating_a_diffusion_model.md
+++ b/docs/contributing/integrating_a_diffusion_model.md
@@ -496,6 +496,11 @@ Every registered diffusion adapter declares one; see
 [`rollout_media.py`](../../verl_omni/pipelines/rollout_media.py) and the
 `test_diffusion_io_spec_on_cpu.py` completeness test.
 
+The in-progress named-artifact migration is documented in
+[Named diffusion media artifacts](diffusion_media_artifacts.md). MiniMax H3 NFT
+uses that contract; other adapters still use the legacy declaration above. Do not
+infer an unverified VAE layout to opt an adapter into the new path.
+
 (request-level-batching)=
 ### 4.3 Request-level batching (optional)
 

--- a/docs/contributing/integrating_a_diffusion_model.md
+++ b/docs/contributing/integrating_a_diffusion_model.md
@@ -1,6 +1,6 @@
 # How to Integrate a New Diffusion Model for FlowGRPO Training
 
-Last updated: 08/21/2026.
+Last updated: 09/07/2026.
 
 This guide walks you through everything required to integrate a new diffusion
 model into VeRL-Omni so it can be trained end-to-end with the **FlowGRPO**
@@ -401,7 +401,7 @@ class MyModelPipelineWithLogProb(MyModelPipeline):
     ...
 ```
 
-Your subclass must do four things:
+Your subclass must do five things:
 
 1. **Replace the upstream scheduler** (typically Euler-based) with
    `FlowMatchSDEDiscreteScheduler`.
@@ -420,86 +420,76 @@ Your subclass must do four things:
 4. **Override `forward(req, ...)`** so that:
    - Sampling parameters come from `req.sampling_params` (use
      `extra_args` for SDE-specific knobs).
-   - Trajectory and metadata fields are returned via `rollout_output(...)`
-     from [`verl_omni.pipelines.diffusion_rollout_output`](../../verl_omni/pipelines/diffusion_rollout_output.py).
+   - Build trajectory and algorithm metadata with `rollout_output(...)` or
+     `with_rollout_data(...)` from
+     [`diffusion_rollout_output`](../../verl_omni/pipelines/diffusion_rollout_output.py).
    - `prompt_embeds`, `prompt_embeds_mask`, `negative_prompt_embeds`,
      and `negative_prompt_embeds_mask` are placed in `prompt_embeddings`. The diffusion agent loop
      ([`diffusion_agent_loop.py`](../../verl_omni/agent_loop/diffusion_agent_loop.py))
      reads these field names verbatim — **do not rename them**.
+5. **Attach named media artifacts** with `with_visual_artifacts`,
+   `with_batched_media_artifacts` or `with_media_artifacts`, including both
+   `forward` and `post_decode` when step execution is supported. Preserve the
+   named envelope through the engine postprocessor; do not return a bare legacy
+   tensor/tuple from the rollout boundary.
 
 ### 4.1 Rollout response contract
 
-The rollout server normalizes the representation transported in `responses`:
+The adapter declares representation, layout and media kind, then normalizes
+**decoded** outputs once. `responses` is a compatibility projection of the
+explicitly selected primary artifact, not an unlabelled media tensor:
 
-- Pixel-valued outputs are quantized once to `torch.uint8` in `[0, 255]`.
-  Images reach a single-sample reward scorer as `(C, H, W)` and videos as
-  `(T, C, H, W)`.
-- `output_type=latent` keeps `responses` in floating point. With
-  `output_type=both`, the pixel response is uint8 and the clean latent remains a
-  separate floating-point field in `extra_info`.
-- Generated audio is transported separately and is not quantized to uint8.
+- Decoded image/video is `torch.uint8` `[0,255]` in `CHW` / `TCHW` per sample.
+- Native/packed latents retain their layout and floating dtype. They coexist
+  with decoded previews rather than standing in for missing preview data.
+- Decoded audio is floating `CT`, with an explicit sample rate; it is never
+  quantized as pixels. Video artifacts carry their own FPS.
 
-Reward managers validate `responses` against the active training or validation
-`output_type` and then forward it without dtype conversion. A pixel scorer that
-needs normalized model input must convert locally with
-`solution_image.float() / 255.0`; this normalizes the quantized pixels but cannot
-restore precision discarded at the rollout boundary. Do not multiply uint8 pixels
-by 255 again before PIL, JPEG, or HTTP serialization.
+Both reward managers reconstruct named artifacts and validate the primary
+projection. Pixel scorers select the decoded preview; latent scoring selects
+`image_latent`. A scorer needing normalized pixels converts locally with
+`.float() / 255.0`, not a second multiplication by 255. See the full
+[named-artifact contract](diffusion_media_artifacts.md) for selectors, requested
+outputs, batching, transport and fail-fast validation.
 
 (diffusion-io-spec)=
 ### 4.2 Declare the media output contract (`diffusion_io_spec`)
 
-Set a `diffusion_io_spec` class attribute on the registered pipeline so the
-shared `DiffusionStrategy` knows what media your `forward` emits. The strategy
-reads it (via `VllmOmniPipelineBase.get_class(architecture, algorithm)`) when it
-converts the raw pipeline output into the rollout response. The primary modality
-and default audio sample rate come from the adapter.
-The current transport supports a single primary output or a `(visual, audio)`
-tuple; it does not support arbitrary auxiliary streams.
+Set `diffusion_io_spec` to the named outputs your adapter can produce. The
+strategy resolves it by `(architecture, algorithm)` and checks returned names,
+modality, representation and layout against it. The positional `primary` /
+`auxiliary` declaration and `MediaSpec` API have been replaced:
 
 ```python
-from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
+from verl_omni.pipelines.rollout_media import DiffusionIOSpec
+from verl_omni.pipelines.rollout_artifacts import ArtifactSpec
 
 @VllmOmniPipelineBase.register("MyModelPipeline", algorithm="flow_grpo")
 class MyModelPipelineWithLogProb(MyModelPipeline):
-    # Image-only pipeline:
-    diffusion_io_spec = DiffusionIOSpec(primary=MediaSpec("image"))
+    diffusion_io_spec = DiffusionIOSpec(artifacts={
+        "image_preview": ArtifactSpec("image", "decoded", "CHW"),
+        "image_latent": ArtifactSpec("image", "latent", "LC"),
+    })
 ```
 
-- **`primary`** — the main media stream (`MediaSpec("image")` or
-  `MediaSpec("video")`), carried in `responses`.
-- **`auxiliary`** — either empty or one audio stream at tuple position `1`
-  (position `0` is the primary visual output). Other auxiliary declarations and
-  extra tuple elements are rejected, not silently discarded. A `forward` that
-  returns `(video, audio)` declares:
+- Declare **canonical decoded axes** and the model's **native final latent
+  axes**, not guessed channel-size conventions. Verify actual VAE outputs
+  separately from the sampler's packed training representation.
+- Runtime selectors identify primary, optional decoded preview and optional
+  decoded audio by name. `preview=None` skips export; a missing non-null selector
+  fails rather than falling back to latents.
+- Runtime video FPS and audio sample rate are required. A fixed sample rate can
+  be constrained in the declaration; otherwise read the real decoder/vocoder
+  configuration. LTX BWE can produce 48000 Hz audio, not 24000 Hz.
+- `pipeline.requested_outputs` requires extra named artifacts, e.g.
+  `[image_preview]` with `output_type=latent`. It is also available in the model
+  and validation configs. See [named artifacts](diffusion_media_artifacts.md)
+  for decoding behavior and batch-union semantics.
+- Subclasses inherit the declaration when they use the same output contract.
 
-```python
-    diffusion_io_spec = DiffusionIOSpec(
-        primary=MediaSpec("video"),
-        auxiliary=(MediaSpec("audio", sample_rate=32000),),
-    )
-```
-
-- **`MediaSpec.sample_rate`** is the *default* audio sample rate in Hz. If your
-  `forward` attaches a runtime rate through the `rl` rollout metadata, that value
-  takes precedence and the strategy only falls back to this default. Declare the
-  rate your model actually decodes (MiniMax H3 → `32000`, LTX-2 → `24000`).
-- `MediaSpec.fps` is an optional declaration; current exporters still use
-  `trainer.video_fps`, not this field. `Modality` is `image | video | audio`.
-- The strategy propagates the primary modality as `media_kind`. Runtime metadata
-  may repeat the same value, but a conflicting modality raises an error.
-- Subclasses inherit the attribute, so a pipeline that subclasses another adapter
-  (e.g. `qwen_image_dual_grpo` extends `qwen_image_flow_grpo`) reuses its
-  `diffusion_io_spec` unless it overrides it.
-
-Every registered diffusion adapter declares one; see
+Every registered diffusion adapter declares named artifacts; see
 [`rollout_media.py`](../../verl_omni/pipelines/rollout_media.py) and the
 `test_diffusion_io_spec_on_cpu.py` completeness test.
-
-The in-progress named-artifact migration is documented in
-[Named diffusion media artifacts](diffusion_media_artifacts.md). MiniMax H3 NFT
-uses that contract; other adapters still use the legacy declaration above. Do not
-infer an unverified VAE layout to opt an adapter into the new path.
 
 (request-level-batching)=
 ### 4.3 Request-level batching (optional)
@@ -685,10 +675,10 @@ Before opening the PR, confirm every box:
       `model_index.json::_class_name`; the `algorithm=` keyword matches
       the algorithm you are integrating against (e.g. `"flow_grpo"` for
       FlowGRPO).
-- [ ] The registered pipeline declares a `diffusion_io_spec`
-      ([`DiffusionIOSpec`](../../verl_omni/pipelines/rollout_media.py)) whose
-      `primary` modality matches what `forward` emits, plus an `auxiliary`
-      audio stream (with its `sample_rate`) for joint audio/video models.
+- [ ] The registered pipeline declares `diffusion_io_spec.artifacts`, verifies
+      real VAE/packed latent layouts, and emits named outputs from every supported
+      execution mode. Runtime FPS/sample rate and primary/preview/audio selectors
+      must be explicit; missing requested media must fail, never fall back.
 - [ ] Scheduler returns latents in fp32 (no `model_output.dtype` cast in `step()`),
       `diffuse()` casts to model dtype before transformer forward and casts
       noise_pred to float32 before `scheduler.step()`

--- a/docs/contributing/integrating_an_i2i_diffusion_model.md
+++ b/docs/contributing/integrating_an_i2i_diffusion_model.md
@@ -324,6 +324,12 @@ Multiple aliases must contain equivalent images; conflicting values raise
 instead of silently selecting one. With no images, the parser returns `[]`.
 Validate the supported number of images and aspect ratios before encoding.
 
+Distinct preprocessing views are not aliases. In the token-native
+Qwen-Image-Edit adapter, read raw `multi_modal_data.image` directly to match the
+processor grid used to expand the prompt tokens; the engine's resized
+`additional_information.condition_images` must not be substituted or compared
+as an equivalent alias. VAE condition tensors and sizes remain separate fields.
+
 ### 4.2 Encode prompts with image features when required
 
 For a VLM-based model such as Qwen-Image-Edit, the prompt contains image

--- a/tests/agent_loop/test_diffusion_agent_loop_correctness_on_cpu.py
+++ b/tests/agent_loop/test_diffusion_agent_loop_correctness_on_cpu.py
@@ -212,6 +212,9 @@ async def test_tq_writer_preserves_allowlisted_non_tensor_trajectory_metadata(mo
         num_turns=2,
         extra_fields={
             "condition_image_latents": torch.zeros(1, 4096, 64),
+            "audio": torch.zeros(1, 1, 16),
+            "audio_sample_rate": 32_000,
+            "media_kind": "video",
             "img_shapes": img_shapes,
             "unrelated_metadata": "do-not-forward",
         },
@@ -233,9 +236,16 @@ async def test_tq_writer_preserves_allowlisted_non_tensor_trajectory_metadata(mo
     )
 
     field = captured["fields"][0]
-    assert field["extra_fields"]["img_shapes"] == img_shapes
+    assert field["extra_fields"] == {
+        "img_shapes": img_shapes,
+        "media_kind": "video",
+        "audio_sample_rate": 32_000,
+        "min_global_steps": 3,
+        "max_global_steps": 3,
+    }
     assert "unrelated_metadata" not in field["extra_fields"]
     assert field["condition_image_latents"].shape == (4096, 64)
+    assert field["audio"].shape == (1, 16)
 
 
 def test_tq_batch_restores_non_tensor_trajectory_metadata(monkeypatch):
@@ -249,7 +259,10 @@ def test_tq_batch_restores_non_tensor_trajectory_metadata(monkeypatch):
         "kv_batch_get",
         lambda **kwargs: {
             "all_latents": torch.zeros(2, 4, 1024, 64),
-            "extra_fields": [{"img_shapes": value} for value in img_shapes],
+            "extra_fields": [
+                {"img_shapes": img_shapes[0], "media_kind": "video", "audio_sample_rate": 32_000},
+                {"img_shapes": img_shapes[1]},
+            ],
         },
     )
 
@@ -258,6 +271,8 @@ def test_tq_batch_restores_non_tensor_trajectory_metadata(monkeypatch):
     )
 
     assert data.non_tensor_batch["img_shapes"].tolist() == img_shapes
+    assert data.non_tensor_batch["media_kind"].tolist() == ["video", None]
+    assert data.non_tensor_batch["audio_sample_rate"].tolist() == [32_000, None]
     assert tu.get(data.to_tensordict(), "img_shapes") == img_shapes
 
 

--- a/tests/agent_loop/test_diffusion_agent_loop_correctness_on_cpu.py
+++ b/tests/agent_loop/test_diffusion_agent_loop_correctness_on_cpu.py
@@ -110,6 +110,7 @@ async def test_single_turn_agent_forwards_all_multimodal_inputs():
     agent_loop.server_manager = SimpleNamespace(
         generate=AsyncMock(
             return_value=SimpleNamespace(
+                artifacts={},
                 diffusion_output=torch.zeros(1),
                 log_probs=None,
                 num_preempted=None,

--- a/tests/agent_loop/test_media_artifact_transport_on_cpu.py
+++ b/tests/agent_loop/test_media_artifact_transport_on_cpu.py
@@ -1,0 +1,90 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Named tensors and declarations survive both diffusion batching transports."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from verl_omni.agent_loop.diffusion_agent_loop import DiffusionAgentLoopWorker
+from verl_omni.agent_loop.diffusion_agent_loop_tq import DiffusionAgentLoopWorkerTQ
+from verl_omni.pipelines.rollout_artifacts import ArtifactSpec, MediaArtifact, artifact_fields, previews_from_batch
+from verl_omni.reward_loop.reward_manager.visual import _reward_extra_info
+from verl_omni.trainer.diffusion.v1 import tq_utils
+from verl_omni.utils.reward_score.clap import _get_audio
+from verl_omni.utils.reward_score.imagebind import _to_tchw
+
+
+def _internal():
+    artifacts = {
+        "video_preview": MediaArtifact(
+            ArtifactSpec("video", "decoded", "TCHW", fps=12), torch.zeros(3, 3, 2, 2, dtype=torch.uint8)
+        ),
+        "video_latent": MediaArtifact(
+            ArtifactSpec("video", "latent", "CTHW"), torch.ones(16, 2, 2, 2, dtype=torch.float16)
+        ),
+        "audio": MediaArtifact(ArtifactSpec("audio", "decoded", "CT", sample_rate=24000), torch.ones(2, 16)),
+    }
+    fields = artifact_fields(artifacts, "video_latent", "video_preview")
+    padded = {key: value.unsqueeze(0) if isinstance(value, torch.Tensor) else value for key, value in fields.items()}
+    return SimpleNamespace(
+        prompt_ids=torch.tensor([[1, 2]]),
+        response_diffusion_output=artifacts["video_latent"].data.unsqueeze(0),
+        response_logprobs=None,
+        reward_score=1.0,
+        num_turns=1,
+        metrics=SimpleNamespace(model_dump=lambda: {}),
+        extra_fields=padded,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("transport", ["ordinary", "tq"])
+async def test_named_media_survives_to_preview_and_reward_consumers(monkeypatch, transport):
+    if transport == "ordinary":
+        worker = object.__new__(DiffusionAgentLoopWorker)
+        data = worker._postprocess([_internal()])
+    else:
+        worker = object.__new__(DiffusionAgentLoopWorkerTQ.__ray_metadata__.modified_class)
+        stored = {}
+
+        async def put(*, keys, fields, **kwargs):
+            stored.update(fields=fields)
+
+        monkeypatch.setattr(tq_utils.tq, "async_kv_batch_put", put)
+        await worker._write_trajectory_to_tq(
+            _internal(), uid="sample", session_id=0, trajectory={"step": 1}, validate=False
+        )
+        monkeypatch.setattr(tq_utils.tq, "kv_batch_get", lambda **kwargs: stored["fields"])
+        data = tq_utils.diffusion_tq_batch_to_dataproto(SimpleNamespace(keys=["sample_0_0"], partition_id="train"))
+
+    assert data.batch["media_artifact__video_latent"].dtype == torch.float16
+    assert data.batch["media_artifact__video_latent"].shape == (1, 16, 2, 2, 2)
+    previews = previews_from_batch(data)
+    assert len(previews) == 1 and previews[0].data.dtype == torch.uint8
+    assert previews[0].spec.fps == 12
+    extra = _reward_extra_info(data[0])
+    assert set(extra["media_artifacts"]) == {"video_preview", "video_latent", "audio"}
+    audio, sample_rate = _get_audio(extra)
+    assert sample_rate == 24000 and audio.shape == (16,)
+    assert _to_tchw(extra["media_artifacts"]["video_preview"]).shape == (3, 3, 2, 2)
+    assert data.batch["responses"].dtype == torch.float16  # preview selection never rewrites training responses
+
+
+def test_named_scorers_reject_missing_stream_instead_of_legacy_fallback():
+    with pytest.raises(ValueError, match="absent"):
+        _get_audio({"media_artifacts": {}, "audio": torch.ones(16), "audio_sample_rate": 32000})
+    with pytest.raises(ValueError, match="decoded video"):
+        _to_tchw(MediaArtifact(ArtifactSpec("video", "latent", "CTHW"), torch.zeros(16, 3, 2, 2)))

--- a/tests/agent_loop/test_media_artifact_transport_on_cpu.py
+++ b/tests/agent_loop/test_media_artifact_transport_on_cpu.py
@@ -20,7 +20,8 @@ import torch
 
 from verl_omni.agent_loop.diffusion_agent_loop import DiffusionAgentLoopWorker
 from verl_omni.agent_loop.diffusion_agent_loop_tq import DiffusionAgentLoopWorkerTQ
-from verl_omni.pipelines.rollout_artifacts import ArtifactSpec, MediaArtifact, artifact_fields, previews_from_batch
+from verl_omni.pipelines.rollout_artifacts import MediaArtifact, artifact_fields, previews_from_batch
+from verl_omni.pipelines.rollout_media import MediaSpec
 from verl_omni.reward_loop.reward_manager.visual import _reward_extra_info
 from verl_omni.trainer.diffusion.v1 import tq_utils
 from verl_omni.utils.reward_score.clap import _get_audio
@@ -30,12 +31,12 @@ from verl_omni.utils.reward_score.imagebind import _to_tchw
 def _internal():
     artifacts = {
         "video_preview": MediaArtifact(
-            ArtifactSpec("video", "decoded", "TCHW", fps=12), torch.zeros(3, 3, 2, 2, dtype=torch.uint8)
+            MediaSpec("video", "decoded", "TCHW", fps=12), torch.zeros(3, 3, 2, 2, dtype=torch.uint8)
         ),
         "video_latent": MediaArtifact(
-            ArtifactSpec("video", "latent", "CTHW"), torch.ones(16, 2, 2, 2, dtype=torch.float16)
+            MediaSpec("video", "latent", "CTHW"), torch.ones(16, 2, 2, 2, dtype=torch.float16)
         ),
-        "audio": MediaArtifact(ArtifactSpec("audio", "decoded", "CT", sample_rate=24000), torch.ones(2, 16)),
+        "audio": MediaArtifact(MediaSpec("audio", "decoded", "CT", sample_rate=24000), torch.ones(2, 16)),
     }
     fields = artifact_fields(artifacts, "video_latent", "video_preview")
     padded = {key: value.unsqueeze(0) if isinstance(value, torch.Tensor) else value for key, value in fields.items()}
@@ -87,4 +88,4 @@ def test_named_scorers_reject_missing_stream_instead_of_legacy_fallback():
     with pytest.raises(ValueError, match="absent"):
         _get_audio({"media_artifacts": {}, "audio": torch.ones(16), "audio_sample_rate": 32000})
     with pytest.raises(ValueError, match="decoded video"):
-        _to_tchw(MediaArtifact(ArtifactSpec("video", "latent", "CTHW"), torch.zeros(16, 3, 2, 2)))
+        _to_tchw(MediaArtifact(MediaSpec("video", "latent", "CTHW"), torch.zeros(16, 3, 2, 2)))

--- a/tests/pipelines/test_diffusion_io_spec_on_cpu.py
+++ b/tests/pipelines/test_diffusion_io_spec_on_cpu.py
@@ -22,6 +22,7 @@ import pytest
 
 pytest.importorskip("verl_omni.pipelines.model_base")
 from verl_omni.pipelines.model_base import VllmOmniPipelineBase
+from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
 
 # (adapter module, architecture, algorithm, primary modality)
 _PRIMARY_MODALITY = [
@@ -72,6 +73,19 @@ _JOINT_AUDIO_SAMPLE_RATE = [
     ),
     ("verl_omni.pipelines.ltx2_flow_grpo.vllm_omni_rollout_adapter", "LTX2Pipeline", "flow_grpo", 24000),
 ]
+
+
+@pytest.mark.parametrize(
+    "auxiliary",
+    [
+        (MediaSpec("image"),),
+        (MediaSpec("image"), MediaSpec("audio", sample_rate=48000)),
+        (MediaSpec("audio"), MediaSpec("audio")),
+    ],
+)
+def test_unsupported_auxiliary_declarations_are_rejected(auxiliary):
+    with pytest.raises(ValueError, match="at most one auxiliary audio stream"):
+        DiffusionIOSpec(primary=MediaSpec("video"), auxiliary=auxiliary)
 
 
 @pytest.mark.parametrize(("module", "architecture", "algorithm", "modality"), _PRIMARY_MODALITY)

--- a/tests/pipelines/test_diffusion_io_spec_on_cpu.py
+++ b/tests/pipelines/test_diffusion_io_spec_on_cpu.py
@@ -18,6 +18,8 @@ the produced modality from the adapter-declared ``DiffusionIOSpec`` instead of
 inferring it from tensor rank, so a missing declaration is a bug.
 """
 
+from dataclasses import asdict
+
 import pytest
 
 pytest.importorskip("verl_omni.pipelines.model_base")
@@ -73,6 +75,22 @@ _JOINT_AUDIO_SAMPLE_RATE = [
     ),
     ("verl_omni.pipelines.ltx2_flow_grpo.vllm_omni_rollout_adapter", "LTX2Pipeline", "flow_grpo", 24000),
 ]
+
+
+def test_media_spec_keeps_public_import_and_serialized_fields():
+    from verl_omni.pipelines.rollout_media import MediaSpec
+
+    fields = {
+        "modality": "video",
+        "representation": "decoded",
+        "layout": "TCHW",
+        "sample_rate": None,
+        "fps": 29.97,
+    }
+    spec = MediaSpec(**fields)
+    assert asdict(spec) == fields
+    assert MediaSpec(**asdict(spec)) == spec
+    assert DiffusionIOSpec(artifacts={"video_preview": spec}).artifacts["video_preview"] is spec
 
 
 @pytest.mark.parametrize("artifacts", [{}, (), {"image_preview": object()}])

--- a/tests/pipelines/test_diffusion_io_spec_on_cpu.py
+++ b/tests/pipelines/test_diffusion_io_spec_on_cpu.py
@@ -22,7 +22,7 @@ import pytest
 
 pytest.importorskip("verl_omni.pipelines.model_base")
 from verl_omni.pipelines.model_base import VllmOmniPipelineBase
-from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
+from verl_omni.pipelines.rollout_media import DiffusionIOSpec
 
 # (adapter module, architecture, algorithm, primary modality)
 _PRIMARY_MODALITY = [
@@ -75,17 +75,10 @@ _JOINT_AUDIO_SAMPLE_RATE = [
 ]
 
 
-@pytest.mark.parametrize(
-    "auxiliary",
-    [
-        (MediaSpec("image"),),
-        (MediaSpec("image"), MediaSpec("audio", sample_rate=48000)),
-        (MediaSpec("audio"), MediaSpec("audio")),
-    ],
-)
-def test_unsupported_auxiliary_declarations_are_rejected(auxiliary):
-    with pytest.raises(ValueError, match="at most one auxiliary audio stream"):
-        DiffusionIOSpec(primary=MediaSpec("video"), auxiliary=auxiliary)
+@pytest.mark.parametrize("artifacts", [{}, (), {"image_preview": object()}])
+def test_invalid_named_declarations_are_rejected(artifacts):
+    with pytest.raises((TypeError, ValueError), match="DiffusionIOSpec requires"):
+        DiffusionIOSpec(artifacts=artifacts)
 
 
 @pytest.mark.parametrize(("module", "architecture", "algorithm", "modality"), _PRIMARY_MODALITY)
@@ -95,7 +88,10 @@ def test_registered_pipeline_declares_primary_modality(module, architecture, alg
     assert cls is not None, f"{architecture}/{algorithm} is not registered"
     spec = getattr(cls, "diffusion_io_spec", None)
     assert spec is not None, f"{architecture}/{algorithm} must declare diffusion_io_spec"
-    assert spec.primary.modality == modality
+    assert isinstance(spec, DiffusionIOSpec)
+    assert spec.artifacts[f"{modality}_preview"].modality == modality
+    assert spec.artifacts[f"{modality}_preview"].representation == "decoded"
+    assert spec.artifacts[f"{modality}_latent"].representation == "latent"
 
 
 @pytest.mark.parametrize(("module", "architecture", "algorithm", "sample_rate"), _JOINT_AUDIO_SAMPLE_RATE)
@@ -104,6 +100,7 @@ def test_joint_pipeline_declares_audio_stream(module, architecture, algorithm, s
     cls = VllmOmniPipelineBase.get_class(architecture, algorithm)
     spec = getattr(cls, "diffusion_io_spec", None)
     assert spec is not None
-    audio = next((stream for stream in spec.auxiliary if stream.modality == "audio"), None)
-    assert audio is not None, f"{architecture}/{algorithm} must declare an auxiliary audio stream"
-    assert audio.sample_rate == sample_rate
+    audio = spec.artifacts["audio"]
+    assert audio.modality == "audio" and audio.representation == "decoded"
+    assert audio.layout == "CT"
+    assert audio.sample_rate == (None if architecture.startswith("LTX") else sample_rate)

--- a/tests/pipelines/test_diffusion_model_base_on_cpu.py
+++ b/tests/pipelines/test_diffusion_model_base_on_cpu.py
@@ -131,7 +131,17 @@ class TestVllmOmniPipelineBaseRegistry:
         postprocess = vllm_omni_rollout_adapter.get_latent_post_process_func(od_config=None)
         latent = torch.zeros(1, 16, 2, 2)
         image = torch.zeros(1, 3, 2, 2)
-        assert postprocess(latent) is latent
+        from verl_omni.pipelines.diffusion_rollout_output import rollout_output, with_visual_artifacts
+
+        named = with_visual_artifacts(
+            rollout_output(media=latent),
+            decoded=None,
+            latents=latent,
+            latent_layout="CHW",
+            output_type="latent",
+            context="SD3 test",
+        ).output
+        assert postprocess(named) is named
         assert postprocess(image) == "decoded"
         assert len(image_outputs) == 1
         assert image_outputs[0] is image

--- a/tests/pipelines/test_diffusion_wire_prompt_on_cpu.py
+++ b/tests/pipelines/test_diffusion_wire_prompt_on_cpu.py
@@ -1,0 +1,133 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Exercise canonical wire prompts at real adapter extraction boundaries."""
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+from verl_omni.pipelines.model_base import VllmOmniPipelineBase
+from verl_omni.pipelines.rollout_request import OmniRolloutRequest, prompt_ids_from_payload
+
+
+def _prompt():
+    return OmniRolloutRequest.from_generate_kwargs(
+        prompt_ids=[1, 2],
+        negative_prompt_ids=[3],
+        prompt_mask=[1, 1],
+        image_data=["image"],
+        audio_data=["audio"],
+        mm_processor_kwargs={"video_fps": 24, "audio_sample_rate": 32000},
+    ).to_diffusion_prompt()
+
+
+def test_wire_has_one_media_location_and_preserves_empty_processor_kwargs():
+    prompt = _prompt()
+    assert prompt["prompt_ids"] == [1, 2]
+    assert prompt["multi_modal_data"] == {"image": ["image"], "audio": ["audio"]}
+    assert prompt["mm_processor_kwargs"]["audio_sample_rate"] == 32000
+    assert "prompt_token_ids" not in prompt
+    assert "extra_args" not in prompt
+    empty = OmniRolloutRequest.from_generate_kwargs(prompt_ids=[], image_data=[], mm_processor_kwargs={})
+    assert empty.to_diffusion_prompt() == {
+        "prompt_ids": [],
+        "multi_modal_data": {"image": []},
+        "mm_processor_kwargs": {},
+    }
+
+
+@pytest.mark.parametrize("key", ["prompt_ids", "prompt_token_ids"])
+def test_token_transport_boundary(key):
+    assert prompt_ids_from_payload({key: []}) == []
+    assert prompt_ids_from_payload({key: [1, 2]}) == [1, 2]
+    assert prompt_ids_from_payload({}) is None
+
+
+def test_conflicting_token_spellings_fail():
+    with pytest.raises(ValueError, match="Conflicting prompt_ids"):
+        prompt_ids_from_payload({"prompt_ids": [1], "prompt_token_ids": [2]})
+
+
+@pytest.mark.parametrize(
+    "architecture,algorithm,method",
+    [
+        ("QwenImagePipeline", "flow_grpo", "_extract_prompt_ids"),
+        ("QwenImagePipeline", "dual_grpo", "_extract_prompt_ids"),
+        ("QwenImagePipeline", "mix_grpo", "_extract_prompt_ids"),
+        ("BooguImagePipeline", "flow_grpo", "_extract_prompt_ids"),
+        ("QwenImagePipeline", "dpo", "_extract_step_prompt_ids"),
+        ("QwenImagePipeline", "diffusion_nft", "_extract_step_prompt_ids"),
+    ],
+)
+def test_image_adapters_consume_canonical_ids(architecture, algorithm, method):
+    cls = VllmOmniPipelineBase.get_class(architecture, algorithm)
+    pipeline = object.__new__(cls)
+    payload = _prompt()
+    result = getattr(pipeline, method)(payload if method == "_extract_step_prompt_ids" else [payload])
+    assert result == ([1, 2], [1, 1], [3], None)
+
+
+def test_sd3_extra_encoders_and_negatives_round_trip():
+    from verl_omni.pipelines.sd3_flow_grpo.vllm_omni_rollout_adapter import _extract_extra_prompt_ids
+
+    prompt = OmniRolloutRequest.from_generate_kwargs(
+        prompt_ids=[1],
+        extra_prompt_ids={"clip": [2], "t5": [3, 4]},
+        negative_extra_prompt_ids={"clip": [5], "t5": [6]},
+    ).to_diffusion_prompt()
+    assert _extract_extra_prompt_ids([prompt]) == {"clip": [[2]], "t5": [[3, 4]]}
+    assert _extract_extra_prompt_ids([prompt], "negative_extra_prompt_ids") == {"clip": [[5]], "t5": [[6]]}
+    with pytest.raises(ValueError, match="nested under extra_args"):
+        _extract_extra_prompt_ids([{"extra_prompt_ids": {"clip": [2], "t5": [3]}}])
+
+
+@pytest.mark.parametrize("algorithm", ["flow_grpo", "diffusion_nft"])
+def test_minimax_canonical_ids_and_references_survive(algorithm):
+    from verl_omni.pipelines.minimax_h3_diffusion_nft.common import MINIMAX_H3_TOKEN_ID_NATIVE_KEY
+
+    cls = VllmOmniPipelineBase.get_class("MiniMaxH3Pipeline", algorithm)
+    pipeline = object.__new__(cls)
+    request = SimpleNamespace(
+        prompts=[_prompt()], sampling_params=SimpleNamespace(extra_args={MINIMAX_H3_TOKEN_ID_NATIVE_KEY: True})
+    )
+    pipeline._ensure_prompt_text(request)
+    torch.testing.assert_close(pipeline._h3_prompt_ids, torch.tensor([1, 2]))
+    _, media = pipeline._extract_prompt(request.prompts[0])
+    assert media == {"image": ["image"], "audio": ["audio"]}
+
+
+def test_bagel_keeps_top_level_media_without_copy_up():
+    cls = VllmOmniPipelineBase.get_class("OmniBagelForConditionalGeneration", "flow_grpo")
+    pipeline = object.__new__(cls)
+    pipeline._decode_token_prompt = Mock(side_effect=["positive", "negative"])
+    request = SimpleNamespace(prompts=[_prompt()], sampling_params=SimpleNamespace(extra_args={}))
+    pipeline._ensure_bagel_prompt_text(request)
+    assert request.prompts[0]["prompt"] == "positive"
+    assert request.prompts[0]["multi_modal_data"]["image"] == ["image"]
+    assert "extra_args" not in request.prompts[0]
+    assert request.sampling_params.extra_args["negative_prompt"] == "negative"
+    assert pipeline._decode_token_prompt.call_args_list[0].args == ([1, 2],)
+
+
+def test_ltx_canonical_ids_reach_encoder():
+    cls = VllmOmniPipelineBase.get_class("LTX2Pipeline", "flow_grpo")
+    pipeline = object.__new__(cls)
+    pipeline._encode_token_ids = Mock(return_value=(torch.ones(1, 2, 4), torch.ones(1, 2)))
+    request = SimpleNamespace(prompt=_prompt(), sampling_params=SimpleNamespace(max_sequence_length=12))
+    pipeline._inject_precomputed_prompt_embeds(request)
+    assert pipeline._encode_token_ids.call_args_list[0].args == ([1, 2], [1, 1], 12)
+    assert pipeline._encode_token_ids.call_args_list[1].args == ([3], None, 12)
+    assert request.prompt["prompt_embeds"].shape == (2, 4)

--- a/tests/pipelines/test_flux_dance_grpo_on_cpu.py
+++ b/tests/pipelines/test_flux_dance_grpo_on_cpu.py
@@ -28,6 +28,7 @@ from verl_omni.pipelines.flux_dance_grpo.vllm_omni_rollout_adapter import (
     _pad_token_ids,
     _sample_sde_windows,
 )
+from verl_omni.pipelines.rollout_request import OmniRolloutRequest
 
 
 class _PipelineConfig(dict):
@@ -128,9 +129,32 @@ def test_pad_token_ids_truncates_and_pads() -> None:
 
 def test_extra_prompt_ids_require_both_configured_tokenizers() -> None:
     with pytest.raises(ValueError, match=r"extra_tokenizers\.clip and \.t5"):
-        _extract_extra_prompt_ids([{"extra_prompt_ids": {"clip": [1, 2]}}])
+        _extract_extra_prompt_ids([{"extra_args": {"extra_prompt_ids": {"clip": [1, 2]}}}])
     with pytest.raises(TypeError, match=r"extra_prompt_ids\['t5'\]"):
-        _extract_extra_prompt_ids([{"extra_prompt_ids": {"clip": [1, 2], "t5": "invalid"}}])
+        _extract_extra_prompt_ids([{"extra_args": {"extra_prompt_ids": {"clip": [1, 2], "t5": "invalid"}}}])
+
+
+def test_extra_prompt_ids_round_trip_through_canonical_wire() -> None:
+    prompts = [
+        OmniRolloutRequest.from_generate_kwargs(
+            prompt_ids=[index], extra_prompt_ids={"clip": [index, 2], "t5": [index, 3]}
+        ).to_diffusion_prompt()
+        for index in (4, 5)
+    ]
+    assert _extract_extra_prompt_ids(prompts) == {"clip": [[4, 2], [5, 2]], "t5": [[4, 3], [5, 3]]}
+
+
+def test_top_level_encoder_ids_are_rejected() -> None:
+    with pytest.raises(ValueError, match="nested under extra_args"):
+        _extract_extra_prompt_ids([{"extra_prompt_ids": {"clip": [1], "t5": [2]}}])
+
+
+@pytest.mark.parametrize("key", ["prompt_ids", "prompt_token_ids"])
+def test_generic_ids_without_encoder_ids_fail_instead_of_returning_empty_output(key) -> None:
+    pipeline = object.__new__(FluxDanceGRPOPipelineWithLogProb)
+    request = SimpleNamespace(request_id="flux-request", prompt={key: [1, 2]})
+    with pytest.raises(ValueError, match="extra_tokenizers"):
+        pipeline.forward(request)
 
 
 def test_rollout_and_actor_use_identical_non_dyadic_sigma_schedule() -> None:

--- a/tests/pipelines/test_ltx2_flow_grpo_on_cpu.py
+++ b/tests/pipelines/test_ltx2_flow_grpo_on_cpu.py
@@ -255,10 +255,15 @@ def test_ltx2_rollout_forward_attaches_trajectory_and_metadata() -> None:
 
     req = MagicMock(spec=DiffusionRequestBatch)
     req.num_reqs = 1
-    req.requests = [MagicMock()]
+    req.requests = [
+        SimpleNamespace(
+            request_id="ltx", sampling_params=SimpleNamespace(output_type="pt", extra_args={}, frame_rate=24)
+        )
+    ]
+    pipeline.distributed_video_decode = False
 
     # Mock super().forward
-    video_tensor = torch.randn(1, 3, 16, 64, 64)
+    video_tensor = torch.rand(1, 16, 3, 64, 64)
     audio_tensor = torch.randn(1, 2, 24000)
     mock_base_output = DiffusionOutput(output=(video_tensor, audio_tensor))
 
@@ -280,11 +285,70 @@ def test_ltx2_rollout_forward_attaches_trajectory_and_metadata() -> None:
     assert "prompt_embeddings" in metadata
     assert "rl" in metadata
     assert metadata["rl"]["video_seq_len"].item() == 5
-    assert metadata["rl"]["audio_sample_rate"] == 24000
+    assert metadata["media_artifacts"]["specs"]["audio"]["sample_rate"] == 24000
+    assert metadata["media_artifacts"]["specs"]["audio_latent"]["layout"] == "CTF"
     assert "audio_prompt_embeds" in metadata["prompt_embeddings"]
+
+
+def test_ltx_phase_passes_declared_sampler_to_pinned_forward_context(monkeypatch):
+    from verl_omni.pipelines.ltx2_flow_grpo import vllm_omni_rollout_adapter as adapter
+
+    class ContextCaptured(Exception):
+        pass
+
+    pipe = SimpleNamespace(
+        device=torch.device("cpu"),
+        scheduler=SimpleNamespace(config={}),
+        _check_forward_inputs=lambda *args, **kwargs: None,
+        _setup_forward_runtime=lambda *args: False,
+        _resolve_video_latent_dimensions=lambda *args: (2, 2, 2),
+        _prepare_video_latents_stage=lambda *args, **kwargs: (torch.zeros(1, 8, 32), None),
+        _prepare_audio_latents_stage=lambda *args, **kwargs: (torch.zeros(1, 2, 32), 2, 2, 16),
+    )
+    monkeypatch.setattr(adapter, "retrieve_timesteps", lambda *args, **kwargs: (torch.tensor([1.0, 0.5]), 2))
+    monkeypatch.setattr(adapter, "LTXVideoAudioStepAdapter", lambda *args, **kwargs: object())
+
+    def capture(pipeline, context, *args):
+        assert context.sampler == "euler"
+        raise ContextCaptured
+
+    monkeypatch.setattr(adapter, "prepare_rope_coords_stage", capture)
+    with pytest.raises(ContextCaptured):
+        adapter.LTX23PipelineWithLogProb.run_phase(
+            pipe,
+            SimpleNamespace(),
+            SimpleNamespace(num_inference_steps=2),
+            noise_scale=1.0,
+            sigmas=None,
+            timesteps=None,
+            attention_kwargs=None,
+            phase_recipe=SimpleNamespace(sampler="euler"),
+            prompt_context=SimpleNamespace(),
+        )
+
+
+def test_ltx_warmup_does_not_emit_serving_media_without_request_metadata():
+    from vllm_omni.diffusion.request import DUMMY_DIFFUSION_REQUEST_ID
+
+    pipeline = object.__new__(LTX23PipelineWithLogProb)
+    pipeline._configure_flow_grpo = MagicMock()
+    pipeline._inject_precomputed_prompt_embeds = MagicMock()
+    request = SimpleNamespace(
+        request_id=DUMMY_DIFFUSION_REQUEST_ID, sampling_params=SimpleNamespace(output_type=None, extra_args={})
+    )
+    batch = SimpleNamespace(num_reqs=1, requests=[request])
+    native = DiffusionOutput(output=(torch.zeros(1, 2, 3, 4, 4), torch.zeros(1, 2, 16)))
+    with unittest_mock_super_forward(pipeline, native):
+        result = pipeline.forward(batch)
+    assert result.output is None
+    assert pipeline._flow_grpo_native_latents is None
 
 
 def unittest_mock_super_forward(target, return_value):
     from unittest.mock import patch
 
-    return patch.object(LTX23PipelineWithLogProb.__bases__[0], "forward", return_value=return_value)
+    def forward(*args, **kwargs):
+        target._flow_grpo_native_latents = (torch.zeros(1, 4, 2, 4, 4), torch.zeros(1, 8, 5, 16))
+        return return_value
+
+    return patch.object(LTX23PipelineWithLogProb.__bases__[0], "forward", side_effect=forward)

--- a/tests/pipelines/test_minimax_h3_diffusion_nft_on_cpu.py
+++ b/tests/pipelines/test_minimax_h3_diffusion_nft_on_cpu.py
@@ -459,7 +459,7 @@ class TestMiniMaxH3TokenIdNativePrompt:
     def test_empty_prompt_ids_are_rejected(self):
         pipeline = _StubSyncPipeline()
 
-        with pytest.raises(ValueError, match="non-empty prompt_token_ids"):
+        with pytest.raises(ValueError, match="non-empty prompt_ids"):
             pipeline._ensure_prompt_text(self._request({"prompt_token_ids": []}))
 
     def test_generic_agent_loop_ids_are_rejected(self):

--- a/tests/pipelines/test_minimax_h3_flow_grpo_on_cpu.py
+++ b/tests/pipelines/test_minimax_h3_flow_grpo_on_cpu.py
@@ -151,9 +151,12 @@ def test_rollout_output_reaches_actor_and_replays_joint_transition(monkeypatch) 
     pipeline.tokenizer = MagicMock()
     pipeline._flow_grpo_trajectory = trajectory
     request = SimpleNamespace(
+        request_id="h3-contract",
         prompt={"prompt_token_ids": [1, 2]},
         sampling_params=SimpleNamespace(
             extra_args={MINIMAX_H3_TOKEN_ID_NATIVE_KEY: True},
+            frame_rate=24,
+            output_type="pt",
             max_sequence_length=2,
             num_outputs_per_prompt=1,
         ),
@@ -163,10 +166,11 @@ def test_rollout_output_reaches_actor_and_replays_joint_transition(monkeypatch) 
         prompts=[request.prompt],
         sampling_params=request.sampling_params,
     )
-    video_pixels = torch.zeros(1, 3, 2, 8, 8, dtype=torch.uint8)
-    audio_waveform = torch.zeros(1, 32000)
+    video_pixels = torch.zeros(1, 2, 8, 8, 3, dtype=torch.uint8)
+    audio_waveform = torch.zeros(1, 2, 32000)
 
     def fake_forward(*args):
+        pipeline._flow_grpo_final_latents = (torch.zeros(1, 24, 2, 4, 4), torch.zeros(2, 32, 8))
         pipeline._flow_grpo_trajectory = trajectory
         return VllmDiffusionOutput(output=(video_pixels, audio_waveform))
 
@@ -182,11 +186,11 @@ def test_rollout_output_reaches_actor_and_replays_joint_transition(monkeypatch) 
     assert "all_next_latents" in metadata["rl"]
 
     final_res = SimpleNamespace(
-        images=[(video_pixels, audio_waveform)],
+        images=rollout_output.output["payload"]["video"],
         trajectory_latents=rollout_output.trajectory_latents,
         trajectory_timesteps=rollout_output.trajectory_timesteps,
         trajectory_log_probs=rollout_output.trajectory_log_probs,
-        multimodal_output=rollout_output.output,
+        multimodal_output={"metadata": rollout_output.output["metadata"]},
         request_output=None,
     )
     server = object.__new__(vLLMOmniHttpServer)

--- a/tests/pipelines/test_minimax_h3_ref2va_nft_on_cpu.py
+++ b/tests/pipelines/test_minimax_h3_ref2va_nft_on_cpu.py
@@ -448,12 +448,16 @@ def test_ref2va_rollout_publishes_fixed_size_reference_replay_fields(monkeypatch
     monkeypatch.setattr(
         MiniMaxH3Pipeline,
         "forward",
-        lambda self, request: DiffusionOutput(output=(torch.zeros(1), torch.zeros(1))),
+        lambda self, request: DiffusionOutput(
+            output=(torch.zeros(1, 5, 8, 8, 3, dtype=torch.uint8), torch.zeros(1, 2, 160))
+        ),
     )
     request = MagicMock(
         prompts=[{"prompt_token_ids": [1, 2]}],
         sampling_params=SimpleNamespace(
             num_outputs_per_prompt=1,
+            frame_rate=24,
+            output_type="pt",
             extra_args={MINIMAX_H3_TOKEN_ID_NATIVE_KEY: True},
         ),
     )

--- a/tests/pipelines/test_minimax_h3_rollout_contract_on_cpu.py
+++ b/tests/pipelines/test_minimax_h3_rollout_contract_on_cpu.py
@@ -93,6 +93,9 @@ class TestH3RolloutOutputContract:
         assert result.extra_fields["audio"] is not None
         assert "audio_sample_rate" in result.extra_fields
         assert result.extra_fields["audio_sample_rate"] == _AUDIO_SR
+        # The real MiniMax H3 adapter declares primary=video, which reaches
+        # downstream consumers so they need not infer the modality from rank.
+        assert result.extra_fields["media_kind"] == "video"
 
     def test_rl_metadata_reaches_extra_fields(self):
         """rl and prompt_embeddings groups flatten into extra_fields."""

--- a/tests/pipelines/test_minimax_h3_rollout_contract_on_cpu.py
+++ b/tests/pipelines/test_minimax_h3_rollout_contract_on_cpu.py
@@ -11,179 +11,148 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""CPU integration tests for the MiniMax H3 rollout output contract.
-
-Simulates the full server-side processing of H3's joint (video, audio)
-rollout output — the exact path that crashed during GPU smoke testing —
-without needing a GPU or the real vLLM-Omni engine.
-"""
+"""CPU integration for H3's declared native/decoded outputs and downstream export."""
 
 from types import SimpleNamespace
 
 import pytest
 import torch
 
-server_module = pytest.importorskip("verl_omni.workers.rollout.vllm_rollout.vllm_omni_async_server")
-tracking_module = pytest.importorskip("verl_omni.utils.tracking")
-# The strategy resolves H3's audio sample rate from the adapter-declared
-# DiffusionIOSpec, so the pipeline adapter must be imported/registered.
-pytest.importorskip("verl_omni.pipelines.minimax_h3_flow_grpo.vllm_omni_rollout_adapter")
-
-_VIDEO_T, _VIDEO_C, _VIDEO_H, _VIDEO_W = 107, 3, 384, 640
-_AUDIO_SR = 32000
-_AUDIO_SAMPLES = 4 * _AUDIO_SR
+from verl_omni.pipelines.diffusion_rollout_output import rollout_output
+from verl_omni.pipelines.minimax_h3_diffusion_nft.artifacts import with_h3_artifacts
+from verl_omni.pipelines.rollout_artifacts import ArtifactSpec, MediaArtifact
+from verl_omni.workers.rollout.vllm_rollout.vllm_omni_diffusion_strategy import DiffusionStrategy
 
 
-def _make_h3_final_res(batch_size: int = 1):
-    """Build a fake OmniRequestOutput matching H3's rollout output."""
-    video = torch.randint(0, 256, (batch_size, _VIDEO_C, _VIDEO_T, _VIDEO_H, _VIDEO_W), dtype=torch.uint8)
-    audio = torch.randn(batch_size, _AUDIO_SAMPLES)
-    metadata = {
-        "rl": {
-            "latents_clean": torch.randn(10, 96),
+def _make_h3_final_res():
+    base = rollout_output(
+        media=None,
+        rl={
+            "latents_clean": torch.randn(1, 10, 96),
             "train_timesteps": torch.randn(1, 9),
             "latent_meta": torch.zeros(1, 6, dtype=torch.long),
         },
-        "prompt_embeddings": {
+        prompt_embeddings={
             "prompt_embeds": torch.randn(1, 5, 8),
             "prompt_embeds_mask": torch.ones(1, 5, dtype=torch.long),
         },
-    }
-    envelope = {"payload": {"image": (video, audio)}, "metadata": metadata}
-    # The engine extracts the payload into images; multimodal_output keeps the envelope.
+    )
+    result = with_h3_artifacts(
+        base,
+        video=torch.randint(256, (1, 5, 8, 12, 3), dtype=torch.uint8),
+        audio=torch.randn(1, 2, 320),
+        video_latent=torch.randn(1, 24, 2, 2, 2),
+        audio_latent=torch.randn(2, 32, 8),
+        sampling=SimpleNamespace(frame_rate=24, output_type="pt", extra_args={}),
+        context="pipeline=H3, request_id=h3-test",
+    )
     return SimpleNamespace(
-        images=[(video, audio)],
-        multimodal_output=envelope,
+        images=result.output["payload"]["video"],
+        multimodal_output={"metadata": result.output["metadata"]},
         trajectory_latents=None,
         trajectory_timesteps=None,
         trajectory_log_probs=None,
         request_output=None,
+        request_id="h3-test",
     )
 
 
-def _server():
-    server = object.__new__(server_module.vLLMOmniHttpServer)
-    server.global_steps = 3
-    # Keys the adapter-declared DiffusionIOSpec (audio sample rate 32000).
-    server.model_config = SimpleNamespace(architecture="MiniMaxH3Pipeline", algorithm="flow_grpo")
-    server._to_tensor = __import__("torchvision").transforms.PILToTensor()
-    return server
-
-
-class TestH3RolloutOutputContract:
-    """Verify the server correctly processes H3's (video, audio) tuple output."""
-
-    def test_tuple_extracted_video_tensor(self):
-        """Video stream routes to the tensor path as uint8."""
-        server = _server()
-        final_res = _make_h3_final_res()
-        sampling_params = {"output_type": "pt"}
-        result = _run_generate(server, final_res, sampling_params)
-        assert result.diffusion_output is not None
-        assert isinstance(result.diffusion_output, torch.Tensor)
-        assert result.diffusion_output.dtype == torch.uint8
-
-    def test_audio_forwarded_to_extra_fields(self):
-        """Audio from the tuple reaches extra_fields for CLAP/ImageBind."""
-        server = _server()
-        final_res = _make_h3_final_res()
-        sampling_params = {"output_type": "pt"}
-        result = _run_generate(server, final_res, sampling_params)
-        assert "audio" in result.extra_fields
-        assert result.extra_fields["audio"] is not None
-        assert "audio_sample_rate" in result.extra_fields
-        assert result.extra_fields["audio_sample_rate"] == _AUDIO_SR
-        # The real MiniMax H3 adapter declares primary=video, which reaches
-        # downstream consumers so they need not infer the modality from rank.
-        assert result.extra_fields["media_kind"] == "video"
-
-    def test_rl_metadata_reaches_extra_fields(self):
-        """rl and prompt_embeddings groups flatten into extra_fields."""
-        server = _server()
-        final_res = _make_h3_final_res()
-        sampling_params = {"output_type": "pt"}
-        result = _run_generate(server, final_res, sampling_params)
-        for key in ("latents_clean", "train_timesteps", "latent_meta", "prompt_embeds", "prompt_embeds_mask"):
-            assert key in result.extra_fields, f"missing {key} in extra_fields"
-
-    def test_channels_first_video_in_reward_utils(self):
-        """video_tensor_to_pil_frames handles [C,T,H,W] channels-first input."""
-        from verl_omni.utils.reward_score.reward_utils import video_tensor_to_pil_frames
-
-        video_cthw = torch.randint(0, 256, (_VIDEO_C, _VIDEO_T, 64, 64), dtype=torch.uint8)
-        frames = video_tensor_to_pil_frames(video_cthw)
-        assert len(frames) == _VIDEO_T
-
-    def test_5d_wandb_video(self):
-        """wrap_val_samples_for_wandb handles H3's [B,C,T,H,W] video."""
-        from verl_omni.utils.tracking import wrap_val_samples_for_wandb
-
-        video = torch.randint(0, 256, (1, _VIDEO_C, _VIDEO_T, 64, 64), dtype=torch.uint8)
-        samples = [("a test prompt", video, 0.5, None, None)]
-        wrapped, tmpdir, media = wrap_val_samples_for_wandb(samples, fps=24, output_dir=None)
-        assert len(wrapped) == 1
-        assert tmpdir is not None
-        import shutil
-
-        shutil.rmtree(tmpdir, ignore_errors=True)
-
-    @pytest.mark.parametrize(
-        ("shape", "expect"),
-        [
-            # Channels-first [N, C, T, H, W] must be normalized to [N, T, C, H, W].
-            ((2, _VIDEO_C, 9, 32, 48), (9, _VIDEO_C, 32, 48)),
-            # Already [N, T, C, H, W]; must be left untouched.
-            ((2, 9, _VIDEO_C, 32, 48), (9, _VIDEO_C, 32, 48)),
-        ],
-        ids=["channels_first", "already_normalized"],
+def _generate():
+    server = SimpleNamespace(
+        global_steps=3, model_config=SimpleNamespace(architecture="MiniMaxH3Pipeline", algorithm="flow_grpo")
     )
-    def test_dump_generations_normalizes_5d_layout(self, shape, expect, monkeypatch, tmp_path):
-        """_dump_generations must hand ``_export_video`` per-sample ``[T, C, H, W]``.
+    return DiffusionStrategy(server).process_output(_make_h3_final_res(), None, {"output_type": "pt"})
 
-        Both batched layouts must converge on the same per-sample shape; assert on the
-        tensor reaching the exporter so a transposed guard cannot slip through.
-        """
-        from verl_omni.trainer.diffusion import ray_diffusion_trainer as rdt
 
-        seen = []
+def test_named_video_has_canonical_shape_and_preserves_native_latents():
+    result = _generate()
+    assert result.diffusion_output.shape == (5, 3, 8, 12)
+    assert result.diffusion_output.dtype == torch.uint8
+    assert result.artifacts["video_latent"].data.shape == (24, 2, 2, 2)
+    assert result.artifacts["audio_latent"].spec.layout == "CLT"
 
-        def _fake_export(output, output_path, **kwargs):
-            seen.append(tuple(output.shape))
-            open(output_path, "wb").close()
 
-        monkeypatch.setattr(rdt, "_export_video", _fake_export)
+def test_named_audio_is_not_unbatched_a_second_time():
+    result = _generate()
+    assert result.extra_fields["audio"].shape == (2, 320)
+    assert result.extra_fields["audio_sample_rate"] == 32000
+    assert result.extra_fields["media_kind"] == "video"
 
-        outputs = torch.randint(0, 256, shape, dtype=torch.uint8)
-        stand_in = SimpleNamespace(global_steps=1)
-        rdt.BaseRayDiffusionTrainer._dump_generations(
-            stand_in,
-            inputs=["p0", "p1"],
-            outputs=outputs,
-            gts=["g0", "g1"],
-            scores=[0.1, 0.2],
+
+def test_training_fields_remain_separate_from_media():
+    result = _generate()
+    assert result.extra_fields["latents_clean"].shape == (10, 96)
+    for key in ("train_timesteps", "latent_meta", "prompt_embeds", "prompt_embeds_mask"):
+        assert key in result.extra_fields
+    assert "latents_clean" not in result.artifacts
+
+
+def test_rewards_reject_undeclared_channels_first_input():
+    from verl_omni.utils.reward_score.reward_utils import video_tensor_to_pil_frames
+
+    video = torch.zeros(3, 5, 8, 12, dtype=torch.uint8)
+    with pytest.raises(ValueError, match="T, 3, H, W"):
+        video_tensor_to_pil_frames(video)
+    artifact = MediaArtifact(ArtifactSpec("video", "decoded", "CTHW", fps=24), video)
+    assert len(video_tensor_to_pil_frames(artifact.normalized(context="adapter", name="video_preview").data)) == 5
+
+
+def test_named_video_is_exported_to_real_mp4():
+    import shutil
+
+    from verl_omni.utils.tracking import wrap_val_samples_for_wandb
+
+    preview = _generate().artifacts["video_preview"]
+    wrapped, temp, media = wrap_val_samples_for_wandb([("prompt", preview, 0.5)])
+    try:
+        assert wrapped[0][1] == "val/videos/sample_1"
+        assert media and temp is not None
+    finally:
+        if temp is not None:
+            shutil.rmtree(temp)
+
+
+@pytest.mark.parametrize("layout,shape", [("CTHW", (3, 9, 8, 12)), ("TCHW", (9, 3, 8, 12))])
+def test_dump_consumes_adapter_normalized_preview(layout, shape, monkeypatch, tmp_path):
+    from verl_omni.trainer.diffusion import ray_diffusion_trainer as trainer
+
+    previews = [
+        MediaArtifact(
+            ArtifactSpec("video", "decoded", layout, fps=24), torch.zeros(shape, dtype=torch.uint8)
+        ).normalized(context="adapter", name="video_preview")
+        for _ in range(2)
+    ]
+    seen = []
+
+    def export(output, path, **kwargs):
+        seen.append(tuple(output.data.shape))
+        open(path, "wb").close()
+
+    monkeypatch.setattr(trainer, "_export_video", export)
+    trainer.BaseRayDiffusionTrainer._dump_generations(
+        SimpleNamespace(global_steps=1),
+        inputs=["a", "b"],
+        outputs=torch.zeros(2, 16, 2, 2),
+        gts=[None, None],
+        scores=[1, 2],
+        reward_extra_infos_dict={},
+        dump_path=str(tmp_path),
+        previews=previews,
+    )
+    assert seen == [(9, 3, 8, 12)] * 2
+
+
+def test_dump_rejects_undeclared_extra_batch_axis(tmp_path):
+    from verl_omni.trainer.diffusion.ray_diffusion_trainer import BaseRayDiffusionTrainer
+
+    with pytest.raises(ValueError, match="canonical batched"):
+        BaseRayDiffusionTrainer._dump_generations(
+            SimpleNamespace(global_steps=1),
+            inputs=["a"],
+            outputs=torch.zeros(1, 1, 5, 3, 8, 12, dtype=torch.uint8),
+            gts=[None],
+            scores=[1],
             reward_extra_infos_dict={},
             dump_path=str(tmp_path),
+            media_kind="video",
         )
-
-        assert seen == [expect] * 2, f"{shape} produced per-sample shapes {seen}, expected {expect}"
-
-    def test_dump_generations_6d(self):
-        """_dump_generations handles [N,1,T,C,H,W] 6D outputs."""
-        import tempfile
-        from pathlib import Path
-
-        from verl_omni.utils.tracking import _export_video
-
-        # Simulate the 6D tensor that reaches _dump_generations
-        outputs = torch.randint(0, 256, (2, 1, _VIDEO_T, _VIDEO_C, 64, 64), dtype=torch.uint8)
-        with tempfile.TemporaryDirectory() as tmpdir:
-            for i in range(outputs.shape[0]):
-                squeezed = outputs[i].squeeze(0)  # [T, C, H, W]
-                _export_video(squeezed, str(Path(tmpdir) / f"{i}.mp4"), fps=24)
-                assert (Path(tmpdir) / f"{i}.mp4").exists()
-
-
-def _run_generate(server, final_res, sampling_params):
-    """Run the production diffusion output strategy with a fake engine result."""
-    strategy = server_module.DiffusionStrategy(server)
-    return strategy.process_output(final_res, params=None, sampling_params=sampling_params)

--- a/tests/pipelines/test_minimax_h3_rollout_contract_on_cpu.py
+++ b/tests/pipelines/test_minimax_h3_rollout_contract_on_cpu.py
@@ -20,7 +20,8 @@ import torch
 
 from verl_omni.pipelines.diffusion_rollout_output import rollout_output
 from verl_omni.pipelines.minimax_h3_diffusion_nft.artifacts import with_h3_artifacts
-from verl_omni.pipelines.rollout_artifacts import ArtifactSpec, MediaArtifact
+from verl_omni.pipelines.rollout_artifacts import MediaArtifact
+from verl_omni.pipelines.rollout_media import MediaSpec
 from verl_omni.workers.rollout.vllm_rollout.vllm_omni_diffusion_strategy import DiffusionStrategy
 
 
@@ -93,7 +94,7 @@ def test_rewards_reject_undeclared_channels_first_input():
     video = torch.zeros(3, 5, 8, 12, dtype=torch.uint8)
     with pytest.raises(ValueError, match="T, 3, H, W"):
         video_tensor_to_pil_frames(video)
-    artifact = MediaArtifact(ArtifactSpec("video", "decoded", "CTHW", fps=24), video)
+    artifact = MediaArtifact(MediaSpec("video", "decoded", "CTHW", fps=24), video)
     assert len(video_tensor_to_pil_frames(artifact.normalized(context="adapter", name="video_preview").data)) == 5
 
 
@@ -117,9 +118,9 @@ def test_dump_consumes_adapter_normalized_preview(layout, shape, monkeypatch, tm
     from verl_omni.trainer.diffusion import ray_diffusion_trainer as trainer
 
     previews = [
-        MediaArtifact(
-            ArtifactSpec("video", "decoded", layout, fps=24), torch.zeros(shape, dtype=torch.uint8)
-        ).normalized(context="adapter", name="video_preview")
+        MediaArtifact(MediaSpec("video", "decoded", layout, fps=24), torch.zeros(shape, dtype=torch.uint8)).normalized(
+            context="adapter", name="video_preview"
+        )
         for _ in range(2)
     ]
     seen = []

--- a/tests/pipelines/test_named_adapter_outputs_on_cpu.py
+++ b/tests/pipelines/test_named_adapter_outputs_on_cpu.py
@@ -16,6 +16,7 @@
 import importlib
 import json
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 import torch
@@ -55,6 +56,7 @@ def _format(native, architecture="QwenImagePipeline", request_id="request"):
         ("qwen_image_flow_grpo", "get_rollout_post_process_func", "QwenImagePipeline", "image", "LC"),
         ("qwen_image_edit_flow_grpo", "get_rollout_post_process_func", "QwenImageEditPlusPipeline", "image", "LC"),
         ("sd3_flow_grpo", "get_latent_post_process_func", "StableDiffusion3Pipeline", "image", "CHW"),
+        ("flux_dance_grpo", "get_rollout_post_process_func", "FluxPipeline", "image", "LC"),
         ("boogu_image_flow_grpo", "get_rollout_post_process_func", "BooguImagePipeline", "image", "CHW"),
         ("wan22_dance_grpo", "get_rollout_post_process_func", "WanPipeline", "video", "CTHW"),
         ("ltx2_flow_grpo", "get_rollout_post_process_func", "LTX2Pipeline", "video", "CTHW"),
@@ -98,6 +100,73 @@ def test_native_postprocessor_and_formatter_preserve_named_streams(
     assert output.extra_fields["sentinel"] == 13
     torch.testing.assert_close(output.artifacts[f"{kind}_latent"].data, latents[0])
     assert output.artifacts[f"{kind}_preview"].spec.layout == ("TCHW" if kind == "video" else "CHW")
+
+
+@pytest.mark.parametrize("output_type,request_preview", [("image", False), ("latent", False), ("latent", True)])
+def test_flux_forward_emits_named_packed_latents_and_optional_batch_preview(output_type, request_preview):
+    from verl_omni.pipelines.flux_dance_grpo.vllm_omni_rollout_adapter import FluxDanceGRPOPipelineWithLogProb
+    from verl_omni.pipelines.rollout_request import OmniRolloutRequest
+
+    pipeline = object.__new__(FluxDanceGRPOPipelineWithLogProb)
+    pipeline.device = torch.device("cpu")
+    pipeline.vae_scale_factor = 8
+    pipeline.transformer = SimpleNamespace(in_channels=64)
+    pipeline.encode_prompt_from_token_ids = MagicMock(
+        return_value=(torch.zeros(2, 4, 8), torch.zeros(2, 8), torch.zeros(4, 3))
+    )
+    pipeline._set_timesteps = MagicMock(return_value=torch.tensor([1000.0, 500.0, 100.0]))
+    native = torch.arange(2 * 16 * 4 * 6, dtype=torch.float32).reshape(2, 16, 4, 6)
+    packed = pipeline._pack_latents(native, 2, 16, 4, 6)
+    trajectory = packed.unsqueeze(1).expand(-1, 3, -1, -1).clone()
+    pipeline.diffuse = MagicMock(return_value=(trajectory, trajectory + 1, torch.zeros(2, 3), torch.ones(2, 3), packed))
+    pixels = torch.linspace(-1, 1, 2 * 3 * 32 * 48).reshape(2, 3, 32, 48)
+    pipeline.vae = SimpleNamespace(
+        config=SimpleNamespace(scaling_factor=2.0, shift_factor=0.5),
+        dtype=torch.float32,
+        decode=MagicMock(return_value=(pixels,)),
+    )
+    requests = [
+        OmniDiffusionRequest(
+            request_id=f"flux-{index}",
+            prompt=OmniRolloutRequest.from_generate_kwargs(
+                prompt_ids=[index], extra_prompt_ids={"clip": [index], "t5": [index, 2]}
+            ).to_diffusion_prompt(),
+            sampling_params=OmniDiffusionSamplingParams(
+                height=32,
+                width=48,
+                num_inference_steps=3,
+                output_type=output_type,
+                seed=index,
+                extra_args={
+                    "timestep_sample_strategy": "continuous",
+                    "drop_last_transition": False,
+                    "requested_outputs": ["image_preview"] if request_preview and index == 1 else [],
+                },
+            ),
+        )
+        for index in range(2)
+    ]
+    outputs = pipeline.forward(DiffusionRequestBatch(requests=requests))
+    decode = output_type == "image" or request_preview
+    assert pipeline.vae.decode.call_count == int(decode)
+    if decode:
+        torch.testing.assert_close(pipeline.vae.decode.call_args.args[0], native / 2 + 0.5)
+    for index, output in enumerate(outputs):
+        converted = DiffusionStrategy(SimpleNamespace(global_steps=1)).process_output(
+            _format(output, "FluxPipeline", requests[index].request_id), None, {"output_type": output_type}
+        )
+        artifact = converted.artifacts["image_latent"]
+        assert artifact.spec.layout == "LC"
+        assert artifact.data.dtype == packed.dtype
+        torch.testing.assert_close(artifact.data, packed[index])
+        torch.testing.assert_close(output.trajectory_latents, trajectory[index : index + 1])
+        torch.testing.assert_close(converted.extra_fields["all_next_latents"], trajectory[index] + 1)
+        assert ("image_preview" in converted.artifacts) == decode
+        if decode:
+            preview = converted.artifacts["image_preview"]
+            assert preview.spec.layout == "CHW"
+            expected = quantize_pixels(pixels[index], "minus_one_one", context="test")
+            torch.testing.assert_close(preview.data, expected)
 
 
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])

--- a/tests/pipelines/test_named_adapter_outputs_on_cpu.py
+++ b/tests/pipelines/test_named_adapter_outputs_on_cpu.py
@@ -1,0 +1,367 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Real postprocessors, request batching and step-decode paths share one artifact contract."""
+
+import importlib
+import json
+from types import SimpleNamespace
+
+import pytest
+import torch
+from vllm_omni.diffusion.data import DiffusionOutput
+from vllm_omni.diffusion.output_formatter import format_diffusion_outputs, normalize_diffusion_postprocess_output
+from vllm_omni.diffusion.request import OmniDiffusionRequest
+from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
+from vllm_omni.diffusion.worker.utils import StepRequestState
+from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
+from verl_omni.pipelines.diffusion_rollout_output import quantize_pixels, rollout_output, with_visual_artifacts
+from verl_omni.pipelines.request_batch import requested_outputs_for_batch, split_diffusion_output_by_request
+from verl_omni.pipelines.rollout_artifacts import (
+    ArtifactContractError,
+    artifact_fields,
+    artifacts_from_fields,
+    select_artifact,
+)
+from verl_omni.workers.rollout.vllm_rollout.vllm_omni_diffusion_strategy import DiffusionStrategy
+
+
+def _format(native, architecture="QwenImagePipeline", request_id="request"):
+    return format_diffusion_outputs(
+        request=SimpleNamespace(
+            request_id=request_id, prompt={"prompt_ids": [1]}, sampling_params=OmniDiffusionSamplingParams()
+        ),
+        od_config=SimpleNamespace(model_class_name=architecture),
+        diffusion_output=native,
+        output_data=native.output,
+        postprocess_output=normalize_diffusion_postprocess_output(native.output),
+    )[0]
+
+
+@pytest.mark.parametrize(
+    "module,factory,architecture,kind,latent_layout",
+    [
+        ("qwen_image_flow_grpo", "get_rollout_post_process_func", "QwenImagePipeline", "image", "LC"),
+        ("qwen_image_edit_flow_grpo", "get_rollout_post_process_func", "QwenImageEditPlusPipeline", "image", "LC"),
+        ("sd3_flow_grpo", "get_latent_post_process_func", "StableDiffusion3Pipeline", "image", "CHW"),
+        ("boogu_image_flow_grpo", "get_rollout_post_process_func", "BooguImagePipeline", "image", "CHW"),
+        ("wan22_dance_grpo", "get_rollout_post_process_func", "WanPipeline", "video", "CTHW"),
+        ("ltx2_flow_grpo", "get_rollout_post_process_func", "LTX2Pipeline", "video", "CTHW"),
+    ],
+)
+@pytest.mark.parametrize("output_type", ["pt", "latent"])
+def test_native_postprocessor_and_formatter_preserve_named_streams(
+    tmp_path, module, factory, architecture, kind, latent_layout, output_type
+):
+    (tmp_path / "vae").mkdir()
+    (tmp_path / "vae/config.json").write_text(
+        json.dumps({"temporal_downsample": [False, True, True], "block_out_channels": [8, 8, 8, 8]})
+    )
+    (tmp_path / "vocoder").mkdir()
+    (tmp_path / "vocoder/config.json").write_text('{"output_sampling_rate": 48000}')
+    adapter = importlib.import_module(f"verl_omni.pipelines.{module}.vllm_omni_rollout_adapter")
+    processor = getattr(adapter, factory)(SimpleNamespace(model=str(tmp_path), output_type="image"))
+    pixels = (
+        torch.linspace(-1, 1, 72).reshape(1, 3, 3, 2, 4)
+        if kind == "video"
+        else torch.linspace(-1, 1, 24).reshape(1, 3, 2, 4)
+    )
+    latent_shape = {"LC": (1, 2, 16), "CHW": (1, 16, 2, 2), "CTHW": (1, 16, 2, 2, 2)}[latent_layout]
+    latents = torch.randn(latent_shape, dtype=torch.bfloat16)
+    native = with_visual_artifacts(
+        rollout_output(media=None, rl={"sentinel": torch.tensor([13])}),
+        decoded=pixels,
+        latents=latents,
+        modality=kind,
+        decoded_layout="CTHW" if kind == "video" else "CHW",
+        latent_layout=latent_layout,
+        output_type=output_type,
+        fps=24 if kind == "video" else None,
+        context="adapter request",
+    )
+    assert processor(native.output) is native.output
+    output = DiffusionStrategy(SimpleNamespace(global_steps=1)).process_output(
+        _format(native, architecture), None, {"output_type": output_type}
+    )
+    assert set(output.artifacts) == {f"{kind}_latent", f"{kind}_preview"}
+    assert output.extra_fields["sentinel"] == 13
+    torch.testing.assert_close(output.artifacts[f"{kind}_latent"].data, latents[0])
+    assert output.artifacts[f"{kind}_preview"].spec.layout == ("TCHW" if kind == "video" else "CHW")
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+def test_quantization_matches_real_vae_image_processor(dtype):
+    from diffusers.image_processor import VaeImageProcessor
+
+    raw = torch.linspace(-2, 2, 48).reshape(2, 3, 2, 4).to(dtype)
+    expected = VaeImageProcessor().postprocess(raw, output_type="pt").float().mul(255).round().to(torch.uint8)
+    torch.testing.assert_close(quantize_pixels(raw, "minus_one_one", context="test"), expected)
+
+
+@pytest.mark.parametrize("outputs_per_prompt", [1, 2])
+def test_request_split_keeps_named_samples_and_training_batch_axes(outputs_per_prompt):
+    batch_size = 2 * outputs_per_prompt
+    latents = torch.arange(batch_size * 32, dtype=torch.float32).reshape(batch_size, 2, 16)
+    trajectory = torch.arange(batch_size * 3 * 32, dtype=torch.float32).reshape(batch_size, 3, 2, 16)
+    native = with_visual_artifacts(
+        rollout_output(media=None, trajectory_latents=trajectory),
+        decoded=torch.zeros(batch_size, 3, 2, 4),
+        latents=latents,
+        latent_layout="LC",
+        output_type="latent",
+        context="batch",
+    )
+    outputs = split_diffusion_output_by_request(
+        native, SimpleNamespace(num_reqs=2), num_outputs_per_prompt=outputs_per_prompt
+    )
+    for index, output in enumerate(outputs):
+        rows = output.output["payload"]["image"]
+        assert len(rows) == outputs_per_prompt
+        start = index * outputs_per_prompt
+        torch.testing.assert_close(rows[0]["image_latent"], latents[start])
+        torch.testing.assert_close(output.trajectory_latents, trajectory[start : start + outputs_per_prompt])
+        assert output.output["metadata"]["media_artifacts"]["specs"]["image_latent"]["layout"] == "LC"
+
+
+def test_batch_preview_request_is_not_lost_when_only_later_request_needs_it():
+    batch = DiffusionRequestBatch(
+        requests=[
+            OmniDiffusionRequest(
+                request_id="latent-only",
+                prompt={"prompt_ids": [1]},
+                sampling_params=OmniDiffusionSamplingParams(output_type="latent"),
+            ),
+            OmniDiffusionRequest(
+                request_id="needs-preview",
+                prompt={"prompt_ids": [2]},
+                sampling_params=OmniDiffusionSamplingParams(
+                    output_type="latent", extra_args={"requested_outputs": ["image_preview"]}
+                ),
+            ),
+        ]
+    )
+    assert requested_outputs_for_batch(batch) == ["image_preview"]
+    assert batch.requests[0].sampling_params.extra_args.get("requested_outputs") is None
+
+
+@pytest.mark.parametrize(
+    "module,cls_name",
+    [
+        ("qwen_image_flow_grpo", "QwenImagePipelineWithLogProb"),
+        ("qwen_image_diffusion_nft", "QwenImageDiffusionNFTPipeline"),
+        ("qwen_image_dpo", "QwenImageDPOPipeline"),
+    ],
+)
+@pytest.mark.parametrize(
+    "output_type,requested,decode_type",
+    [
+        ("pt", [], "pil"),
+        ("latent", [], "latent"),
+        ("latent", ["image_preview"], "pil"),
+    ],
+)
+def test_real_step_decode_hooks_emit_explicit_latent_and_optional_preview(
+    monkeypatch, module, cls_name, output_type, requested, decode_type
+):
+    from vllm_omni.diffusion.models.qwen_image import QwenImagePipeline
+
+    calls = []
+    pixels = torch.ones(1, 3, 2, 4)
+
+    def decode(self, latents, height, width, output_type):
+        calls.append(output_type)
+        return DiffusionOutput(output=latents if output_type == "latent" else pixels)
+
+    monkeypatch.setattr(QwenImagePipeline, "_decode_latents", decode)
+    cls = getattr(importlib.import_module(f"verl_omni.pipelines.{module}.vllm_omni_rollout_adapter"), cls_name)
+    pipeline = object.__new__(cls)
+    state = StepRequestState(
+        request_id="step",
+        sampling=OmniDiffusionSamplingParams(
+            height=16, width=32, output_type=output_type, extra_args={"requested_outputs": requested}
+        ),
+    )
+    state.latents = torch.ones(1, 2, 16, dtype=torch.bfloat16)
+    state.timesteps = torch.tensor([1.0])
+    state.extra.update(height=16, width=32)
+    state.all_latents = [state.latents]
+    state.all_log_probs = [torch.zeros(1)]
+    state.all_timesteps = [torch.tensor(1.0)]
+    output = pipeline.post_decode(state)
+    assert calls == [decode_type]
+    header = output.output["metadata"]["media_artifacts"]
+    row = output.output["payload"]["image"][0]
+    assert header["primary"] == ("image_latent" if output_type == "latent" else "image_preview")
+    assert ("image_preview" in row) == (decode_type == "pil")
+    torch.testing.assert_close(row["image_latent"], state.latents[0])
+    if "rl" in output.output["metadata"]:
+        assert "latents_clean" in output.output["metadata"]["rl"]
+
+
+@pytest.mark.parametrize(
+    "module,cls_name",
+    [
+        ("qwen_image_flow_grpo", "QwenImagePipelineWithLogProb"),
+        ("qwen_image_diffusion_nft", "QwenImageDiffusionNFTPipeline"),
+        ("qwen_image_dpo", "QwenImageDPOPipeline"),
+    ],
+)
+def test_step_warmup_media_is_discarded_but_real_nonfinite_pixels_fail(monkeypatch, module, cls_name):
+    from vllm_omni.diffusion.models.qwen_image import QwenImagePipeline
+    from vllm_omni.diffusion.request import DUMMY_DIFFUSION_REQUEST_ID
+
+    calls = []
+
+    def decode(self, *args):
+        calls.append(args)
+        return DiffusionOutput(output=torch.full((1, 3, 2, 4), float("nan")))
+
+    monkeypatch.setattr(QwenImagePipeline, "_decode_latents", decode)
+    cls = getattr(importlib.import_module(f"verl_omni.pipelines.{module}.vllm_omni_rollout_adapter"), cls_name)
+    pipeline = object.__new__(cls)
+    state = StepRequestState(
+        request_id=DUMMY_DIFFUSION_REQUEST_ID, sampling=OmniDiffusionSamplingParams(height=16, width=32)
+    )
+    state.latents = torch.ones(1, 2, 16)
+    state.timesteps = torch.tensor([1.0])
+    state.extra.update(height=16, width=32)
+    state.all_latents = [state.latents]
+    state.all_log_probs = [torch.zeros(1)]
+    state.all_timesteps = [torch.tensor(1.0)]
+    output = pipeline.post_decode(state)
+    assert output.output is None and len(calls) == 1
+    state.request_id = "real-request"
+    with pytest.raises(ValueError, match="real-request.*nonfinite decoded pixels"):
+        pipeline.post_decode(state)
+
+
+@pytest.mark.parametrize("conflict", ["values", "dtype"])
+def test_complementary_engine_sources_are_merged_and_conflicts_fail(conflict):
+    native = with_visual_artifacts(
+        rollout_output(media=None),
+        decoded=torch.ones(1, 3, 2, 4),
+        latents=torch.ones(1, 2, 16),
+        latent_layout="LC",
+        output_type="pt",
+        context="adapter",
+    )
+    final = _format(native, request_id="merge-test")
+    row = final.images[0]
+    final.multimodal_output["image_latent"] = row["image_latent"]
+    final.images = [row["image_preview"]]
+    strategy = DiffusionStrategy(SimpleNamespace(global_steps=1))
+    output = strategy.process_output(final, None, {})
+    assert set(output.artifacts) == {"image_latent", "image_preview"}
+    final.images = [row]
+    final.multimodal_output["image_latent"] = (
+        row["image_latent"] + 1 if conflict == "values" else row["image_latent"].half()
+    )
+    with pytest.raises(ValueError, match="merge-test.*conflicting artifact='image_latent'"):
+        strategy.process_output(final, None, {})
+
+
+@pytest.mark.parametrize("requested", ["image_preview", ["image_preview", "image_preview"], ["missing_artifact"]])
+def test_request_artifact_selection_fails_before_engine_generation(monkeypatch, requested):
+    from verl_omni.pipelines.qwen_image_flow_grpo.vllm_omni_rollout_adapter import QwenImagePipelineWithLogProb
+    from verl_omni.pipelines.rollout_request import OmniRolloutRequest
+
+    engine = SimpleNamespace(
+        default_sampling_params_list=[None],
+        engine=SimpleNamespace(get_stage_metadata=lambda index: SimpleNamespace(stage_type="diffusion")),
+    )
+    strategy = DiffusionStrategy(SimpleNamespace(engine=engine))
+    monkeypatch.setattr(strategy, "_diffusion_io_spec", lambda: QwenImagePipelineWithLogProb.diffusion_io_spec)
+    with pytest.raises(ValueError, match="requested_outputs|undeclared artifacts"):
+        strategy.preprocess_input(
+            OmniRolloutRequest.from_generate_kwargs(prompt_ids=[1]), {"requested_outputs": requested}, None
+        )
+
+
+def test_batch_split_never_infers_static_metadata_batch_axes():
+    native = with_visual_artifacts(
+        rollout_output(media=None),
+        decoded=torch.zeros(2, 3, 2, 4),
+        latents=torch.ones(2, 2, 16),
+        latent_layout="LC",
+        output_type="pt",
+        context="batch",
+    )
+    shared = torch.arange(2)  # Coincidentally the same length as the request batch.
+    native.output["metadata"]["shared_schedule"] = shared
+    split = split_diffusion_output_by_request(native, SimpleNamespace(num_reqs=2), num_outputs_per_prompt=1)
+    for item in split:
+        torch.testing.assert_close(item.output["metadata"]["shared_schedule"], shared)
+        assert item.output["metadata"]["shared_schedule"].data_ptr() == shared.data_ptr()
+    native.trajectory_latents = torch.zeros(3, 4, 2, 16)
+    with pytest.raises(ValueError, match="Expected rollout batch size 2"):
+        split_diffusion_output_by_request(native, SimpleNamespace(num_reqs=2), num_outputs_per_prompt=1)
+
+
+@pytest.mark.parametrize("field", ["trajectory", "rl"])
+def test_unbatch_never_silently_discards_training_rows(field):
+    native = with_visual_artifacts(
+        rollout_output(media=None),
+        decoded=torch.zeros(1, 3, 2, 4),
+        latents=torch.ones(1, 2, 16),
+        latent_layout="LC",
+        output_type="pt",
+        context="batch",
+    )
+    final = _format(native, request_id="bad-meta")
+    if field == "trajectory":
+        final.trajectory_latents = torch.zeros(3, 2, 16)
+    else:
+        final.multimodal_output["metadata"]["rl"] = {"latents_clean": torch.zeros(3, 2, 16)}
+    with pytest.raises(ValueError, match="bad-meta.*expected batch size 1"):
+        DiffusionStrategy(SimpleNamespace(global_steps=1)).process_output(final, None, {})
+
+
+@pytest.mark.parametrize("output_type", ["unknown", "", False])
+def test_unknown_representation_is_not_treated_as_pixels(output_type):
+    from verl_omni.pipelines.rollout_request import OmniRolloutRequest
+
+    engine = SimpleNamespace(
+        default_sampling_params_list=[None],
+        engine=SimpleNamespace(get_stage_metadata=lambda index: SimpleNamespace(stage_type="diffusion")),
+    )
+    with pytest.raises(ValueError, match="Unsupported diffusion output_type"):
+        DiffusionStrategy(SimpleNamespace(engine=engine)).preprocess_input(
+            OmniRolloutRequest.from_generate_kwargs(prompt_ids=[1]),
+            {"output_type": output_type},
+            None,
+        )
+
+
+def test_ltx_declares_single_request_state_ownership():
+    from verl_omni.pipelines.ltx2_flow_grpo.vllm_omni_rollout_adapter import LTX23PipelineWithLogProb
+
+    assert LTX23PipelineWithLogProb.supports_request_batch is False
+
+
+def test_error_provenance_survives_tensor_transport():
+    native = with_visual_artifacts(
+        rollout_output(media=None),
+        decoded=None,
+        latents=torch.ones(1, 2, 16),
+        latent_layout="LC",
+        output_type="latent",
+        context="adapter",
+    )
+    output = DiffusionStrategy(SimpleNamespace(global_steps=1)).process_output(
+        _format(native, request_id="trace-me"), None, {"output_type": "latent"}
+    )
+    fields = artifact_fields(output.artifacts, output.primary_artifact, output.preview_artifact)
+    restored = artifacts_from_fields(fields, context="reward")
+    with pytest.raises(ArtifactContractError, match="trace-me.*image_preview"):
+        select_artifact(restored, name="image_preview", modality="image", representation="decoded")

--- a/tests/pipelines/test_prompt_embed_cache_on_cpu.py
+++ b/tests/pipelines/test_prompt_embed_cache_on_cpu.py
@@ -541,6 +541,7 @@ def test_dpo_forward_passes_list_inputs_to_encode_prompt():
         seed=None,
         true_cfg_scale=None,
         num_outputs_per_prompt=None,
+        output_type="pil",
     )
     request = SimpleNamespace(
         prompts=[

--- a/tests/pipelines/test_qwen_image_edit_on_cpu.py
+++ b/tests/pipelines/test_qwen_image_edit_on_cpu.py
@@ -195,6 +195,39 @@ def test_prompt_encoding_requires_condition_images():
         )
 
 
+@pytest.mark.parametrize("as_list", [False, True])
+def test_raw_and_engine_preprocessed_images_are_distinct_named_views(monkeypatch, as_list):
+    from types import SimpleNamespace
+
+    from PIL import Image
+
+    from verl_omni.pipelines.qwen_image_edit_flow_grpo import vllm_omni_rollout_adapter as adapter
+
+    class Captured(Exception):
+        pass
+
+    raw = Image.new("RGB", (32, 32), "blue")
+    processed = raw.resize((384, 384))
+    prompt = {
+        "prompt_ids": [1, 2],
+        "multi_modal_data": {"image": [raw] if as_list else raw},
+        "additional_information": {"condition_images": [processed], "vae_image_sizes": [(1024, 1024)]},
+    }
+    request = SimpleNamespace(
+        prompts=[prompt], sampling_params=SimpleNamespace(height=64, width=64, output_type="image")
+    )
+
+    def capture(images, sizes, **kwargs):
+        assert images == [raw]
+        assert images[0].size == (32, 32)
+        assert sizes == [(1024, 1024)]
+        raise Captured
+
+    monkeypatch.setattr(adapter, "_validate_condition_image_sizes", capture)
+    with pytest.raises(Captured):
+        QwenImageEditPlusPipelineWithLogProb.forward(SimpleNamespace(), request)
+
+
 def test_condition_images_require_fixed_square_latents():
     _validate_condition_image_sizes(["image"], [(1024, 1024)])
     with pytest.raises(ValueError, match="vae_image_sizes"):

--- a/tests/pipelines/test_rollout_artifacts_on_cpu.py
+++ b/tests/pipelines/test_rollout_artifacts_on_cpu.py
@@ -1,0 +1,210 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Named media is shape-declared, lossless and independent of tuple position."""
+
+from dataclasses import replace
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from verl_omni.pipelines.diffusion_rollout_output import with_media_artifacts, wrap_rollout_postprocessor
+from verl_omni.pipelines.rollout_artifacts import (
+    ArtifactSpec,
+    MediaArtifact,
+    artifact_fields,
+    artifacts_from_fields,
+    select_artifact,
+    validate_artifacts,
+)
+from verl_omni.workers.rollout.vllm_rollout.vllm_omni_diffusion_strategy import DiffusionStrategy
+
+
+@pytest.mark.parametrize("layout", ["TCHW", "CTHW", "THWC"])
+@pytest.mark.parametrize("frames,channels", [(3, 3), (3, 4), (4, 1)])
+def test_decoded_video_axes_do_not_depend_on_channel_count(layout, frames, channels):
+    canonical = torch.arange(frames * channels * 2 * 4, dtype=torch.uint8).reshape(frames, channels, 2, 4)
+    raw = canonical.permute(*("TCHW".index(axis) for axis in layout))
+    result = MediaArtifact(ArtifactSpec("video", "decoded", layout, fps=24), raw).normalized(
+        context="test", name="preview"
+    )
+    assert result.spec.layout == "TCHW"
+    torch.testing.assert_close(result.data, canonical)
+
+
+@pytest.mark.parametrize("layout,shape", [("CTHW", (16, 3, 2, 2)), ("LC", (13, 64)), ("CLT", (2, 32, 8))])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+def test_native_latents_keep_dtype_axes_and_storage(layout, shape, dtype):
+    data = torch.randn(shape).to(dtype)
+    artifact = MediaArtifact(ArtifactSpec("video", "latent", layout), data)
+    assert artifact.normalized(context="native", name="latent") is artifact
+    assert artifact.data.data_ptr() == data.data_ptr()
+
+
+@pytest.mark.parametrize(
+    "spec,data,error",
+    [
+        (ArtifactSpec("video", "decoded", "TCHW"), torch.zeros(3, 3, 2, 2), "uint8"),
+        (ArtifactSpec("video", "latent", "CTHW"), torch.zeros(3, 3, 2, 2, dtype=torch.uint8), "floating latent"),
+        (ArtifactSpec("audio", "decoded", "CT"), torch.zeros(2, 8), "sample_rate"),
+        (ArtifactSpec("audio", "decoded", "CT", sample_rate=0), torch.zeros(2, 8), "sample_rate"),
+        (ArtifactSpec("audio", "decoded", "CT", sample_rate=True), torch.zeros(2, 8), "sample_rate"),
+        (ArtifactSpec("video", "decoded", "CHW"), torch.zeros(3, 2, 2, dtype=torch.uint8), "layout"),
+        (ArtifactSpec("video", "latent", "CTHW"), torch.zeros(3, 2, 2), "shape"),
+        (ArtifactSpec("image", "decoded", "CHW", fps=24), torch.zeros(3, 2, 2, dtype=torch.uint8), "fps"),
+        (ArtifactSpec("depth", "decoded", "CHW"), torch.zeros(3, 2, 2, dtype=torch.uint8), "modality"),
+    ],
+)
+def test_invalid_artifact_fails_with_context(spec, data, error):
+    with pytest.raises(ValueError, match=error) as caught:
+        MediaArtifact(spec, data).validate(context="pipeline=test, request_id=req", name="broken")
+    assert "pipeline=test" in str(caught.value) and "artifact='broken'" in str(caught.value)
+    assert "request_id=req" in str(caught.value)
+
+
+def _artifacts():
+    return {
+        "video_preview": MediaArtifact(
+            ArtifactSpec("video", "decoded", "THWC", fps=12), torch.zeros(3, 4, 5, 3, dtype=torch.uint8)
+        ),
+        "video_latent": MediaArtifact(
+            ArtifactSpec("video", "latent", "CTHW"), torch.zeros(16, 2, 2, 2, dtype=torch.bfloat16)
+        ),
+        "audio": MediaArtifact(ArtifactSpec("audio", "decoded", "CT", sample_rate=32000), torch.zeros(2, 160)),
+    }
+
+
+@pytest.mark.parametrize("mode", ["missing", "extra", "duplicate", "requested", "spec", "primary"])
+def test_name_and_declaration_mismatches_are_errors(mode):
+    items = list(_artifacts().items())
+    specs = {name: artifact.spec for name, artifact in items}
+    primary, requested = "video_preview", None
+    if mode == "missing":
+        items.pop()
+    elif mode == "extra":
+        items.append(("extra", items[0][1]))
+    elif mode == "duplicate":
+        items.append(items[0])
+    elif mode == "requested":
+        requested = ["missing_preview"]
+    elif mode == "spec":
+        specs["video_preview"] = replace(specs["video_preview"], fps=30)
+    else:
+        primary = "missing"
+    with pytest.raises(ValueError):
+        validate_artifacts(items, specs, primary=primary, requested=requested, context="test")
+
+
+@pytest.mark.parametrize("primary,output_type", [("video_preview", "pt"), ("video_latent", "latent"), ("audio", "pt")])
+def test_named_media_survives_real_upstream_formatter_and_strategy(primary, output_type):
+    from vllm_omni.diffusion.data import DiffusionOutput
+    from vllm_omni.diffusion.models.minimax_h3.pipeline_minimax_h3 import _minimax_h3_post_process
+    from vllm_omni.diffusion.output_formatter import format_diffusion_outputs, normalize_diffusion_postprocess_output
+    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
+    artifacts = _artifacts()
+    native = with_media_artifacts(
+        DiffusionOutput(output={"payload": {"video": torch.zeros(1)}, "metadata": {"rl": {"sentinel": 7}}}),
+        artifacts=list(artifacts.items()),
+        specs={name: item.spec for name, item in artifacts.items()},
+        primary=primary,
+        preview="video_preview",
+        audio="audio",
+        context="pipeline=test, request_id=req",
+    )
+    processed = _minimax_h3_post_process(native.output)
+    normalized = normalize_diffusion_postprocess_output(processed)
+    request = SimpleNamespace(
+        request_id="req", prompt={"prompt_ids": [1]}, sampling_params=OmniDiffusionSamplingParams()
+    )
+    final = format_diffusion_outputs(
+        request=request,
+        od_config=SimpleNamespace(model_class_name="MiniMaxH3Pipeline"),
+        diffusion_output=native,
+        output_data=processed,
+        postprocess_output=normalized,
+    )[0]
+    result = DiffusionStrategy(SimpleNamespace(global_steps=1)).process_output(
+        final, None, {"output_type": output_type}
+    )
+    assert set(result.artifacts) == set(artifacts)
+    assert result.primary_artifact == primary and result.preview_artifact == "video_preview"
+    assert result.artifacts["video_preview"].spec.layout == "TCHW"
+    assert result.artifacts["video_latent"].data.dtype == torch.bfloat16
+    assert result.artifacts["audio"].spec.sample_rate == 32000
+    assert result.extra_fields["sentinel"] == 7
+    assert result.extra_fields["audio"].shape == (2, 160)
+    fields = artifact_fields(result.artifacts, primary, result.preview_artifact)
+    restored = artifacts_from_fields(fields, context="transport")
+    assert set(restored) == set(artifacts)
+    torch.testing.assert_close(restored[primary].data, result.diffusion_output)
+
+
+def test_artifact_transport_rejects_dropped_declarations_and_data():
+    artifacts = _artifacts()
+    fields = artifact_fields(artifacts, "video_latent", "video_preview")
+    del fields["media_artifact__audio"]
+    with pytest.raises(ValueError, match="declared artifacts missing"):
+        artifacts_from_fields(fields, context="test")
+    del fields["media_artifact_specs"]
+    with pytest.raises(ValueError, match="no declarations"):
+        artifacts_from_fields(fields, context="test")
+
+
+def test_named_empty_payload_is_not_misreported_as_abort():
+    final = SimpleNamespace(
+        images=[],
+        request_id="missing-output",
+        multimodal_output={"metadata": {"media_artifacts": {"primary": "video_preview", "specs": {}}}},
+    )
+    with pytest.raises(ValueError, match="missing-output.*named artifact payload"):
+        DiffusionStrategy(SimpleNamespace(global_steps=1)).process_output(final, None, {})
+
+
+def test_media_only_postprocessor_does_not_touch_named_payloads():
+    wrapped = wrap_rollout_postprocessor(
+        lambda *args, **kwargs: pytest.fail("already-normalized media was reprocessed")
+    )
+    data = {"payload": {"video": {}}, "metadata": {"media_artifacts": {"specs": {}}}}
+    assert wrapped(data) is data
+    with pytest.raises(ValueError, match="multiple payload"):
+        wrapped({"payload": {"video": torch.zeros(1), "audio": torch.zeros(1)}})
+
+
+@pytest.mark.parametrize("nested", [False, True])
+def test_requested_outputs_survive_sampling_lowering(nested):
+    from verl_omni.pipelines.rollout_request import OmniRolloutRequest
+
+    strategy = DiffusionStrategy(SimpleNamespace(engine=SimpleNamespace(default_sampling_params_list=[None])))
+    sampling = {"requested_outputs": ["video_preview", "video_latent"]}
+    _, params = strategy.preprocess_input(
+        OmniRolloutRequest.from_generate_kwargs(prompt_ids=[1]), {"extra_args": sampling} if nested else sampling, None
+    )
+    assert params[0].extra_args == sampling
+    with pytest.raises(ValueError, match="Conflicting diffusion sampling"):
+        strategy.preprocess_input(
+            OmniRolloutRequest.from_generate_kwargs(prompt_ids=[1]),
+            {"requested_outputs": ["one"], "extra_args": {"requested_outputs": ["two"]}},
+            None,
+        )
+
+
+def test_preview_selection_never_falls_back_to_latent():
+    with pytest.raises(ValueError, match="absent"):
+        select_artifact(
+            {"video_latent": _artifacts()["video_latent"]},
+            name="video_preview",
+            modality="video",
+            representation="decoded",
+        )

--- a/tests/pipelines/test_rollout_artifacts_on_cpu.py
+++ b/tests/pipelines/test_rollout_artifacts_on_cpu.py
@@ -21,13 +21,13 @@ import torch
 
 from verl_omni.pipelines.diffusion_rollout_output import with_media_artifacts, wrap_rollout_postprocessor
 from verl_omni.pipelines.rollout_artifacts import (
-    ArtifactSpec,
     MediaArtifact,
     artifact_fields,
     artifacts_from_fields,
     select_artifact,
     validate_artifacts,
 )
+from verl_omni.pipelines.rollout_media import MediaSpec
 from verl_omni.workers.rollout.vllm_rollout.vllm_omni_diffusion_strategy import DiffusionStrategy
 
 
@@ -36,7 +36,7 @@ from verl_omni.workers.rollout.vllm_rollout.vllm_omni_diffusion_strategy import 
 def test_decoded_video_axes_do_not_depend_on_channel_count(layout, frames, channels):
     canonical = torch.arange(frames * channels * 2 * 4, dtype=torch.uint8).reshape(frames, channels, 2, 4)
     raw = canonical.permute(*("TCHW".index(axis) for axis in layout))
-    result = MediaArtifact(ArtifactSpec("video", "decoded", layout, fps=24), raw).normalized(
+    result = MediaArtifact(MediaSpec("video", "decoded", layout, fps=24), raw).normalized(
         context="test", name="preview"
     )
     assert result.spec.layout == "TCHW"
@@ -47,7 +47,7 @@ def test_decoded_video_axes_do_not_depend_on_channel_count(layout, frames, chann
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
 def test_native_latents_keep_dtype_axes_and_storage(layout, shape, dtype):
     data = torch.randn(shape).to(dtype)
-    artifact = MediaArtifact(ArtifactSpec("video", "latent", layout), data)
+    artifact = MediaArtifact(MediaSpec("video", "latent", layout), data)
     assert artifact.normalized(context="native", name="latent") is artifact
     assert artifact.data.data_ptr() == data.data_ptr()
 
@@ -55,15 +55,15 @@ def test_native_latents_keep_dtype_axes_and_storage(layout, shape, dtype):
 @pytest.mark.parametrize(
     "spec,data,error",
     [
-        (ArtifactSpec("video", "decoded", "TCHW"), torch.zeros(3, 3, 2, 2), "uint8"),
-        (ArtifactSpec("video", "latent", "CTHW"), torch.zeros(3, 3, 2, 2, dtype=torch.uint8), "floating latent"),
-        (ArtifactSpec("audio", "decoded", "CT"), torch.zeros(2, 8), "sample_rate"),
-        (ArtifactSpec("audio", "decoded", "CT", sample_rate=0), torch.zeros(2, 8), "sample_rate"),
-        (ArtifactSpec("audio", "decoded", "CT", sample_rate=True), torch.zeros(2, 8), "sample_rate"),
-        (ArtifactSpec("video", "decoded", "CHW"), torch.zeros(3, 2, 2, dtype=torch.uint8), "layout"),
-        (ArtifactSpec("video", "latent", "CTHW"), torch.zeros(3, 2, 2), "shape"),
-        (ArtifactSpec("image", "decoded", "CHW", fps=24), torch.zeros(3, 2, 2, dtype=torch.uint8), "fps"),
-        (ArtifactSpec("depth", "decoded", "CHW"), torch.zeros(3, 2, 2, dtype=torch.uint8), "modality"),
+        (MediaSpec("video", "decoded", "TCHW"), torch.zeros(3, 3, 2, 2), "uint8"),
+        (MediaSpec("video", "latent", "CTHW"), torch.zeros(3, 3, 2, 2, dtype=torch.uint8), "floating latent"),
+        (MediaSpec("audio", "decoded", "CT"), torch.zeros(2, 8), "sample_rate"),
+        (MediaSpec("audio", "decoded", "CT", sample_rate=0), torch.zeros(2, 8), "sample_rate"),
+        (MediaSpec("audio", "decoded", "CT", sample_rate=True), torch.zeros(2, 8), "sample_rate"),
+        (MediaSpec("video", "decoded", "CHW"), torch.zeros(3, 2, 2, dtype=torch.uint8), "layout"),
+        (MediaSpec("video", "latent", "CTHW"), torch.zeros(3, 2, 2), "shape"),
+        (MediaSpec("image", "decoded", "CHW", fps=24), torch.zeros(3, 2, 2, dtype=torch.uint8), "fps"),
+        (MediaSpec("depth", "decoded", "CHW"), torch.zeros(3, 2, 2, dtype=torch.uint8), "modality"),
     ],
 )
 def test_invalid_artifact_fails_with_context(spec, data, error):
@@ -76,12 +76,12 @@ def test_invalid_artifact_fails_with_context(spec, data, error):
 def _artifacts():
     return {
         "video_preview": MediaArtifact(
-            ArtifactSpec("video", "decoded", "THWC", fps=12), torch.zeros(3, 4, 5, 3, dtype=torch.uint8)
+            MediaSpec("video", "decoded", "THWC", fps=12), torch.zeros(3, 4, 5, 3, dtype=torch.uint8)
         ),
         "video_latent": MediaArtifact(
-            ArtifactSpec("video", "latent", "CTHW"), torch.zeros(16, 2, 2, 2, dtype=torch.bfloat16)
+            MediaSpec("video", "latent", "CTHW"), torch.zeros(16, 2, 2, 2, dtype=torch.bfloat16)
         ),
-        "audio": MediaArtifact(ArtifactSpec("audio", "decoded", "CT", sample_rate=32000), torch.zeros(2, 160)),
+        "audio": MediaArtifact(MediaSpec("audio", "decoded", "CT", sample_rate=32000), torch.zeros(2, 160)),
     }
 
 
@@ -172,7 +172,7 @@ def test_named_empty_payload_is_not_misreported_as_abort():
                     "primary": "video_preview",
                     "preview": "video_preview",
                     "audio": None,
-                    "specs": {"video_preview": asdict(ArtifactSpec("video", "decoded", "TCHW", fps=24))},
+                    "specs": {"video_preview": asdict(MediaSpec("video", "decoded", "TCHW", fps=24))},
                 }
             }
         },

--- a/tests/pipelines/test_rollout_artifacts_on_cpu.py
+++ b/tests/pipelines/test_rollout_artifacts_on_cpu.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Named media is shape-declared, lossless and independent of tuple position."""
 
-from dataclasses import replace
+from dataclasses import asdict, replace
 from types import SimpleNamespace
 
 import pytest
@@ -166,7 +166,16 @@ def test_named_empty_payload_is_not_misreported_as_abort():
     final = SimpleNamespace(
         images=[],
         request_id="missing-output",
-        multimodal_output={"metadata": {"media_artifacts": {"primary": "video_preview", "specs": {}}}},
+        multimodal_output={
+            "metadata": {
+                "media_artifacts": {
+                    "primary": "video_preview",
+                    "preview": "video_preview",
+                    "audio": None,
+                    "specs": {"video_preview": asdict(ArtifactSpec("video", "decoded", "TCHW", fps=24))},
+                }
+            }
+        },
     )
     with pytest.raises(ValueError, match="missing-output.*named artifact payload"):
         DiffusionStrategy(SimpleNamespace(global_steps=1)).process_output(final, None, {})
@@ -186,7 +195,14 @@ def test_media_only_postprocessor_does_not_touch_named_payloads():
 def test_requested_outputs_survive_sampling_lowering(nested):
     from verl_omni.pipelines.rollout_request import OmniRolloutRequest
 
-    strategy = DiffusionStrategy(SimpleNamespace(engine=SimpleNamespace(default_sampling_params_list=[None])))
+    strategy = DiffusionStrategy(
+        SimpleNamespace(
+            engine=SimpleNamespace(
+                default_sampling_params_list=[None],
+                engine=SimpleNamespace(get_stage_metadata=lambda index: SimpleNamespace(stage_type="diffusion")),
+            )
+        )
+    )
     sampling = {"requested_outputs": ["video_preview", "video_latent"]}
     _, params = strategy.preprocess_input(
         OmniRolloutRequest.from_generate_kwargs(prompt_ids=[1]), {"extra_args": sampling} if nested else sampling, None

--- a/tests/pipelines/test_wan22_dance_grpo_on_cpu.py
+++ b/tests/pipelines/test_wan22_dance_grpo_on_cpu.py
@@ -129,7 +129,8 @@ def test_wan22_dance_grpo_forward_accepts_vllm_omni_request_batch(monkeypatch) -
         output_type="np",
     )
 
-    assert output is expected
+    assert output.output["metadata"]["media_artifacts"]["primary"] == "video_latent"
+    torch.testing.assert_close(output.output["payload"]["video"][0]["video_latent"], latents[0])
     encoded_prompt_ids = pipeline.encode_prompt.call_args.kwargs["prompt_ids"]
     assert encoded_prompt_ids.tolist() == [11, 12, 13]
     prepare_kwargs = pipeline.prepare_latents.call_args.kwargs
@@ -139,7 +140,7 @@ def test_wan22_dance_grpo_forward_accepts_vllm_omni_request_batch(monkeypatch) -
     assert prepare_kwargs["generator"].initial_seed() == 321
     pipeline.diffuse.assert_called_once()
     rollout_output.assert_called_once_with(
-        media=latents,
+        media=None,
         media_key="video",
         trajectory_latents=trajectory_latents,
         trajectory_log_probs=trajectory_log_probs,

--- a/tests/reward_loop/test_audio_reward_manager_on_cpu.py
+++ b/tests/reward_loop/test_audio_reward_manager_on_cpu.py
@@ -160,6 +160,41 @@ def test_run_single_forwards_reward_router_arguments():
     assert result["reward_score"] == 0.5
 
 
+@pytest.mark.parametrize("field,value", [("audio_sample_rate", 16000), ("audio", np.zeros(8)), ("media_kind", "video")])
+def test_conflicting_media_fails_before_audio_scoring(field, value):
+    data = _data(np.ones(8, dtype=np.float32))
+    data.non_tensor_batch["tool_extra_fields"][0]["media_kind"] = "audio"
+    data.non_tensor_batch[field] = np.array([value], dtype=object)
+    manager = _manager(lambda **kwargs: pytest.fail("Conflicting media reached the scorer"))
+    with pytest.raises(ValueError, match=f"Conflicting rollout media field.*{field}"):
+        manager.loop.run_until_complete(manager.run_single(data))
+
+
+def test_audio_metadata_projection_keeps_copy_and_scalar_mapping_compatibility():
+    data = _data(np.ones(8, dtype=np.float32))
+    original = {"id": "kept", "audio": "conditioning audio"}
+    data.non_tensor_batch["extra_info"][0] = np.array(original, dtype=object)
+    data.non_tensor_batch["tool_extra_fields"][0] = np.array(
+        data.non_tensor_batch["tool_extra_fields"][0], dtype=object
+    )
+    data.non_tensor_batch["media_kind"] = np.array(["audio"], dtype=object)
+    data.non_tensor_batch["__num_turns__"] = np.array([2])
+    data.non_tensor_batch["global_steps"] = np.array([7])
+
+    def scorer(extra_info, **kwargs):
+        assert extra_info["media_kind"] == "audio"
+        assert extra_info["num_turns"] == 2
+        assert extra_info["global_steps"] == 7
+        assert extra_info["id"] == "kept"
+        assert extra_info["audio_sample_rate"] == 24000
+        extra_info["id"] = "changed"
+        return 0.5
+
+    manager = _manager(scorer)
+    manager.loop.run_until_complete(manager.run_single(data))
+    assert original == {"id": "kept", "audio": "conditioning audio"}
+
+
 def test_run_single_reads_finalized_top_level_audio_layout():
     def compute_score(solution_audio, extra_info, **kwargs):
         waveform, sample_rate = solution_audio

--- a/tests/reward_loop/test_media_metadata_on_cpu.py
+++ b/tests/reward_loop/test_media_metadata_on_cpu.py
@@ -1,0 +1,96 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Generated media must reach scorers through both reward execution paths."""
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+from omegaconf import OmegaConf
+from verl import DataProto
+
+from verl_omni.reward_loop.reward_manager import multi
+from verl_omni.reward_loop.reward_manager.visual import VisualRewardManager
+from verl_omni.trainer.diffusion.v1 import tq_utils
+
+
+def _manager(monkeypatch, manager_cls, scorer):
+    config = OmegaConf.create(
+        {
+            "actor_rollout_ref": {"rollout": {"pipeline": {"output_type": "pt"}}},
+            "reward": {"reward_functions": {"audio": {"path": "test", "name": "score", "required": True}}},
+        }
+    )
+    monkeypatch.setattr(multi, "load_extern_object", lambda *args: scorer)
+    return manager_cls(config, tokenizer=None, compute_score=scorer)
+
+
+def _data(monkeypatch, transport):
+    audio = torch.arange(16, dtype=torch.float16).reshape(1, 1, 16)
+    tensors = {"responses": torch.zeros(1, 4, 3, 8, 8, dtype=torch.uint8)}
+    non_tensors = {
+        "data_source": ["test"],
+        "reward_model": [{"ground_truth": "prompt"}],
+        "extra_info": [{"dataset_field": "kept", "audio": "reference audio"}],
+    }
+    metadata = {"media_kind": "video", "audio_sample_rate": 32000}
+    if transport == "tool":
+        non_tensors["tool_extra_fields"] = [{"audio": audio[0], **metadata}]
+    elif transport in ("top", "both"):
+        tensors["audio"] = audio
+        non_tensors.update({key: [value] for key, value in metadata.items()})
+        if transport == "both":
+            non_tensors["tool_extra_fields"] = [{"audio": audio[0].clone(), **metadata}]
+    else:
+        payload = {**tensors, **non_tensors, "audio": audio, "extra_fields": [metadata]}
+        monkeypatch.setattr(tq_utils.tq, "kv_batch_get", lambda **kwargs: payload)
+        return tq_utils.diffusion_tq_batch_to_dataproto(SimpleNamespace(keys=["sample"], partition_id="train")), audio
+    return DataProto.from_dict(tensors=tensors, non_tensors=non_tensors), audio
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("manager_cls", [VisualRewardManager, multi.MultiVisualRewardManager])
+@pytest.mark.parametrize("transport", ["tool", "top", "tq", "both"])
+async def test_generated_media_reaches_scorer(monkeypatch, manager_cls, transport):
+    data, audio = _data(monkeypatch, transport)
+
+    async def scorer(data_source, solution_image, ground_truth, extra_info):
+        assert data_source == "test" and ground_truth == "prompt"
+        assert solution_image.dtype == torch.uint8
+        torch.testing.assert_close(extra_info["audio"], audio[0])
+        assert extra_info["audio_sample_rate"] == 32000
+        assert extra_info["media_kind"] == "video"
+        assert extra_info["dataset_field"] == "kept"
+        assert "responses" not in extra_info
+        return {"score": 1.0}
+
+    result = await _manager(monkeypatch, manager_cls, scorer).run_single(data)
+    assert result["reward_score"] == 1.0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("manager_cls", [VisualRewardManager, multi.MultiVisualRewardManager])
+@pytest.mark.parametrize(
+    "field, value", [("media_kind", "image"), ("audio_sample_rate", 24000), ("audio", torch.zeros(1, 16))]
+)
+async def test_conflicting_generated_media_sources_fail_before_scoring(monkeypatch, manager_cls, field, value):
+    data, _ = _data(monkeypatch, "top")
+    data.non_tensor_batch["tool_extra_fields"] = np.array([{field: value}], dtype=object)
+
+    async def scorer(**kwargs):
+        pytest.fail("Conflicting generated media must not reach the scorer")
+
+    with pytest.raises(ValueError, match=f"Conflicting rollout media field.*{field}"):
+        await _manager(monkeypatch, manager_cls, scorer).run_single(data)

--- a/tests/reward_loop/test_media_metadata_on_cpu.py
+++ b/tests/reward_loop/test_media_metadata_on_cpu.py
@@ -83,16 +83,17 @@ async def test_generated_media_reaches_scorer(monkeypatch, manager_cls, transpor
 @pytest.mark.asyncio
 @pytest.mark.parametrize("manager_cls", [VisualRewardManager, multi.MultiVisualRewardManager])
 async def test_latent_primary_and_decoded_artifacts_reach_real_reward_managers(monkeypatch, manager_cls):
-    from verl_omni.pipelines.rollout_artifacts import ArtifactSpec, MediaArtifact, artifact_fields
+    from verl_omni.pipelines.rollout_artifacts import MediaArtifact, artifact_fields
+    from verl_omni.pipelines.rollout_media import MediaSpec
     from verl_omni.utils.reward_score.clap import _get_audio
 
     latent = torch.zeros(16, 2, 2, 2, dtype=torch.float16)
     artifacts = {
-        "video_latent": MediaArtifact(ArtifactSpec("video", "latent", "CTHW"), latent),
+        "video_latent": MediaArtifact(MediaSpec("video", "latent", "CTHW"), latent),
         "video_preview": MediaArtifact(
-            ArtifactSpec("video", "decoded", "TCHW", fps=24), torch.zeros(3, 3, 2, 2, dtype=torch.uint8)
+            MediaSpec("video", "decoded", "TCHW", fps=24), torch.zeros(3, 3, 2, 2, dtype=torch.uint8)
         ),
-        "audio": MediaArtifact(ArtifactSpec("audio", "decoded", "CT", sample_rate=32000), torch.ones(2, 16)),
+        "audio": MediaArtifact(MediaSpec("audio", "decoded", "CT", sample_rate=32000), torch.ones(2, 16)),
     }
     fields = artifact_fields(artifacts, "video_latent", "video_preview")
     data = DataProto.from_dict(
@@ -126,17 +127,13 @@ async def test_latent_primary_and_decoded_artifacts_reach_real_reward_managers(m
 async def test_decoded_audio_primary_is_self_describing_not_inferred_from_pixel_config(
     monkeypatch, manager_cls, mismatch
 ):
-    from verl_omni.pipelines.rollout_artifacts import (
-        ArtifactContractError,
-        ArtifactSpec,
-        MediaArtifact,
-        artifact_fields,
-    )
+    from verl_omni.pipelines.rollout_artifacts import ArtifactContractError, MediaArtifact, artifact_fields
+    from verl_omni.pipelines.rollout_media import MediaSpec
     from verl_omni.utils.reward_score.clap import _get_audio
 
     audio = torch.ones(2, 16)
     fields = artifact_fields(
-        {"audio": MediaArtifact(ArtifactSpec("audio", "decoded", "CT", sample_rate=32000), audio)}, "audio"
+        {"audio": MediaArtifact(MediaSpec("audio", "decoded", "CT", sample_rate=32000), audio)}, "audio"
     )
     data = DataProto.from_dict(
         tensors={

--- a/tests/reward_loop/test_media_metadata_on_cpu.py
+++ b/tests/reward_loop/test_media_metadata_on_cpu.py
@@ -122,6 +122,51 @@ async def test_latent_primary_and_decoded_artifacts_reach_real_reward_managers(m
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("manager_cls", [VisualRewardManager, multi.MultiVisualRewardManager])
+@pytest.mark.parametrize("mismatch", [False, True])
+async def test_decoded_audio_primary_is_self_describing_not_inferred_from_pixel_config(
+    monkeypatch, manager_cls, mismatch
+):
+    from verl_omni.pipelines.rollout_artifacts import (
+        ArtifactContractError,
+        ArtifactSpec,
+        MediaArtifact,
+        artifact_fields,
+    )
+    from verl_omni.utils.reward_score.clap import _get_audio
+
+    audio = torch.ones(2, 16)
+    fields = artifact_fields(
+        {"audio": MediaArtifact(ArtifactSpec("audio", "decoded", "CT", sample_rate=32000), audio)}, "audio"
+    )
+    data = DataProto.from_dict(
+        tensors={
+            "responses": (audio + 1 if mismatch else audio).unsqueeze(0),
+            **{key: value.unsqueeze(0) for key, value in fields.items() if isinstance(value, torch.Tensor)},
+        },
+        non_tensors={
+            "data_source": ["test"],
+            "reward_model": [{"ground_truth": "sound"}],
+            **{key: [value] for key, value in fields.items() if not isinstance(value, torch.Tensor)},
+        },
+    )
+
+    async def scorer(solution_image, extra_info, **kwargs):
+        assert solution_image.dtype == torch.float32
+        waveform, rate = _get_audio(extra_info)
+        assert waveform.shape == (16,) and rate == 32000
+        return {"score": 1.0}
+
+    manager = _manager(monkeypatch, manager_cls, scorer)
+    if mismatch:
+        with pytest.raises(ArtifactContractError, match="responses projection"):
+            await manager.run_single(data)
+    else:
+        result = await manager.run_single(data)
+        assert result["reward_score"] == 1.0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("manager_cls", [VisualRewardManager, multi.MultiVisualRewardManager])
 @pytest.mark.parametrize(
     "field, value", [("media_kind", "image"), ("audio_sample_rate", 24000), ("audio", torch.zeros(1, 16))]
 )

--- a/tests/reward_loop/test_media_metadata_on_cpu.py
+++ b/tests/reward_loop/test_media_metadata_on_cpu.py
@@ -82,6 +82,46 @@ async def test_generated_media_reaches_scorer(monkeypatch, manager_cls, transpor
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("manager_cls", [VisualRewardManager, multi.MultiVisualRewardManager])
+async def test_latent_primary_and_decoded_artifacts_reach_real_reward_managers(monkeypatch, manager_cls):
+    from verl_omni.pipelines.rollout_artifacts import ArtifactSpec, MediaArtifact, artifact_fields
+    from verl_omni.utils.reward_score.clap import _get_audio
+
+    latent = torch.zeros(16, 2, 2, 2, dtype=torch.float16)
+    artifacts = {
+        "video_latent": MediaArtifact(ArtifactSpec("video", "latent", "CTHW"), latent),
+        "video_preview": MediaArtifact(
+            ArtifactSpec("video", "decoded", "TCHW", fps=24), torch.zeros(3, 3, 2, 2, dtype=torch.uint8)
+        ),
+        "audio": MediaArtifact(ArtifactSpec("audio", "decoded", "CT", sample_rate=32000), torch.ones(2, 16)),
+    }
+    fields = artifact_fields(artifacts, "video_latent", "video_preview")
+    data = DataProto.from_dict(
+        tensors={
+            "responses": latent.unsqueeze(0),
+            **{key: value.unsqueeze(0) for key, value in fields.items() if isinstance(value, torch.Tensor)},
+        },
+        non_tensors={
+            "data_source": ["test"],
+            "reward_model": [{"ground_truth": "prompt"}],
+            **{key: [value] for key, value in fields.items() if not isinstance(value, torch.Tensor)},
+        },
+    )
+
+    async def scorer(solution_image, extra_info, **kwargs):
+        assert solution_image.dtype == torch.float16
+        assert extra_info["media_artifacts"]["video_preview"].data.dtype == torch.uint8
+        audio, rate = _get_audio(extra_info)
+        assert rate == 32000 and audio.shape == (16,)
+        return {"score": 1.0}
+
+    manager = _manager(monkeypatch, manager_cls, scorer)
+    manager.config.actor_rollout_ref.rollout.pipeline.output_type = "latent"
+    result = await manager.run_single(data)
+    assert result["reward_score"] == 1.0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("manager_cls", [VisualRewardManager, multi.MultiVisualRewardManager])
 @pytest.mark.parametrize(
     "field, value", [("media_kind", "image"), ("audio_sample_rate", 24000), ("audio", torch.zeros(1, 16))]
 )

--- a/tests/reward_loop/test_multi_reward_manager_on_cpu.py
+++ b/tests/reward_loop/test_multi_reward_manager_on_cpu.py
@@ -49,6 +49,14 @@ def reward_raises(data_source, solution_image, ground_truth, extra_info):
     raise ValueError("intentional failure")
 
 
+def reward_requires_audio(data_source, solution_image, ground_truth, extra_info):
+    """Exercise a real artifact selection failure, not an optional network failure."""
+    from verl_omni.utils.reward_score.clap import _get_audio
+
+    _get_audio(extra_info)
+    return {"score": 1.0}
+
+
 async def reward_async(data_source, solution_image, ground_truth, extra_info):
     """Async reward that returns 0.8."""
     return 0.8
@@ -89,6 +97,7 @@ def _make_single_data(data_source: str = "test_source") -> DataProto:
         non_tensors={
             "data_source": [data_source],
             "reward_model": [{"ground_truth": "hello"}],
+            "media_kind": ["image"],
             "extra_info": [{}],
         },
     )
@@ -98,6 +107,16 @@ def _build_manager(reward_functions: dict) -> MultiVisualRewardManager:
     config = _make_config(reward_functions)
     tokenizer = MagicMock()
     return MultiVisualRewardManager(config, tokenizer, compute_score=None)
+
+
+def test_optional_reward_does_not_swallow_artifact_contract_errors():
+    from verl_omni.pipelines.rollout_artifacts import ArtifactContractError
+
+    manager = _build_manager(
+        {"audio": {"path": DUMMY_REWARDS_PATH, "name": "reward_requires_audio", "required": False}}
+    )
+    with pytest.raises(ArtifactContractError, match="audio.*absent"):
+        manager.loop.run_until_complete(manager.run_single(_make_single_data()))
 
 
 def _build_visual_latent_manager() -> VisualRewardManager:
@@ -295,6 +314,7 @@ class TestMultiVisualRewardManagerRunSingle:
             non_tensors={
                 "data_source": ["jpeg_compressibility"],
                 "reward_model": [{"ground_truth": "hello"}],
+                "media_kind": ["image"],
                 "extra_info": [{}],
             },
         )

--- a/tests/special_e2e/check_diffusion_vae_layouts.py
+++ b/tests/special_e2e/check_diffusion_vae_layouts.py
@@ -29,7 +29,8 @@ from pathlib import Path
 import torch
 
 from verl_omni.pipelines.diffusion_rollout_output import quantize_pixels
-from verl_omni.pipelines.rollout_artifacts import ArtifactSpec, MediaArtifact
+from verl_omni.pipelines.rollout_artifacts import MediaArtifact
+from verl_omni.pipelines.rollout_media import MediaSpec
 
 
 def _load_diffusers(root, subfolder, device):
@@ -113,23 +114,23 @@ def probe(case, checkpoint, device):
     assert decoded.shape[0] == 1 and torch.isfinite(decoded).all(), case
     if audio:
         assert decoded.shape[1] == 2, (case, tuple(decoded.shape))
-        artifact = MediaArtifact(ArtifactSpec("audio", "decoded", "CT", sample_rate=sample_rate), decoded[0])
+        artifact = MediaArtifact(MediaSpec("audio", "decoded", "CT", sample_rate=sample_rate), decoded[0])
     elif case == "h3-video":
         from vllm_omni.diffusion.models.minimax_h3.pipeline_minimax_h3 import _prepare_minimax_h3_video_output
 
         assert decoded.shape[1] == 3, tuple(decoded.shape)
         pixels = _prepare_minimax_h3_video_output(decoded)
-        artifact = MediaArtifact(ArtifactSpec("video", "decoded", "THWC", fps=24), pixels[0])
+        artifact = MediaArtifact(MediaSpec("video", "decoded", "THWC", fps=24), pixels[0])
     elif case == "qwen-image":
         assert decoded.shape[1] == 3 and decoded.shape[2] == 1, tuple(decoded.shape)
         artifact = MediaArtifact(
-            ArtifactSpec("image", "decoded", "CHW"), quantize_pixels(decoded[0, :, 0], "minus_one_one", context=case)
+            MediaSpec("image", "decoded", "CHW"), quantize_pixels(decoded[0, :, 0], "minus_one_one", context=case)
         )
     else:
         assert decoded.shape[1] == 3, (case, tuple(decoded.shape))
         kind = "video" if decoded_layout == "NCTHW" else "image"
         artifact = MediaArtifact(
-            ArtifactSpec(kind, "decoded", "CTHW" if kind == "video" else "CHW", fps=24 if kind == "video" else None),
+            MediaSpec(kind, "decoded", "CTHW" if kind == "video" else "CHW", fps=24 if kind == "video" else None),
             quantize_pixels(decoded[0], "minus_one_one", context=case),
         )
     artifact = artifact.normalized(context=f"pipeline={case}, request_id=vae-probe", name="decoded")

--- a/tests/special_e2e/check_diffusion_vae_layouts.py
+++ b/tests/special_e2e/check_diffusion_vae_layouts.py
@@ -1,0 +1,179 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""GPU probes for actual checkpoint VAE implementations, independently of DiT quality.
+
+Run with CUDA_VISIBLE_DEVICES selecting one device and --models-json pointing to
+an explicit case-name -> local checkpoint-root mapping. Nothing is downloaded,
+no Ray cluster is touched, and cases run sequentially. JSON records checkpoint
+paths, actual module classes, parameter counts, and native/decoded shapes/dtypes.
+This is VAE layout evidence, not a substitute for an end-to-end training smoke.
+"""
+
+import argparse
+import gc
+import json
+import traceback
+from pathlib import Path
+
+import torch
+
+from verl_omni.pipelines.diffusion_rollout_output import quantize_pixels
+from verl_omni.pipelines.rollout_artifacts import ArtifactSpec, MediaArtifact
+
+
+def _load_diffusers(root, subfolder, device):
+    import diffusers
+
+    config = json.loads((root / subfolder / "config.json").read_text())
+    if subfolder == "vocoder":
+        from diffusers.pipelines.ltx2 import vocoder
+
+        cls = getattr(vocoder, config["_class_name"])
+    else:
+        cls = getattr(diffusers, config["_class_name"])
+    return (
+        cls.from_pretrained(str(root), subfolder=subfolder, local_files_only=True, torch_dtype=torch.float32)
+        .eval()
+        .to(device)
+    )
+
+
+@torch.inference_mode()
+def probe(case, checkpoint, device):
+    """Decode a small native latent using a real VAE, then check the declared axes."""
+    root = Path(checkpoint)
+    audio = case.endswith("audio")
+    if case.startswith("h3-"):
+        from vllm_omni.diffusion.models.minimax_h3.vae import MiniMaxH3AudioVAE, MiniMaxH3VideoVAE
+
+        component = "audio_vae" if audio else "video_vae"
+        cls = MiniMaxH3AudioVAE if audio else MiniMaxH3VideoVAE
+        model = cls(str(root / component), device=device)
+        channels = int(model.config_dict["latent_channels"])
+        shape = (2, channels, 16) if audio else (1, channels, 7, 8, 12)
+        latents = torch.zeros(shape, device=device)
+        if audio:
+            decoded = model.decode_latent(latents)
+        else:
+            # Match MiniMaxH3Pipeline.decode's FP16 decoder autocast contract.
+            with torch.autocast(device_type=device.type, dtype=torch.float16):
+                decoded = model.decode_latent(latents)
+        native_layout, decoded_layout = ("CLT", "NCT") if audio else ("NCTHW", "NCTHW")
+        sample_rate = model.sample_rate if audio else None
+    elif case == "bagel":
+        from safetensors.torch import load_file
+        from vllm_omni.diffusion.models.bagel.pipeline_bagel import AutoEncoder, default_ae_params
+
+        model = AutoEncoder(default_ae_params())
+        model.load_state_dict(load_file(str(root / "ae.safetensors")))
+        model = model.eval().to(device)
+        latents = torch.zeros(1, 16, 4, 6, device=device)
+        decoded = model.decode(latents)
+        native_layout, decoded_layout, sample_rate = "NCHW", "NCHW", None
+    else:
+        model = _load_diffusers(root, "audio_vae" if audio else "vae", device)
+        channels = model.config.z_dim if case in ("qwen-image", "wan") else model.config.latent_channels
+        if case == "qwen-image":
+            shape, native_layout = (1, channels, 1, 4, 6), "NCTHW"
+        elif case in ("sd3", "boogu"):
+            shape, native_layout = (1, channels, 4, 6), "NCHW"
+        elif case in ("wan", "ltx-video"):
+            shape, native_layout = (1, channels, 2, 4, 6), "NCTHW"
+        elif case == "ltx-audio":
+            shape, native_layout = (1, channels, 8, 16), "NCTF"
+        else:
+            raise ValueError(f"Unknown probe case {case!r}")
+        latents = torch.zeros(shape, device=device)
+        kwargs = {"return_dict": False}
+        if case == "ltx-video" and model.config.timestep_conditioning:
+            kwargs["timestep"] = torch.zeros(1, device=device)
+        decoded = model.decode(latents, **kwargs)[0]
+        sample_rate = None
+        if audio:
+            vocoder = _load_diffusers(root, "vocoder", device)
+            decoded = vocoder(decoded)
+            sample_rate = int(vocoder.config.output_sampling_rate)
+            decoded_layout = "NCT"
+        else:
+            decoded_layout = native_layout
+
+    expected_rank = len(decoded_layout)
+    assert decoded.ndim == expected_rank, (case, decoded_layout, tuple(decoded.shape))
+    assert decoded.shape[0] == 1 and torch.isfinite(decoded).all(), case
+    if audio:
+        assert decoded.shape[1] == 2, (case, tuple(decoded.shape))
+        artifact = MediaArtifact(ArtifactSpec("audio", "decoded", "CT", sample_rate=sample_rate), decoded[0])
+    elif case == "h3-video":
+        from vllm_omni.diffusion.models.minimax_h3.pipeline_minimax_h3 import _prepare_minimax_h3_video_output
+
+        assert decoded.shape[1] == 3, tuple(decoded.shape)
+        pixels = _prepare_minimax_h3_video_output(decoded)
+        artifact = MediaArtifact(ArtifactSpec("video", "decoded", "THWC", fps=24), pixels[0])
+    elif case == "qwen-image":
+        assert decoded.shape[1] == 3 and decoded.shape[2] == 1, tuple(decoded.shape)
+        artifact = MediaArtifact(
+            ArtifactSpec("image", "decoded", "CHW"), quantize_pixels(decoded[0, :, 0], "minus_one_one", context=case)
+        )
+    else:
+        assert decoded.shape[1] == 3, (case, tuple(decoded.shape))
+        kind = "video" if decoded_layout == "NCTHW" else "image"
+        artifact = MediaArtifact(
+            ArtifactSpec(kind, "decoded", "CTHW" if kind == "video" else "CHW", fps=24 if kind == "video" else None),
+            quantize_pixels(decoded[0], "minus_one_one", context=case),
+        )
+    artifact = artifact.normalized(context=f"pipeline={case}, request_id=vae-probe", name="decoded")
+    return {
+        "checkpoint": str(root.resolve()),
+        "implementation": f"{type(model).__module__}.{type(model).__name__}",
+        "parameters": sum(p.numel() for p in model.parameters()),
+        "native_layout": native_layout,
+        "native_shape": list(latents.shape),
+        "native_dtype": str(latents.dtype),
+        "decoded_layout": decoded_layout,
+        "decoded_shape": list(decoded.shape),
+        "decoded_dtype": str(decoded.dtype),
+        "canonical_layout": artifact.spec.layout,
+        "canonical_shape": list(artifact.data.shape),
+        "sample_rate": sample_rate,
+        "peak_allocated_bytes": torch.cuda.max_memory_allocated(),
+    }
+
+
+def main():
+    """Probe only explicitly supplied local checkpoints and fail if any case fails."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--models-json", required=True)
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+    cases = json.loads(Path(args.models_json).read_text())
+    torch.cuda.set_device(0)
+    torch.cuda.set_per_process_memory_fraction(0.35)
+    device = torch.device("cuda", 0)
+    results = {}
+    for case, checkpoint in cases.items():
+        torch.cuda.reset_peak_memory_stats()
+        try:
+            results[case] = {"status": "passed", **probe(case, checkpoint, device)}
+        except Exception as error:
+            traceback.print_exc()
+            results[case] = {"status": "failed", "checkpoint": checkpoint, "error": str(error)}
+        gc.collect()
+        torch.cuda.empty_cache()
+        Path(args.output).write_text(json.dumps(results, indent=2) + "\n")
+        print(case, results[case], flush=True)
+    raise SystemExit(any(result["status"] != "passed" for result in results.values()))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/special_e2e/check_named_diffusion_rollout.py
+++ b/tests/special_e2e/check_named_diffusion_rollout.py
@@ -1,0 +1,209 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Real-engine GPU check of typed request -> adapter -> named output -> reward/export.
+
+Uses one explicitly selected local checkpoint and a registered adapter. This
+unconditional fixture covers text-to-image/video/audio-video; image-edit and
+reference-conditioned inputs use their existing end-to-end recipe fixtures.
+The process owns and closes only its own AsyncOmni instance, never a Ray cluster.
+"""
+
+import argparse
+import asyncio
+import json
+import os
+import socket
+from argparse import Namespace
+from dataclasses import asdict
+from pathlib import Path
+from types import SimpleNamespace
+
+import torch
+from transformers import AutoTokenizer
+from vllm_omni.entrypoints import AsyncOmni
+
+from verl_omni.pipelines.model_base import VllmOmniPipelineBase
+from verl_omni.pipelines.rollout_request import OmniRolloutRequest
+from verl_omni.utils.reward_score.reward_utils import image_tensor_to_pil, visual_reward_frames
+from verl_omni.utils.tracking import _export_video
+from verl_omni.workers.rollout.vllm_rollout.vllm_omni_diffusion_strategy import DiffusionStrategy
+
+_SYSTEM_PROMPT = (
+    "Describe the image by detailing the color, shape, size, texture, quantity, "
+    "text, spatial relationships of the objects and background:"
+)
+
+
+def _request(model, architecture, index, tokenizer_path=None):
+    text = f"A red circle and a blue square in soft light, example {index}."
+    tokenizer = AutoTokenizer.from_pretrained(
+        tokenizer_path or Path(model) / "tokenizer", local_files_only=True, trust_remote_code=True
+    )
+    if architecture == "QwenImagePipeline":
+        text = tokenizer.apply_chat_template(
+            [{"role": "system", "content": _SYSTEM_PROMPT}, {"role": "user", "content": text}],
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+    extra = {}
+    if architecture == "StableDiffusion3Pipeline":
+        t5 = AutoTokenizer.from_pretrained(Path(model) / "tokenizer_3", local_files_only=True)
+        extra["extra_prompt_ids"] = {
+            "clip": tokenizer.encode(text),
+            "t5": t5.encode(text),
+        }
+    return OmniRolloutRequest.from_generate_kwargs(prompt_ids=tokenizer.encode(text), **extra)
+
+
+async def check(args):
+    """Exercise production lowering and output parsing against the pinned engine."""
+    config = SimpleNamespace(
+        external_lib=None,
+        enable_prompt_embed_cache=False,
+        prompt_embed_cache_size=16,
+        step_execution=args.step_execution,
+    )
+    server = SimpleNamespace(
+        global_steps=1,
+        config=config,
+        model_config=SimpleNamespace(architecture=args.architecture, algorithm=args.algorithm),
+    )
+    strategy = DiffusionStrategy(server)
+    engine_args = {
+        "model": args.model,
+        "model_class_name": args.engine_class_name or args.architecture,
+        "trust_remote_code": True,
+        "enforce_eager": True,
+        "enable_sleep_mode": False,
+        "enable_cpu_offload": args.cpu_offload,
+        "skip_tokenizer_init": True,
+        "max_num_seqs": args.num_requests,
+        "diffusion_batch_size": args.num_requests if args.require_request_batch else 1,
+        "request_batch_max_wait_ms": 200.0 if args.require_request_batch else 0.0,
+        "step_execution": args.step_execution,
+        "diffusion_attention_config": {"default": {"backend": "TORCH_SDPA"}},
+        "dtype": "bfloat16",
+    }
+    if args.deploy_config:
+        engine_args["deploy_config"] = args.deploy_config
+    strategy.prepare_engine_args(engine_args, Namespace())
+    cls = VllmOmniPipelineBase.get_class(args.architecture, args.algorithm)
+    if args.require_request_batch and not getattr(cls, "supports_request_batch", False):
+        raise ValueError(f"{args.architecture}/{args.algorithm} does not advertise request batching")
+    requested = list(cls.diffusion_io_spec.artifacts)
+    sampling = {
+        "height": args.height,
+        "width": args.width,
+        "num_frames": args.num_frames,
+        "frame_rate": 24.0,
+        "num_inference_steps": 4,
+        "seed": 42,
+        "output_type": args.output_type,
+        "guidance_scale": 1.0,
+        "true_cfg_scale": 1.0,
+        "max_sequence_length": 256,
+        "noise_level": 0.5,
+        "sde_type": "sde",
+        "sde_window_size": 2,
+        "sde_window_range": [0, 4],
+        "logprobs": args.algorithm in ("flow_grpo", "dance_grpo", "mix_grpo", "dual_grpo"),
+        "requested_outputs": requested,
+        **json.loads(args.extra_json),
+    }
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        port = sock.getsockname()[1]
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+    print("Engine args:", engine_args, flush=True)
+    requests = [
+        _request(args.model, args.architecture, index, args.tokenizer_path) for index in range(args.num_requests)
+    ]
+    server.engine = AsyncOmni(**engine_args)
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    try:
+
+        async def generate(index):
+            prompt, params = strategy.preprocess_input(requests[index], sampling, None)
+            raw = await strategy.run_generation(prompt, params, f"artifact-check-{index}", None, 0)
+            producer_context = raw.multimodal_output["metadata"]["media_artifacts"]["context"]
+            if args.require_request_batch:
+                assert args.num_requests > 1 and not args.step_execution
+                assert all(f"artifact-check-{i}" in producer_context for i in range(args.num_requests)), (
+                    producer_context
+                )
+            result = strategy.process_output(raw, params, sampling)
+            assert set(result.artifacts) == set(requested), (requested, result.artifacts.keys())
+            assert all(item.data.device.type == "cpu" for item in result.artifacts.values())
+            extra_info = {"media_artifacts": result.artifacts, "preview_artifact": result.preview_artifact}
+            frames = visual_reward_frames(result.diffusion_output, extra_info)
+            assert frames.dtype == torch.uint8
+            preview = result.artifacts[result.preview_artifact]
+            if preview.spec.modality == "image":
+                image_tensor_to_pil(preview.data).save(output_dir / f"{index}.png")
+            else:
+                _export_video(
+                    preview,
+                    str(output_dir / f"{index}.mp4"),
+                    audio=result.extra_fields.get("audio"),
+                    audio_sample_rate=result.extra_fields.get("audio_sample_rate"),
+                )
+            return {
+                "request_id": raw.request_id,
+                "producer_context": producer_context,
+                "primary": result.primary_artifact,
+                "artifacts": {
+                    name: {**asdict(item.spec), "shape": list(item.data.shape), "dtype": str(item.data.dtype)}
+                    for name, item in result.artifacts.items()
+                },
+                "training_fields": {
+                    name: {"shape": list(value.shape), "dtype": str(value.dtype)}
+                    for name, value in result.extra_fields.items()
+                    if isinstance(value, torch.Tensor)
+                },
+            }
+
+        results = await asyncio.gather(*(generate(index) for index in range(args.num_requests)))
+        (output_dir / "results.json").write_text(json.dumps(results, indent=2) + "\n")
+        print("PASS", args.architecture, args.algorithm, "step_execution=", args.step_execution, flush=True)
+    finally:
+        server.engine.shutdown()
+
+
+def main():
+    """Run one explicitly configured adapter GPU check without downloading checkpoints."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--tokenizer-path")
+    parser.add_argument("--architecture", required=True)
+    parser.add_argument("--algorithm", required=True)
+    parser.add_argument("--engine-class-name")
+    parser.add_argument("--deploy-config")
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--output-type", default="image")
+    parser.add_argument("--num-requests", type=int, default=1)
+    parser.add_argument("--height", type=int, default=64)
+    parser.add_argument("--width", type=int, default=64)
+    parser.add_argument("--num-frames", type=int, default=5)
+    parser.add_argument("--step-execution", action="store_true")
+    parser.add_argument("--require-request-batch", action="store_true")
+    parser.add_argument("--cpu-offload", action="store_true")
+    parser.add_argument("--extra-json", default="{}")
+    args = parser.parse_args()
+    asyncio.run(check(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/trainer/diffusion/test_artifact_preview_dump_on_cpu.py
+++ b/tests/trainer/diffusion/test_artifact_preview_dump_on_cpu.py
@@ -14,7 +14,7 @@
 """A latent response can be scored while an independently named preview is dumped."""
 
 import sys
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import Future, ThreadPoolExecutor
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import Mock
@@ -123,3 +123,77 @@ def test_tracking_explicit_layout_bypasses_legacy_normalizer(monkeypatch):
     frames, width, height = tracking._video_tensor_to_rgb24(preview)
     assert frames.shape == (3, 2, 5, 3) and (width, height) == (5, 2)
     torch.testing.assert_close(torch.from_numpy(frames).permute(0, 3, 1, 2), canonical)
+
+
+@pytest.mark.parametrize("version", [0, 1])
+def test_intentionally_absent_preview_skips_dump_without_using_latents(tmp_path, version):
+    context = SimpleNamespace(global_steps=1, _dump_executor=Mock())
+    dump = v0.BaseRayDiffusionTrainer._dump_generations if version == 0 else V1._dump_generations
+    dump(context, ["one"], torch.zeros(1, 16, 2, 2), [None], [1], {}, str(tmp_path), previews=[None])
+    context._dump_executor.submit.assert_not_called()
+    assert not (tmp_path / "1.jsonl").exists()
+
+
+@pytest.mark.parametrize("version", [0, 1])
+def test_invalid_audio_fails_before_dump_io(tmp_path, version):
+    context = SimpleNamespace(global_steps=1, _dump_executor=Mock())
+    dump = v0.BaseRayDiffusionTrainer._dump_generations if version == 0 else V1._dump_generations
+    with pytest.raises(ValueError, match="expected layout=CT"):
+        dump(
+            context,
+            ["one"],
+            torch.zeros(1, 4, 3, 2, 2, dtype=torch.uint8),
+            [None],
+            [1],
+            {},
+            str(tmp_path),
+            media_kind="video",
+            fps=24,
+            audios=[torch.zeros(1, 2, 8)],
+            audio_sample_rates=[32000],
+        )
+    context._dump_executor.submit.assert_not_called()
+    assert not (tmp_path / "1").exists()
+
+
+@pytest.mark.parametrize("data", [torch.zeros(3, 2, 2), torch.zeros(1, 3, 2, 2, dtype=torch.uint8)])
+def test_wandb_schema_errors_are_not_observability_failures(monkeypatch, data):
+    monkeypatch.setitem(sys.modules, "wandb", SimpleNamespace(Image=Mock()))
+    with pytest.raises(ValueError, match="artifact='preview'"):
+        tracking.wrap_val_samples_for_wandb([("one", data, 1)], media_kinds=["image"])
+    sys.modules["wandb"].Image.assert_not_called()
+
+
+def test_v1_dump_queue_is_bounded_and_does_not_retain_full_batch_storage(tmp_path, caplog):
+    future = Future()
+    context = SimpleNamespace(global_steps=1, _dump_executor=Mock(), _dump_futures=[])
+    context._dump_executor.submit.return_value = future
+    context._write_generations = V1._write_generations
+    context._drain_dump_futures = lambda: V1._drain_dump_futures(context)
+    context._report_dump_failure = V1._report_dump_failure
+    pixels = torch.zeros(4, 3, 8, 8, dtype=torch.uint8)
+    previews = [MediaArtifact(ArtifactSpec("image", "decoded", "CHW"), row) for row in pixels]
+    args = dict(
+        inputs=[str(i) for i in range(4)],
+        outputs=torch.zeros(4, 16, 2, 2),
+        gts=[None] * 4,
+        scores=[0] * 4,
+        reward_extra_infos_dict={"uid": [str(i) for i in range(4)]},
+        dump_path=str(tmp_path),
+        previews=previews,
+        max_samples=1,
+    )
+    V1._dump_generations(context, **args)
+    queued = context._dump_executor.submit.call_args.args[1:]
+    assert queued[1] is None  # No unused primary/training tensor is retained.
+    assert queued[4]["uid"] == ["0"]
+    assert len(queued[12]) == 1
+    copy = queued[12][0].data
+    assert copy.data_ptr() != pixels[0].data_ptr()
+    assert copy.untyped_storage().nbytes() == pixels[0].numel()
+    V1._dump_generations(context, **args)
+    assert context._dump_executor.submit.call_count == 1
+    assert "previous dump is still running" in caplog.text
+    future.set_result(None)
+    context._drain_dump_futures()
+    assert context._dump_futures == []

--- a/tests/trainer/diffusion/test_artifact_preview_dump_on_cpu.py
+++ b/tests/trainer/diffusion/test_artifact_preview_dump_on_cpu.py
@@ -1,0 +1,125 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""A latent response can be scored while an independently named preview is dumped."""
+
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+from verl_omni.pipelines.rollout_artifacts import ArtifactSpec, MediaArtifact
+from verl_omni.trainer.diffusion import ray_diffusion_trainer as v0
+from verl_omni.trainer.diffusion.v1.trainer_base import PolicyGradientDiffusionTrainerV1 as V1
+from verl_omni.utils import tracking
+
+
+@pytest.mark.parametrize("version", [0, 1])
+def test_latent_primary_dumps_declared_preview_without_axis_guessing(monkeypatch, tmp_path, version):
+    preview = MediaArtifact(
+        ArtifactSpec("video", "decoded", "TCHW", fps=12), torch.zeros(3, 4, 2, 5, dtype=torch.uint8)
+    )
+    latents = torch.randn(2, 16, 2, 2, 2, dtype=torch.bfloat16)
+    before = latents.clone()
+    captured = []
+
+    def export(output, path, **kwargs):
+        captured.append(output)
+        Path(path).write_bytes(b"video")
+
+    monkeypatch.setattr(v0, "_export_video", export)
+    args = dict(
+        inputs=["one", "two"],
+        outputs=latents,
+        gts=[None, None],
+        scores=[1, 2],
+        reward_extra_infos_dict={},
+        dump_path=str(tmp_path),
+        max_samples=1,
+        media_kind="video",
+        previews=[preview, preview],
+    )
+    context = SimpleNamespace(global_steps=5)
+    if version == 0:
+        v0.BaseRayDiffusionTrainer._dump_generations(context, **args)
+    else:
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            context._dump_executor = executor
+            context._dump_futures = []
+            context._drain_dump_futures = lambda: None
+            context._write_generations = V1._write_generations
+            V1._dump_generations(context, **args)
+            for future, step in context._dump_futures:
+                future.result()
+                assert step == 5
+    assert len(captured) == 1
+    assert captured[0].data.shape == (3, 4, 2, 5)  # T=3, C=4 is not CTHW
+    assert captured[0].spec.fps == 12
+    torch.testing.assert_close(latents, before)
+    assert (tmp_path / "5.jsonl").is_file()
+
+
+def test_invalid_preview_fails_before_background_submission(tmp_path):
+    context = SimpleNamespace(_dump_executor=Mock())
+    latent = MediaArtifact(ArtifactSpec("video", "latent", "CTHW"), torch.zeros(16, 2, 2, 2))
+    with pytest.raises(ValueError, match="decoded visual"):
+        V1._dump_generations(
+            context, ["one"], torch.zeros(1, 16, 2, 2, 2), [None], [0], {}, str(tmp_path), previews=[latent]
+        )
+    context._dump_executor.submit.assert_not_called()
+
+
+@pytest.mark.parametrize("export_fails", [False, True])
+def test_wandb_uses_named_preview_and_retains_best_effort_io(monkeypatch, tmp_path, export_fails):
+    preview = MediaArtifact(
+        ArtifactSpec("video", "decoded", "TCHW", fps=12), torch.zeros(3, 3, 2, 5, dtype=torch.uint8)
+    )
+    monkeypatch.setitem(sys.modules, "wandb", SimpleNamespace(Video=lambda path, **kwargs: path))
+
+    def export(output, path, **kwargs):
+        assert output is preview
+        if export_fails:
+            raise OSError("simulated encoder failure")
+        Path(path).write_bytes(b"video")
+
+    monkeypatch.setattr(tracking, "_export_video", export)
+    wrapped, _, media = tracking.wrap_val_samples_for_wandb([("prompt", preview, 1.0)], output_dir=str(tmp_path))
+    assert bool(media) is not export_fails
+    if export_fails:
+        assert "simulated encoder failure" in wrapped[0][1]
+    else:
+        assert wrapped[0][1] == "val/videos/sample_1"
+
+
+def test_artifact_export_preserves_fractional_fps(monkeypatch, tmp_path):
+    preview = MediaArtifact(
+        ArtifactSpec("video", "decoded", "TCHW", fps=29.97), torch.zeros(3, 3, 2, 4, dtype=torch.uint8)
+    )
+    commands = []
+    monkeypatch.setattr(tracking.subprocess, "run", lambda command, **kwargs: commands.append(command))
+    tracking._export_video(preview, str(tmp_path / "preview.mp4"), fps=24, ffmpeg_exe="/fake/ffmpeg")
+    command = commands[0]
+    assert command[command.index("-r") + 1] == "29.97"
+
+
+def test_tracking_explicit_layout_bypasses_legacy_normalizer(monkeypatch):
+    monkeypatch.setattr(tracking, "normalize_video_tensor", lambda data: pytest.fail("inferred artifact layout"))
+    canonical = torch.arange(3 * 3 * 2 * 5, dtype=torch.uint8).reshape(3, 3, 2, 5)
+    preview = MediaArtifact(ArtifactSpec("video", "decoded", "TCHW", fps=24), canonical)
+    frames, width, height = tracking._video_tensor_to_rgb24(preview)
+    assert frames.shape == (3, 2, 5, 3) and (width, height) == (5, 2)
+    torch.testing.assert_close(torch.from_numpy(frames).permute(0, 3, 1, 2), canonical)

--- a/tests/trainer/diffusion/test_artifact_preview_dump_on_cpu.py
+++ b/tests/trainer/diffusion/test_artifact_preview_dump_on_cpu.py
@@ -22,7 +22,8 @@ from unittest.mock import Mock
 import pytest
 import torch
 
-from verl_omni.pipelines.rollout_artifacts import ArtifactSpec, MediaArtifact
+from verl_omni.pipelines.rollout_artifacts import MediaArtifact
+from verl_omni.pipelines.rollout_media import MediaSpec
 from verl_omni.trainer.diffusion import ray_diffusion_trainer as v0
 from verl_omni.trainer.diffusion.v1.trainer_base import PolicyGradientDiffusionTrainerV1 as V1
 from verl_omni.utils import tracking
@@ -30,9 +31,7 @@ from verl_omni.utils import tracking
 
 @pytest.mark.parametrize("version", [0, 1])
 def test_latent_primary_dumps_declared_preview_without_axis_guessing(monkeypatch, tmp_path, version):
-    preview = MediaArtifact(
-        ArtifactSpec("video", "decoded", "TCHW", fps=12), torch.zeros(3, 4, 2, 5, dtype=torch.uint8)
-    )
+    preview = MediaArtifact(MediaSpec("video", "decoded", "TCHW", fps=12), torch.zeros(3, 4, 2, 5, dtype=torch.uint8))
     latents = torch.randn(2, 16, 2, 2, 2, dtype=torch.bfloat16)
     before = latents.clone()
     captured = []
@@ -75,7 +74,7 @@ def test_latent_primary_dumps_declared_preview_without_axis_guessing(monkeypatch
 
 def test_invalid_preview_fails_before_background_submission(tmp_path):
     context = SimpleNamespace(_dump_executor=Mock())
-    latent = MediaArtifact(ArtifactSpec("video", "latent", "CTHW"), torch.zeros(16, 2, 2, 2))
+    latent = MediaArtifact(MediaSpec("video", "latent", "CTHW"), torch.zeros(16, 2, 2, 2))
     with pytest.raises(ValueError, match="decoded visual"):
         V1._dump_generations(
             context, ["one"], torch.zeros(1, 16, 2, 2, 2), [None], [0], {}, str(tmp_path), previews=[latent]
@@ -85,9 +84,7 @@ def test_invalid_preview_fails_before_background_submission(tmp_path):
 
 @pytest.mark.parametrize("export_fails", [False, True])
 def test_wandb_uses_named_preview_and_retains_best_effort_io(monkeypatch, tmp_path, export_fails):
-    preview = MediaArtifact(
-        ArtifactSpec("video", "decoded", "TCHW", fps=12), torch.zeros(3, 3, 2, 5, dtype=torch.uint8)
-    )
+    preview = MediaArtifact(MediaSpec("video", "decoded", "TCHW", fps=12), torch.zeros(3, 3, 2, 5, dtype=torch.uint8))
     monkeypatch.setitem(sys.modules, "wandb", SimpleNamespace(Video=lambda path, **kwargs: path))
 
     def export(output, path, **kwargs):
@@ -107,7 +104,7 @@ def test_wandb_uses_named_preview_and_retains_best_effort_io(monkeypatch, tmp_pa
 
 def test_artifact_export_preserves_fractional_fps(monkeypatch, tmp_path):
     preview = MediaArtifact(
-        ArtifactSpec("video", "decoded", "TCHW", fps=29.97), torch.zeros(3, 3, 2, 4, dtype=torch.uint8)
+        MediaSpec("video", "decoded", "TCHW", fps=29.97), torch.zeros(3, 3, 2, 4, dtype=torch.uint8)
     )
     commands = []
     monkeypatch.setattr(tracking.subprocess, "run", lambda command, **kwargs: commands.append(command))
@@ -119,7 +116,7 @@ def test_artifact_export_preserves_fractional_fps(monkeypatch, tmp_path):
 def test_tracking_explicit_layout_bypasses_legacy_normalizer(monkeypatch):
     monkeypatch.setattr(tracking, "normalize_video_tensor", lambda data: pytest.fail("inferred artifact layout"))
     canonical = torch.arange(3 * 3 * 2 * 5, dtype=torch.uint8).reshape(3, 3, 2, 5)
-    preview = MediaArtifact(ArtifactSpec("video", "decoded", "TCHW", fps=24), canonical)
+    preview = MediaArtifact(MediaSpec("video", "decoded", "TCHW", fps=24), canonical)
     frames, width, height = tracking._video_tensor_to_rgb24(preview)
     assert frames.shape == (3, 2, 5, 3) and (width, height) == (5, 2)
     torch.testing.assert_close(torch.from_numpy(frames).permute(0, 3, 1, 2), canonical)
@@ -172,7 +169,7 @@ def test_v1_dump_queue_is_bounded_and_does_not_retain_full_batch_storage(tmp_pat
     context._drain_dump_futures = lambda: V1._drain_dump_futures(context)
     context._report_dump_failure = V1._report_dump_failure
     pixels = torch.zeros(4, 3, 8, 8, dtype=torch.uint8)
-    previews = [MediaArtifact(ArtifactSpec("image", "decoded", "CHW"), row) for row in pixels]
+    previews = [MediaArtifact(MediaSpec("image", "decoded", "CHW"), row) for row in pixels]
     args = dict(
         inputs=[str(i) for i in range(4)],
         outputs=torch.zeros(4, 16, 2, 2),

--- a/tests/trainer/diffusion/test_dump_generations_video_on_cpu.py
+++ b/tests/trainer/diffusion/test_dump_generations_video_on_cpu.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """CPU tests for ``BaseRayDiffusionTrainer._dump_generations`` media handling.
 
-The dump branches on tensor rank: 5-D video batches ``[N, T, C, H, W]`` are
+The dump reads the declared media kind: video batches ``[N, T, C, H, W]`` are
 written as ``{i}.mp4`` and 4-D image batches ``[N, C, H, W]`` as ``{i}.jpg``,
 while ``max_samples`` bounds how many samples (and JSONL rows) are emitted.
 The method only reads ``self.global_steps``, so a lightweight stub stands in
@@ -38,7 +38,9 @@ import verl_omni.trainer.diffusion.ray_diffusion_trainer as ray_diffusion_traine
 from verl_omni.trainer.diffusion.ray_diffusion_trainer import BaseRayDiffusionTrainer
 
 
-def _dump(dump_path, outputs, *, max_samples=None, global_steps=0, audios=None, audio_sample_rates=None):
+def _dump(
+    dump_path, outputs, *, max_samples=None, global_steps=0, audios=None, audio_sample_rates=None, media_kind="video"
+):
     """Invoke the unbound ``_dump_generations`` with a minimal stub ``self``."""
     n = outputs.shape[0]
     stub = SimpleNamespace(global_steps=global_steps)
@@ -60,6 +62,7 @@ def _dump(dump_path, outputs, *, max_samples=None, global_steps=0, audios=None, 
         str(dump_path),
         max_samples=max_samples,
         fps=8,
+        media_kind=media_kind,
         **kwargs,
     )
 
@@ -130,7 +133,7 @@ class TestDumpGenerations:
     def test_image_batch_writes_one_jpg_per_sample(self, tmp_path):
         # Image regression: the 4-D path must stay byte-for-byte behaviour.
         outputs = torch.randint(256, (2, 3, 16, 16), dtype=torch.uint8)  # [N, C, H, W]
-        _dump(tmp_path, outputs)
+        _dump(tmp_path, outputs, media_kind="image")
 
         visual = os.path.join(str(tmp_path), "0")
         jpgs = sorted(f for f in os.listdir(visual) if f.endswith(".jpg"))
@@ -151,7 +154,7 @@ class TestDumpGenerations:
             return original_save(image, filename, *args, **kwargs)
 
         monkeypatch.setattr(ray_diffusion_trainer.Image.Image, "save", save)
-        _dump(tmp_path, torch.zeros(2, 3, 8, 8, dtype=torch.uint8))
+        _dump(tmp_path, torch.zeros(2, 3, 8, 8, dtype=torch.uint8), media_kind="image")
 
         rows = _read_jsonl(tmp_path)
         assert rows[0]["output"] is None
@@ -170,7 +173,7 @@ class TestDumpGenerations:
             monkeypatch.setattr(ray_diffusion_trainer.os, "makedirs", fail)
         else:
             monkeypatch.setattr(ray_diffusion_trainer, "open", fail, raising=False)
-        _dump(tmp_path, torch.zeros(1, 3, 8, 8, dtype=torch.uint8), global_steps=7)
+        _dump(tmp_path, torch.zeros(1, 3, 8, 8, dtype=torch.uint8), global_steps=7, media_kind="image")
         assert "step 7" in caplog.text
         assert "simulated filesystem failure" in caplog.text
 

--- a/tests/trainer/diffusion/test_dump_generations_video_on_cpu.py
+++ b/tests/trainer/diffusion/test_dump_generations_video_on_cpu.py
@@ -21,6 +21,7 @@ for the trainer.
 """
 
 import json
+import logging
 import os
 import subprocess
 from pathlib import Path
@@ -139,6 +140,39 @@ class TestDumpGenerations:
         rows = _read_jsonl(tmp_path)
         assert len(rows) == 2
         assert all(row["output"].endswith(".jpg") for row in rows)
+
+    def test_image_save_failure_is_recorded_without_losing_other_samples(self, monkeypatch, tmp_path, caplog):
+        caplog.set_level(logging.WARNING, logger=ray_diffusion_trainer.sys_logger.name)
+        original_save = ray_diffusion_trainer.Image.Image.save
+
+        def save(image, filename, *args, **kwargs):
+            if str(filename).endswith("0.jpg"):
+                raise OSError("simulated full filesystem")
+            return original_save(image, filename, *args, **kwargs)
+
+        monkeypatch.setattr(ray_diffusion_trainer.Image.Image, "save", save)
+        _dump(tmp_path, torch.zeros(2, 3, 8, 8, dtype=torch.uint8))
+
+        rows = _read_jsonl(tmp_path)
+        assert rows[0]["output"] is None
+        assert "simulated full filesystem" in rows[0]["image_export_error"]
+        assert rows[1]["output"].endswith("1.jpg")
+        assert "step 0 sample 0" in caplog.text
+
+    @pytest.mark.parametrize("operation", ["mkdir", "jsonl"])
+    def test_filesystem_failure_is_logged_and_skipped(self, monkeypatch, tmp_path, caplog, operation):
+        caplog.set_level(logging.WARNING, logger=ray_diffusion_trainer.sys_logger.name)
+
+        def fail(*args, **kwargs):
+            raise OSError("simulated filesystem failure")
+
+        if operation == "mkdir":
+            monkeypatch.setattr(ray_diffusion_trainer.os, "makedirs", fail)
+        else:
+            monkeypatch.setattr(ray_diffusion_trainer, "open", fail, raising=False)
+        _dump(tmp_path, torch.zeros(1, 3, 8, 8, dtype=torch.uint8), global_steps=7)
+        assert "step 7" in caplog.text
+        assert "simulated filesystem failure" in caplog.text
 
     def test_max_samples_bounds_video_dump(self, tmp_path):
         outputs = torch.randint(256, (3, 8, 3, 16, 16), dtype=torch.uint8)

--- a/tests/trainer/diffusion/test_v1_media_dump_on_cpu.py
+++ b/tests/trainer/diffusion/test_v1_media_dump_on_cpu.py
@@ -1,0 +1,144 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU tests for best-effort media dumping in the diffusion V1 trainer."""
+
+import json
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import torch
+from omegaconf import OmegaConf
+
+import verl_omni.trainer.diffusion.ray_diffusion_trainer as ray_diffusion_trainer
+import verl_omni.trainer.diffusion.v1.trainer_base as trainer_base_module
+from verl_omni.trainer.diffusion.v1.trainer_base import PolicyGradientDiffusionTrainerV1
+
+
+class _ConcreteTrainer(PolicyGradientDiffusionTrainerV1):
+    def on_step_end(self):
+        return None
+
+    def on_sample_end(self):
+        return None
+
+
+class _FakeData:
+    def __init__(self, batch, non_tensor_batch):
+        self.batch = batch
+        self.non_tensor_batch = non_tensor_batch
+
+    def __len__(self):
+        return len(self.batch["responses"])
+
+
+def _trainer(global_steps: int = 1) -> _ConcreteTrainer:
+    trainer = object.__new__(_ConcreteTrainer)
+    trainer.global_steps = global_steps
+    trainer._init_dump_executor()
+    return trainer
+
+
+def test_v1_video_dump_reuses_shared_export_and_honors_max_samples(monkeypatch, tmp_path):
+    exported = []
+
+    def fake_export(output, output_path, **kwargs):
+        exported.append((output.clone(), output_path, kwargs))
+        Path(output_path).write_bytes(b"video")
+
+    monkeypatch.setattr(ray_diffusion_trainer, "_export_video", fake_export)
+    trainer = _trainer(global_steps=7)
+    outputs = torch.randint(256, (2, 4, 3, 8, 8), dtype=torch.uint8)
+
+    trainer._dump_generations(
+        inputs=["first", "second"],
+        outputs=outputs,
+        gts=[None, None],
+        scores=[1.0, 2.0],
+        reward_extra_infos_dict={},
+        dump_path=str(tmp_path),
+        max_samples=1,
+        fps=12,
+        media_kind="video",
+    )
+    trainer._shutdown_dump_executor()
+
+    assert len(exported) == 1
+    torch.testing.assert_close(exported[0][0], outputs[0])
+    assert exported[0][1].endswith("7/0.mp4")
+    assert exported[0][2]["fps"] == 12
+    rows = [json.loads(line) for line in (tmp_path / "7.jsonl").read_text().splitlines()]
+    assert rows == [{"input": "first", "output": str(tmp_path / "7/0.mp4"), "gts": None, "score": 1.0, "step": 7}]
+
+
+def test_v1_background_dump_failure_is_logged_and_does_not_raise(caplog, tmp_path):
+    trainer = _trainer(global_steps=3)
+
+    with caplog.at_level(logging.WARNING):
+        trainer._dump_generations(
+            inputs=["prompt"],
+            outputs=torch.zeros(1, 3, 8, 8),
+            gts=[None],
+            scores=[0.0],
+            reward_extra_infos_dict={},
+            dump_path=str(tmp_path),
+            media_kind="image",
+        )
+        trainer._shutdown_dump_executor()
+
+    assert "Ignoring background media dump failure at step 3" in caplog.text
+
+
+def test_v1_rollout_dump_sorts_and_forwards_media_metadata(monkeypatch):
+    trainer = object.__new__(_ConcreteTrainer)
+    trainer.config = OmegaConf.create({"trainer": {"rollout_data_max_samples": 1, "video_fps": 12}})
+    trainer.tokenizer = SimpleNamespace(
+        pad_token_id=0,
+        batch_decode=lambda prompts, skip_special_tokens: ["second", "first"],
+    )
+    captured = {}
+    trainer._dump_generations = lambda **kwargs: captured.update(kwargs)
+
+    audio = torch.stack((torch.full((1, 4), 2.0), torch.full((1, 4), 1.0)))
+    data = _FakeData(
+        batch={
+            "prompts": torch.tensor([[2], [1]]),
+            "responses": torch.stack(
+                (
+                    torch.full((2, 3, 4, 4), 2, dtype=torch.uint8),
+                    torch.full((2, 3, 4, 4), 1, dtype=torch.uint8),
+                )
+            ),
+            "sample_level_scores": torch.tensor([[2.0], [1.0]]),
+            "audio": audio,
+        },
+        non_tensor_batch={
+            "media_kind": np.array(["video", "video"], dtype=object),
+            "audio_sample_rate": np.array([48_000, 48_000], dtype=object),
+        },
+    )
+    monkeypatch.setattr(trainer_base_module, "diffusion_tq_batch_to_dataproto", lambda *args, **kwargs: data)
+
+    batch_meta = SimpleNamespace(keys=["second_0_0", "first_0_0"], partition_id="train")
+    trainer._log_rollout_data(batch_meta, {}, "/tmp/unused")
+
+    assert captured["inputs"] == ["first", "second"]
+    assert captured["scores"] == [1.0, 2.0]
+    torch.testing.assert_close(captured["outputs"][0], data.batch["responses"][1])
+    torch.testing.assert_close(captured["audios"][0], audio[1])
+    assert captured["audio_sample_rates"] == [48_000, 48_000]
+    assert captured["media_kind"] == "video"
+    assert captured["max_samples"] == 1
+    assert captured["fps"] == 12

--- a/tests/trainer/diffusion/test_v1_media_dump_on_cpu.py
+++ b/tests/trainer/diffusion/test_v1_media_dump_on_cpu.py
@@ -84,13 +84,18 @@ def test_v1_video_dump_reuses_shared_export_and_honors_max_samples(monkeypatch, 
     assert rows == [{"input": "first", "output": str(tmp_path / "7/0.mp4"), "gts": None, "score": 1.0, "step": 7}]
 
 
-def test_v1_background_dump_failure_is_logged_and_does_not_raise(caplog, tmp_path):
+def test_v1_background_dump_failure_is_logged_and_does_not_raise(monkeypatch, caplog, tmp_path):
     trainer = _trainer(global_steps=3)
+
+    def fail(*args, **kwargs):
+        raise OSError("simulated background I/O failure")
+
+    monkeypatch.setattr(trainer, "_write_generations", fail)
 
     with caplog.at_level(logging.WARNING):
         trainer._dump_generations(
             inputs=["prompt"],
-            outputs=torch.zeros(1, 3, 8, 8),
+            outputs=torch.zeros(1, 3, 8, 8, dtype=torch.uint8),
             gts=[None],
             scores=[0.0],
             reward_extra_infos_dict={},
@@ -146,7 +151,7 @@ def test_invalid_modality_is_not_hidden_by_logging(trainer_cls):
         global_steps=1,
         config=OmegaConf.create({"trainer": {"logger": ["wandb"], "log_val_generations": 1}}),
     )
-    with pytest.raises(ValueError, match="Unsupported media kind"):
+    with pytest.raises(ValueError, match="Explicit media_kind required"):
         trainer_cls._maybe_log_val_generations(
             trainer, ["prompt"], torch.zeros(1, 3, 8, 8, dtype=torch.uint8), [1.0], media_kinds=["depth"]
         )
@@ -155,7 +160,7 @@ def test_invalid_modality_is_not_hidden_by_logging(trainer_cls):
 def test_v1_invalid_modality_fails_before_background_submission(tmp_path):
     trainer = _trainer()
     try:
-        with pytest.raises(ValueError, match="Unsupported media kind"):
+        with pytest.raises(ValueError, match="Explicit media_kind required"):
             trainer._dump_generations(
                 inputs=["prompt"],
                 outputs=torch.zeros(1, 3, 8, 8, dtype=torch.uint8),

--- a/tests/trainer/diffusion/test_v1_media_dump_on_cpu.py
+++ b/tests/trainer/diffusion/test_v1_media_dump_on_cpu.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import numpy as np
+import pytest
 import torch
 from omegaconf import OmegaConf
 
@@ -99,6 +100,74 @@ def test_v1_background_dump_failure_is_logged_and_does_not_raise(caplog, tmp_pat
         trainer._shutdown_dump_executor()
 
     assert "Ignoring background media dump failure at step 3" in caplog.text
+
+
+@pytest.mark.parametrize("trainer_cls", [ray_diffusion_trainer.BaseRayDiffusionTrainer, _ConcreteTrainer])
+@pytest.mark.parametrize("failure", ["media", "table"])
+def test_validation_logger_failures_are_best_effort(monkeypatch, tmp_path, caplog, trainer_cls, failure):
+    import wandb
+
+    import verl_omni.utils.tracking as tracking
+
+    caplog.set_level(logging.WARNING, logger=ray_diffusion_trainer.sys_logger.name)
+    trainer = SimpleNamespace(global_steps=7)
+    trainer.config = OmegaConf.create({"trainer": {"logger": ["wandb"], "log_val_generations": 1}})
+    video_dir = tmp_path / "temporary-video"
+    video_dir.mkdir()
+    table_calls = []
+
+    def fail(*args, **kwargs):
+        raise OSError("simulated logger failure")
+
+    monkeypatch.setattr(
+        ray_diffusion_trainer,
+        "wrap_val_samples_for_wandb",
+        lambda *args, **kwargs: ([("prompt", "video", 1.0)], str(video_dir), {"val/videos/1": "video"}),
+    )
+    monkeypatch.setattr(wandb, "run", object())
+    monkeypatch.setattr(wandb, "log", fail if failure == "media" else lambda *args, **kwargs: None)
+    monkeypatch.setattr(ray_diffusion_trainer, "log_wandb_media", tracking.log_wandb_media)
+    trainer.validation_generations_logger = SimpleNamespace(
+        log=fail if failure == "table" else lambda *args: table_calls.append(args)
+    )
+
+    trainer_cls._maybe_log_val_generations(
+        trainer, ["prompt"], torch.zeros(1, 4, 3, 8, 8, dtype=torch.uint8), [1.0], media_kinds=["video"]
+    )
+    assert "step 7" in caplog.text and "simulated logger failure" in caplog.text
+    assert not video_dir.exists()
+    if failure == "media":
+        assert len(table_calls) == 1
+
+
+@pytest.mark.parametrize("trainer_cls", [ray_diffusion_trainer.BaseRayDiffusionTrainer, _ConcreteTrainer])
+def test_invalid_modality_is_not_hidden_by_logging(trainer_cls):
+    trainer = SimpleNamespace(
+        global_steps=1,
+        config=OmegaConf.create({"trainer": {"logger": ["wandb"], "log_val_generations": 1}}),
+    )
+    with pytest.raises(ValueError, match="Unsupported media kind"):
+        trainer_cls._maybe_log_val_generations(
+            trainer, ["prompt"], torch.zeros(1, 3, 8, 8, dtype=torch.uint8), [1.0], media_kinds=["depth"]
+        )
+
+
+def test_v1_invalid_modality_fails_before_background_submission(tmp_path):
+    trainer = _trainer()
+    try:
+        with pytest.raises(ValueError, match="Unsupported media kind"):
+            trainer._dump_generations(
+                inputs=["prompt"],
+                outputs=torch.zeros(1, 3, 8, 8, dtype=torch.uint8),
+                gts=[None],
+                scores=[1.0],
+                reward_extra_infos_dict={},
+                dump_path=str(tmp_path),
+                media_kind="depth",
+            )
+        assert trainer._dump_futures == []
+    finally:
+        trainer._shutdown_dump_executor()
 
 
 def test_v1_rollout_dump_sorts_and_forwards_media_metadata(monkeypatch):

--- a/tests/trainer/diffusion/test_v1_media_dump_on_cpu.py
+++ b/tests/trainer/diffusion/test_v1_media_dump_on_cpu.py
@@ -15,6 +15,7 @@
 
 import json
 import logging
+from concurrent.futures import Future
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -22,6 +23,7 @@ import numpy as np
 import pytest
 import torch
 from omegaconf import OmegaConf
+from verl import DataProto
 
 import verl_omni.trainer.diffusion.ray_diffusion_trainer as ray_diffusion_trainer
 import verl_omni.trainer.diffusion.v1.trainer_base as trainer_base_module
@@ -84,13 +86,17 @@ def test_v1_video_dump_reuses_shared_export_and_honors_max_samples(monkeypatch, 
     assert rows == [{"input": "first", "output": str(tmp_path / "7/0.mp4"), "gts": None, "score": 1.0, "step": 7}]
 
 
-def test_v1_background_dump_failure_is_logged_and_does_not_raise(caplog, tmp_path):
+def test_v1_background_dump_failure_is_logged_and_does_not_raise(monkeypatch, caplog, tmp_path):
     trainer = _trainer(global_steps=3)
 
+    def fail(*args, **kwargs):
+        raise OSError("simulated background I/O failure")
+
+    monkeypatch.setattr(trainer_base_module, "dump_generations", fail)
     with caplog.at_level(logging.WARNING):
         trainer._dump_generations(
             inputs=["prompt"],
-            outputs=torch.zeros(1, 3, 8, 8),
+            outputs=torch.zeros(1, 3, 8, 8, dtype=torch.uint8),
             gts=[None],
             scores=[0.0],
             reward_extra_infos_dict={},
@@ -100,6 +106,55 @@ def test_v1_background_dump_failure_is_logged_and_does_not_raise(caplog, tmp_pat
         trainer._shutdown_dump_executor()
 
     assert "Ignoring background media dump failure at step 3" in caplog.text
+
+
+def test_v1_background_export_uses_submission_step_snapshot(tmp_path):
+    queued = []
+    trainer = object.__new__(_ConcreteTrainer)
+    trainer.global_steps = 7
+    trainer._dump_futures = []
+    trainer._dump_executor = SimpleNamespace(submit=lambda *args: queued.append(args) or Future())
+    trainer._dump_generations(
+        ["prompt"], torch.zeros(1, 3, 8, 8, dtype=torch.uint8), [None], [1.0], {}, str(tmp_path), media_kind="image"
+    )
+    trainer.global_steps = 8
+    fn, *args = queued[0]
+    assert fn is ray_diffusion_trainer.dump_generations
+    fn(*args)
+    assert (tmp_path / "7" / "0.jpg").exists()
+    assert not (tmp_path / "8").exists()
+    assert json.loads((tmp_path / "7.jsonl").read_text())["step"] == 7
+
+
+@pytest.mark.parametrize("transport", ["top", "tool"])
+@pytest.mark.parametrize("kinds", [["image", "video"], [None, "video"], [None, None]])
+def test_v0_rollout_validates_all_declared_kinds(transport, kinds):
+    captured = {}
+    non_tensors = {"reward_model": [{}, {}]}
+    if transport == "top":
+        non_tensors["media_kind"] = kinds
+    else:
+        non_tensors["tool_extra_fields"] = [{"media_kind": kind} for kind in kinds]
+    data = DataProto.from_dict(
+        tensors={
+            "prompts": torch.ones(2, 1, dtype=torch.long),
+            "responses": torch.zeros(2, 4, 3, 8, 8, dtype=torch.uint8),
+            "sample_level_scores": torch.zeros(2, 1),
+        },
+        non_tensors=non_tensors,
+    )
+    trainer = SimpleNamespace(
+        config=OmegaConf.create({"trainer": {}}),
+        tokenizer=SimpleNamespace(batch_decode=lambda *args, **kwargs: ["first", "second"]),
+        _dump_generations=lambda **kwargs: captured.update(kwargs),
+    )
+    if kinds == ["image", "video"]:
+        with pytest.raises(ValueError, match="Conflicting media kinds"):
+            ray_diffusion_trainer.BaseRayDiffusionTrainer._log_rollout_data(trainer, data, {}, {}, "/tmp/unused")
+        assert captured == {}
+    else:
+        ray_diffusion_trainer.BaseRayDiffusionTrainer._log_rollout_data(trainer, data, {}, {}, "/tmp/unused")
+        assert captured["media_kind"] == kinds[-1]
 
 
 @pytest.mark.parametrize("trainer_cls", [ray_diffusion_trainer.BaseRayDiffusionTrainer, _ConcreteTrainer])
@@ -170,7 +225,19 @@ def test_v1_invalid_modality_fails_before_background_submission(tmp_path):
         trainer._shutdown_dump_executor()
 
 
-def test_v1_rollout_dump_sorts_and_forwards_media_metadata(monkeypatch):
+@pytest.mark.parametrize("outputs", [torch.zeros(1, 3, 8, 8), [torch.zeros(3, 8, 8)]])
+def test_v1_invalid_dtype_fails_before_background_submission(tmp_path, outputs):
+    trainer = _trainer()
+    try:
+        with pytest.raises(ValueError, match="uint8"):
+            trainer._dump_generations(["prompt"], outputs, [None], [0.0], {}, str(tmp_path), media_kind="image")
+        assert trainer._dump_futures == []
+    finally:
+        trainer._shutdown_dump_executor()
+
+
+@pytest.mark.parametrize("media_kinds", [["video", "video"], ["video", "image"], ["video", "depth"]])
+def test_v1_rollout_dump_sorts_and_forwards_media_metadata(monkeypatch, media_kinds):
     trainer = object.__new__(_ConcreteTrainer)
     trainer.config = OmegaConf.create({"trainer": {"rollout_data_max_samples": 1, "video_fps": 12}})
     trainer.tokenizer = SimpleNamespace(
@@ -194,13 +261,18 @@ def test_v1_rollout_dump_sorts_and_forwards_media_metadata(monkeypatch):
             "audio": audio,
         },
         non_tensor_batch={
-            "media_kind": np.array(["video", "video"], dtype=object),
+            "media_kind": np.array(media_kinds, dtype=object),
             "audio_sample_rate": np.array([48_000, 48_000], dtype=object),
         },
     )
     monkeypatch.setattr(trainer_base_module, "diffusion_tq_batch_to_dataproto", lambda *args, **kwargs: data)
 
     batch_meta = SimpleNamespace(keys=["second_0_0", "first_0_0"], partition_id="train")
+    if media_kinds != ["video", "video"]:
+        with pytest.raises(ValueError, match="media kind"):
+            trainer._log_rollout_data(batch_meta, {}, "/tmp/unused")
+        assert captured == {}
+        return
     trainer._log_rollout_data(batch_meta, {}, "/tmp/unused")
 
     assert captured["inputs"] == ["first", "second"]

--- a/tests/trainer/diffusion/test_v1_replay_buffer_on_cpu.py
+++ b/tests/trainer/diffusion/test_v1_replay_buffer_on_cpu.py
@@ -122,33 +122,35 @@ def _sample(trainer, batch_size):
     return PolicyGradientDiffusionTrainerV1._sample_training_batch(trainer, batch_size)
 
 
-def test_wandb_validation_logging_rejects_non_uint8_images():
+def test_wandb_validation_media_failure_is_best_effort():
+    calls = []
     trainer = SimpleNamespace(
-        config=OmegaConf.create({"trainer": {"log_val_generations": 1, "logger": ["wandb"]}}),
+        config=OmegaConf.create(
+            {
+                "trainer": {
+                    "log_val_generations": 1,
+                    "logger": ["wandb"],
+                    "video_fps": 24,
+                    "validation_data_dir": None,
+                    "default_local_dir": None,
+                }
+            }
+        ),
+        global_steps=1,
+        validation_generations_logger=SimpleNamespace(log=lambda *args: calls.append(args)),
     )
 
-    with pytest.raises(ValueError, match=r"Expected a uint8 image tensor, got torch\.float32\."):
-        PolicyGradientDiffusionTrainerV1._maybe_log_val_generations(
-            trainer,
-            inputs=["prompt"],
-            outputs=torch.zeros(1, 3, 8, 8),
-            scores=[0.0],
-        )
+    PolicyGradientDiffusionTrainerV1._maybe_log_val_generations(
+        trainer,
+        inputs=["prompt"],
+        outputs=torch.zeros(1, 3, 8, 8),
+        scores=[0.0],
+        media_kinds=["image"],
+    )
 
-
-def test_v1_generation_dump_rejects_non_uint8_outputs_before_submission():
-    trainer = SimpleNamespace()
-
-    with pytest.raises(ValueError, match=r"Expected generation outputs to be a uint8 tensor, got torch\.float32\."):
-        PolicyGradientDiffusionTrainerV1._dump_generations(
-            trainer,
-            inputs=["prompt"],
-            outputs=torch.zeros(1, 3, 8, 8),
-            gts=[""],
-            scores=[0.0],
-            reward_extra_infos_dict={},
-            dump_path="unused",
-        )
+    assert calls[0][1] == [
+        ("prompt", "[validation media unavailable: ValueError: Expected a uint8 image tensor, got torch.float32.]", 0.0)
+    ]
 
 
 def test_sample_evicts_partial_failure_and_refills_exact_prompt_count(monkeypatch):

--- a/tests/trainer/diffusion/test_v1_replay_buffer_on_cpu.py
+++ b/tests/trainer/diffusion/test_v1_replay_buffer_on_cpu.py
@@ -122,7 +122,13 @@ def _sample(trainer, batch_size):
     return PolicyGradientDiffusionTrainerV1._sample_training_batch(trainer, batch_size)
 
 
-def test_wandb_validation_media_failure_is_best_effort():
+def test_wandb_validation_media_failure_is_best_effort(monkeypatch):
+    import wandb
+
+    def fail(*args, **kwargs):
+        raise OSError("simulated W&B image write failure")
+
+    monkeypatch.setattr(wandb, "Image", fail)
     calls = []
     trainer = SimpleNamespace(
         config=OmegaConf.create(
@@ -143,13 +149,13 @@ def test_wandb_validation_media_failure_is_best_effort():
     PolicyGradientDiffusionTrainerV1._maybe_log_val_generations(
         trainer,
         inputs=["prompt"],
-        outputs=torch.zeros(1, 3, 8, 8),
+        outputs=torch.zeros(1, 3, 8, 8, dtype=torch.uint8),
         scores=[0.0],
         media_kinds=["image"],
     )
 
     assert calls[0][1] == [
-        ("prompt", "[validation media unavailable: ValueError: Expected a uint8 image tensor, got torch.float32.]", 0.0)
+        ("prompt", "[validation media unavailable: OSError: simulated W&B image write failure]", 0.0)
     ]
 
 

--- a/tests/trainer/diffusion/test_v1_replay_buffer_on_cpu.py
+++ b/tests/trainer/diffusion/test_v1_replay_buffer_on_cpu.py
@@ -122,7 +122,7 @@ def _sample(trainer, batch_size):
     return PolicyGradientDiffusionTrainerV1._sample_training_batch(trainer, batch_size)
 
 
-def test_wandb_validation_media_failure_is_best_effort():
+def test_wandb_validation_logging_rejects_non_uint8_images():
     calls = []
     trainer = SimpleNamespace(
         config=OmegaConf.create(
@@ -140,17 +140,15 @@ def test_wandb_validation_media_failure_is_best_effort():
         validation_generations_logger=SimpleNamespace(log=lambda *args: calls.append(args)),
     )
 
-    PolicyGradientDiffusionTrainerV1._maybe_log_val_generations(
-        trainer,
-        inputs=["prompt"],
-        outputs=torch.zeros(1, 3, 8, 8),
-        scores=[0.0],
-        media_kinds=["image"],
-    )
-
-    assert calls[0][1] == [
-        ("prompt", "[validation media unavailable: ValueError: Expected a uint8 image tensor, got torch.float32.]", 0.0)
-    ]
+    with pytest.raises(ValueError, match="uint8"):
+        PolicyGradientDiffusionTrainerV1._maybe_log_val_generations(
+            trainer,
+            inputs=["prompt"],
+            outputs=torch.zeros(1, 3, 8, 8),
+            scores=[0.0],
+            media_kinds=["image"],
+        )
+    assert calls == []
 
 
 def test_sample_evicts_partial_failure_and_refills_exact_prompt_count(monkeypatch):

--- a/tests/trainer/diffusion/test_val_video_logging_on_cpu.py
+++ b/tests/trainer/diffusion/test_val_video_logging_on_cpu.py
@@ -60,7 +60,7 @@ def _run_val_logging(
     n = outputs.shape[0] if hasattr(outputs, "shape") else len(outputs)
     inputs = [f"prompt {i}" for i in range(n)]
     scores = [float(i) for i in range(n)]
-    BaseRayDiffusionTrainer._maybe_log_val_generations(stub, inputs, outputs, scores)
+    BaseRayDiffusionTrainer._maybe_log_val_generations(stub, inputs, outputs, scores, media_kinds=["video"] * n)
     return val_logger
 
 

--- a/tests/utils/reward_score/test_clap_on_cpu.py
+++ b/tests/utils/reward_score/test_clap_on_cpu.py
@@ -23,6 +23,8 @@ from types import ModuleType, SimpleNamespace
 import pytest
 import torch
 
+from verl_omni.pipelines.rollout_artifacts import ArtifactContractError, ArtifactSpec, MediaArtifact
+
 
 def _load_scorer_module():
     module_path = Path(__file__).parents[3] / "verl_omni/utils/reward_score/clap.py"
@@ -36,11 +38,12 @@ def _load_scorer_module():
 clap = _load_scorer_module()
 
 
-def test_get_audio_normalizes_batch_and_channels():
+def test_get_audio_uses_canonical_channels_and_declared_rate():
     audio, sample_rate = clap._get_audio(
         {
-            "audio": torch.ones(1, 2, 16),
-            "audio_sample_rate": torch.tensor(48_000),
+            "media_artifacts": {
+                "audio": MediaArtifact(ArtifactSpec("audio", "decoded", "CT", sample_rate=48000), torch.ones(2, 16)),
+            }
         }
     )
 
@@ -122,7 +125,13 @@ def _score(prompt, waveform, sample_rate=48_000, **kwargs):
         data_source="test",
         solution_image=None,
         ground_truth=prompt,
-        extra_info={"audio": torch.tensor(waveform), "audio_sample_rate": sample_rate},
+        extra_info={
+            "media_artifacts": {
+                "audio": MediaArtifact(
+                    ArtifactSpec("audio", "decoded", "CT", sample_rate=sample_rate), torch.tensor(waveform).unsqueeze(0)
+                ),
+            }
+        },
         device="cpu",
         **kwargs,
     )
@@ -287,7 +296,7 @@ async def test_consumer_isolates_invalid_audio_and_resamples_valid_requests(monk
     await _stop_consumer(state)
 
     assert results[0] == {"score": pytest.approx(1.0), "source_sample_rate": 24_000}
-    assert isinstance(results[1], KeyError)
+    assert isinstance(results[1], ArtifactContractError)
     assert results[2] == {"score": pytest.approx(1.0), "source_sample_rate": 48_000}
     assert resample_calls == [(24_000, 48_000)]
     assert len(processor.batches) == 1

--- a/tests/utils/reward_score/test_clap_on_cpu.py
+++ b/tests/utils/reward_score/test_clap_on_cpu.py
@@ -23,7 +23,8 @@ from types import ModuleType, SimpleNamespace
 import pytest
 import torch
 
-from verl_omni.pipelines.rollout_artifacts import ArtifactContractError, ArtifactSpec, MediaArtifact
+from verl_omni.pipelines.rollout_artifacts import ArtifactContractError, MediaArtifact
+from verl_omni.pipelines.rollout_media import MediaSpec
 
 
 def _load_scorer_module():
@@ -42,7 +43,7 @@ def test_get_audio_uses_canonical_channels_and_declared_rate():
     audio, sample_rate = clap._get_audio(
         {
             "media_artifacts": {
-                "audio": MediaArtifact(ArtifactSpec("audio", "decoded", "CT", sample_rate=48000), torch.ones(2, 16)),
+                "audio": MediaArtifact(MediaSpec("audio", "decoded", "CT", sample_rate=48000), torch.ones(2, 16)),
             }
         }
     )
@@ -128,7 +129,7 @@ def _score(prompt, waveform, sample_rate=48_000, **kwargs):
         extra_info={
             "media_artifacts": {
                 "audio": MediaArtifact(
-                    ArtifactSpec("audio", "decoded", "CT", sample_rate=sample_rate), torch.tensor(waveform).unsqueeze(0)
+                    MediaSpec("audio", "decoded", "CT", sample_rate=sample_rate), torch.tensor(waveform).unsqueeze(0)
                 ),
             }
         },

--- a/tests/utils/reward_score/test_imagebind_on_cpu.py
+++ b/tests/utils/reward_score/test_imagebind_on_cpu.py
@@ -21,6 +21,8 @@ from types import ModuleType
 import pytest
 import torch
 
+from verl_omni.pipelines.rollout_artifacts import ArtifactSpec, MediaArtifact
+
 
 def _load_scorer_module():
     module_path = Path(__file__).parents[3] / "verl_omni/utils/reward_score/imagebind.py"
@@ -51,10 +53,12 @@ def _install_imagebind_modules(monkeypatch, imagebind_model=None):
     monkeypatch.setitem(sys.modules, "imagebind.models.imagebind_model", model_module)
 
 
-def test_to_tchw_accepts_channels_last_video():  # trufflehog:ignore
+def test_to_tchw_requires_adapter_normalized_video():
     video = torch.full((3, 8, 10, 3), 255, dtype=torch.uint8)
-
-    converted = imagebind._to_tchw(video)
+    with pytest.raises(ValueError, match="T, 3, H, W"):
+        imagebind._to_tchw(video)
+    artifact = MediaArtifact(ArtifactSpec("video", "decoded", "THWC", fps=24), video)
+    converted = imagebind._to_tchw(artifact.normalized(context="adapter", name="video_preview"))
 
     assert converted.shape == (3, 3, 8, 10)
     assert converted.max() == 1.0
@@ -62,7 +66,7 @@ def test_to_tchw_accepts_channels_last_video():  # trufflehog:ignore
 
 @pytest.mark.parametrize("dtype", [torch.float32, torch.int32])
 def test_to_tchw_rejects_non_uint8_video(dtype):
-    with pytest.raises(ValueError, match=rf"Expected uint8 video input, got {dtype}\."):
+    with pytest.raises(ValueError, match=rf"Expected a uint8 video tensor, got {dtype}"):
         imagebind._to_tchw(torch.zeros(3, 8, 10, 3, dtype=dtype))
 
 
@@ -107,7 +111,14 @@ def test_compute_score_supports_flowfactory_modes(
         data_source="test",
         solution_image=torch.zeros(2, 3, 8, 8, dtype=torch.uint8),
         ground_truth="forest ambience",
-        extra_info={} if mode == "text_video" else {"audio": torch.ones(16)},
+        extra_info={
+            "media_artifacts": {
+                "video_preview": MediaArtifact(
+                    ArtifactSpec("video", "decoded", "TCHW", fps=24), torch.zeros(2, 3, 8, 8, dtype=torch.uint8)
+                ),
+                "audio": MediaArtifact(ArtifactSpec("audio", "decoded", "CT", sample_rate=16000), torch.ones(1, 16)),
+            }
+        },
         device="cpu",
         mode=mode,
     )

--- a/tests/utils/reward_score/test_imagebind_on_cpu.py
+++ b/tests/utils/reward_score/test_imagebind_on_cpu.py
@@ -21,7 +21,8 @@ from types import ModuleType
 import pytest
 import torch
 
-from verl_omni.pipelines.rollout_artifacts import ArtifactSpec, MediaArtifact
+from verl_omni.pipelines.rollout_artifacts import MediaArtifact
+from verl_omni.pipelines.rollout_media import MediaSpec
 
 
 def _load_scorer_module():
@@ -57,7 +58,7 @@ def test_to_tchw_requires_adapter_normalized_video():
     video = torch.full((3, 8, 10, 3), 255, dtype=torch.uint8)
     with pytest.raises(ValueError, match="T, 3, H, W"):
         imagebind._to_tchw(video)
-    artifact = MediaArtifact(ArtifactSpec("video", "decoded", "THWC", fps=24), video)
+    artifact = MediaArtifact(MediaSpec("video", "decoded", "THWC", fps=24), video)
     converted = imagebind._to_tchw(artifact.normalized(context="adapter", name="video_preview"))
 
     assert converted.shape == (3, 3, 8, 10)
@@ -114,9 +115,9 @@ def test_compute_score_supports_flowfactory_modes(
         extra_info={
             "media_artifacts": {
                 "video_preview": MediaArtifact(
-                    ArtifactSpec("video", "decoded", "TCHW", fps=24), torch.zeros(2, 3, 8, 8, dtype=torch.uint8)
+                    MediaSpec("video", "decoded", "TCHW", fps=24), torch.zeros(2, 3, 8, 8, dtype=torch.uint8)
                 ),
-                "audio": MediaArtifact(ArtifactSpec("audio", "decoded", "CT", sample_rate=16000), torch.ones(1, 16)),
+                "audio": MediaArtifact(MediaSpec("audio", "decoded", "CT", sample_rate=16000), torch.ones(1, 16)),
             }
         },
         device="cpu",

--- a/tests/utils/reward_score/test_jpeg_compressibility_on_cpu.py
+++ b/tests/utils/reward_score/test_jpeg_compressibility_on_cpu.py
@@ -47,7 +47,7 @@ def test_jpeg_compressibility_is_negative_scaled_incompressibility():
 def test_compute_score_accepts_single_image_tensor():
     image = torch.zeros(3, 8, 8, dtype=torch.uint8)
 
-    score = compute_score(image)
+    score = compute_score(image, extra_info={"media_kind": "image"})
 
     assert isinstance(score, float)
     assert score < 0

--- a/tests/utils/reward_score/test_latent_http_scorer_client_on_cpu.py
+++ b/tests/utils/reward_score/test_latent_http_scorer_client_on_cpu.py
@@ -22,6 +22,8 @@ import pytest
 import torch
 from safetensors.torch import load as load_tensors
 
+from verl_omni.pipelines.rollout_artifacts import ArtifactSpec, MediaArtifact
+
 
 def _load_client_module():
     module_path = Path(__file__).parents[3] / "verl_omni/utils/reward_score/latent_http_scorer_client.py"
@@ -39,6 +41,9 @@ def _reward_inputs():
         "solution_image": torch.zeros(16, 2, 2),
         "ground_truth": "",
         "extra_info": {
+            "media_artifacts": {
+                "image_latent": MediaArtifact(ArtifactSpec("image", "latent", "CHW"), torch.zeros(16, 2, 2))
+            },
             "prompt_embeds": torch.arange(32, dtype=torch.float32).reshape(4, 8),
             "pooled_prompt_embeds": torch.arange(8, dtype=torch.float32),
         },
@@ -46,7 +51,7 @@ def _reward_inputs():
     }
 
 
-def test_serialize_request_uses_solution_latent_and_protocol_fields():
+def test_serialize_request_uses_named_latent_and_protocol_fields():
     inputs = _reward_inputs()
     payload = client._serialize_request(
         inputs["solution_image"],
@@ -64,10 +69,13 @@ def test_serialize_request_uses_solution_latent_and_protocol_fields():
     torch.testing.assert_close(tensors["seeds"], torch.tensor([7]))
 
 
-def test_serialize_request_prefers_explicit_clean_latent():
+def test_serialize_request_prefers_named_latent_over_legacy_fields():
     inputs = _reward_inputs()
     explicit_latent = torch.ones(16, 2, 2)
-    inputs["extra_info"]["latents_clean"] = explicit_latent
+    inputs["extra_info"]["latents_clean"] = torch.full_like(explicit_latent, 99)
+    inputs["extra_info"]["media_artifacts"]["image_latent"] = MediaArtifact(
+        ArtifactSpec("image", "latent", "CHW"), explicit_latent
+    )
 
     tensors = load_tensors(
         client._serialize_request(

--- a/tests/utils/reward_score/test_latent_http_scorer_client_on_cpu.py
+++ b/tests/utils/reward_score/test_latent_http_scorer_client_on_cpu.py
@@ -22,7 +22,8 @@ import pytest
 import torch
 from safetensors.torch import load as load_tensors
 
-from verl_omni.pipelines.rollout_artifacts import ArtifactSpec, MediaArtifact
+from verl_omni.pipelines.rollout_artifacts import MediaArtifact
+from verl_omni.pipelines.rollout_media import MediaSpec
 
 
 def _load_client_module():
@@ -42,7 +43,7 @@ def _reward_inputs():
         "ground_truth": "",
         "extra_info": {
             "media_artifacts": {
-                "image_latent": MediaArtifact(ArtifactSpec("image", "latent", "CHW"), torch.zeros(16, 2, 2))
+                "image_latent": MediaArtifact(MediaSpec("image", "latent", "CHW"), torch.zeros(16, 2, 2))
             },
             "prompt_embeds": torch.arange(32, dtype=torch.float32).reshape(4, 8),
             "pooled_prompt_embeds": torch.arange(8, dtype=torch.float32),
@@ -74,7 +75,7 @@ def test_serialize_request_prefers_named_latent_over_legacy_fields():
     explicit_latent = torch.ones(16, 2, 2)
     inputs["extra_info"]["latents_clean"] = torch.full_like(explicit_latent, 99)
     inputs["extra_info"]["media_artifacts"]["image_latent"] = MediaArtifact(
-        ArtifactSpec("image", "latent", "CHW"), explicit_latent
+        MediaSpec("image", "latent", "CHW"), explicit_latent
     )
 
     tensors = load_tensors(

--- a/tests/utils/reward_score/test_pickscore_reward_on_cpu.py
+++ b/tests/utils/reward_score/test_pickscore_reward_on_cpu.py
@@ -107,7 +107,7 @@ class _FakeInferencer:
 
     def score(self, prompts, images):
         self.batches.append((list(prompts), list(images)))
-        return torch.tensor([float(image.getpixel((0, 0))) for image in images])
+        return torch.tensor([float(image.convert("L").getpixel((0, 0))) for image in images])
 
 
 @pytest.mark.asyncio
@@ -124,9 +124,9 @@ async def test_consumer_batches_burst_requests_and_preserves_order(monkeypatch):
         *(
             pickscore_reward.compute_score_pickscore(
                 data_source="test",
-                solution_image=Image.new("L", (1, 1), index),
+                solution_image=torch.full((3, 1, 1), index, dtype=torch.uint8),
                 ground_truth="shared prompt",
-                extra_info={},
+                extra_info={"media_kind": "image"},
                 device="cpu",
             )
             for index in range(4)
@@ -184,7 +184,7 @@ async def test_consumer_isolates_invalid_image_from_batch(monkeypatch):
     await consumer
 
     assert results[0] == 1.0
-    assert isinstance(results[1], AssertionError)
+    assert isinstance(results[1], TypeError)
     assert results[2] == 3.0
     assert len(inferencer.batches) == 1
     assert inferencer.batches[0][0] == ["prompt", "prompt"]

--- a/tests/utils/reward_score/test_reward_utils_on_cpu.py
+++ b/tests/utils/reward_score/test_reward_utils_on_cpu.py
@@ -36,7 +36,7 @@ pil_image_to_base64 = _MODULE.pil_image_to_base64
 
 
 @pytest.mark.parametrize("layout", ["tchw", "cthw", "thwc"])
-def test_normalize_video_tensor_accepts_supported_rgb_layouts(layout):
+def test_video_consumers_accept_only_canonical_layout(layout):
     canonical = torch.arange(2 * 3 * 4 * 5, dtype=torch.uint8).reshape(2, 3, 4, 5)
     video = {
         "tchw": canonical,
@@ -44,7 +44,11 @@ def test_normalize_video_tensor_accepts_supported_rgb_layouts(layout):
         "thwc": canonical.permute(0, 2, 3, 1),
     }[layout]
 
-    torch.testing.assert_close(normalize_video_tensor(video), canonical)
+    if layout != "tchw":
+        with pytest.raises(ValueError, match="T, 3, H, W"):
+            normalize_video_tensor(video)
+    else:
+        torch.testing.assert_close(normalize_video_tensor(video), canonical)
 
 
 def test_video_tensor_to_pil_frames_preserves_uint8_pixels():
@@ -67,7 +71,7 @@ def test_video_tensor_to_pil_frames_rejects_non_uint8(dtype):
 
 @pytest.mark.parametrize("shape", [(3, 4, 5), (2, 4, 4, 5), (2, 3, 4, 5, 1)])
 def test_video_tensor_to_pil_frames_rejects_non_tchw_rgb(shape):
-    with pytest.raises(ValueError, match="Expected an RGB video tensor"):
+    with pytest.raises(ValueError, match="T, 3, H, W"):
         video_tensor_to_pil_frames(torch.zeros(shape, dtype=torch.uint8))
 
 

--- a/tests/utils/test_tracking_audio_on_cpu.py
+++ b/tests/utils/test_tracking_audio_on_cpu.py
@@ -101,7 +101,7 @@ def test_export_video_encodes_rgb_and_audio_in_one_ffmpeg_invocation(monkeypatch
 
 
 @pytest.mark.parametrize("layout", ["tchw", "cthw", "thwc"])
-def test_video_tensor_to_rgb24_normalizes_supported_layouts(monkeypatch, layout):
+def test_video_tensor_to_rgb24_requires_canonical_or_declared_layout(monkeypatch, layout):
     tracking = _load_tracking_module(monkeypatch)
     canonical = torch.arange(2 * 3 * 4 * 5, dtype=torch.uint8).reshape(2, 3, 4, 5)
     video = {
@@ -110,7 +110,14 @@ def test_video_tensor_to_rgb24_normalizes_supported_layouts(monkeypatch, layout)
         "thwc": canonical.permute(0, 2, 3, 1),
     }[layout]
 
-    frames, width, height = tracking._video_tensor_to_rgb24(video)
+    from verl_omni.pipelines.rollout_artifacts import ArtifactSpec, MediaArtifact
+
+    if layout != "tchw":
+        with pytest.raises(ValueError, match="T, 3, H, W"):
+            tracking._video_tensor_to_rgb24(video)
+    declared = MediaArtifact(ArtifactSpec("video", "decoded", layout.upper(), fps=24), video)
+    canonical_artifact = declared.normalized(context="adapter", name="video_preview")
+    frames, width, height = tracking._video_tensor_to_rgb24(canonical_artifact)
 
     assert (width, height) == (5, 4)
     assert frames.tobytes() == canonical.permute(0, 2, 3, 1).contiguous().numpy().tobytes()
@@ -152,10 +159,11 @@ def test_wandb_wrapper_forwards_audio_to_video_export(monkeypatch):
         captured.append((output, path, kwargs))
 
     monkeypatch.setattr(tracking, "_export_video", fake_export)
-    clip = torch.zeros(5, 3, 8, 10)
+    clip = torch.zeros(5, 3, 8, 10, dtype=torch.uint8)
     audio = torch.zeros(1, 800)
     wrapped, temp_dir, media_to_log = tracking.wrap_val_samples_for_wandb(
         [("prompt", clip, 0.5, audio, 48_000)],
+        media_kinds=["video"],
         fps=24,
     )
 
@@ -183,6 +191,8 @@ def test_wandb_wrapper_skips_media_failure_and_continues(monkeypatch, tmp_path):
     clip = torch.zeros(5, 3, 8, 10, dtype=torch.uint8)
     wrapped, temp_dir, media_to_log = tracking.wrap_val_samples_for_wandb(
         [("first", clip, 0.5), ("second", clip, 0.6)],
+        media_kinds=["video", "video"],
+        fps=24,
         output_dir=str(tmp_path),
     )
 

--- a/tests/utils/test_tracking_audio_on_cpu.py
+++ b/tests/utils/test_tracking_audio_on_cpu.py
@@ -110,12 +110,13 @@ def test_video_tensor_to_rgb24_requires_canonical_or_declared_layout(monkeypatch
         "thwc": canonical.permute(0, 2, 3, 1),
     }[layout]
 
-    from verl_omni.pipelines.rollout_artifacts import ArtifactSpec, MediaArtifact
+    from verl_omni.pipelines.rollout_artifacts import MediaArtifact
+    from verl_omni.pipelines.rollout_media import MediaSpec
 
     if layout != "tchw":
         with pytest.raises(ValueError, match="T, 3, H, W"):
             tracking._video_tensor_to_rgb24(video)
-    declared = MediaArtifact(ArtifactSpec("video", "decoded", layout.upper(), fps=24), video)
+    declared = MediaArtifact(MediaSpec("video", "decoded", layout.upper(), fps=24), video)
     canonical_artifact = declared.normalized(context="adapter", name="video_preview")
     frames, width, height = tracking._video_tensor_to_rgb24(canonical_artifact)
 

--- a/tests/utils/test_tracking_media_on_cpu.py
+++ b/tests/utils/test_tracking_media_on_cpu.py
@@ -1,0 +1,39 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the declared-media-kind resolution used by the diffusion trainer dump."""
+
+import pytest
+
+from verl_omni.utils.tracking import resolve_is_video
+
+
+class TestResolveIsVideo:
+    def test_declared_video_wins_over_rank(self):
+        # A short 3-frame video can share an image batch's rank; the declaration
+        # keeps it classified as video.
+        assert resolve_is_video(ndim=4, media_kind="video") is True
+
+    def test_declared_image_wins_over_rank(self):
+        assert resolve_is_video(ndim=5, media_kind="image") is False
+
+    def test_declared_audio_is_not_video(self):
+        assert resolve_is_video(ndim=2, media_kind="audio") is False
+
+    def test_falls_back_to_rank_when_undeclared(self):
+        assert resolve_is_video(ndim=5, media_kind=None) is True
+        assert resolve_is_video(ndim=4, media_kind=None) is False
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/utils/test_tracking_media_on_cpu.py
+++ b/tests/utils/test_tracking_media_on_cpu.py
@@ -20,8 +20,7 @@ from verl_omni.utils.tracking import resolve_is_video
 
 class TestResolveIsVideo:
     def test_declared_video_wins_over_rank(self):
-        # A short 3-frame video can share an image batch's rank; the declaration
-        # keeps it classified as video.
+        # A per-sample video and a batched image can both have rank four.
         assert resolve_is_video(ndim=4, media_kind="video") is True
 
     def test_declared_image_wins_over_rank(self):
@@ -29,6 +28,10 @@ class TestResolveIsVideo:
 
     def test_declared_audio_is_not_video(self):
         assert resolve_is_video(ndim=2, media_kind="audio") is False
+
+    def test_unknown_media_kind_is_rejected(self):
+        with pytest.raises(ValueError, match="Unsupported media kind"):
+            resolve_is_video(ndim=5, media_kind="depth")
 
     def test_falls_back_to_rank_when_undeclared(self):
         assert resolve_is_video(ndim=5, media_kind=None) is True

--- a/tests/utils/test_tracking_media_on_cpu.py
+++ b/tests/utils/test_tracking_media_on_cpu.py
@@ -30,12 +30,13 @@ class TestResolveIsVideo:
         assert resolve_is_video(ndim=2, media_kind="audio") is False
 
     def test_unknown_media_kind_is_rejected(self):
-        with pytest.raises(ValueError, match="Unsupported media kind"):
+        with pytest.raises(ValueError, match="Explicit media_kind required"):
             resolve_is_video(ndim=5, media_kind="depth")
 
-    def test_falls_back_to_rank_when_undeclared(self):
-        assert resolve_is_video(ndim=5, media_kind=None) is True
-        assert resolve_is_video(ndim=4, media_kind=None) is False
+    @pytest.mark.parametrize("rank", [4, 5])
+    def test_never_falls_back_to_rank_when_undeclared(self, rank):
+        with pytest.raises(ValueError, match="Explicit media_kind required"):
+            resolve_is_video(ndim=rank, media_kind=None)
 
 
 if __name__ == "__main__":

--- a/tests/utils/test_tracking_on_cpu.py
+++ b/tests/utils/test_tracking_on_cpu.py
@@ -134,11 +134,33 @@ def test_image_samples_become_wandb_image_and_no_temp_dir(monkeypatch):
     assert captured[0][1] == {"file_type": "jpg"}
 
 
-def test_image_samples_reject_non_uint8_input(monkeypatch):
+def test_image_media_failure_is_reported_without_raising(monkeypatch):
     monkeypatch.setattr(wandb, "Image", lambda *args, **kwargs: pytest.fail("wandb.Image should not be called"))
 
-    with pytest.raises(ValueError, match=r"Expected a uint8 image tensor, got torch\.float32\."):
-        wrap_val_samples_for_wandb([("prompt", torch.rand(3, 16, 16), 1.0)])
+    wrapped, video_tmp_dir, media_to_log = wrap_val_samples_for_wandb([("prompt", torch.rand(3, 16, 16), 1.0)])
+
+    assert wrapped == [
+        ("prompt", "[validation media unavailable: ValueError: Expected a uint8 image tensor, got torch.float32.]", 1.0)
+    ]
+    assert video_tmp_dir is None
+    assert media_to_log == {}
+
+
+def test_declared_image_kind_wins_over_video_rank(monkeypatch):
+    captured = []
+    monkeypatch.setattr(wandb, "Image", lambda output, **kwargs: captured.append(output) or "image")
+    monkeypatch.setattr(wandb, "Video", lambda *args, **kwargs: pytest.fail("wandb.Video should not be called"))
+    output = torch.zeros(1, 3, 8, 8, dtype=torch.uint8)
+
+    wrapped, video_tmp_dir, media_to_log = wrap_val_samples_for_wandb(
+        [("prompt", output, 1.0)],
+        media_kinds=["image"],
+    )
+
+    assert captured == [output]
+    assert wrapped == [("prompt", "image", 1.0)]
+    assert video_tmp_dir is None
+    assert media_to_log == {}
 
 
 def test_uint8_image_is_logged_by_real_wandb_offline_run(monkeypatch, tmp_path):

--- a/tests/utils/test_tracking_on_cpu.py
+++ b/tests/utils/test_tracking_on_cpu.py
@@ -40,10 +40,16 @@ def _warm_clip(t=8, h=32, w=32):
     return clip
 
 
-def test_channels_first_video_is_normalized_to_rgb24_frames():
-    video = _warm_clip(t=5, h=8, w=12).permute(1, 0, 2, 3)
+def test_adapter_declared_video_is_exported_without_axis_guessing():
+    from verl_omni.pipelines.rollout_artifacts import ArtifactSpec, MediaArtifact
 
-    frames, width, height = _video_tensor_to_rgb24(video)
+    video = _warm_clip(t=5, h=8, w=12).permute(1, 0, 2, 3)
+    with pytest.raises(ValueError, match="T, 3, H, W"):
+        _video_tensor_to_rgb24(video)
+    preview = MediaArtifact(ArtifactSpec("video", "decoded", "CTHW", fps=24), video).normalized(
+        context="adapter", name="video_preview"
+    )
+    frames, width, height = _video_tensor_to_rgb24(preview)
 
     assert frames.shape == (5, 8, 12, 3)
     assert (width, height) == (12, 8)
@@ -70,7 +76,9 @@ def test_video_samples_become_wandb_video_with_a_real_mp4_in_output_dir(monkeypa
 
     output_dir = tmp_path / "wandb_val_media" / "global_step_3"
     samples = [(f"prompt {i}", _warm_clip(), float(i)) for i in range(2)]
-    wrapped, video_tmp_dir, media_to_log = wrap_val_samples_for_wandb(samples, fps=8, output_dir=str(output_dir))
+    wrapped, video_tmp_dir, media_to_log = wrap_val_samples_for_wandb(
+        samples, fps=8, output_dir=str(output_dir), media_kinds=["video"] * 2
+    )
 
     assert video_tmp_dir is None
     assert len(wrapped) == 2
@@ -98,7 +106,7 @@ def test_video_samples_without_output_dir_return_cleanup_temp_dir(monkeypatch):
     monkeypatch.setattr(wandb, "Video", _FakeVideo)
 
     samples = [("prompt", _warm_clip(), 1.0)]
-    wrapped, video_tmp_dir, media_to_log = wrap_val_samples_for_wandb(samples, fps=8)
+    wrapped, video_tmp_dir, media_to_log = wrap_val_samples_for_wandb(samples, fps=8, media_kinds=["video"])
 
     try:
         assert video_tmp_dir is not None
@@ -125,7 +133,7 @@ def test_image_samples_become_wandb_image_and_no_temp_dir(monkeypatch):
     monkeypatch.setattr(wandb, "Image", _fake_image)
 
     samples = [("prompt", torch.randint(256, (3, 16, 16), dtype=torch.uint8), 1.0)]
-    wrapped, video_tmp_dir, media_to_log = wrap_val_samples_for_wandb(samples)
+    wrapped, video_tmp_dir, media_to_log = wrap_val_samples_for_wandb(samples, media_kinds=["image"])
 
     assert video_tmp_dir is None
     assert media_to_log == {}
@@ -135,32 +143,27 @@ def test_image_samples_become_wandb_image_and_no_temp_dir(monkeypatch):
 
 
 def test_image_media_failure_is_reported_without_raising(monkeypatch):
-    monkeypatch.setattr(wandb, "Image", lambda *args, **kwargs: pytest.fail("wandb.Image should not be called"))
+    def fail(*args, **kwargs):
+        raise OSError("simulated image writer failure")
 
-    wrapped, video_tmp_dir, media_to_log = wrap_val_samples_for_wandb([("prompt", torch.rand(3, 16, 16), 1.0)])
-
-    assert wrapped == [
-        ("prompt", "[validation media unavailable: ValueError: Expected a uint8 image tensor, got torch.float32.]", 1.0)
-    ]
+    monkeypatch.setattr(wandb, "Image", fail)
+    wrapped, video_tmp_dir, media_to_log = wrap_val_samples_for_wandb(
+        [("prompt", torch.zeros(3, 16, 16, dtype=torch.uint8), 1.0)], media_kinds=["image"]
+    )
+    assert wrapped == [("prompt", "[validation media unavailable: OSError: simulated image writer failure]", 1.0)]
     assert video_tmp_dir is None
     assert media_to_log == {}
 
 
-def test_declared_image_kind_wins_over_video_rank(monkeypatch):
+def test_declared_image_rejects_extra_batch_axis(monkeypatch):
     captured = []
     monkeypatch.setattr(wandb, "Image", lambda output, **kwargs: captured.append(output) or "image")
     monkeypatch.setattr(wandb, "Video", lambda *args, **kwargs: pytest.fail("wandb.Video should not be called"))
     output = torch.zeros(1, 3, 8, 8, dtype=torch.uint8)
 
-    wrapped, video_tmp_dir, media_to_log = wrap_val_samples_for_wandb(
-        [("prompt", output, 1.0)],
-        media_kinds=["image"],
-    )
-
-    assert captured == [output]
-    assert wrapped == [("prompt", "image", 1.0)]
-    assert video_tmp_dir is None
-    assert media_to_log == {}
+    with pytest.raises(ValueError, match="expected layout=CHW"):
+        wrap_val_samples_for_wandb([("prompt", output, 1.0)], media_kinds=["image"])
+    assert captured == []
 
 
 def test_uint8_image_is_logged_by_real_wandb_offline_run(monkeypatch, tmp_path):
@@ -186,7 +189,9 @@ def test_uint8_image_is_logged_by_real_wandb_offline_run(monkeypatch, tmp_path):
     assert run.offline
     run_dir = Path(run.dir)
     try:
-        wrapped, video_tmp_dir, media_to_log = wrap_val_samples_for_wandb([("synthetic", image, 1.0)])
+        wrapped, video_tmp_dir, media_to_log = wrap_val_samples_for_wandb(
+            [("synthetic", image, 1.0)], media_kinds=["image"]
+        )
         assert video_tmp_dir is None
         assert media_to_log == {}
         wandb.log({"verification/image": wrapped[0][1]}, step=1)

--- a/tests/utils/test_tracking_on_cpu.py
+++ b/tests/utils/test_tracking_on_cpu.py
@@ -41,12 +41,13 @@ def _warm_clip(t=8, h=32, w=32):
 
 
 def test_adapter_declared_video_is_exported_without_axis_guessing():
-    from verl_omni.pipelines.rollout_artifacts import ArtifactSpec, MediaArtifact
+    from verl_omni.pipelines.rollout_artifacts import MediaArtifact
+    from verl_omni.pipelines.rollout_media import MediaSpec
 
     video = _warm_clip(t=5, h=8, w=12).permute(1, 0, 2, 3)
     with pytest.raises(ValueError, match="T, 3, H, W"):
         _video_tensor_to_rgb24(video)
-    preview = MediaArtifact(ArtifactSpec("video", "decoded", "CTHW", fps=24), video).normalized(
+    preview = MediaArtifact(MediaSpec("video", "decoded", "CTHW", fps=24), video).normalized(
         context="adapter", name="video_preview"
     )
     frames, width, height = _video_tensor_to_rgb24(preview)

--- a/tests/workers/config/test_diffusion_config_on_cpu.py
+++ b/tests/workers/config/test_diffusion_config_on_cpu.py
@@ -33,6 +33,27 @@ from verl_omni.workers.config.diffusion.rollout import (
 # ---------------------------------------------------------------------------
 
 
+def test_requested_artifacts_are_available_in_rollout_validation_and_model_configs():
+    from pathlib import Path
+
+    from hydra import compose, initialize_config_dir
+    from verl.utils.config import omega_conf_to_dataclass
+
+    config_dir = str(Path(__file__).resolve().parents[3] / "verl_omni/trainer/config")
+    with initialize_config_dir(config_dir=config_dir, version_base=None):
+        config = compose(
+            config_name="diffusion_trainer",
+            overrides=[
+                "actor_rollout_ref.rollout.pipeline.requested_outputs=[image_preview]",
+            ],
+        )
+    assert list(config.actor_rollout_ref.rollout.val_kwargs.pipeline.requested_outputs) == ["image_preview"]
+    assert list(config.actor_rollout_ref.model.pipeline.requested_outputs) == ["image_preview"]
+    pipeline = omega_conf_to_dataclass(config.actor_rollout_ref.rollout.pipeline)
+    assert pipeline.requested_outputs == ["image_preview"]
+    assert DiffusionPipelineConfig().requested_outputs is None
+
+
 class TestDiffusionLossConfig:
     def test_defaults(self):
         cfg = DiffusionLossConfig()

--- a/tests/workers/rollout/rollout_vllm/test_vllm_omni_output_on_cpu.py
+++ b/tests/workers/rollout/rollout_vllm/test_vllm_omni_output_on_cpu.py
@@ -41,7 +41,10 @@ def _request_output(diffusion_output, multimodal_output=None):
 
 
 def test_diffusion_prompt_preserves_multimodal_processor_kwargs(diffusion_strategy):
-    diffusion_strategy.server.engine = SimpleNamespace(default_sampling_params_list=[object()])
+    diffusion_strategy.server.engine = SimpleNamespace(
+        default_sampling_params_list=[object()],
+        engine=SimpleNamespace(get_stage_metadata=lambda stage_id: SimpleNamespace(stage_type="diffusion")),
+    )
     multi_modal_data = {"image": ["image"], "audio": ["audio"]}
     mm_processor_kwargs = {"fps": 24, "sampling_rate": 32000}
 

--- a/tests/workers/rollout/rollout_vllm/test_vllm_omni_output_on_cpu.py
+++ b/tests/workers/rollout/rollout_vllm/test_vllm_omni_output_on_cpu.py
@@ -19,7 +19,8 @@ import pytest
 import torch
 
 from verl_omni.pipelines.diffusion_rollout_output import quantize_pixels
-from verl_omni.pipelines.rollout_artifacts import ArtifactSpec, MediaArtifact
+from verl_omni.pipelines.rollout_artifacts import MediaArtifact
+from verl_omni.pipelines.rollout_media import MediaSpec
 from verl_omni.pipelines.rollout_request import OmniRolloutRequest
 from verl_omni.workers.rollout.vllm_rollout.vllm_omni_async_server import vLLMOmniHttpServer
 from verl_omni.workers.rollout.vllm_rollout.vllm_omni_diffusion_strategy import DiffusionStrategy
@@ -54,7 +55,7 @@ def _request_output(artifacts, primary="image_preview", audio=None):
 def _pixels_output(pixels):
     encoded = quantize_pixels(pixels, "zero_one", context="adapter")
     return _request_output(
-        {"image_preview": MediaArtifact(ArtifactSpec("image", "decoded", "CHW"), encoded.reshape(1, 1, -1))}
+        {"image_preview": MediaArtifact(MediaSpec("image", "decoded", "CHW"), encoded.reshape(1, 1, -1))}
     )
 
 
@@ -103,8 +104,8 @@ def test_pixel_quantization_preserves_float_audio(diffusion_strategy):
     output = diffusion_strategy.process_output(
         _request_output(
             {
-                "image_preview": MediaArtifact(ArtifactSpec("image", "decoded", "CHW"), pixels.reshape(3, 1, 1)),
-                "audio": MediaArtifact(ArtifactSpec("audio", "decoded", "CT", sample_rate=48000), audio),
+                "image_preview": MediaArtifact(MediaSpec("image", "decoded", "CHW"), pixels.reshape(3, 1, 1)),
+                "audio": MediaArtifact(MediaSpec("audio", "decoded", "CT", sample_rate=48000), audio),
             },
             audio="audio",
         ),
@@ -121,7 +122,7 @@ def test_latent_output_preserves_native_dtype_and_axes(diffusion_strategy, dtype
     output = diffusion_strategy.process_output(
         _request_output(
             {
-                "image_latent": MediaArtifact(ArtifactSpec("image", "latent", "LC"), latents),
+                "image_latent": MediaArtifact(MediaSpec("image", "latent", "LC"), latents),
             },
             primary="image_latent",
         ),

--- a/tests/workers/rollout/rollout_vllm/test_vllm_omni_output_on_cpu.py
+++ b/tests/workers/rollout/rollout_vllm/test_vllm_omni_output_on_cpu.py
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from dataclasses import asdict
 from types import SimpleNamespace
 
-import numpy as np
 import pytest
 import torch
 
+from verl_omni.pipelines.diffusion_rollout_output import quantize_pixels
+from verl_omni.pipelines.rollout_artifacts import ArtifactSpec, MediaArtifact
 from verl_omni.pipelines.rollout_request import OmniRolloutRequest
 from verl_omni.workers.rollout.vllm_rollout.vllm_omni_async_server import vLLMOmniHttpServer
 from verl_omni.workers.rollout.vllm_rollout.vllm_omni_diffusion_strategy import DiffusionStrategy
@@ -30,13 +32,29 @@ def diffusion_strategy():
     return DiffusionStrategy(server)
 
 
-def _request_output(diffusion_output, multimodal_output=None):
+def _request_output(artifacts, primary="image_preview", audio=None):
     return SimpleNamespace(
-        images=[diffusion_output],
-        multimodal_output=multimodal_output or {},
+        images=[{name: artifact.data for name, artifact in artifacts.items()}],
+        multimodal_output={
+            "metadata": {
+                "media_artifacts": {
+                    "primary": primary,
+                    "audio": audio,
+                    "preview": "image_preview" if "image_preview" in artifacts else None,
+                    "specs": {name: asdict(artifact.spec) for name, artifact in artifacts.items()},
+                }
+            }
+        },
         trajectory_latents=None,
         trajectory_log_probs=None,
         trajectory_timesteps=None,
+    )
+
+
+def _pixels_output(pixels):
+    encoded = quantize_pixels(pixels, "zero_one", context="adapter")
+    return _request_output(
+        {"image_preview": MediaArtifact(ArtifactSpec("image", "decoded", "CHW"), encoded.reshape(1, 1, -1))}
     )
 
 
@@ -45,86 +63,83 @@ def test_diffusion_prompt_preserves_multimodal_processor_kwargs(diffusion_strate
         default_sampling_params_list=[object()],
         engine=SimpleNamespace(get_stage_metadata=lambda stage_id: SimpleNamespace(stage_type="diffusion")),
     )
-    multi_modal_data = {"image": ["image"], "audio": ["audio"]}
     mm_processor_kwargs = {"fps": 24, "sampling_rate": 32000}
-
     request = OmniRolloutRequest.from_generate_kwargs(
         prompt_ids=[1, 2, 3],
-        image_data=multi_modal_data["image"],
-        audio_data=multi_modal_data["audio"],
+        image_data=["image"],
+        audio_data=["audio"],
         mm_processor_kwargs=mm_processor_kwargs,
     )
     prompt, _ = diffusion_strategy.preprocess_input(request, {"task": "ref2va"}, None)
-
-    assert prompt["multi_modal_data"] == multi_modal_data
+    assert prompt["multi_modal_data"] == {"image": ["image"], "audio": ["audio"]}
     assert prompt["mm_processor_kwargs"] == mm_processor_kwargs
 
 
 def test_pixel_output_is_always_uint8(diffusion_strategy):
     pixels = torch.tensor([-1.0, 0.0, 0.25, 0.5, 1.0, 2.0])
-
-    output = diffusion_strategy.process_output(_request_output(pixels), params=None, sampling_params={})
-
+    output = diffusion_strategy.process_output(_pixels_output(pixels), None, {})
     assert output.diffusion_output.dtype == torch.uint8
-    assert output.diffusion_output.tolist() == [0, 0, 64, 128, 255, 255]
+    assert output.diffusion_output.flatten().tolist() == [0, 0, 64, 128, 255, 255]
 
 
 @pytest.mark.parametrize("dtype", [torch.float16, torch.float32])
 def test_pixel_quantization_does_not_mutate_input(diffusion_strategy, dtype):
     pixels = torch.tensor([-1.0, 0.25, 0.5, 2.0], dtype=dtype)
     original = pixels.clone()
-
-    output = diffusion_strategy.process_output(_request_output(pixels), params=None, sampling_params={})
-
+    output = diffusion_strategy.process_output(_pixels_output(pixels), None, {})
     torch.testing.assert_close(pixels, original)
-    assert output.diffusion_output.tolist() == [0, 64, 128, 255]
+    assert output.diffusion_output.flatten().tolist() == [0, 64, 128, 255]
 
 
 @pytest.mark.parametrize("nonfinite", [float("nan"), float("inf"), -float("inf")])
-def test_pixel_output_rejects_nonfinite_values(diffusion_strategy, nonfinite):
-    pixels = torch.tensor([0.0, nonfinite, 1.0])
-
-    with pytest.raises(ValueError, match="Pixel rollout output must contain only finite values"):
-        diffusion_strategy.process_output(_request_output(pixels), params=None, sampling_params={})
+def test_pixel_output_rejects_nonfinite_values(nonfinite):
+    with pytest.raises(ValueError, match="nonfinite decoded pixels"):
+        quantize_pixels(torch.tensor([0.0, nonfinite, 1.0]), "zero_one", context="adapter")
 
 
 def test_pixel_quantization_preserves_float_audio(diffusion_strategy):
-    pixels = torch.tensor([0.0, 0.5, 1.0])
-    audio = torch.tensor([[0.125, -0.25, 0.5]], dtype=torch.float32)
-
+    pixels = quantize_pixels(torch.tensor([0.0, 0.5, 1.0]), "zero_one", context="adapter")
+    audio = torch.tensor([[0.125, -0.25, 0.5]], dtype=torch.float16)
     output = diffusion_strategy.process_output(
         _request_output(
-            pixels,
-            {"metadata": {"rl": {"audio": audio, "audio_sample_rate": 48_000}}},
+            {
+                "image_preview": MediaArtifact(ArtifactSpec("image", "decoded", "CHW"), pixels.reshape(3, 1, 1)),
+                "audio": MediaArtifact(ArtifactSpec("audio", "decoded", "CT", sample_rate=48000), audio),
+            },
+            audio="audio",
         ),
-        params=None,
-        sampling_params={},
+        None,
+        {},
     )
-
-    assert output.diffusion_output.dtype == torch.uint8
-    assert output.extra_fields["audio"].dtype == torch.float32
-    torch.testing.assert_close(output.extra_fields["audio"], audio[0])
-    assert output.extra_fields["audio_sample_rate"] == 48_000
+    torch.testing.assert_close(output.extra_fields["audio"], audio)
+    assert output.extra_fields["audio_sample_rate"] == 48000
 
 
-@pytest.mark.parametrize(
-    "latents",
-    [
-        torch.tensor([-1.0, 0.5, 2.0], dtype=torch.float16),
-        np.array([-1.0, 0.5, 2.0], dtype=np.float16),
-    ],
-)
-def test_latent_output_remains_float(diffusion_strategy, latents):
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+def test_latent_output_preserves_native_dtype_and_axes(diffusion_strategy, dtype):
+    latents = torch.tensor([[-1.0, 0.5, 2.0]], dtype=dtype)
     output = diffusion_strategy.process_output(
-        _request_output(latents), params=None, sampling_params={"output_type": "latent"}
+        _request_output(
+            {
+                "image_latent": MediaArtifact(ArtifactSpec("image", "latent", "LC"), latents),
+            },
+            primary="image_latent",
+        ),
+        None,
+        {"output_type": "latent"},
     )
+    torch.testing.assert_close(output.diffusion_output, latents)
+    assert output.diffusion_output.data_ptr() == latents.data_ptr()
 
-    assert output.diffusion_output.dtype == torch.float32
-    torch.testing.assert_close(output.diffusion_output, torch.as_tensor(latents).float())
+
+@pytest.mark.parametrize("raw", [torch.zeros(1, 3, 2, 2), (torch.zeros(3, 2, 2), torch.zeros(2, 8))])
+def test_legacy_output_is_not_interpreted_from_shape(diffusion_strategy, raw):
+    with pytest.raises(ValueError, match="named media_artifacts declaration required"):
+        diffusion_strategy.process_output(SimpleNamespace(images=[raw], multimodal_output=None), None, {})
 
 
 @pytest.mark.parametrize(
-    ("sampling_params", "expected_dtype"),
+    "sampling_params,expected_dtype",
     [
         ({}, torch.uint8),
         ({"output_type": "latent"}, torch.float32),
@@ -132,7 +147,6 @@ def test_latent_output_remains_float(diffusion_strategy, latents):
     ],
 )
 def test_empty_output_uses_modality_dtype(diffusion_strategy, sampling_params, expected_dtype):
-    output = diffusion_strategy.process_output(None, params=None, sampling_params=sampling_params)
-
+    output = diffusion_strategy.process_output(None, None, sampling_params)
     assert output.diffusion_output.dtype == expected_dtype
     assert output.diffusion_output.numel() == 0

--- a/tests/workers/rollout/rollout_vllm/test_vllm_omni_strategy_on_cpu.py
+++ b/tests/workers/rollout/rollout_vllm/test_vllm_omni_strategy_on_cpu.py
@@ -745,10 +745,16 @@ def test_diffusion_strategy_preserves_engine_argument_preparation(monkeypatch):
     }
 
 
-@pytest.mark.parametrize("multistage", [False, True])
-def test_diffusion_strategy_emits_canonical_prompt(multistage):
-    defaults = ["ar-stage", "diffusion-stage"] if multistage else ["diffusion-stage"]
-    server = SimpleNamespace(engine=SimpleNamespace(default_sampling_params_list=defaults))
+@pytest.mark.parametrize("num_stages", [1, 2])
+@pytest.mark.parametrize("first_stage_type", ["llm", "diffusion"])
+def test_diffusion_strategy_emits_canonical_prompt(num_stages, first_stage_type):
+    defaults = [object() for _ in range(num_stages)]
+    server = SimpleNamespace(
+        engine=SimpleNamespace(
+            default_sampling_params_list=defaults,
+            engine=SimpleNamespace(get_stage_metadata=lambda stage_id: SimpleNamespace(stage_type=first_stage_type)),
+        )
+    )
     strategy = DiffusionStrategy(server)
     prompt_mask = torch.tensor([True, False])
 
@@ -763,13 +769,16 @@ def test_diffusion_strategy_emits_canonical_prompt(multistage):
     )
     prompt, params = strategy.preprocess_input(request, {"pipeline_private_arg": 7}, None)
 
-    key = "prompt_token_ids" if multistage else "prompt_ids"
+    ar_entrance = first_stage_type != "diffusion"
+    key = "prompt_token_ids" if ar_entrance else "prompt_ids"
     assert prompt[key] == [1, 2]
-    assert ("prompt_ids" if multistage else "prompt_token_ids") not in prompt
+    assert ("prompt_ids" if ar_entrance else "prompt_token_ids") not in prompt
     assert prompt["prompt_mask"] is prompt_mask
-    if multistage:
+    if ar_entrance:
         assert prompt["modalities"] == ["image"]
-        assert params[0] == "ar-stage"
+    else:
+        assert "modalities" not in prompt
+    assert params[:-1] == defaults[:-1]
     assert prompt["negative_prompt_ids"] == [3, 4]
     assert "extra_prompt_ids" not in prompt
     assert "negative_extra_prompt_ids" not in prompt

--- a/tests/workers/rollout/rollout_vllm/test_vllm_omni_strategy_on_cpu.py
+++ b/tests/workers/rollout/rollout_vllm/test_vllm_omni_strategy_on_cpu.py
@@ -23,7 +23,8 @@ import yaml
 
 from verl_omni.pipelines.model_base import OmniRolloutPipelineBase
 from verl_omni.pipelines.qwen3_omni.omni_rollout_adapter import Qwen3OmniRolloutAdapter
-from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
+from verl_omni.pipelines.rollout_artifacts import ArtifactSpec
+from verl_omni.pipelines.rollout_media import DiffusionIOSpec
 from verl_omni.pipelines.rollout_request import OmniRolloutRequest
 from verl_omni.workers.rollout.vllm_rollout import vllm_omni_ar_strategy as ar_strategy_module
 from verl_omni.workers.rollout.vllm_rollout import vllm_omni_async_server as server_module
@@ -799,27 +800,42 @@ async def test_diffusion_strategy_rejects_nonzero_priority():
         await strategy.run_generation(None, None, "request-id", None, priority=1)
 
 
-def _joint_video_audio_final_res():
-    video = torch.zeros(1, 3, 2, 8, 8, dtype=torch.uint8)
+def _joint_spec(sample_rate=48000):
+    return DiffusionIOSpec(
+        artifacts={
+            "video_preview": ArtifactSpec("video", "decoded", "TCHW", fps=24),
+            "audio": ArtifactSpec("audio", "decoded", "CT", sample_rate=sample_rate),
+        }
+    )
+
+
+def _joint_video_audio_final_res(sample_rate=48000):
+    from dataclasses import asdict
+
+    video = torch.zeros(2, 3, 8, 8, dtype=torch.uint8)
     audio = torch.zeros(1, 16)
     final_res = SimpleNamespace(
-        images=[(video, audio)],
+        images=[{"video_preview": video, "audio": audio}],
         trajectory_latents=None,
         trajectory_timesteps=None,
         trajectory_log_probs=None,
-        multimodal_output=None,
+        multimodal_output={
+            "metadata": {
+                "media_artifacts": {
+                    "primary": "video_preview",
+                    "preview": "video_preview",
+                    "audio": "audio",
+                    "specs": {name: asdict(spec) for name, spec in _joint_spec(sample_rate).artifacts.items()},
+                }
+            }
+        },
         request_output=None,
     )
     return final_res, audio
 
 
 def test_diffusion_strategy_uses_declared_audio_sample_rate(monkeypatch):
-    pipeline_cls = SimpleNamespace(
-        diffusion_io_spec=DiffusionIOSpec(
-            primary=MediaSpec("video"),
-            auxiliary=(MediaSpec("audio", sample_rate=48000),),
-        )
-    )
+    pipeline_cls = SimpleNamespace(diffusion_io_spec=_joint_spec())
     monkeypatch.setattr(
         diffusion_strategy_module.VllmOmniPipelineBase,
         "get_class",
@@ -836,8 +852,8 @@ def test_diffusion_strategy_uses_declared_audio_sample_rate(monkeypatch):
     # The audio sample rate comes from the adapter-declared DiffusionIOSpec,
     # not the strategy's legacy 32 kHz fallback.
     assert processed.extra_fields["audio_sample_rate"] == 48000
-    # process_output unbatches the leading dimension of auxiliary media.
-    torch.testing.assert_close(processed.extra_fields["audio"], audio[0])
+    # Audio is already a declared per-sample CT artifact, not a positional batch.
+    torch.testing.assert_close(processed.extra_fields["audio"], audio)
     # The declared primary modality rides to downstream consumers so they read
     # the media kind instead of inferring it from the tensor rank.
     assert processed.extra_fields["media_kind"] == "video"
@@ -849,13 +865,13 @@ def test_diffusion_strategy_rejects_conflicting_media_kind(monkeypatch, runtime_
     monkeypatch.setattr(
         strategy,
         "_diffusion_io_spec",
-        lambda: DiffusionIOSpec(MediaSpec("video"), (MediaSpec("audio", sample_rate=48000),)),
+        _joint_spec,
     )
     final_res, _ = _joint_video_audio_final_res()
     final_res.request_id = "request-conflict"
-    final_res.multimodal_output = {"metadata": {"rl": {"media_kind": runtime_kind}}}
+    final_res.multimodal_output["metadata"]["rl"] = {"media_kind": runtime_kind}
 
-    with pytest.raises(ValueError, match="media_kind.*request-conflict.*video"):
+    with pytest.raises(ValueError, match="request-conflict.*media_kind"):
         strategy.process_output(final_res, None, {"output_type": "pt"})
 
 
@@ -864,10 +880,10 @@ def test_diffusion_strategy_accepts_matching_kind_and_runtime_audio_rate(monkeyp
     monkeypatch.setattr(
         strategy,
         "_diffusion_io_spec",
-        lambda: DiffusionIOSpec(MediaSpec("video"), (MediaSpec("audio", sample_rate=48000),)),
+        lambda: _joint_spec(sample_rate=None),
     )
-    final_res, _ = _joint_video_audio_final_res()
-    final_res.multimodal_output = {"metadata": {"rl": {"media_kind": "video", "audio_sample_rate": 24000}}}
+    final_res, _ = _joint_video_audio_final_res(sample_rate=24000)
+    final_res.multimodal_output["metadata"]["rl"] = {"media_kind": "video", "audio_sample_rate": 24000}
 
     result = strategy.process_output(final_res, None, {"output_type": "pt"})
     assert result.extra_fields["media_kind"] == "video"
@@ -877,25 +893,33 @@ def test_diffusion_strategy_accepts_matching_kind_and_runtime_audio_rate(monkeyp
 @pytest.mark.parametrize("declared", [False, True])
 def test_diffusion_strategy_rejects_extra_tuple_streams(monkeypatch, declared):
     strategy = DiffusionStrategy(SimpleNamespace(global_steps=1))
-    spec = DiffusionIOSpec(MediaSpec("video"), (MediaSpec("audio", sample_rate=48000),)) if declared else None
+    spec = _joint_spec() if declared else None
     monkeypatch.setattr(strategy, "_diffusion_io_spec", lambda: spec)
     final_res, audio = _joint_video_audio_final_res()
-    final_res.images[0] += (audio.clone(),)
-    with pytest.raises(ValueError, match="Unsupported diffusion media tuple"):
+    final_res.images = [(final_res.images[0]["video_preview"], audio, audio.clone())]
+    final_res.multimodal_output = None
+    with pytest.raises(ValueError, match="named media_artifacts declaration required"):
         strategy.process_output(final_res, None, {"output_type": "pt"})
 
 
-def test_diffusion_strategy_rejects_undeclared_tuple_audio(monkeypatch):
+def test_diffusion_strategy_rejects_undeclared_named_audio(monkeypatch):
     strategy = DiffusionStrategy(SimpleNamespace(global_steps=1))
-    monkeypatch.setattr(strategy, "_diffusion_io_spec", lambda: DiffusionIOSpec(MediaSpec("video")))
+    monkeypatch.setattr(
+        strategy,
+        "_diffusion_io_spec",
+        lambda: DiffusionIOSpec(
+            artifacts={
+                "video_preview": ArtifactSpec("video", "decoded", "TCHW"),
+            }
+        ),
+    )
     final_res, _ = _joint_video_audio_final_res()
-    with pytest.raises(ValueError, match="Unsupported diffusion media tuple"):
+    with pytest.raises(ValueError, match="undeclared artifact='audio'"):
         strategy.process_output(final_res, None, {"output_type": "pt"})
 
 
-def test_diffusion_strategy_omits_audio_sample_rate_without_declared_spec(monkeypatch):
-    # Without an adapter-declared DiffusionIOSpec the strategy still surfaces the
-    # auxiliary audio stream but attaches no model-specific sample-rate default.
+def test_diffusion_strategy_uses_runtime_header_without_static_spec(monkeypatch):
+    # The actual artifact carries its rate; the strategy supplies no default.
     monkeypatch.setattr(
         diffusion_strategy_module.VllmOmniPipelineBase,
         "get_class",
@@ -909,10 +933,9 @@ def test_diffusion_strategy_omits_audio_sample_rate_without_declared_spec(monkey
 
     processed = DiffusionStrategy(server).process_output(final_res, None, {"output_type": "pt", "logprobs": False})
 
-    torch.testing.assert_close(processed.extra_fields["audio"], audio[0])
-    assert "audio_sample_rate" not in processed.extra_fields
-    # No declared spec => no declared media kind is surfaced either.
-    assert "media_kind" not in processed.extra_fields
+    torch.testing.assert_close(processed.extra_fields["audio"], audio)
+    assert processed.extra_fields["audio_sample_rate"] == 48000
+    assert processed.extra_fields["media_kind"] == "video"
 
 
 @pytest.mark.parametrize(

--- a/tests/workers/rollout/rollout_vllm/test_vllm_omni_strategy_on_cpu.py
+++ b/tests/workers/rollout/rollout_vllm/test_vllm_omni_strategy_on_cpu.py
@@ -23,8 +23,7 @@ import yaml
 
 from verl_omni.pipelines.model_base import OmniRolloutPipelineBase
 from verl_omni.pipelines.qwen3_omni.omni_rollout_adapter import Qwen3OmniRolloutAdapter
-from verl_omni.pipelines.rollout_artifacts import ArtifactSpec
-from verl_omni.pipelines.rollout_media import DiffusionIOSpec
+from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
 from verl_omni.pipelines.rollout_request import OmniRolloutRequest
 from verl_omni.workers.rollout.vllm_rollout import vllm_omni_ar_strategy as ar_strategy_module
 from verl_omni.workers.rollout.vllm_rollout import vllm_omni_async_server as server_module
@@ -803,8 +802,8 @@ async def test_diffusion_strategy_rejects_nonzero_priority():
 def _joint_spec(sample_rate=48000):
     return DiffusionIOSpec(
         artifacts={
-            "video_preview": ArtifactSpec("video", "decoded", "TCHW", fps=24),
-            "audio": ArtifactSpec("audio", "decoded", "CT", sample_rate=sample_rate),
+            "video_preview": MediaSpec("video", "decoded", "TCHW", fps=24),
+            "audio": MediaSpec("audio", "decoded", "CT", sample_rate=sample_rate),
         }
     )
 
@@ -909,7 +908,7 @@ def test_diffusion_strategy_rejects_undeclared_named_audio(monkeypatch):
         "_diffusion_io_spec",
         lambda: DiffusionIOSpec(
             artifacts={
-                "video_preview": ArtifactSpec("video", "decoded", "TCHW"),
+                "video_preview": MediaSpec("video", "decoded", "TCHW"),
             }
         ),
     )

--- a/tests/workers/rollout/rollout_vllm/test_vllm_omni_strategy_on_cpu.py
+++ b/tests/workers/rollout/rollout_vllm/test_vllm_omni_strategy_on_cpu.py
@@ -745,8 +745,10 @@ def test_diffusion_strategy_preserves_engine_argument_preparation(monkeypatch):
     }
 
 
-def test_diffusion_strategy_preserves_multistage_prompt_shape():
-    server = SimpleNamespace(engine=SimpleNamespace(default_sampling_params_list=["ar-stage", "diffusion-stage"]))
+@pytest.mark.parametrize("multistage", [False, True])
+def test_diffusion_strategy_emits_canonical_prompt(multistage):
+    defaults = ["ar-stage", "diffusion-stage"] if multistage else ["diffusion-stage"]
+    server = SimpleNamespace(engine=SimpleNamespace(default_sampling_params_list=defaults))
     strategy = DiffusionStrategy(server)
     prompt_mask = torch.tensor([True, False])
 
@@ -761,16 +763,22 @@ def test_diffusion_strategy_preserves_multistage_prompt_shape():
     )
     prompt, params = strategy.preprocess_input(request, {"pipeline_private_arg": 7}, None)
 
-    assert prompt["prompt_token_ids"] == [1, 2]
+    key = "prompt_token_ids" if multistage else "prompt_ids"
+    assert prompt[key] == [1, 2]
+    assert ("prompt_ids" if multistage else "prompt_token_ids") not in prompt
     assert prompt["prompt_mask"] is prompt_mask
-    assert prompt["modalities"] == ["image"]
+    if multistage:
+        assert prompt["modalities"] == ["image"]
+        assert params[0] == "ar-stage"
     assert prompt["negative_prompt_ids"] == [3, 4]
-    assert prompt["extra_prompt_ids"] == {"encoder": [5]}
-    assert prompt["negative_extra_prompt_ids"] == {"encoder": [6]}
+    assert "extra_prompt_ids" not in prompt
+    assert "negative_extra_prompt_ids" not in prompt
     assert prompt["multi_modal_data"] == {"image": ["image"]}
-    assert prompt["extra_args"] == {"multi_modal_data": {"image": ["image"]}}
+    assert prompt["extra_args"] == {
+        "extra_prompt_ids": {"encoder": [5]},
+        "negative_extra_prompt_ids": {"encoder": [6]},
+    }
     assert prompt["mm_processor_kwargs"] == {"video_fps": 24, "audio_sample_rate": 32_000}
-    assert params[0] == "ar-stage"
     assert params[-1].extra_args == {"pipeline_private_arg": 7}
 
 

--- a/tests/workers/rollout/rollout_vllm/test_vllm_omni_strategy_on_cpu.py
+++ b/tests/workers/rollout/rollout_vllm/test_vllm_omni_strategy_on_cpu.py
@@ -826,6 +826,56 @@ def test_diffusion_strategy_uses_declared_audio_sample_rate(monkeypatch):
     assert processed.extra_fields["media_kind"] == "video"
 
 
+@pytest.mark.parametrize("runtime_kind", ["image", "depth"])
+def test_diffusion_strategy_rejects_conflicting_media_kind(monkeypatch, runtime_kind):
+    strategy = DiffusionStrategy(SimpleNamespace(global_steps=1))
+    monkeypatch.setattr(
+        strategy,
+        "_diffusion_io_spec",
+        lambda: DiffusionIOSpec(MediaSpec("video"), (MediaSpec("audio", sample_rate=48000),)),
+    )
+    final_res, _ = _joint_video_audio_final_res()
+    final_res.request_id = "request-conflict"
+    final_res.multimodal_output = {"metadata": {"rl": {"media_kind": runtime_kind}}}
+
+    with pytest.raises(ValueError, match="media_kind.*request-conflict.*video"):
+        strategy.process_output(final_res, None, {"output_type": "pt"})
+
+
+def test_diffusion_strategy_accepts_matching_kind_and_runtime_audio_rate(monkeypatch):
+    strategy = DiffusionStrategy(SimpleNamespace(global_steps=1))
+    monkeypatch.setattr(
+        strategy,
+        "_diffusion_io_spec",
+        lambda: DiffusionIOSpec(MediaSpec("video"), (MediaSpec("audio", sample_rate=48000),)),
+    )
+    final_res, _ = _joint_video_audio_final_res()
+    final_res.multimodal_output = {"metadata": {"rl": {"media_kind": "video", "audio_sample_rate": 24000}}}
+
+    result = strategy.process_output(final_res, None, {"output_type": "pt"})
+    assert result.extra_fields["media_kind"] == "video"
+    assert result.extra_fields["audio_sample_rate"] == 24000
+
+
+@pytest.mark.parametrize("declared", [False, True])
+def test_diffusion_strategy_rejects_extra_tuple_streams(monkeypatch, declared):
+    strategy = DiffusionStrategy(SimpleNamespace(global_steps=1))
+    spec = DiffusionIOSpec(MediaSpec("video"), (MediaSpec("audio", sample_rate=48000),)) if declared else None
+    monkeypatch.setattr(strategy, "_diffusion_io_spec", lambda: spec)
+    final_res, audio = _joint_video_audio_final_res()
+    final_res.images[0] += (audio.clone(),)
+    with pytest.raises(ValueError, match="Unsupported diffusion media tuple"):
+        strategy.process_output(final_res, None, {"output_type": "pt"})
+
+
+def test_diffusion_strategy_rejects_undeclared_tuple_audio(monkeypatch):
+    strategy = DiffusionStrategy(SimpleNamespace(global_steps=1))
+    monkeypatch.setattr(strategy, "_diffusion_io_spec", lambda: DiffusionIOSpec(MediaSpec("video")))
+    final_res, _ = _joint_video_audio_final_res()
+    with pytest.raises(ValueError, match="Unsupported diffusion media tuple"):
+        strategy.process_output(final_res, None, {"output_type": "pt"})
+
+
 def test_diffusion_strategy_omits_audio_sample_rate_without_declared_spec(monkeypatch):
     # Without an adapter-declared DiffusionIOSpec the strategy still surfaces the
     # auxiliary audio stream but attaches no model-specific sample-rate default.

--- a/tests/workers/rollout/rollout_vllm/test_vllm_omni_strategy_on_cpu.py
+++ b/tests/workers/rollout/rollout_vllm/test_vllm_omni_strategy_on_cpu.py
@@ -821,6 +821,9 @@ def test_diffusion_strategy_uses_declared_audio_sample_rate(monkeypatch):
     assert processed.extra_fields["audio_sample_rate"] == 48000
     # process_output unbatches the leading dimension of auxiliary media.
     torch.testing.assert_close(processed.extra_fields["audio"], audio[0])
+    # The declared primary modality rides to downstream consumers so they read
+    # the media kind instead of inferring it from the tensor rank.
+    assert processed.extra_fields["media_kind"] == "video"
 
 
 def test_diffusion_strategy_omits_audio_sample_rate_without_declared_spec(monkeypatch):
@@ -841,6 +844,8 @@ def test_diffusion_strategy_omits_audio_sample_rate_without_declared_spec(monkey
 
     torch.testing.assert_close(processed.extra_fields["audio"], audio[0])
     assert "audio_sample_rate" not in processed.extra_fields
+    # No declared spec => no declared media kind is surfaced either.
+    assert "media_kind" not in processed.extra_fields
 
 
 @pytest.mark.parametrize(

--- a/verl_omni/agent_loop/diffusion_agent_loop_tq.py
+++ b/verl_omni/agent_loop/diffusion_agent_loop_tq.py
@@ -238,6 +238,13 @@ class DiffusionAgentLoopWorkerTQ(DiffusionAgentLoopWorker):
             extra_fields_out["img_shapes"] = extra["img_shapes"]
         if reward_extra_info is not None:
             extra_fields_out["reward_extra_info"] = reward_extra_info
+        # Tensor media (for example generated audio) is already carried as a
+        # top-level TQ field above. Preserve its non-tensor declaration/metadata
+        # in the envelope that ``diffusion_tq_batch_to_dataproto`` restores.
+        for media_key in ("media_kind", "audio_sample_rate"):
+            media_value = extra.get(media_key)
+            if media_value is not None and not isinstance(media_value, torch.Tensor):
+                extra_fields_out[media_key] = media_value
         # Track the rollout model version this trajectory was generated against.
         step = trajectory["step"] if trajectory else global_steps
         extra_fields_out["min_global_steps"] = step

--- a/verl_omni/agent_loop/diffusion_agent_loop_tq.py
+++ b/verl_omni/agent_loop/diffusion_agent_loop_tq.py
@@ -31,7 +31,7 @@ from verl_omni.agent_loop.diffusion_agent_loop import (
     _InternalDiffusionAgentLoopOutput,
 )
 from verl_omni.agent_loop.utils import _derive_rollout_seed
-from verl_omni.pipelines.rollout_artifacts import ARTIFACT_SPECS, PREVIEW_ARTIFACT, PRIMARY_ARTIFACT
+from verl_omni.pipelines.rollout_artifacts import ARTIFACT_CONTEXT, ARTIFACT_SPECS, PREVIEW_ARTIFACT, PRIMARY_ARTIFACT
 
 logger = logging.getLogger(__name__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "INFO"))
@@ -242,9 +242,16 @@ class DiffusionAgentLoopWorkerTQ(DiffusionAgentLoopWorker):
         # Tensor media (for example generated audio) is already carried as a
         # top-level TQ field above. Preserve its non-tensor declaration/metadata
         # in the envelope that ``diffusion_tq_batch_to_dataproto`` restores.
-        for media_key in ("media_kind", "audio_sample_rate", ARTIFACT_SPECS, PRIMARY_ARTIFACT, PREVIEW_ARTIFACT):
+        for media_key in (
+            "media_kind",
+            "audio_sample_rate",
+            ARTIFACT_SPECS,
+            PRIMARY_ARTIFACT,
+            PREVIEW_ARTIFACT,
+            ARTIFACT_CONTEXT,
+        ):
             media_value = extra.get(media_key)
-            if media_value is not None and not isinstance(media_value, torch.Tensor):
+            if media_key in extra and not isinstance(media_value, torch.Tensor):
                 extra_fields_out[media_key] = media_value
         # Track the rollout model version this trajectory was generated against.
         step = trajectory["step"] if trajectory else global_steps

--- a/verl_omni/agent_loop/diffusion_agent_loop_tq.py
+++ b/verl_omni/agent_loop/diffusion_agent_loop_tq.py
@@ -31,6 +31,7 @@ from verl_omni.agent_loop.diffusion_agent_loop import (
     _InternalDiffusionAgentLoopOutput,
 )
 from verl_omni.agent_loop.utils import _derive_rollout_seed
+from verl_omni.pipelines.rollout_artifacts import ARTIFACT_SPECS, PREVIEW_ARTIFACT, PRIMARY_ARTIFACT
 
 logger = logging.getLogger(__name__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "INFO"))
@@ -241,7 +242,7 @@ class DiffusionAgentLoopWorkerTQ(DiffusionAgentLoopWorker):
         # Tensor media (for example generated audio) is already carried as a
         # top-level TQ field above. Preserve its non-tensor declaration/metadata
         # in the envelope that ``diffusion_tq_batch_to_dataproto`` restores.
-        for media_key in ("media_kind", "audio_sample_rate"):
+        for media_key in ("media_kind", "audio_sample_rate", ARTIFACT_SPECS, PRIMARY_ARTIFACT, PREVIEW_ARTIFACT):
             media_value = extra.get(media_key)
             if media_value is not None and not isinstance(media_value, torch.Tensor):
                 extra_fields_out[media_key] = media_value

--- a/verl_omni/agent_loop/single_turn_agent_loop.py
+++ b/verl_omni/agent_loop/single_turn_agent_loop.py
@@ -195,6 +195,15 @@ class DiffusionSingleTurnAgentLoop(AgentLoopBase):
         if metrics.get("num_preempted") is None:
             metrics["num_preempted"] = output.num_preempted if output.num_preempted is not None else -1
 
+        if output.artifacts:
+            from verl_omni.pipelines.rollout_artifacts import artifact_fields
+
+            fields = artifact_fields(output.artifacts, output.primary_artifact, output.preview_artifact)
+            collisions = fields.keys() & output.extra_fields.keys()
+            if collisions:
+                raise ValueError(f"Artifact transport collides with rollout metadata: {sorted(collisions)}")
+            output.extra_fields.update(fields)
+
         output = DiffusionAgentLoopOutput(
             prompt_ids=prompt_ids,
             response_diffusion_output=output.diffusion_output,

--- a/verl_omni/pipelines/bagel_flow_grpo/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/bagel_flow_grpo/vllm_omni_rollout_adapter.py
@@ -40,8 +40,7 @@ from verl_omni.pipelines.bagel_flow_grpo.common import (
 )
 from verl_omni.pipelines.diffusion_rollout_output import rollout_output, with_visual_artifacts
 from verl_omni.pipelines.model_base import VllmOmniPipelineBase
-from verl_omni.pipelines.rollout_artifacts import ArtifactSpec
-from verl_omni.pipelines.rollout_media import DiffusionIOSpec
+from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
 from verl_omni.pipelines.rollout_request import prompt_ids_from_payload
 from verl_omni.pipelines.schedulers import FlowMatchSDEDiscreteScheduler
 
@@ -250,8 +249,8 @@ class BagelPipelineWithLogProb(BagelPipeline):
     #: the modality from the adapter instead of inferring it from tensor rank.
     diffusion_io_spec = DiffusionIOSpec(
         artifacts={
-            "image_preview": ArtifactSpec("image", "decoded", "CHW"),
-            "image_latent": ArtifactSpec("image", "latent", "LC"),
+            "image_preview": MediaSpec("image", "decoded", "CHW"),
+            "image_latent": MediaSpec("image", "latent", "LC"),
         }
     )
 

--- a/verl_omni/pipelines/bagel_flow_grpo/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/bagel_flow_grpo/vllm_omni_rollout_adapter.py
@@ -27,6 +27,7 @@ import random
 from dataclasses import dataclass
 from typing import Any, Iterable, Optional
 
+import numpy as np
 import torch
 from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.models.bagel.pipeline_bagel import BagelPipeline
@@ -37,9 +38,10 @@ from verl_omni.pipelines.bagel_flow_grpo.common import (
     maybe_to_cpu,
     setup_bagel_sigmas,
 )
-from verl_omni.pipelines.diffusion_rollout_output import rollout_output
+from verl_omni.pipelines.diffusion_rollout_output import rollout_output, with_visual_artifacts
 from verl_omni.pipelines.model_base import VllmOmniPipelineBase
-from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
+from verl_omni.pipelines.rollout_artifacts import ArtifactSpec
+from verl_omni.pipelines.rollout_media import DiffusionIOSpec
 from verl_omni.pipelines.rollout_request import prompt_ids_from_payload
 from verl_omni.pipelines.schedulers import FlowMatchSDEDiscreteScheduler
 
@@ -246,7 +248,12 @@ class BagelPipelineWithLogProb(BagelPipeline):
 
     #: Declares the primary rollout media stream so downstream consumers read
     #: the modality from the adapter instead of inferring it from tensor rank.
-    diffusion_io_spec = DiffusionIOSpec(primary=MediaSpec("image"))
+    diffusion_io_spec = DiffusionIOSpec(
+        artifacts={
+            "image_preview": ArtifactSpec("image", "decoded", "CHW"),
+            "image_latent": ArtifactSpec("image", "latent", "LC"),
+        }
+    )
 
     def __init__(self, *, od_config: OmniDiffusionConfig, prefix: str = ""):
         super().__init__(od_config=od_config, prefix=prefix)
@@ -303,6 +310,12 @@ class BagelPipelineWithLogProb(BagelPipeline):
             if negative_prompt is not None:
                 extra_args["negative_prompt"] = negative_prompt
 
+    def _decode_image_from_latent(self, bagel, vae, latent, image_shape):
+        # Upstream decodes the final sample before optional trajectory previews.
+        if self._final_image_latent is None:
+            self._final_image_latent = latent
+        return super()._decode_image_from_latent(bagel, vae, latent, image_shape)
+
     def forward(self, req: OmniDiffusionRequest) -> DiffusionOutput:
         self._ensure_bagel_prompt_text(req)
 
@@ -353,7 +366,14 @@ class BagelPipelineWithLogProb(BagelPipeline):
         )
 
         # vllm-omni >= 0.24 (#4509) matches official BAGEL: n schedule points, n-1 denoise steps.
+        self._final_image_latent = None
         output = super().forward(req)
+        native_latent = self._final_image_latent
+        self._final_image_latent = None
+        if native_latent is None:
+            raise RuntimeError(
+                f"pipeline={type(self).__name__}, request_id={req.request_id}: no final native image latent"
+            )
 
         # Slice trajectory to the SDE window so training only sees noisy steps.
         traj_latents, traj_timesteps, traj_log_probs = _extract_bagel_trajectory(output)
@@ -375,24 +395,28 @@ class BagelPipelineWithLogProb(BagelPipeline):
         if traj_log_probs is not None:
             traj_log_probs = traj_log_probs.unsqueeze(0)
 
-        media = output.output
-        media_key = "image"
-        metadata = None
-        if isinstance(media, dict) and isinstance(media.get("payload"), dict):
-            payload = dict(media["payload"])
-            metadata = dict(media.get("metadata") or {})
-            for key in ("image", "video", "output", "audio", "text"):
-                if key in payload:
-                    media = payload[key]
-                    media_key = key
-                    break
-
-        return rollout_output(
-            media=maybe_to_cpu(media),
-            media_key=media_key,
+        payload = output.output["payload"]
+        context = f"pipeline={type(self).__name__}, request_id={req.request_id}"
+        if "image" not in payload or payload.keys() - {"image", "trajectory"}:
+            raise ValueError(f"{context}: expected image and optional trajectory, got {list(payload)}")
+        media = torch.from_numpy(np.array(payload["image"], copy=True)).permute(2, 0, 1).unsqueeze(0)
+        metadata = dict(output.output.get("metadata") or {})
+        result = rollout_output(
+            media=media,
+            trajectory_decoded=payload.get("trajectory", {}).get("decoded"),
             trajectory_latents=maybe_to_cpu(traj_latents),
             trajectory_timesteps=maybe_to_cpu(traj_timesteps),
             trajectory_log_probs=maybe_to_cpu(traj_log_probs),
             metadata=metadata,
             to_cpu=False,
+        )
+        return with_visual_artifacts(
+            result,
+            decoded=media,
+            pixel_range="uint8",
+            latents=maybe_to_cpu(native_latent).unsqueeze(0),
+            latent_layout="LC",
+            output_type=req.sampling_params.output_type or "pil",
+            context=context,
+            requested=(req.sampling_params.extra_args or {}).get("requested_outputs"),
         )

--- a/verl_omni/pipelines/bagel_flow_grpo/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/bagel_flow_grpo/vllm_omni_rollout_adapter.py
@@ -40,6 +40,7 @@ from verl_omni.pipelines.bagel_flow_grpo.common import (
 from verl_omni.pipelines.diffusion_rollout_output import rollout_output
 from verl_omni.pipelines.model_base import VllmOmniPipelineBase
 from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
+from verl_omni.pipelines.rollout_request import prompt_ids_from_payload
 from verl_omni.pipelines.schedulers import FlowMatchSDEDiscreteScheduler
 
 logger = logging.getLogger(__name__)
@@ -292,7 +293,7 @@ class BagelPipelineWithLogProb(BagelPipeline):
 
         custom_prompt = req.prompts[0]
         if not custom_prompt.get("prompt"):
-            prompt = self._decode_token_prompt(custom_prompt.get("prompt_token_ids"))
+            prompt = self._decode_token_prompt(prompt_ids_from_payload(custom_prompt))
             if prompt is not None:
                 custom_prompt["prompt"] = prompt
 
@@ -301,12 +302,6 @@ class BagelPipelineWithLogProb(BagelPipeline):
             negative_prompt = self._decode_token_prompt(custom_prompt.get("negative_prompt_ids"))
             if negative_prompt is not None:
                 extra_args["negative_prompt"] = negative_prompt
-
-        prompt_extra_args = custom_prompt.get("extra_args")
-        if isinstance(prompt_extra_args, dict):
-            multi_modal_data = prompt_extra_args.get("multi_modal_data")
-            if multi_modal_data is not None and "multi_modal_data" not in custom_prompt:
-                custom_prompt["multi_modal_data"] = multi_modal_data
 
     def forward(self, req: OmniDiffusionRequest) -> DiffusionOutput:
         self._ensure_bagel_prompt_text(req)

--- a/verl_omni/pipelines/boogu_image_flow_grpo/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/boogu_image_flow_grpo/vllm_omni_rollout_adapter.py
@@ -47,8 +47,7 @@ from verl_omni.pipelines.request_batch import (
 from verl_omni.pipelines.request_batch import (
     split_diffusion_output_by_request as _split_diffusion_output_by_request,
 )
-from verl_omni.pipelines.rollout_artifacts import ArtifactSpec
-from verl_omni.pipelines.rollout_media import DiffusionIOSpec
+from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
 from verl_omni.pipelines.rollout_request import condition_images_from_payload, prompt_ids_from_payload
 from verl_omni.pipelines.schedulers import FlowMatchSDEDiscreteScheduler
 
@@ -101,8 +100,8 @@ class BooguImagePipelineWithLogProb(QwenImageTokenIdPromptMixin, BooguImagePipel
     #: the modality from the adapter instead of inferring it from tensor rank.
     diffusion_io_spec = DiffusionIOSpec(
         artifacts={
-            "image_preview": ArtifactSpec("image", "decoded", "CHW"),
-            "image_latent": ArtifactSpec("image", "latent", "CHW"),
+            "image_preview": MediaSpec("image", "decoded", "CHW"),
+            "image_latent": MediaSpec("image", "latent", "CHW"),
         }
     )
 

--- a/verl_omni/pipelines/boogu_image_flow_grpo/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/boogu_image_flow_grpo/vllm_omni_rollout_adapter.py
@@ -27,7 +27,11 @@ from vllm_omni.diffusion.models.boogu_image.pipeline_boogu_image import BooguIma
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
 
-from verl_omni.pipelines.diffusion_rollout_output import rollout_output, wrap_rollout_postprocessor
+from verl_omni.pipelines.diffusion_rollout_output import (
+    rollout_output,
+    with_visual_artifacts,
+    wrap_rollout_postprocessor,
+)
 from verl_omni.pipelines.model_base import VllmOmniPipelineBase
 from verl_omni.pipelines.qwen_image_flow_grpo.common import QwenImageTokenIdPromptMixin, coalesce_not_none
 from verl_omni.pipelines.request_batch import (
@@ -36,13 +40,15 @@ from verl_omni.pipelines.request_batch import (
 from verl_omni.pipelines.request_batch import (
     collate_prompt_rows as _collate_prompt_rows,
 )
+from verl_omni.pipelines.request_batch import requested_outputs_for_batch
 from verl_omni.pipelines.request_batch import (
     sample_per_sample_sde_windows as _sample_per_sample_sde_windows,
 )
 from verl_omni.pipelines.request_batch import (
     split_diffusion_output_by_request as _split_diffusion_output_by_request,
 )
-from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
+from verl_omni.pipelines.rollout_artifacts import ArtifactSpec
+from verl_omni.pipelines.rollout_media import DiffusionIOSpec
 from verl_omni.pipelines.rollout_request import condition_images_from_payload, prompt_ids_from_payload
 from verl_omni.pipelines.schedulers import FlowMatchSDEDiscreteScheduler
 
@@ -93,7 +99,12 @@ class BooguImagePipelineWithLogProb(QwenImageTokenIdPromptMixin, BooguImagePipel
 
     #: Declares the primary rollout media stream so downstream consumers read
     #: the modality from the adapter instead of inferring it from tensor rank.
-    diffusion_io_spec = DiffusionIOSpec(primary=MediaSpec("image"))
+    diffusion_io_spec = DiffusionIOSpec(
+        artifacts={
+            "image_preview": ArtifactSpec("image", "decoded", "CHW"),
+            "image_latent": ArtifactSpec("image", "latent", "CHW"),
+        }
+    )
 
     def __init__(self, *, od_config: OmniDiffusionConfig, prefix: str = "") -> None:
         super().__init__(od_config=od_config, prefix=prefix)
@@ -453,6 +464,7 @@ class BooguImagePipelineWithLogProb(QwenImageTokenIdPromptMixin, BooguImagePipel
             return outputs if return_batch else outputs[0]
 
         sampling_params = request_batch.sampling_params_list[0]
+        requested_outputs = requested_outputs_for_batch(request_batch)
         height = sampling_params.height or self.default_sample_size * self.vae_scale_factor
         width = sampling_params.width or self.default_sample_size * self.vae_scale_factor
         num_inference_steps = sampling_params.num_inference_steps or 50
@@ -579,8 +591,8 @@ class BooguImagePipelineWithLogProb(QwenImageTokenIdPromptMixin, BooguImagePipel
 
         # Decode the way upstream does: undo the VAE scaling/shift, resize back.
         output_type = sampling_params.output_type or "pil"
-        if output_type == "latent":
-            image = latents
+        if output_type == "latent" and "image_preview" not in requested_outputs:
+            image = None
         else:
             decode_latents = latents.to(dtype=self.vae.dtype)
             if self.vae.config.scaling_factor is not None:
@@ -606,6 +618,15 @@ class BooguImagePipelineWithLogProb(QwenImageTokenIdPromptMixin, BooguImagePipel
             # training side's ``condition_image_latents`` stays absent there.
             rl=None if condition_image_latents is None else {"condition_image_latents": condition_image_latents},
             to_cpu=True,
+        )
+        result = with_visual_artifacts(
+            result,
+            decoded=image,
+            latents=latents,
+            latent_layout="CHW",
+            output_type=output_type,
+            context=f"pipeline={type(self).__name__}, request_id={[r.request_id for r in request_batch.requests]}",
+            requested=requested_outputs,
         )
         outputs = _split_diffusion_output_by_request(
             result,

--- a/verl_omni/pipelines/boogu_image_flow_grpo/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/boogu_image_flow_grpo/vllm_omni_rollout_adapter.py
@@ -43,7 +43,7 @@ from verl_omni.pipelines.request_batch import (
     split_diffusion_output_by_request as _split_diffusion_output_by_request,
 )
 from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
-from verl_omni.pipelines.rollout_request import condition_images_from_payload
+from verl_omni.pipelines.rollout_request import condition_images_from_payload, prompt_ids_from_payload
 from verl_omni.pipelines.schedulers import FlowMatchSDEDiscreteScheduler
 
 from .common import (
@@ -218,7 +218,7 @@ class BooguImagePipelineWithLogProb(QwenImageTokenIdPromptMixin, BooguImagePipel
         if prompts:
             p0 = prompts[0]
             if isinstance(p0, dict):
-                prompt_ids = p0.get("prompt_token_ids", None)
+                prompt_ids = prompt_ids_from_payload(p0)
                 prompt_mask = p0.get("prompt_mask", None)
                 negative_prompt_ids = p0.get("negative_prompt_ids", None)
                 negative_prompt_mask = p0.get("negative_prompt_mask", None)
@@ -240,7 +240,7 @@ class BooguImagePipelineWithLogProb(QwenImageTokenIdPromptMixin, BooguImagePipel
         """
         prompt_ids, token_lengths = _collate_prompt_rows(
             prompts,
-            ("prompt_token_ids", "prompt_ids"),
+            ("prompt_ids",),
             None,
             device=self.device,
             field_name="prompt_token_ids",

--- a/verl_omni/pipelines/diffusion_rollout_output.py
+++ b/verl_omni/pipelines/diffusion_rollout_output.py
@@ -22,10 +22,12 @@ from __future__ import annotations
 
 import functools
 from collections.abc import Callable, Mapping
-from dataclasses import replace
+from dataclasses import asdict, replace
 from typing import Any
 
 from vllm_omni.diffusion.data import DiffusionOutput
+
+from verl_omni.pipelines.rollout_artifacts import ArtifactSpec, MediaArtifact, select_artifact, validate_artifacts
 
 _MEDIA_KEYS = ("image", "video", "output", "audio")
 
@@ -81,6 +83,53 @@ def with_rollout_data(
     )
 
 
+def with_media_artifacts(
+    base: DiffusionOutput,
+    *,
+    artifacts: list[tuple[str, MediaArtifact]],
+    specs: Mapping[str, ArtifactSpec],
+    primary: str,
+    context: str,
+    audio: str | None = None,
+    preview: str | None = None,
+    requested: list[str] | None = None,
+) -> DiffusionOutput:
+    """Replace legacy media with a named, already-normalized per-sample payload.
+
+    One modality-keyed payload holds all named tensors so the pinned upstream
+    formatter cannot discard non-primary streams. Trajectories and algorithm
+    metadata remain separate. This does not require changing upstream types.
+    """
+    normalized = validate_artifacts(artifacts, specs, primary=primary, context=context, requested=requested)
+    metadata = dict(base.output.get("metadata") or {}) if _is_envelope(base.output) else {}
+    if "media_artifacts" in metadata:
+        raise ValueError(f"{context}: duplicate media_artifacts metadata")
+    if audio is not None:
+        select_artifact(normalized, name=audio, modality="audio", representation="decoded")
+    if preview is not None:
+        artifact = normalized.get(preview)
+        if (
+            artifact is None
+            or artifact.spec.representation != "decoded"
+            or artifact.spec.modality not in ("image", "video")
+        ):
+            raise ValueError(f"{context}: preview artifact={preview!r} must be decoded visual media")
+    metadata["media_artifacts"] = {
+        "primary": primary,
+        "audio": audio,
+        "preview": preview,
+        "specs": {name: asdict(artifact.spec) for name, artifact in normalized.items()},
+    }
+    modality = normalized[primary].spec.modality
+    return replace(
+        base,
+        output={
+            "payload": {modality: {name: artifact.data for name, artifact in normalized.items()}},
+            "metadata": metadata,
+        },
+    )
+
+
 def wrap_rollout_postprocessor(postprocess: Callable[..., Any]) -> Callable[..., Any]:
     """Adapt a media-only upstream postprocessor to preserve rollout payload and metadata."""
 
@@ -91,6 +140,10 @@ def wrap_rollout_postprocessor(postprocess: Callable[..., Any]) -> Callable[...,
 
         payload = data["payload"]
         metadata = dict(data.get("metadata") or {})
+        if "media_artifacts" in metadata:
+            return data  # Named tensors are already decoded/normalized by the adapter.
+        if len(payload) != 1:
+            raise ValueError("A media-only postprocessor cannot consume multiple payload keys; use named artifacts.")
         media_key = next((key for key in _MEDIA_KEYS if key in payload), None)
         if media_key is None:
             raise ValueError("Diffusion output envelope has no media payload.")
@@ -131,6 +184,8 @@ def _unwrap_output(output: Any, default_key: str) -> tuple[Any, str, dict[str, A
     if not _is_envelope(output):
         return output, default_key, {}
     payload = output["payload"]
+    if len(payload) != 1:
+        raise ValueError("Cannot unwrap multiple diffusion payload keys without dropping media; use named artifacts.")
     for key in _MEDIA_KEYS:
         if key in payload:
             return payload[key], key, dict(output.get("metadata") or {})

--- a/verl_omni/pipelines/diffusion_rollout_output.py
+++ b/verl_omni/pipelines/diffusion_rollout_output.py
@@ -28,7 +28,8 @@ from typing import Any, Literal
 import torch
 from vllm_omni.diffusion.data import DiffusionOutput
 
-from verl_omni.pipelines.rollout_artifacts import ArtifactSpec, MediaArtifact, select_artifact, validate_artifacts
+from verl_omni.pipelines.rollout_artifacts import MediaArtifact, select_artifact, validate_artifacts
+from verl_omni.pipelines.rollout_media import MediaSpec
 
 _MEDIA_KEYS = frozenset(("image", "video", "output", "audio"))
 
@@ -88,7 +89,7 @@ def with_media_artifacts(
     base: DiffusionOutput,
     *,
     artifacts: list[tuple[str, MediaArtifact]],
-    specs: Mapping[str, ArtifactSpec],
+    specs: Mapping[str, MediaSpec],
     primary: str,
     context: str,
     audio: str | None = None,
@@ -136,7 +137,7 @@ def with_batched_media_artifacts(
     base: DiffusionOutput,
     *,
     data: Mapping[str, torch.Tensor],
-    specs: Mapping[str, ArtifactSpec],
+    specs: Mapping[str, MediaSpec],
     primary: str,
     context: str,
     preview: str | None = None,
@@ -215,10 +216,10 @@ def with_visual_artifacts(
     """
     latent_name, preview_name = f"{modality}_latent", f"{modality}_preview"
     data = {latent_name: latents}
-    specs = {latent_name: ArtifactSpec(modality, "latent", latent_layout)}
+    specs = {latent_name: MediaSpec(modality, "latent", latent_layout)}
     if decoded is not None:
         data[preview_name] = quantize_pixels(decoded, pixel_range, context=context)
-        specs[preview_name] = ArtifactSpec(modality, "decoded", decoded_layout, fps=fps)
+        specs[preview_name] = MediaSpec(modality, "decoded", decoded_layout, fps=fps)
     return with_batched_media_artifacts(
         base,
         data=data,

--- a/verl_omni/pipelines/diffusion_rollout_output.py
+++ b/verl_omni/pipelines/diffusion_rollout_output.py
@@ -23,13 +23,14 @@ from __future__ import annotations
 import functools
 from collections.abc import Callable, Mapping
 from dataclasses import asdict, replace
-from typing import Any
+from typing import Any, Literal
 
+import torch
 from vllm_omni.diffusion.data import DiffusionOutput
 
 from verl_omni.pipelines.rollout_artifacts import ArtifactSpec, MediaArtifact, select_artifact, validate_artifacts
 
-_MEDIA_KEYS = ("image", "video", "output", "audio")
+_MEDIA_KEYS = frozenset(("image", "video", "output", "audio"))
 
 
 def rollout_output(
@@ -115,6 +116,7 @@ def with_media_artifacts(
         ):
             raise ValueError(f"{context}: preview artifact={preview!r} must be decoded visual media")
     metadata["media_artifacts"] = {
+        "context": context,
         "primary": primary,
         "audio": audio,
         "preview": preview,
@@ -127,6 +129,104 @@ def with_media_artifacts(
             "payload": {modality: {name: artifact.data for name, artifact in normalized.items()}},
             "metadata": metadata,
         },
+    )
+
+
+def with_batched_media_artifacts(
+    base: DiffusionOutput,
+    *,
+    data: Mapping[str, torch.Tensor],
+    specs: Mapping[str, ArtifactSpec],
+    primary: str,
+    context: str,
+    preview: str | None = None,
+    audio: str | None = None,
+    requested: list[str] | None = None,
+) -> DiffusionOutput:
+    """Normalize explicit B-prefixed tensors and retain the sample list for request splitting."""
+    if primary not in data:
+        raise ValueError(f"{context}: missing primary artifact={primary!r}")
+    batch_size = data[primary].shape[0]
+    if batch_size < 1:
+        raise ValueError(f"{context}: expected a nonempty artifact batch")
+    for name, tensor in data.items():
+        if name not in specs:
+            raise ValueError(f"{context}: undeclared artifact={name!r}")
+        if tensor.ndim != len(specs[name].layout) + 1 or tensor.shape[0] != batch_size:
+            raise ValueError(
+                f"{context}, artifact={name!r}: expected B{specs[name].layout}, B={batch_size}, got {tensor.shape}"
+            )
+    samples = []
+    for index in range(batch_size):
+        result = with_media_artifacts(
+            base,
+            artifacts=[(name, MediaArtifact(specs[name], tensor[index])) for name, tensor in data.items()],
+            specs=specs,
+            primary=primary,
+            preview=preview,
+            audio=audio,
+            context=f"{context}, sample={index}",
+            requested=requested,
+        )
+        samples.append(result.output["payload"][specs[primary].modality])
+    result.output["payload"][specs[primary].modality] = samples
+    return result
+
+
+def wants_decoded_preview(output_type: str, sampling_params: Any, *, modality: str = "image") -> bool:
+    """Honor explicit preview requests even when the primary output is latent."""
+    requested = (sampling_params.extra_args or {}).get("requested_outputs") or []
+    return output_type != "latent" or f"{modality}_preview" in requested
+
+
+def quantize_pixels(decoded: torch.Tensor, pixel_range: str, *, context: str) -> torch.Tensor:
+    """Quantize an explicitly declared VAE range, never infer encoding from dtype or extrema."""
+    if pixel_range == "uint8":
+        if decoded.dtype != torch.uint8:
+            raise ValueError(f"{context}: expected uint8 pixels, got {decoded.dtype}")
+        return decoded
+    if pixel_range not in ("minus_one_one", "zero_one") or not decoded.is_floating_point():
+        raise ValueError(f"{context}: invalid floating pixel encoding {pixel_range!r}, dtype={decoded.dtype}")
+    if not torch.isfinite(decoded).all():
+        raise ValueError(f"{context}: nonfinite decoded pixels")
+    # Match VaeImageProcessor's denormalization before float32 quantization.
+    pixels = decoded / 2 + 0.5 if pixel_range == "minus_one_one" else decoded
+    return pixels.float().clamp(0, 1).mul(255).round().to(torch.uint8)
+
+
+def with_visual_artifacts(
+    base: DiffusionOutput,
+    *,
+    decoded: torch.Tensor | None,
+    latents: torch.Tensor,
+    latent_layout: str,
+    output_type: str,
+    context: str,
+    requested: list[str] | None = None,
+    modality: Literal["image", "video"] = "image",
+    decoded_layout: str = "CHW",
+    pixel_range: Literal["minus_one_one", "zero_one", "uint8"] = "minus_one_one",
+    fps: float | None = None,
+) -> DiffusionOutput:
+    """Adapter boundary for explicit batched VAE pixels plus unchanged native latents.
+
+    The caller declares the pixel range and every axis; neither dtype nor shape
+    is used to infer representation. Training/replay tensors in ``base`` are untouched.
+    """
+    latent_name, preview_name = f"{modality}_latent", f"{modality}_preview"
+    data = {latent_name: latents}
+    specs = {latent_name: ArtifactSpec(modality, "latent", latent_layout)}
+    if decoded is not None:
+        data[preview_name] = quantize_pixels(decoded, pixel_range, context=context)
+        specs[preview_name] = ArtifactSpec(modality, "decoded", decoded_layout, fps=fps)
+    return with_batched_media_artifacts(
+        base,
+        data=data,
+        specs=specs,
+        primary=latent_name if output_type == "latent" else preview_name,
+        preview=preview_name if decoded is not None else None,
+        context=context,
+        requested=requested,
     )
 
 
@@ -144,8 +244,8 @@ def wrap_rollout_postprocessor(postprocess: Callable[..., Any]) -> Callable[...,
             return data  # Named tensors are already decoded/normalized by the adapter.
         if len(payload) != 1:
             raise ValueError("A media-only postprocessor cannot consume multiple payload keys; use named artifacts.")
-        media_key = next((key for key in _MEDIA_KEYS if key in payload), None)
-        if media_key is None:
+        (media_key,) = payload
+        if media_key not in _MEDIA_KEYS:
             raise ValueError("Diffusion output envelope has no media payload.")
 
         processed = postprocess(payload[media_key], **kwargs)
@@ -186,7 +286,7 @@ def _unwrap_output(output: Any, default_key: str) -> tuple[Any, str, dict[str, A
     payload = output["payload"]
     if len(payload) != 1:
         raise ValueError("Cannot unwrap multiple diffusion payload keys without dropping media; use named artifacts.")
-    for key in _MEDIA_KEYS:
-        if key in payload:
-            return payload[key], key, dict(output.get("metadata") or {})
-    raise ValueError("Diffusion output envelope has no media payload.")
+    (key,) = payload
+    if key not in _MEDIA_KEYS:
+        raise ValueError("Diffusion output envelope has no media payload.")
+    return payload[key], key, dict(output.get("metadata") or {})

--- a/verl_omni/pipelines/flux_dance_grpo/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/flux_dance_grpo/vllm_omni_rollout_adapter.py
@@ -29,9 +29,13 @@ from vllm_omni.diffusion.models.flux.pipeline_flux import FluxPipeline
 from vllm_omni.diffusion.request import DUMMY_DIFFUSION_REQUEST_ID, OmniDiffusionRequest
 from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
 
-from verl_omni.pipelines.diffusion_rollout_output import rollout_output, wrap_rollout_postprocessor
+from verl_omni.pipelines.diffusion_rollout_output import (
+    rollout_output,
+    with_visual_artifacts,
+    wrap_rollout_postprocessor,
+)
 from verl_omni.pipelines.model_base import VllmOmniPipelineBase
-from verl_omni.pipelines.request_batch import split_diffusion_output_by_request
+from verl_omni.pipelines.request_batch import requested_outputs_for_batch, split_diffusion_output_by_request
 from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
 from verl_omni.pipelines.rollout_request import prompt_ids_from_payload
 from verl_omni.pipelines.schedulers import FlowMatchSDEDiscreteScheduler
@@ -163,7 +167,12 @@ class FluxDanceGRPOPipelineWithLogProb(FluxPipeline):
     """FLUX.1-dev generation plus aligned DanceGRPO transition capture."""
 
     supports_request_batch = True
-    diffusion_io_spec = DiffusionIOSpec(primary=MediaSpec("image"))
+    diffusion_io_spec = DiffusionIOSpec(
+        artifacts={
+            "image_preview": MediaSpec("image", "decoded", "CHW"),
+            "image_latent": MediaSpec("image", "latent", "LC"),
+        }
+    )
 
     def __init__(self, *, od_config: OmniDiffusionConfig, prefix: str = ""):
         super().__init__(od_config=od_config, prefix=prefix)
@@ -390,6 +399,8 @@ class FluxDanceGRPOPipelineWithLogProb(FluxPipeline):
         output_type = sampling.output_type or extra_args.get("output_type") or output_type
         if output_type not in ("image", "latent"):
             raise ValueError(f"FLUX DanceGRPO output_type must be 'image' or 'latent', got {output_type!r}")
+        requested_outputs = requested_outputs_for_batch(request_batch)
+        decode = output_type != "latent" or "image_preview" in requested_outputs
         num_outputs = sampling.num_outputs_per_prompt if sampling.num_outputs_per_prompt > 0 else 1
         self._guidance_scale = guidance_scale
         self._interrupt = False
@@ -489,9 +500,8 @@ class FluxDanceGRPOPipelineWithLogProb(FluxPipeline):
         )
 
         self._current_timestep = None
-        if output_type == "latent":
-            output = pred_original
-        else:
+        output = None
+        if decode:
             clean = self._unpack_latents(pred_original, height, width, self.vae_scale_factor)
             clean = (clean / self.vae.config.scaling_factor) + self.vae.config.shift_factor
             output = self.vae.decode(clean.to(self.vae.dtype), return_dict=False)[0]
@@ -511,6 +521,15 @@ class FluxDanceGRPOPipelineWithLogProb(FluxPipeline):
             },
             rl={"all_next_latents": next_latents},
             to_cpu=True,
+        )
+        result = with_visual_artifacts(
+            result,
+            decoded=output,
+            latents=pred_original,
+            latent_layout="LC",
+            output_type=output_type,
+            context=f"pipeline={type(self).__name__}, request_id={request_batch.request_ids}",
+            requested=requested_outputs,
         )
         outputs = split_diffusion_output_by_request(
             result,

--- a/verl_omni/pipelines/flux_dance_grpo/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/flux_dance_grpo/vllm_omni_rollout_adapter.py
@@ -33,6 +33,7 @@ from verl_omni.pipelines.diffusion_rollout_output import rollout_output, wrap_ro
 from verl_omni.pipelines.model_base import VllmOmniPipelineBase
 from verl_omni.pipelines.request_batch import split_diffusion_output_by_request
 from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
+from verl_omni.pipelines.rollout_request import prompt_ids_from_payload
 from verl_omni.pipelines.schedulers import FlowMatchSDEDiscreteScheduler
 from verl_omni.pipelines.wan22_dance_grpo.common import seed_from_prompt_ids
 
@@ -75,9 +76,14 @@ def _extract_extra_prompt_ids(prompts: list[Any]) -> dict[str, list[list[int]]] 
         return None
     per_prompt: list[dict[str, Any]] = []
     for prompt in prompts:
-        if not isinstance(prompt, dict) or not prompt.get("extra_prompt_ids"):
+        if not isinstance(prompt, dict):
             return None
-        per_prompt.append(prompt["extra_prompt_ids"])
+        if prompt.get("extra_prompt_ids") is not None:
+            raise ValueError("FLUX extra_prompt_ids must be nested under extra_args, not at the prompt top level")
+        extra = (prompt.get("extra_args") or {}).get("extra_prompt_ids")
+        if not extra:
+            return None
+        per_prompt.append(extra)
 
     for index, extra in enumerate(per_prompt):
         missing = [key for key in FLUX_ENCODER_TOKEN_KEYS if key not in extra]
@@ -362,11 +368,11 @@ class FluxDanceGRPOPipelineWithLogProb(FluxPipeline):
             if any(
                 request.request_id != DUMMY_DIFFUSION_REQUEST_ID
                 and isinstance(prompt, dict)
-                and prompt.get("prompt_token_ids") is not None
+                and prompt_ids_from_payload(prompt) is not None
                 for request, prompt in zip(request_batch.requests, prompts, strict=False)
             ):
                 raise ValueError(
-                    "FLUX received only the generic prompt_token_ids. Configure "
+                    "FLUX received only the generic prompt_ids. Configure "
                     "actor_rollout_ref.model.extra_tokenizers.clip={path: tokenizer, max_length: 77} "
                     "and .t5={path: tokenizer_2, max_length: 512}."
                 )

--- a/verl_omni/pipelines/ltx2_flow_grpo/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/ltx2_flow_grpo/vllm_omni_rollout_adapter.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import copy
 import os
+from dataclasses import replace
 from typing import Any
 
 import numpy as np
@@ -42,15 +43,18 @@ from vllm_omni.diffusion.models.ltx2.ltx2_latents import (
 from vllm_omni.diffusion.models.ltx2.ltx2_recipes import LTXPhaseRecipe
 from vllm_omni.diffusion.models.ltx2.ltx2_request import LTXRequestInputs
 from vllm_omni.diffusion.models.ltx2.pipeline_ltx2 import LTX2Pipeline
-from vllm_omni.diffusion.request import OmniDiffusionRequest
+from vllm_omni.diffusion.request import DUMMY_DIFFUSION_REQUEST_ID, OmniDiffusionRequest
 from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
 
 from verl_omni.pipelines.diffusion_rollout_output import (
+    quantize_pixels,
     rollout_output,
+    with_batched_media_artifacts,
     wrap_rollout_postprocessor,
 )
 from verl_omni.pipelines.model_base import VllmOmniPipelineBase
-from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
+from verl_omni.pipelines.rollout_artifacts import ArtifactSpec
+from verl_omni.pipelines.rollout_media import DiffusionIOSpec
 from verl_omni.pipelines.rollout_request import prompt_ids_from_payload
 from verl_omni.pipelines.schedulers import FlowMatchSDEDiscreteScheduler
 
@@ -76,12 +80,13 @@ class LTX23PipelineWithLogProb(LTX2Pipeline):
 
     supports_request_batch = False
 
-    #: Declares the joint video/audio rollout streams. The runtime audio sample
-    #: rate (from the vocoder) is attached via rollout metadata and takes
-    #: precedence over this declared default.
     diffusion_io_spec = DiffusionIOSpec(
-        primary=MediaSpec("video"),
-        auxiliary=(MediaSpec("audio", sample_rate=24000),),
+        artifacts={
+            "video_preview": ArtifactSpec("video", "decoded", "TCHW"),
+            "audio": ArtifactSpec("audio", "decoded", "CT"),
+            "video_latent": ArtifactSpec("video", "latent", "CTHW"),
+            "audio_latent": ArtifactSpec("audio", "latent", "CTF"),
+        }
     )
 
     def __init__(self, *, od_config: OmniDiffusionConfig, prefix: str = "") -> None:
@@ -229,7 +234,6 @@ class LTX23PipelineWithLogProb(LTX2Pipeline):
         prompt_context: LTXPromptContext | None = None,
     ) -> LTXPhaseResult:
         """Prepare and execute one phase with FlowGRPO SDE transitions."""
-        del phase_recipe
         self._check_forward_inputs(request_inputs, image=image)
         guidance_parallel_ready = self._setup_forward_runtime(req, request_inputs, attention_kwargs)
         device = self.device
@@ -314,6 +318,7 @@ class LTX23PipelineWithLogProb(LTX2Pipeline):
             original_audio_num_frames=original_audio_num_frames,
             padded_audio_num_frames=padded_audio_num_frames,
             timesteps=timesteps_tensor,
+            sampler=phase_recipe.sampler,
             audio_scheduler=audio_scheduler,
             video_audio_step_adapter=video_audio_step_adapter,
         )
@@ -429,6 +434,15 @@ class LTX23PipelineWithLogProb(LTX2Pipeline):
         )
         return LTXAVState(video=video, audio=audio)
 
+    def _decode_output(self, *, latents, audio_latents, output_type, **kwargs):
+        self._flow_grpo_native_latents = (latents, audio_latents)
+        return super()._decode_output(
+            latents=latents,
+            audio_latents=audio_latents,
+            output_type="pt" if self._artifact_decode else "latent",
+            **kwargs,
+        )
+
     @torch.no_grad()
     def forward(self, req: DiffusionRequestBatch, **kwargs: Any) -> DiffusionOutput | list[DiffusionOutput]:
         """Generate one request and attach the FlowGRPO trajectory contract."""
@@ -437,25 +451,31 @@ class LTX23PipelineWithLogProb(LTX2Pipeline):
         request = req.requests[0]
         self._configure_flow_grpo(request)
         self._inject_precomputed_prompt_embeds(request)
+        output_type = request.sampling_params.output_type or "pt"
+        requested = (request.sampling_params.extra_args or {}).get("requested_outputs")
+        self._artifact_decode = output_type != "latent" or bool(set(requested or ()) & {"video_preview", "audio"})
+        self._flow_grpo_native_latents = None
         output = super().forward(req, **kwargs)
         if isinstance(output, list):
             if len(output) != 1:
                 raise RuntimeError(f"Single-request LTX rollout returned {len(output)} outputs.")
             output = output[0]
+        if request.request_id == DUMMY_DIFFUSION_REQUEST_ID:
+            self._flow_grpo_native_latents = None
+            return replace(output, output=None, to_cpu=True)
         video, audio = output.output
-        if isinstance(video, torch.Tensor) and video.ndim == 5:
-            if video.shape[0] != 1:
-                raise ValueError(f"Expected one video per diffusion request, got shape {tuple(video.shape)}.")
-            video = video[0]
+        if self.distributed_video_decode and torch.distributed.is_initialized() and torch.distributed.get_rank() != 0:
+            self._flow_grpo_native_latents = None
+            return output
+        if self._flow_grpo_native_latents is None:
+            raise RuntimeError("LTX rollout did not capture native final latents")
+        video_latent, audio_latent = self._flow_grpo_native_latents
+        self._flow_grpo_native_latents = None
         prompt_context = self._flow_grpo_prompt_context
         if prompt_context is None:
             raise RuntimeError("LTX-2.3 rollout did not prepare prompt connector outputs.")
 
-        audio_sample_rate = (
-            self.vocoder.config.output_sampling_rate
-            if hasattr(self, "vocoder") and self.vocoder is not None and hasattr(self.vocoder, "config")
-            else 24000
-        )
+        audio_sample_rate = self.vocoder.config.output_sampling_rate if self._artifact_decode else None
         result = rollout_output(
             media=(video, audio),
             media_key="video",
@@ -473,10 +493,31 @@ class LTX23PipelineWithLogProb(LTX2Pipeline):
             rl={
                 "all_next_latents": self._flow_grpo_trajectory.get("all_next_latents"),
                 "video_seq_len": self._flow_grpo_trajectory.get("video_seq_len"),
-                "audio": audio,
-                "audio_sample_rate": audio_sample_rate,
             },
             to_cpu=True,
         )
         self._current_timestep = None
-        return result
+        context = f"pipeline={type(self).__name__}, request_id={request.request_id}"
+        specs = {
+            "video_latent": ArtifactSpec("video", "latent", "CTHW"),
+            "audio_latent": ArtifactSpec("audio", "latent", "CTF"),
+        }
+        data = {"video_latent": video_latent, "audio_latent": audio_latent}
+        if self._artifact_decode:
+            specs.update(
+                {
+                    "video_preview": ArtifactSpec("video", "decoded", "TCHW", fps=request.sampling_params.frame_rate),
+                    "audio": ArtifactSpec("audio", "decoded", "CT", sample_rate=audio_sample_rate),
+                }
+            )
+            data.update({"video_preview": quantize_pixels(video, "zero_one", context=context), "audio": audio})
+        return with_batched_media_artifacts(
+            result,
+            data=data,
+            specs=specs,
+            primary="video_latent" if output_type == "latent" else "video_preview",
+            preview="video_preview" if self._artifact_decode else None,
+            audio="audio" if self._artifact_decode else None,
+            context=context,
+            requested=requested,
+        )

--- a/verl_omni/pipelines/ltx2_flow_grpo/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/ltx2_flow_grpo/vllm_omni_rollout_adapter.py
@@ -51,6 +51,7 @@ from verl_omni.pipelines.diffusion_rollout_output import (
 )
 from verl_omni.pipelines.model_base import VllmOmniPipelineBase
 from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
+from verl_omni.pipelines.rollout_request import prompt_ids_from_payload
 from verl_omni.pipelines.schedulers import FlowMatchSDEDiscreteScheduler
 
 from .common import calculate_shift, normalize_ltx_output_type
@@ -149,9 +150,9 @@ class LTX23PipelineWithLogProb(LTX2Pipeline):
     def _inject_precomputed_prompt_embeds(self, req: OmniDiffusionRequest) -> None:
         """Convert verl token-ID request fields into LTX raw text-encoder embeddings."""
         if not isinstance(req.prompt, dict):
-            raise TypeError("LTX-2.3 FlowGRPO expects a dict prompt containing `prompt_token_ids`.")
+            raise TypeError("LTX-2.3 FlowGRPO expects a dict prompt containing `prompt_ids`.")
         payload = dict(req.prompt)
-        prompt_ids = payload.get("prompt_token_ids")
+        prompt_ids = prompt_ids_from_payload(payload)
         if prompt_ids is None:
             return
 

--- a/verl_omni/pipelines/ltx2_flow_grpo/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/ltx2_flow_grpo/vllm_omni_rollout_adapter.py
@@ -53,8 +53,7 @@ from verl_omni.pipelines.diffusion_rollout_output import (
     wrap_rollout_postprocessor,
 )
 from verl_omni.pipelines.model_base import VllmOmniPipelineBase
-from verl_omni.pipelines.rollout_artifacts import ArtifactSpec
-from verl_omni.pipelines.rollout_media import DiffusionIOSpec
+from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
 from verl_omni.pipelines.rollout_request import prompt_ids_from_payload
 from verl_omni.pipelines.schedulers import FlowMatchSDEDiscreteScheduler
 
@@ -82,10 +81,10 @@ class LTX23PipelineWithLogProb(LTX2Pipeline):
 
     diffusion_io_spec = DiffusionIOSpec(
         artifacts={
-            "video_preview": ArtifactSpec("video", "decoded", "TCHW"),
-            "audio": ArtifactSpec("audio", "decoded", "CT"),
-            "video_latent": ArtifactSpec("video", "latent", "CTHW"),
-            "audio_latent": ArtifactSpec("audio", "latent", "CTF"),
+            "video_preview": MediaSpec("video", "decoded", "TCHW"),
+            "audio": MediaSpec("audio", "decoded", "CT"),
+            "video_latent": MediaSpec("video", "latent", "CTHW"),
+            "audio_latent": MediaSpec("audio", "latent", "CTF"),
         }
     )
 
@@ -499,15 +498,15 @@ class LTX23PipelineWithLogProb(LTX2Pipeline):
         self._current_timestep = None
         context = f"pipeline={type(self).__name__}, request_id={request.request_id}"
         specs = {
-            "video_latent": ArtifactSpec("video", "latent", "CTHW"),
-            "audio_latent": ArtifactSpec("audio", "latent", "CTF"),
+            "video_latent": MediaSpec("video", "latent", "CTHW"),
+            "audio_latent": MediaSpec("audio", "latent", "CTF"),
         }
         data = {"video_latent": video_latent, "audio_latent": audio_latent}
         if self._artifact_decode:
             specs.update(
                 {
-                    "video_preview": ArtifactSpec("video", "decoded", "TCHW", fps=request.sampling_params.frame_rate),
-                    "audio": ArtifactSpec("audio", "decoded", "CT", sample_rate=audio_sample_rate),
+                    "video_preview": MediaSpec("video", "decoded", "TCHW", fps=request.sampling_params.frame_rate),
+                    "audio": MediaSpec("audio", "decoded", "CT", sample_rate=audio_sample_rate),
                 }
             )
             data.update({"video_preview": quantize_pixels(video, "zero_one", context=context), "audio": audio})

--- a/verl_omni/pipelines/minimax_h3_diffusion_nft/artifacts.py
+++ b/verl_omni/pipelines/minimax_h3_diffusion_nft/artifacts.py
@@ -1,0 +1,49 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""The pinned H3 decoder and packed-token layouts, shared by NFT and FlowGRPO."""
+
+from verl_omni.pipelines.diffusion_rollout_output import with_batched_media_artifacts
+from verl_omni.pipelines.rollout_artifacts import ArtifactSpec
+
+
+def with_h3_artifacts(base, *, video, audio, video_latent, audio_latent, sampling, context):
+    """Transport NTHWC/NCT decoded media and native NCTHW/CLT latents separately."""
+    extra = sampling.extra_args or {}
+    output_type = extra.get("output_type", sampling.output_type)
+    specs = {
+        "video_preview": ArtifactSpec(
+            "video",
+            "decoded",
+            "THWC",
+            fps=24 if sampling.frame_rate is None else sampling.frame_rate,
+        ),
+        "audio": ArtifactSpec("audio", "decoded", "CT", sample_rate=32000),
+        "video_latent": ArtifactSpec("video", "latent", "CTHW"),
+        "audio_latent": ArtifactSpec("audio", "latent", "CLT"),
+    }
+    return with_batched_media_artifacts(
+        base,
+        data={
+            "video_preview": video,
+            "audio": audio,
+            "video_latent": video_latent,
+            "audio_latent": audio_latent.unsqueeze(0),
+        },
+        specs=specs,
+        primary="video_latent" if output_type == "latent" else "video_preview",
+        preview="video_preview",
+        audio="audio",
+        context=context,
+        requested=extra.get("requested_outputs"),
+    )

--- a/verl_omni/pipelines/minimax_h3_diffusion_nft/artifacts.py
+++ b/verl_omni/pipelines/minimax_h3_diffusion_nft/artifacts.py
@@ -14,7 +14,7 @@
 """The pinned H3 decoder and packed-token layouts, shared by NFT and FlowGRPO."""
 
 from verl_omni.pipelines.diffusion_rollout_output import with_batched_media_artifacts
-from verl_omni.pipelines.rollout_artifacts import ArtifactSpec
+from verl_omni.pipelines.rollout_media import MediaSpec
 
 
 def with_h3_artifacts(base, *, video, audio, video_latent, audio_latent, sampling, context):
@@ -22,15 +22,15 @@ def with_h3_artifacts(base, *, video, audio, video_latent, audio_latent, samplin
     extra = sampling.extra_args or {}
     output_type = extra.get("output_type", sampling.output_type)
     specs = {
-        "video_preview": ArtifactSpec(
+        "video_preview": MediaSpec(
             "video",
             "decoded",
             "THWC",
             fps=24 if sampling.frame_rate is None else sampling.frame_rate,
         ),
-        "audio": ArtifactSpec("audio", "decoded", "CT", sample_rate=32000),
-        "video_latent": ArtifactSpec("video", "latent", "CTHW"),
-        "audio_latent": ArtifactSpec("audio", "latent", "CLT"),
+        "audio": MediaSpec("audio", "decoded", "CT", sample_rate=32000),
+        "video_latent": MediaSpec("video", "latent", "CTHW"),
+        "audio_latent": MediaSpec("audio", "latent", "CLT"),
     }
     return with_batched_media_artifacts(
         base,

--- a/verl_omni/pipelines/minimax_h3_diffusion_nft/common.py
+++ b/verl_omni/pipelines/minimax_h3_diffusion_nft/common.py
@@ -24,6 +24,8 @@ from typing import Any
 import numpy as np
 import torch
 
+from verl_omni.pipelines.rollout_request import prompt_ids_from_payload
+
 VIDEO_ROW_WIDTH = 96
 AUDIO_ROW_WIDTH = 32
 LATENT_META_WIDTH = 6
@@ -706,7 +708,7 @@ class MiniMaxH3RolloutWeightSyncMixin:
         if not prompts or not isinstance(prompts[0], dict):
             return
         custom_prompt = prompts[0]
-        token_ids = custom_prompt.get("prompt_token_ids")
+        token_ids = prompt_ids_from_payload(custom_prompt)
         if token_ids is None:
             return
         sampling_params = getattr(request, "sampling_params", None)
@@ -723,5 +725,5 @@ class MiniMaxH3RolloutWeightSyncMixin:
             token_ids = token_ids[0]
         self._h3_prompt_ids = torch.as_tensor([int(token) for token in token_ids], dtype=torch.long)
         if self._h3_prompt_ids.numel() == 0:
-            raise ValueError("MiniMax H3 requires non-empty prompt_token_ids.")
+            raise ValueError("MiniMax H3 requires non-empty prompt_ids.")
         custom_prompt["prompt"] = "[pretokenized]"

--- a/verl_omni/pipelines/minimax_h3_diffusion_nft/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/minimax_h3_diffusion_nft/vllm_omni_rollout_adapter.py
@@ -31,11 +31,12 @@ from vllm_omni.diffusion.models.minimax_h3.packed_tokens import (
 from vllm_omni.diffusion.models.minimax_h3.pipeline_minimax_h3 import MiniMaxH3Pipeline
 from vllm_omni.diffusion.models.minimax_h3.time_request import minimax_h3_time_shift_sigmas
 
-from verl_omni.pipelines.diffusion_rollout_output import with_media_artifacts, with_rollout_data
+from verl_omni.pipelines.diffusion_rollout_output import with_rollout_data
 from verl_omni.pipelines.model_base import VllmOmniPipelineBase
-from verl_omni.pipelines.rollout_artifacts import ArtifactSpec, MediaArtifact
-from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
+from verl_omni.pipelines.rollout_artifacts import ArtifactSpec
+from verl_omni.pipelines.rollout_media import DiffusionIOSpec
 
+from .artifacts import with_h3_artifacts
 from .common import (
     AUDIO_ROW_WIDTH,
     MiniMaxH3RolloutWeightSyncMixin,
@@ -57,8 +58,12 @@ class MiniMaxH3DiffusionNFTPipeline(MiniMaxH3RolloutWeightSyncMixin, MiniMaxH3Pi
     #: Declares the joint video/audio rollout streams so the diffusion strategy
     #: does not hard-code the audio tuple position or its 32 kHz sample rate.
     diffusion_io_spec = DiffusionIOSpec(
-        primary=MediaSpec("video"),
-        auxiliary=(MediaSpec("audio", sample_rate=32000),),
+        artifacts={
+            "video_preview": ArtifactSpec("video", "decoded", "TCHW"),
+            "audio": ArtifactSpec("audio", "decoded", "CT", sample_rate=32000),
+            "video_latent": ArtifactSpec("video", "latent", "CTHW"),
+            "audio_latent": ArtifactSpec("audio", "latent", "CLT"),
+        }
     )
 
     def __init__(self, *, od_config: Any, prefix: str = "") -> None:
@@ -228,38 +233,15 @@ class MiniMaxH3DiffusionNFTPipeline(MiniMaxH3RolloutWeightSyncMixin, MiniMaxH3Pi
             rl=rl,
             to_cpu=True,
         )
-        context = f"pipeline=MiniMaxH3Pipeline/diffusion_nft, request_id={getattr(request, 'request_id', 'unknown')}"
         video, audio = output.output
-        if video.ndim != 5 or video.shape[0] != 1 or audio.ndim != 3 or audio.shape[0] != 1:
-            raise ValueError(f"{context}: expected one NTHWC video and NCT waveform, got {video.shape}, {audio.shape}")
-        video_latent = capture["video_latent"]
-        if video_latent.ndim != 5 or video_latent.shape[0] != 1:
-            raise ValueError(f"{context}: expected one NCTHW video latent, got {video_latent.shape}")
-        # Pinned H3 forward quantizes NTHWC; packed_tokens.py defines NCTHW/CLT latents.
-        specs = {
-            "video_preview": ArtifactSpec("video", "decoded", "THWC", fps=request.sampling_params.frame_rate or 24),
-            "audio": ArtifactSpec(
-                "audio", "decoded", "CT", sample_rate=self.diffusion_io_spec.auxiliary[0].sample_rate
-            ),
-            "video_latent": ArtifactSpec("video", "latent", "CTHW"),
-            "audio_latent": ArtifactSpec("audio", "latent", "CLT"),
-        }
-        data = {
-            "video_preview": video[0],
-            "audio": audio[0],
-            "video_latent": video_latent[0],
-            "audio_latent": capture["audio_latent"],
-        }
-        output_type = extra_args.get("output_type", request.sampling_params.output_type)
-        return with_media_artifacts(
+        return with_h3_artifacts(
             result,
-            specs=specs,
-            artifacts=[(name, MediaArtifact(specs[name], tensor)) for name, tensor in data.items()],
-            primary="video_latent" if output_type == "latent" else "video_preview",
-            audio="audio",
-            preview="video_preview",
-            context=context,
-            requested=extra_args.get("requested_outputs"),
+            video=video,
+            audio=audio,
+            video_latent=capture["video_latent"],
+            audio_latent=capture["audio_latent"],
+            sampling=request.sampling_params,
+            context=f"pipeline={type(self).__name__}, request_id={request.request_id}",
         )
 
     @staticmethod

--- a/verl_omni/pipelines/minimax_h3_diffusion_nft/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/minimax_h3_diffusion_nft/vllm_omni_rollout_adapter.py
@@ -31,8 +31,9 @@ from vllm_omni.diffusion.models.minimax_h3.packed_tokens import (
 from vllm_omni.diffusion.models.minimax_h3.pipeline_minimax_h3 import MiniMaxH3Pipeline
 from vllm_omni.diffusion.models.minimax_h3.time_request import minimax_h3_time_shift_sigmas
 
-from verl_omni.pipelines.diffusion_rollout_output import with_rollout_data
+from verl_omni.pipelines.diffusion_rollout_output import with_media_artifacts, with_rollout_data
 from verl_omni.pipelines.model_base import VllmOmniPipelineBase
+from verl_omni.pipelines.rollout_artifacts import ArtifactSpec, MediaArtifact
 from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
 
 from .common import (
@@ -218,7 +219,7 @@ class MiniMaxH3DiffusionNFTPipeline(MiniMaxH3RolloutWeightSyncMixin, MiniMaxH3Pi
                 }
             )
 
-        return with_rollout_data(
+        result = with_rollout_data(
             output,
             prompt_embeddings={
                 "prompt_embeds": prompt_embeds,
@@ -226,6 +227,39 @@ class MiniMaxH3DiffusionNFTPipeline(MiniMaxH3RolloutWeightSyncMixin, MiniMaxH3Pi
             },
             rl=rl,
             to_cpu=True,
+        )
+        context = f"pipeline=MiniMaxH3Pipeline/diffusion_nft, request_id={getattr(request, 'request_id', 'unknown')}"
+        video, audio = output.output
+        if video.ndim != 5 or video.shape[0] != 1 or audio.ndim != 3 or audio.shape[0] != 1:
+            raise ValueError(f"{context}: expected one NTHWC video and NCT waveform, got {video.shape}, {audio.shape}")
+        video_latent = capture["video_latent"]
+        if video_latent.ndim != 5 or video_latent.shape[0] != 1:
+            raise ValueError(f"{context}: expected one NCTHW video latent, got {video_latent.shape}")
+        # Pinned H3 forward quantizes NTHWC; packed_tokens.py defines NCTHW/CLT latents.
+        specs = {
+            "video_preview": ArtifactSpec("video", "decoded", "THWC", fps=request.sampling_params.frame_rate or 24),
+            "audio": ArtifactSpec(
+                "audio", "decoded", "CT", sample_rate=self.diffusion_io_spec.auxiliary[0].sample_rate
+            ),
+            "video_latent": ArtifactSpec("video", "latent", "CTHW"),
+            "audio_latent": ArtifactSpec("audio", "latent", "CLT"),
+        }
+        data = {
+            "video_preview": video[0],
+            "audio": audio[0],
+            "video_latent": video_latent[0],
+            "audio_latent": capture["audio_latent"],
+        }
+        output_type = extra_args.get("output_type", request.sampling_params.output_type)
+        return with_media_artifacts(
+            result,
+            specs=specs,
+            artifacts=[(name, MediaArtifact(specs[name], tensor)) for name, tensor in data.items()],
+            primary="video_latent" if output_type == "latent" else "video_preview",
+            audio="audio",
+            preview="video_preview",
+            context=context,
+            requested=extra_args.get("requested_outputs"),
         )
 
     @staticmethod

--- a/verl_omni/pipelines/minimax_h3_diffusion_nft/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/minimax_h3_diffusion_nft/vllm_omni_rollout_adapter.py
@@ -33,8 +33,7 @@ from vllm_omni.diffusion.models.minimax_h3.time_request import minimax_h3_time_s
 
 from verl_omni.pipelines.diffusion_rollout_output import with_rollout_data
 from verl_omni.pipelines.model_base import VllmOmniPipelineBase
-from verl_omni.pipelines.rollout_artifacts import ArtifactSpec
-from verl_omni.pipelines.rollout_media import DiffusionIOSpec
+from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
 
 from .artifacts import with_h3_artifacts
 from .common import (
@@ -59,10 +58,10 @@ class MiniMaxH3DiffusionNFTPipeline(MiniMaxH3RolloutWeightSyncMixin, MiniMaxH3Pi
     #: does not hard-code the audio tuple position or its 32 kHz sample rate.
     diffusion_io_spec = DiffusionIOSpec(
         artifacts={
-            "video_preview": ArtifactSpec("video", "decoded", "TCHW"),
-            "audio": ArtifactSpec("audio", "decoded", "CT", sample_rate=32000),
-            "video_latent": ArtifactSpec("video", "latent", "CTHW"),
-            "audio_latent": ArtifactSpec("audio", "latent", "CLT"),
+            "video_preview": MediaSpec("video", "decoded", "TCHW"),
+            "audio": MediaSpec("audio", "decoded", "CT", sample_rate=32000),
+            "video_latent": MediaSpec("video", "latent", "CTHW"),
+            "audio_latent": MediaSpec("audio", "latent", "CLT"),
         }
     )
 

--- a/verl_omni/pipelines/minimax_h3_flow_grpo/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/minimax_h3_flow_grpo/vllm_omni_rollout_adapter.py
@@ -45,13 +45,15 @@ from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
 
 from verl_omni.pipelines.diffusion_rollout_output import with_rollout_data
+from verl_omni.pipelines.minimax_h3_diffusion_nft.artifacts import with_h3_artifacts
 from verl_omni.pipelines.minimax_h3_diffusion_nft.common import (
     ref2va_reference_image_short_edge,
     serialize_ref_blocks,
     validate_ref2va_reference_image_short_edge,
 )
 from verl_omni.pipelines.model_base import VllmOmniPipelineBase
-from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
+from verl_omni.pipelines.rollout_artifacts import ArtifactSpec
+from verl_omni.pipelines.rollout_media import DiffusionIOSpec
 from verl_omni.pipelines.schedulers import FlowMatchSDEDiscreteScheduler
 
 from .common import (
@@ -91,8 +93,12 @@ class MiniMaxH3PipelineWithLogProb(MiniMaxH3WeightSyncMixin, MiniMaxH3Pipeline):
     supports_request_batch = False
 
     diffusion_io_spec = DiffusionIOSpec(
-        primary=MediaSpec("video"),
-        auxiliary=(MediaSpec("audio", sample_rate=32000),),
+        artifacts={
+            "video_preview": ArtifactSpec("video", "decoded", "TCHW"),
+            "audio": ArtifactSpec("audio", "decoded", "CT", sample_rate=32000),
+            "video_latent": ArtifactSpec("video", "latent", "CTHW"),
+            "audio_latent": ArtifactSpec("audio", "latent", "CLT"),
+        }
     )
 
     def __init__(self, *, od_config: OmniDiffusionConfig, prefix: str = ""):
@@ -496,6 +502,7 @@ class MiniMaxH3PipelineWithLogProb(MiniMaxH3WeightSyncMixin, MiniMaxH3Pipeline):
             audio_t=audio_t * 2,
             audio_channel=2,
         )
+        self._flow_grpo_final_latents = (video_latent, audio_latent)
         return video_latent, audio_latent
 
     @torch.no_grad()
@@ -504,6 +511,7 @@ class MiniMaxH3PipelineWithLogProb(MiniMaxH3WeightSyncMixin, MiniMaxH3Pipeline):
             raise ValueError(f"MiniMax H3 FlowGRPO expects one request, got {len(request.requests)}.")
         req = request.requests[0]
         self._configure_flow_grpo(req)
+        self._flow_grpo_final_latents = None
         extra_args = req.sampling_params.extra_args or {}
         short_edge = extra_args.get(
             "reference_image_short_edge",
@@ -546,7 +554,7 @@ class MiniMaxH3PipelineWithLogProb(MiniMaxH3WeightSyncMixin, MiniMaxH3Pipeline):
             "ref_block_count",
         )
         replay_fields = tuple(key for key in replay_fields if key in trajectory)
-        return with_rollout_data(
+        result = with_rollout_data(
             output,
             trajectory_latents=trajectory["all_latents"],
             trajectory_log_probs=trajectory["all_log_probs"],
@@ -557,4 +565,18 @@ class MiniMaxH3PipelineWithLogProb(MiniMaxH3WeightSyncMixin, MiniMaxH3Pipeline):
             },
             rl={key: trajectory[key] for key in replay_fields},
             to_cpu=True,
+        )
+        if self._flow_grpo_final_latents is None:
+            raise RuntimeError("MiniMax H3 rollout did not capture final native latents")
+        video_latent, audio_latent = self._flow_grpo_final_latents
+        self._flow_grpo_final_latents = None
+        video, audio = output.output
+        return with_h3_artifacts(
+            result,
+            video=video,
+            audio=audio,
+            video_latent=video_latent,
+            audio_latent=audio_latent,
+            sampling=req.sampling_params,
+            context=f"pipeline={type(self).__name__}, request_id={req.request_id}",
         )

--- a/verl_omni/pipelines/minimax_h3_flow_grpo/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/minimax_h3_flow_grpo/vllm_omni_rollout_adapter.py
@@ -52,8 +52,7 @@ from verl_omni.pipelines.minimax_h3_diffusion_nft.common import (
     validate_ref2va_reference_image_short_edge,
 )
 from verl_omni.pipelines.model_base import VllmOmniPipelineBase
-from verl_omni.pipelines.rollout_artifacts import ArtifactSpec
-from verl_omni.pipelines.rollout_media import DiffusionIOSpec
+from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
 from verl_omni.pipelines.schedulers import FlowMatchSDEDiscreteScheduler
 
 from .common import (
@@ -94,10 +93,10 @@ class MiniMaxH3PipelineWithLogProb(MiniMaxH3WeightSyncMixin, MiniMaxH3Pipeline):
 
     diffusion_io_spec = DiffusionIOSpec(
         artifacts={
-            "video_preview": ArtifactSpec("video", "decoded", "TCHW"),
-            "audio": ArtifactSpec("audio", "decoded", "CT", sample_rate=32000),
-            "video_latent": ArtifactSpec("video", "latent", "CTHW"),
-            "audio_latent": ArtifactSpec("audio", "latent", "CLT"),
+            "video_preview": MediaSpec("video", "decoded", "TCHW"),
+            "audio": MediaSpec("audio", "decoded", "CT", sample_rate=32000),
+            "video_latent": MediaSpec("video", "latent", "CTHW"),
+            "audio_latent": MediaSpec("audio", "latent", "CLT"),
         }
     )
 

--- a/verl_omni/pipelines/minimax_h3_flow_grpo/weight_sync.py
+++ b/verl_omni/pipelines/minimax_h3_flow_grpo/weight_sync.py
@@ -20,6 +20,7 @@ from typing import Any
 import torch
 
 from verl_omni.pipelines.minimax_h3_diffusion_nft.common import MINIMAX_H3_TOKEN_ID_NATIVE_KEY
+from verl_omni.pipelines.rollout_request import prompt_ids_from_payload
 
 # Diffusers and vLLM-Omni use different names for the same H3 modules. QKV
 # and GEGLU projections also have different tensor layouts and are handled
@@ -120,7 +121,7 @@ class MiniMaxH3WeightSyncMixin:
         custom_prompt = prompts[0] if prompts and isinstance(prompts[0], dict) else getattr(request, "prompt", None)
         if not isinstance(custom_prompt, dict):
             return
-        token_ids = custom_prompt.get("prompt_token_ids")
+        token_ids = prompt_ids_from_payload(custom_prompt)
         if token_ids is None:
             return
         sampling_params = getattr(request, "sampling_params", None)
@@ -137,7 +138,7 @@ class MiniMaxH3WeightSyncMixin:
             token_ids = token_ids[0]
         self._h3_prompt_ids = torch.as_tensor([int(token) for token in token_ids], dtype=torch.long)
         if self._h3_prompt_ids.numel() == 0:
-            raise ValueError("MiniMax H3 requires non-empty prompt_token_ids.")
+            raise ValueError("MiniMax H3 requires non-empty prompt_ids.")
         custom_prompt["prompt"] = "[pretokenized]"
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:

--- a/verl_omni/pipelines/qwen_image_diffusion_nft/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/qwen_image_diffusion_nft/vllm_omni_rollout_adapter.py
@@ -14,23 +14,30 @@
 """Qwen-Image rollout adapter for DiffusionNFT."""
 
 import copy
+from dataclasses import replace
 from typing import Any
 
 import torch
 from vllm_omni.diffusion.data import DiffusionOutput
 from vllm_omni.diffusion.models.qwen_image import QwenImagePipeline
-from vllm_omni.diffusion.request import OmniDiffusionRequest
+from vllm_omni.diffusion.request import DUMMY_DIFFUSION_REQUEST_ID, OmniDiffusionRequest
 from vllm_omni.diffusion.utils.size_utils import normalize_min_aligned_size
 from vllm_omni.diffusion.worker.utils import StepRequestState
 
-from verl_omni.pipelines.diffusion_rollout_output import rollout_output, with_rollout_data
+from verl_omni.pipelines.diffusion_rollout_output import (
+    rollout_output,
+    wants_decoded_preview,
+    with_rollout_data,
+    with_visual_artifacts,
+)
 from verl_omni.pipelines.model_base import VllmOmniPipelineBase
 from verl_omni.pipelines.qwen_image_flow_grpo.common import (
     QwenImageTokenIdPromptMixin,
     build_img_shapes,
     coalesce_not_none,
 )
-from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
+from verl_omni.pipelines.rollout_artifacts import ArtifactSpec
+from verl_omni.pipelines.rollout_media import DiffusionIOSpec
 from verl_omni.pipelines.rollout_request import prompt_ids_from_payload
 
 __all__ = ["QwenImageDiffusionNFTPipeline"]
@@ -47,7 +54,12 @@ class QwenImageDiffusionNFTPipeline(QwenImageTokenIdPromptMixin, QwenImagePipeli
 
     #: Declares the primary rollout media stream so downstream consumers read
     #: the modality from the adapter instead of inferring it from tensor rank.
-    diffusion_io_spec = DiffusionIOSpec(primary=MediaSpec("image"))
+    diffusion_io_spec = DiffusionIOSpec(
+        artifacts={
+            "image_preview": ArtifactSpec("image", "decoded", "CHW"),
+            "image_latent": ArtifactSpec("image", "latent", "LC"),
+        }
+    )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -170,10 +182,14 @@ class QwenImageDiffusionNFTPipeline(QwenImageTokenIdPromptMixin, QwenImagePipeli
         self._current_timestep = None
         height = state.extra["height"]
         width = state.extra["width"]
-        output = self._decode_latents(state.latents, height, width, kwargs.get("output_type") or "pil")
+        output_type = kwargs.get("output_type") or state.sampling.output_type or "pil"
+        decode = wants_decoded_preview(output_type, state.sampling)
+        output = self._decode_latents(state.latents, height, width, "pil" if decode else "latent")
+        if state.request_id == DUMMY_DIFFUSION_REQUEST_ID:
+            return replace(output, output=None, to_cpu=True)
 
         latents_clean = state.latents.float()
-        return with_rollout_data(
+        result = with_rollout_data(
             output,
             prompt_embeddings={
                 "prompt_embeds": state.prompt_embeds,
@@ -186,6 +202,15 @@ class QwenImageDiffusionNFTPipeline(QwenImageTokenIdPromptMixin, QwenImagePipeli
                 "train_timesteps": state.timesteps.unsqueeze(0).expand(latents_clean.shape[0], -1),
             },
             to_cpu=True,
+        )
+        return with_visual_artifacts(
+            result,
+            decoded=output.output if decode else None,
+            latents=state.latents,
+            latent_layout="LC",
+            output_type=output_type,
+            context=f"pipeline={type(self).__name__}, request_id={state.request_id}",
+            requested=(state.sampling.extra_args or {}).get("requested_outputs"),
         )
 
     def _prepare_token_id_generation_context(
@@ -330,6 +355,7 @@ class QwenImageDiffusionNFTPipeline(QwenImageTokenIdPromptMixin, QwenImagePipeli
             negative_prompt_mask = custom_prompt.get("negative_prompt_mask", negative_prompt_mask)
 
         sampling_params = req.sampling_params
+        output_type = sampling_params.output_type or output_type or "pil"
         height = sampling_params.height or height or self.default_sample_size * self.vae_scale_factor
         width = sampling_params.width or width or self.default_sample_size * self.vae_scale_factor
         height, width = normalize_min_aligned_size(height, width, self.vae_scale_factor * 2)
@@ -395,9 +421,10 @@ class QwenImageDiffusionNFTPipeline(QwenImageTokenIdPromptMixin, QwenImagePipeli
 
         self._current_timestep = None
         latents_clean = latents.float()
-        decoded = self._decode_latents(latents, height, width, output_type or "pil")
+        decode = wants_decoded_preview(output_type, sampling_params)
+        decoded = self._decode_latents(latents, height, width, "pil" if decode else "latent")
 
-        return rollout_output(
+        result = rollout_output(
             media=decoded.output,
             prompt_embeddings={
                 "prompt_embeds": ctx["prompt_embeds"],
@@ -410,4 +437,13 @@ class QwenImageDiffusionNFTPipeline(QwenImageTokenIdPromptMixin, QwenImagePipeli
                 "train_timesteps": ctx["timesteps"].unsqueeze(0).expand(latents_clean.shape[0], -1),
             },
             to_cpu=True,
+        )
+        return with_visual_artifacts(
+            result,
+            decoded=decoded.output if decode else None,
+            latents=latents,
+            latent_layout="LC",
+            output_type=output_type,
+            context=f"pipeline={type(self).__name__}, request_id={req.request_id}",
+            requested=(sampling_params.extra_args or {}).get("requested_outputs"),
         )

--- a/verl_omni/pipelines/qwen_image_diffusion_nft/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/qwen_image_diffusion_nft/vllm_omni_rollout_adapter.py
@@ -36,8 +36,7 @@ from verl_omni.pipelines.qwen_image_flow_grpo.common import (
     build_img_shapes,
     coalesce_not_none,
 )
-from verl_omni.pipelines.rollout_artifacts import ArtifactSpec
-from verl_omni.pipelines.rollout_media import DiffusionIOSpec
+from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
 from verl_omni.pipelines.rollout_request import prompt_ids_from_payload
 
 __all__ = ["QwenImageDiffusionNFTPipeline"]
@@ -56,8 +55,8 @@ class QwenImageDiffusionNFTPipeline(QwenImageTokenIdPromptMixin, QwenImagePipeli
     #: the modality from the adapter instead of inferring it from tensor rank.
     diffusion_io_spec = DiffusionIOSpec(
         artifacts={
-            "image_preview": ArtifactSpec("image", "decoded", "CHW"),
-            "image_latent": ArtifactSpec("image", "latent", "LC"),
+            "image_preview": MediaSpec("image", "decoded", "CHW"),
+            "image_latent": MediaSpec("image", "latent", "LC"),
         }
     )
 

--- a/verl_omni/pipelines/qwen_image_diffusion_nft/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/qwen_image_diffusion_nft/vllm_omni_rollout_adapter.py
@@ -31,6 +31,7 @@ from verl_omni.pipelines.qwen_image_flow_grpo.common import (
     coalesce_not_none,
 )
 from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
+from verl_omni.pipelines.rollout_request import prompt_ids_from_payload
 
 __all__ = ["QwenImageDiffusionNFTPipeline"]
 
@@ -59,7 +60,7 @@ class QwenImageDiffusionNFTPipeline(QwenImageTokenIdPromptMixin, QwenImagePipeli
         negative_prompt_ids = None
         negative_prompt_mask = None
         if isinstance(prompt, dict):
-            prompt_ids = prompt.get("prompt_token_ids")
+            prompt_ids = prompt_ids_from_payload(prompt)
             prompt_mask = prompt.get("prompt_mask")
             negative_prompt_ids = prompt.get("negative_prompt_ids")
             negative_prompt_mask = prompt.get("negative_prompt_mask")
@@ -100,7 +101,7 @@ class QwenImageDiffusionNFTPipeline(QwenImageTokenIdPromptMixin, QwenImagePipeli
         if prompt_ids is None:
             raise ValueError(
                 f"{self.__class__.__name__}.prepare_encode requires either "
-                "'prompt_token_ids' or a text 'prompt' on state.prompt."
+                "'prompt_ids' or a text 'prompt' on state.prompt."
             )
 
         height = sampling.height or self.default_sample_size * self.vae_scale_factor
@@ -323,7 +324,7 @@ class QwenImageDiffusionNFTPipeline(QwenImageTokenIdPromptMixin, QwenImagePipeli
 
         custom_prompt = req.prompts[0] if req.prompts else {}
         if isinstance(custom_prompt, dict):
-            prompt_ids = custom_prompt.get("prompt_token_ids", prompt_ids)
+            prompt_ids = prompt_ids_from_payload(custom_prompt, prompt_ids)
             prompt_mask = custom_prompt.get("prompt_mask", prompt_mask)
             negative_prompt_ids = custom_prompt.get("negative_prompt_ids", negative_prompt_ids)
             negative_prompt_mask = custom_prompt.get("negative_prompt_mask", negative_prompt_mask)

--- a/verl_omni/pipelines/qwen_image_dpo/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/qwen_image_dpo/vllm_omni_rollout_adapter.py
@@ -28,6 +28,7 @@ from verl_omni.pipelines.diffusion_rollout_output import rollout_output, with_ro
 from verl_omni.pipelines.model_base import VllmOmniPipelineBase
 from verl_omni.pipelines.qwen_image_flow_grpo.common import apply_true_cfg, build_img_shapes
 from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
+from verl_omni.pipelines.rollout_request import prompt_ids_from_payload
 
 __all__ = ["QwenImageDPOPipeline"]
 
@@ -55,7 +56,7 @@ class QwenImageDPOPipeline(QwenImagePipeline):
         negative_prompt_ids = None
         negative_prompt_mask = None
         if isinstance(prompt, dict):
-            prompt_ids = prompt.get("prompt_token_ids")
+            prompt_ids = prompt_ids_from_payload(prompt)
             prompt_mask = prompt.get("prompt_mask")
             negative_prompt_ids = prompt.get("negative_prompt_ids")
             negative_prompt_mask = prompt.get("negative_prompt_mask")
@@ -96,7 +97,7 @@ class QwenImageDPOPipeline(QwenImagePipeline):
         if prompt_ids is None:
             raise ValueError(
                 f"{self.__class__.__name__}.prepare_encode requires either "
-                "'prompt_token_ids' or a text 'prompt' on state.prompt."
+                "'prompt_ids' or a text 'prompt' on state.prompt."
             )
 
         height = sampling.height or self.default_sample_size * self.vae_scale_factor
@@ -357,7 +358,7 @@ class QwenImageDPOPipeline(QwenImagePipeline):
         del output_type
         custom_prompt = req.prompts[0] if req.prompts else {}
         if isinstance(custom_prompt, dict):
-            prompt_ids = custom_prompt.get("prompt_token_ids", prompt_ids)
+            prompt_ids = prompt_ids_from_payload(custom_prompt, prompt_ids)
             prompt_mask = custom_prompt.get("prompt_mask", prompt_mask)
             negative_prompt_ids = custom_prompt.get("negative_prompt_ids", negative_prompt_ids)
             negative_prompt_mask = custom_prompt.get("negative_prompt_mask", negative_prompt_mask)

--- a/verl_omni/pipelines/qwen_image_dpo/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/qwen_image_dpo/vllm_omni_rollout_adapter.py
@@ -33,8 +33,7 @@ from verl_omni.pipelines.diffusion_rollout_output import (
 )
 from verl_omni.pipelines.model_base import VllmOmniPipelineBase
 from verl_omni.pipelines.qwen_image_flow_grpo.common import apply_true_cfg, build_img_shapes
-from verl_omni.pipelines.rollout_artifacts import ArtifactSpec
-from verl_omni.pipelines.rollout_media import DiffusionIOSpec
+from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
 from verl_omni.pipelines.rollout_request import prompt_ids_from_payload
 
 __all__ = ["QwenImageDPOPipeline"]
@@ -52,8 +51,8 @@ class QwenImageDPOPipeline(QwenImagePipeline):
     #: the modality from the adapter instead of inferring it from tensor rank.
     diffusion_io_spec = DiffusionIOSpec(
         artifacts={
-            "image_preview": ArtifactSpec("image", "decoded", "CHW"),
-            "image_latent": ArtifactSpec("image", "latent", "LC"),
+            "image_preview": MediaSpec("image", "decoded", "CHW"),
+            "image_latent": MediaSpec("image", "latent", "LC"),
         }
     )
 

--- a/verl_omni/pipelines/qwen_image_dpo/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/qwen_image_dpo/vllm_omni_rollout_adapter.py
@@ -15,19 +15,26 @@
 """Qwen-Image rollout-side adapter for online diffusion DPO."""
 
 import copy
+from dataclasses import replace
 from typing import Any
 
 import torch
 from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.models.qwen_image import QwenImagePipeline
-from vllm_omni.diffusion.request import OmniDiffusionRequest
+from vllm_omni.diffusion.request import DUMMY_DIFFUSION_REQUEST_ID, OmniDiffusionRequest
 from vllm_omni.diffusion.worker.utils import StepRequestState
 
-from verl_omni.pipelines.diffusion_rollout_output import rollout_output, with_rollout_data
+from verl_omni.pipelines.diffusion_rollout_output import (
+    rollout_output,
+    wants_decoded_preview,
+    with_rollout_data,
+    with_visual_artifacts,
+)
 from verl_omni.pipelines.model_base import VllmOmniPipelineBase
 from verl_omni.pipelines.qwen_image_flow_grpo.common import apply_true_cfg, build_img_shapes
-from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
+from verl_omni.pipelines.rollout_artifacts import ArtifactSpec
+from verl_omni.pipelines.rollout_media import DiffusionIOSpec
 from verl_omni.pipelines.rollout_request import prompt_ids_from_payload
 
 __all__ = ["QwenImageDPOPipeline"]
@@ -43,7 +50,12 @@ class QwenImageDPOPipeline(QwenImagePipeline):
 
     #: Declares the primary rollout media stream so downstream consumers read
     #: the modality from the adapter instead of inferring it from tensor rank.
-    diffusion_io_spec = DiffusionIOSpec(primary=MediaSpec("image"))
+    diffusion_io_spec = DiffusionIOSpec(
+        artifacts={
+            "image_preview": ArtifactSpec("image", "decoded", "CHW"),
+            "image_latent": ArtifactSpec("image", "latent", "LC"),
+        }
+    )
 
     def __init__(self, *, od_config: OmniDiffusionConfig, prefix: str = ""):
         super().__init__(od_config=od_config, prefix=prefix)
@@ -242,10 +254,15 @@ class QwenImageDPOPipeline(QwenImagePipeline):
         **kwargs: Any,
     ) -> DiffusionOutput:
         """Decode step execution output with DPO training tensors."""
-        del kwargs
         self._current_timestep = None
-        output = self._decode_latents(state.latents, state.extra["height"], state.extra["width"], "pil")
-        return with_rollout_data(
+        output_type = kwargs.get("output_type") or state.sampling.output_type or "pil"
+        decode = wants_decoded_preview(output_type, state.sampling)
+        output = self._decode_latents(
+            state.latents, state.extra["height"], state.extra["width"], "pil" if decode else "latent"
+        )
+        if state.request_id == DUMMY_DIFFUSION_REQUEST_ID:
+            return replace(output, output=None, to_cpu=True)
+        result = with_rollout_data(
             output,
             prompt_embeddings={
                 "prompt_embeds": state.prompt_embeds,
@@ -255,6 +272,15 @@ class QwenImageDPOPipeline(QwenImagePipeline):
             },
             rl={"latents_clean": state.latents.float()},
             to_cpu=True,
+        )
+        return with_visual_artifacts(
+            result,
+            decoded=output.output if decode else None,
+            latents=state.latents,
+            latent_layout="LC",
+            output_type=output_type,
+            context=f"pipeline={type(self).__name__}, request_id={state.request_id}",
+            requested=(state.sampling.extra_args or {}).get("requested_outputs"),
         )
 
     def _get_qwen_prompt_embeds(
@@ -355,7 +381,6 @@ class QwenImageDPOPipeline(QwenImagePipeline):
         attention_kwargs: dict[str, Any] | None = None,
         max_sequence_length: int = 512,
     ) -> DiffusionOutput:
-        del output_type
         custom_prompt = req.prompts[0] if req.prompts else {}
         if isinstance(custom_prompt, dict):
             prompt_ids = prompt_ids_from_payload(custom_prompt, prompt_ids)
@@ -364,6 +389,7 @@ class QwenImageDPOPipeline(QwenImagePipeline):
             negative_prompt_mask = custom_prompt.get("negative_prompt_mask", negative_prompt_mask)
 
         sampling_params = req.sampling_params
+        output_type = sampling_params.output_type or output_type or "pil"
         height = sampling_params.height or self.default_sample_size * self.vae_scale_factor
         width = sampling_params.width or self.default_sample_size * self.vae_scale_factor
         num_inference_steps = sampling_params.num_inference_steps or num_inference_steps
@@ -483,20 +509,10 @@ class QwenImageDPOPipeline(QwenImagePipeline):
 
         self._current_timestep = None
         latents_clean = latents.float()
-        unpacked_latents = self._unpack_latents(latents, height, width, self.vae_scale_factor)
-        unpacked_latents = unpacked_latents.to(self.vae.dtype)
-        latents_mean = (
-            torch.tensor(self.vae.config.latents_mean)
-            .view(1, self.vae.config.z_dim, 1, 1, 1)
-            .to(unpacked_latents.device, unpacked_latents.dtype)
-        )
-        latents_std = 1.0 / torch.tensor(self.vae.config.latents_std).view(1, self.vae.config.z_dim, 1, 1, 1).to(
-            unpacked_latents.device, unpacked_latents.dtype
-        )
-        unpacked_latents = unpacked_latents / latents_std + latents_mean
-        image = self.vae.decode(unpacked_latents, return_dict=False)[0][:, :, 0]
+        decode = wants_decoded_preview(output_type, sampling_params)
+        image = self._decode_latents(latents, height, width, "pil").output if decode else None
 
-        return rollout_output(
+        result = rollout_output(
             media=image,
             prompt_embeddings={
                 "prompt_embeds": prompt_embeds,
@@ -506,4 +522,13 @@ class QwenImageDPOPipeline(QwenImagePipeline):
             },
             rl={"latents_clean": latents_clean},
             to_cpu=True,
+        )
+        return with_visual_artifacts(
+            result,
+            decoded=image,
+            latents=latents,
+            latent_layout="LC",
+            output_type=output_type,
+            context=f"pipeline={type(self).__name__}, request_id={req.request_id}",
+            requested=(sampling_params.extra_args or {}).get("requested_outputs"),
         )

--- a/verl_omni/pipelines/qwen_image_dual_grpo/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/qwen_image_dual_grpo/vllm_omni_rollout_adapter.py
@@ -24,7 +24,7 @@ from vllm_omni.diffusion.data import DiffusionOutput
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
 
-from verl_omni.pipelines.diffusion_rollout_output import rollout_output
+from verl_omni.pipelines.diffusion_rollout_output import rollout_output, with_visual_artifacts
 from verl_omni.pipelines.model_base import VllmOmniPipelineBase
 from verl_omni.pipelines.qwen_image_flow_grpo.common import build_img_shapes, coalesce_not_none
 from verl_omni.pipelines.qwen_image_flow_grpo.vllm_omni_rollout_adapter import QwenImagePipelineWithLogProb
@@ -34,6 +34,7 @@ from verl_omni.pipelines.request_batch import (
 from verl_omni.pipelines.request_batch import (
     collate_prompt_rows as _collate_prompt_rows,
 )
+from verl_omni.pipelines.request_batch import requested_outputs_for_batch
 from verl_omni.pipelines.request_batch import (
     sample_per_sample_sde_windows as _sample_per_sample_sde_windows,
 )
@@ -246,6 +247,7 @@ class QwenImagePipelineWithDualLogProb(QwenImagePipelineWithLogProb):
         )
 
         sampling_params = request_batch.sampling_params_list[0]
+        requested_outputs = requested_outputs_for_batch(request_batch)
         height = sampling_params.height or self.default_sample_size * self.vae_scale_factor
         width = sampling_params.width or self.default_sample_size * self.vae_scale_factor
         num_inference_steps = sampling_params.num_inference_steps or num_inference_steps
@@ -375,8 +377,9 @@ class QwenImagePipelineWithDualLogProb(QwenImagePipelineWithLogProb):
         )
 
         self._current_timestep = None
-        if output_type == "latent":
-            image = latents
+        native_latents = latents
+        if output_type == "latent" and "image_preview" not in requested_outputs:
+            image = None
         else:
             latents = self._unpack_latents(latents, height, width, self.vae_scale_factor)
             latents = latents.to(self.vae.dtype)
@@ -431,6 +434,15 @@ class QwenImagePipelineWithDualLogProb(QwenImagePipelineWithLogProb):
                 "text_encoder_responses": text_encoder_responses,
             },
             to_cpu=True,
+        )
+        result = with_visual_artifacts(
+            result,
+            decoded=image,
+            latents=native_latents,
+            latent_layout="LC",
+            output_type=output_type,
+            context=f"pipeline={type(self).__name__}, request_id={[r.request_id for r in request_batch.requests]}",
+            requested=requested_outputs,
         )
         outputs = _split_diffusion_output_by_request(
             result,

--- a/verl_omni/pipelines/qwen_image_dual_grpo/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/qwen_image_dual_grpo/vllm_omni_rollout_adapter.py
@@ -214,7 +214,7 @@ class QwenImagePipelineWithDualLogProb(QwenImagePipelineWithLogProb):
         prompts = request_batch.prompts
         prompt_token_ids, prompt_token_lengths = _collate_prompt_rows(
             prompts,
-            ("prompt_token_ids", "prompt_ids"),
+            ("prompt_ids",),
             prompt_token_ids,
             device=self.device,
             field_name="prompt_token_ids",

--- a/verl_omni/pipelines/qwen_image_edit_flow_grpo/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/qwen_image_edit_flow_grpo/vllm_omni_rollout_adapter.py
@@ -39,7 +39,7 @@ from verl_omni.pipelines.qwen_image_flow_grpo.common import (
     coalesce_not_none,
 )
 from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
-from verl_omni.pipelines.rollout_request import condition_images_from_payload
+from verl_omni.pipelines.rollout_request import condition_images_from_payload, prompt_ids_from_payload
 from verl_omni.pipelines.schedulers import FlowMatchSDEDiscreteScheduler
 
 __all__ = ["QwenImageEditPlusPipelineWithLogProb"]
@@ -373,7 +373,7 @@ class QwenImageEditPlusPipelineWithLogProb(QwenImageTokenIdPromptMixin, QwenImag
             raise ValueError("Qwen-Image-Edit requires at least one condition image")
 
         if isinstance(custom_prompt, dict):
-            prompt_ids = custom_prompt.get("prompt_token_ids", prompt_ids)
+            prompt_ids = prompt_ids_from_payload(custom_prompt, prompt_ids)
             prompt_mask = custom_prompt.get("prompt_mask", prompt_mask)
             negative_prompt_ids = custom_prompt.get("negative_prompt_ids", negative_prompt_ids)
             negative_prompt_mask = custom_prompt.get("negative_prompt_mask", negative_prompt_mask)

--- a/verl_omni/pipelines/qwen_image_edit_flow_grpo/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/qwen_image_edit_flow_grpo/vllm_omni_rollout_adapter.py
@@ -40,8 +40,7 @@ from verl_omni.pipelines.qwen_image_flow_grpo.common import (
     apply_true_cfg,
     coalesce_not_none,
 )
-from verl_omni.pipelines.rollout_artifacts import ArtifactSpec
-from verl_omni.pipelines.rollout_media import DiffusionIOSpec
+from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
 from verl_omni.pipelines.rollout_request import prompt_ids_from_payload
 from verl_omni.pipelines.schedulers import FlowMatchSDEDiscreteScheduler
 
@@ -123,8 +122,8 @@ class QwenImageEditPlusPipelineWithLogProb(QwenImageTokenIdPromptMixin, QwenImag
     #: the modality from the adapter instead of inferring it from tensor rank.
     diffusion_io_spec = DiffusionIOSpec(
         artifacts={
-            "image_preview": ArtifactSpec("image", "decoded", "CHW"),
-            "image_latent": ArtifactSpec("image", "latent", "LC"),
+            "image_preview": MediaSpec("image", "decoded", "CHW"),
+            "image_latent": MediaSpec("image", "latent", "LC"),
         }
     )
 

--- a/verl_omni/pipelines/qwen_image_edit_flow_grpo/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/qwen_image_edit_flow_grpo/vllm_omni_rollout_adapter.py
@@ -30,6 +30,8 @@ from vllm_omni.diffusion.request import OmniDiffusionRequest
 
 from verl_omni.pipelines.diffusion_rollout_output import (
     rollout_output,
+    wants_decoded_preview,
+    with_visual_artifacts,
     wrap_rollout_postprocessor,
 )
 from verl_omni.pipelines.model_base import VllmOmniPipelineBase
@@ -38,8 +40,9 @@ from verl_omni.pipelines.qwen_image_flow_grpo.common import (
     apply_true_cfg,
     coalesce_not_none,
 )
-from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
-from verl_omni.pipelines.rollout_request import condition_images_from_payload, prompt_ids_from_payload
+from verl_omni.pipelines.rollout_artifacts import ArtifactSpec
+from verl_omni.pipelines.rollout_media import DiffusionIOSpec
+from verl_omni.pipelines.rollout_request import prompt_ids_from_payload
 from verl_omni.pipelines.schedulers import FlowMatchSDEDiscreteScheduler
 
 __all__ = ["QwenImageEditPlusPipelineWithLogProb"]
@@ -118,7 +121,12 @@ class QwenImageEditPlusPipelineWithLogProb(QwenImageTokenIdPromptMixin, QwenImag
 
     #: Declares the primary rollout media stream so downstream consumers read
     #: the modality from the adapter instead of inferring it from tensor rank.
-    diffusion_io_spec = DiffusionIOSpec(primary=MediaSpec("image"))
+    diffusion_io_spec = DiffusionIOSpec(
+        artifacts={
+            "image_preview": ArtifactSpec("image", "decoded", "CHW"),
+            "image_latent": ArtifactSpec("image", "latent", "LC"),
+        }
+    )
 
     def __init__(self, *, od_config: OmniDiffusionConfig, prefix: str = ""):
         super().__init__(od_config=od_config, prefix=prefix)
@@ -366,11 +374,15 @@ class QwenImageEditPlusPipelineWithLogProb(QwenImageTokenIdPromptMixin, QwenImag
         """
         custom_prompt = req.prompts[0] if req.prompts else {}
 
-        # Condition images are parsed from the rollout request payload; the prompt
-        # itself is read from custom_prompt below.
-        condition_images = condition_images_from_payload(custom_prompt) if isinstance(custom_prompt, dict) else None
+        # Token IDs were expanded against the raw image's processor grid. The
+        # engine's resized condition_images is a different view, not an alias.
+        condition_images = (
+            custom_prompt.get("multi_modal_data", {}).get("image") if isinstance(custom_prompt, dict) else None
+        )
+        if condition_images is not None and not isinstance(condition_images, list | tuple):
+            condition_images = [condition_images]
         if not condition_images:
-            raise ValueError("Qwen-Image-Edit requires at least one condition image")
+            raise ValueError("Qwen-Image-Edit requires raw multi_modal_data.image")
 
         if isinstance(custom_prompt, dict):
             prompt_ids = prompt_ids_from_payload(custom_prompt, prompt_ids)
@@ -385,6 +397,7 @@ class QwenImageEditPlusPipelineWithLogProb(QwenImageTokenIdPromptMixin, QwenImag
             vae_image_sizes = None
 
         sampling_params = req.sampling_params
+        output_type = sampling_params.output_type or output_type or "pil"
         height = sampling_params.height or self.default_sample_size * self.vae_scale_factor
         width = sampling_params.width or self.default_sample_size * self.vae_scale_factor
         _validate_condition_image_sizes(condition_images, vae_image_sizes, target_size=(height, width))
@@ -525,8 +538,9 @@ class QwenImageEditPlusPipelineWithLogProb(QwenImageTokenIdPromptMixin, QwenImag
         )
 
         self._current_timestep = None
-        if output_type == "latent":
-            image = latents
+        native_latents = latents
+        if not wants_decoded_preview(output_type, sampling_params):
+            image = None
         else:
             latents = self._unpack_latents(latents, height, width, self.vae_scale_factor)
             latents = latents.to(self.vae.dtype)
@@ -541,7 +555,7 @@ class QwenImageEditPlusPipelineWithLogProb(QwenImageTokenIdPromptMixin, QwenImag
             latents = latents / latents_std + latents_mean
             image = self.vae.decode(latents, return_dict=False)[0][:, :, 0]
 
-        return rollout_output(
+        result = rollout_output(
             media=_maybe_to_cpu(image),
             trajectory_latents=_maybe_to_cpu(all_latents),
             trajectory_log_probs=_maybe_to_cpu(all_log_probs),
@@ -557,4 +571,13 @@ class QwenImageEditPlusPipelineWithLogProb(QwenImageTokenIdPromptMixin, QwenImag
                 "img_shapes": img_shapes,
             },
             to_cpu=False,
+        )
+        return with_visual_artifacts(
+            result,
+            decoded=_maybe_to_cpu(image),
+            latents=_maybe_to_cpu(native_latents),
+            latent_layout="LC",
+            output_type=output_type,
+            context=f"pipeline={type(self).__name__}, request_id={req.request_id}",
+            requested=(sampling_params.extra_args or {}).get("requested_outputs"),
         )

--- a/verl_omni/pipelines/qwen_image_flow_grpo/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/qwen_image_flow_grpo/vllm_omni_rollout_adapter.py
@@ -49,8 +49,7 @@ from verl_omni.pipelines.request_batch import (
 from verl_omni.pipelines.request_batch import (
     split_diffusion_output_by_request as _split_diffusion_output_by_request,
 )
-from verl_omni.pipelines.rollout_artifacts import ArtifactSpec
-from verl_omni.pipelines.rollout_media import DiffusionIOSpec
+from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
 from verl_omni.pipelines.rollout_request import prompt_ids_from_payload
 from verl_omni.pipelines.schedulers import FlowMatchSDEDiscreteScheduler
 
@@ -86,8 +85,8 @@ class QwenImagePipelineWithLogProb(QwenImageTokenIdPromptMixin, QwenImagePipelin
 
     diffusion_io_spec = DiffusionIOSpec(
         artifacts={
-            "image_preview": ArtifactSpec("image", "decoded", "CHW"),
-            "image_latent": ArtifactSpec("image", "latent", "LC"),
+            "image_preview": MediaSpec("image", "decoded", "CHW"),
+            "image_latent": MediaSpec("image", "latent", "LC"),
         }
     )
 

--- a/verl_omni/pipelines/qwen_image_flow_grpo/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/qwen_image_flow_grpo/vllm_omni_rollout_adapter.py
@@ -16,18 +16,25 @@ from __future__ import annotations
 
 import copy
 import os
+from dataclasses import replace
 from typing import Any, Literal
 
 import torch
 from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.distributed.utils import get_local_device
-from vllm_omni.diffusion.models.qwen_image import QwenImagePipeline
+from vllm_omni.diffusion.models.qwen_image import QwenImagePipeline, pipeline_qwen_image
 from vllm_omni.diffusion.models.qwen_image.rope_utils import txt_seq_lens_from_embeds
-from vllm_omni.diffusion.request import OmniDiffusionRequest
+from vllm_omni.diffusion.request import DUMMY_DIFFUSION_REQUEST_ID, OmniDiffusionRequest
 from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
 from vllm_omni.diffusion.worker.utils import StepRequestState
 
-from verl_omni.pipelines.diffusion_rollout_output import rollout_output, with_rollout_data
+from verl_omni.pipelines.diffusion_rollout_output import (
+    rollout_output,
+    wants_decoded_preview,
+    with_rollout_data,
+    with_visual_artifacts,
+    wrap_rollout_postprocessor,
+)
 from verl_omni.pipelines.model_base import VllmOmniPipelineBase
 from verl_omni.pipelines.request_batch import (
     collate_prompt_mask as _collate_prompt_mask,
@@ -35,19 +42,31 @@ from verl_omni.pipelines.request_batch import (
 from verl_omni.pipelines.request_batch import (
     collate_prompt_rows as _collate_prompt_rows,
 )
+from verl_omni.pipelines.request_batch import requested_outputs_for_batch
 from verl_omni.pipelines.request_batch import (
     sample_per_sample_sde_windows as _sample_per_sample_sde_windows,
 )
 from verl_omni.pipelines.request_batch import (
     split_diffusion_output_by_request as _split_diffusion_output_by_request,
 )
-from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
+from verl_omni.pipelines.rollout_artifacts import ArtifactSpec
+from verl_omni.pipelines.rollout_media import DiffusionIOSpec
 from verl_omni.pipelines.rollout_request import prompt_ids_from_payload
 from verl_omni.pipelines.schedulers import FlowMatchSDEDiscreteScheduler
 
 from .common import QwenImageTokenIdPromptMixin, apply_true_cfg, build_img_shapes, coalesce_not_none
 
 __all__ = ["QwenImagePipelineWithLogProb"]
+
+_QWEN_POST_PROCESS_FACTORY = pipeline_qwen_image.get_qwen_image_post_process_func
+
+
+def get_rollout_post_process_func(od_config):
+    """Leave named media intact; ordinary upstream inference still uses its native processor."""
+    return wrap_rollout_postprocessor(_QWEN_POST_PROCESS_FACTORY(od_config))
+
+
+pipeline_qwen_image.get_qwen_image_post_process_func = get_rollout_post_process_func
 
 
 @VllmOmniPipelineBase.register("QwenImagePipeline", algorithm="flow_grpo")
@@ -65,10 +84,12 @@ class QwenImagePipelineWithLogProb(QwenImageTokenIdPromptMixin, QwenImagePipelin
 
     supports_request_batch = True
 
-    #: Declares the primary rollout media stream so downstream consumers read
-    #: the modality from the adapter instead of inferring it from tensor rank.
-    #: Inherited by the dual-GRPO and mix-GRPO Qwen-Image subclasses.
-    diffusion_io_spec = DiffusionIOSpec(primary=MediaSpec("image"))
+    diffusion_io_spec = DiffusionIOSpec(
+        artifacts={
+            "image_preview": ArtifactSpec("image", "decoded", "CHW"),
+            "image_latent": ArtifactSpec("image", "latent", "LC"),
+        }
+    )
 
     def __init__(self, *, od_config: OmniDiffusionConfig, prefix: str = ""):
         super().__init__(od_config=od_config, prefix=prefix)
@@ -632,9 +653,14 @@ class QwenImagePipelineWithLogProb(QwenImageTokenIdPromptMixin, QwenImagePipelin
         ``None`` (which becomes a non-tensor ``LinkedList`` in the
         ``TensorDict`` and breaks ``mask.shape[0]``).
         """
-        output = super().post_decode(state, **kwargs)
+        output_type = kwargs.get("output_type") or state.sampling.output_type or "pil"
+        decode = wants_decoded_preview(output_type, state.sampling)
+        output = super().post_decode(state, **{**kwargs, "output_type": "pil" if decode else "latent"})
         if not isinstance(output, DiffusionOutput):
             return output
+        if state.request_id == DUMMY_DIFFUSION_REQUEST_ID:
+            # One-step scheduler warmup may contain NaNs; it is not a serving result.
+            return replace(output, output=None, to_cpu=True)
 
         all_latents = state.all_latents
         all_log_probs = state.all_log_probs
@@ -648,7 +674,7 @@ class QwenImagePipelineWithLogProb(QwenImageTokenIdPromptMixin, QwenImagePipelin
             torch.stack(all_timesteps).unsqueeze(0).expand(state.latents.shape[0], -1) if all_timesteps else None
         )
 
-        return with_rollout_data(
+        result = with_rollout_data(
             output,
             trajectory_latents=stacked_latents,
             trajectory_log_probs=stacked_log_probs,
@@ -660,6 +686,15 @@ class QwenImagePipelineWithLogProb(QwenImageTokenIdPromptMixin, QwenImagePipelin
                 "negative_prompt_embeds_mask": state.negative_prompt_embeds_mask,
             },
             to_cpu=True,
+        )
+        return with_visual_artifacts(
+            result,
+            decoded=output.output if decode else None,
+            latents=state.latents,
+            latent_layout="LC",
+            output_type=output_type,
+            context=f"pipeline={type(self).__name__}, request_id={state.request_id}",
+            requested=(state.sampling.extra_args or {}).get("requested_outputs"),
         )
 
     def forward(
@@ -793,6 +828,7 @@ class QwenImagePipelineWithLogProb(QwenImageTokenIdPromptMixin, QwenImagePipelin
         )
 
         sampling_params = request_batch.sampling_params_list[0]
+        requested_outputs = requested_outputs_for_batch(request_batch)
         height = sampling_params.height or self.default_sample_size * self.vae_scale_factor
         width = sampling_params.width or self.default_sample_size * self.vae_scale_factor
         num_inference_steps = sampling_params.num_inference_steps or num_inference_steps
@@ -922,8 +958,10 @@ class QwenImagePipelineWithLogProb(QwenImageTokenIdPromptMixin, QwenImagePipelin
         )
 
         self._current_timestep = None
-        if output_type == "latent":
-            image = latents
+        native_latents = latents
+        decode = output_type != "latent" or "image_preview" in requested_outputs
+        if not decode:
+            image = None
         else:
             latents = self._unpack_latents(latents, height, width, self.vae_scale_factor)
             latents = latents.to(self.vae.dtype)
@@ -950,6 +988,15 @@ class QwenImagePipelineWithLogProb(QwenImageTokenIdPromptMixin, QwenImagePipelin
                 "negative_prompt_embeds_mask": negative_prompt_embeds_mask,
             },
             to_cpu=True,
+        )
+        result = with_visual_artifacts(
+            result,
+            decoded=image,
+            latents=native_latents,
+            latent_layout="LC",
+            output_type=output_type,
+            context=f"pipeline={type(self).__name__}, request_id={[r.request_id for r in request_batch.requests]}",
+            requested=requested_outputs,
         )
         outputs = _split_diffusion_output_by_request(
             result,

--- a/verl_omni/pipelines/qwen_image_flow_grpo/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/qwen_image_flow_grpo/vllm_omni_rollout_adapter.py
@@ -42,6 +42,7 @@ from verl_omni.pipelines.request_batch import (
     split_diffusion_output_by_request as _split_diffusion_output_by_request,
 )
 from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
+from verl_omni.pipelines.rollout_request import prompt_ids_from_payload
 from verl_omni.pipelines.schedulers import FlowMatchSDEDiscreteScheduler
 
 from .common import QwenImageTokenIdPromptMixin, apply_true_cfg, build_img_shapes, coalesce_not_none
@@ -192,7 +193,7 @@ class QwenImagePipelineWithLogProb(QwenImageTokenIdPromptMixin, QwenImagePipelin
         if prompts:
             p0 = prompts[0]
             if isinstance(p0, dict):
-                prompt_ids = p0.get("prompt_token_ids", None)
+                prompt_ids = prompt_ids_from_payload(p0)
                 prompt_mask = p0.get("prompt_mask", None)
                 negative_prompt_ids = p0.get("negative_prompt_ids", None)
                 negative_prompt_mask = p0.get("negative_prompt_mask", None)
@@ -245,7 +246,7 @@ class QwenImagePipelineWithLogProb(QwenImageTokenIdPromptMixin, QwenImagePipelin
         if prompt_ids is None:
             raise ValueError(
                 f"{self.__class__.__name__}.prepare_encode requires either "
-                "'prompt_ids'/'prompt_token_ids' or a text 'prompt' on state.prompt."
+                "'prompt_ids' or a text 'prompt' on state.prompt."
             )
 
         height = sampling.height or self.default_sample_size * self.vae_scale_factor
@@ -756,7 +757,7 @@ class QwenImagePipelineWithLogProb(QwenImageTokenIdPromptMixin, QwenImagePipelin
         # The prompt cache wraps encode_prompt, so keep token inputs as lists until that boundary.
         prompt_token_ids, prompt_token_lengths = _collate_prompt_rows(
             prompts,
-            ("prompt_token_ids", "prompt_ids"),
+            ("prompt_ids",),
             prompt_token_ids,
             device=self.device,
             field_name="prompt_token_ids",

--- a/verl_omni/pipelines/request_batch.py
+++ b/verl_omni/pipelines/request_batch.py
@@ -21,6 +21,8 @@ from typing import Any
 import numpy as np
 import torch
 
+from verl_omni.pipelines.rollout_request import prompt_ids_from_payload
+
 __all__ = [
     "collate_prompt_mask",
     "collate_prompt_rows",
@@ -71,7 +73,7 @@ def _get_prompt_field(prompt: Any, aliases: tuple[str, ...]) -> Any:
     if isinstance(prompt, str) or not hasattr(prompt, "get"):
         return None
     for name in aliases:
-        value = prompt.get(name)
+        value = prompt_ids_from_payload(prompt) if name == "prompt_ids" else prompt.get(name)
         if value is None:
             additional = prompt.get("additional_information")
             if isinstance(additional, dict):

--- a/verl_omni/pipelines/request_batch.py
+++ b/verl_omni/pipelines/request_batch.py
@@ -31,6 +31,18 @@ __all__ = [
 ]
 
 
+def requested_outputs_for_batch(request_batch: Any) -> list[str]:
+    """Keep every request's required artifacts when a shared decode serves a packed batch."""
+    from verl_omni.pipelines.rollout_artifacts import requested_artifact_names
+
+    names = {}
+    for request in request_batch.requests:
+        requested = (request.sampling_params.extra_args or {}).get("requested_outputs")
+        for name in requested_artifact_names(requested, context=f"request_id={request.request_id}"):
+            names[name] = None
+    return list(names)
+
+
 def sample_per_sample_sde_windows(
     *,
     sde_window_size: int | None,
@@ -256,18 +268,33 @@ def collate_prompt_mask(
 
 
 def _slice_batch_value(value: Any, start: int, stop: int, expected_batch_size: int) -> Any:
-    # Slice only when leading size matches the packed batch; leave shared T/L axes alone.
-    if value is None:
-        return None
+    # These fields declare a leading batch axis; a mismatched size is not a shared tensor.
     if isinstance(value, torch.Tensor | np.ndarray):
-        return value[start:stop] if value.ndim > 0 and value.shape[0] == expected_batch_size else value
+        if value.ndim == 0:
+            return value
+        if value.shape[0] != expected_batch_size:
+            raise ValueError(f"Expected rollout batch size {expected_batch_size}, got shape={tuple(value.shape)}")
+        return value[start:stop]
     if isinstance(value, dict):
         return {key: _slice_batch_value(item, start, stop, expected_batch_size) for key, item in value.items()}
     if isinstance(value, tuple):
         return tuple(_slice_batch_value(item, start, stop, expected_batch_size) for item in value)
     if isinstance(value, list):
-        return value[start:stop] if len(value) == expected_batch_size else value
+        if len(value) != expected_batch_size:
+            raise ValueError(f"Expected {expected_batch_size} rollout samples, got {len(value)}")
+        return value[start:stop]
     return value
+
+
+def _slice_rollout_output(output: Any, start: int, stop: int, batch_size: int) -> Any:
+    if not isinstance(output, dict) or "payload" not in output:
+        return _slice_batch_value(output, start, stop, batch_size)
+    metadata = dict(output.get("metadata") or {})
+    for group in ("prompt_embeddings", "rl"):
+        if group in metadata:
+            metadata[group] = _slice_batch_value(metadata[group], start, stop, batch_size)
+    # Declarations, context and other model metadata are request-independent, not batch tensors.
+    return {**output, "payload": _slice_batch_value(output["payload"], start, stop, batch_size), "metadata": metadata}
 
 
 def split_diffusion_output_by_request(
@@ -278,9 +305,9 @@ def split_diffusion_output_by_request(
 ) -> list[Any]:
     """Split a packed ``DiffusionOutput`` into one output per request.
 
-    Tensors whose leading dimension equals ``req.num_reqs * num_outputs_per_prompt``
-    are sliced along the batch axis; shared schedule / sequence axes are left
-    intact. Nested payload/metadata envelopes are sliced recursively.
+    Payload samples, native trajectory fields and training groups explicitly carry
+    a leading batch axis. Static declarations and non-training metadata are shared;
+    no tensor is classified as shared merely because its first dimension differs.
     """
     outputs: list[Any] = []
     expected_batch_size = req.num_reqs * num_outputs_per_prompt
@@ -289,7 +316,7 @@ def split_diffusion_output_by_request(
         stop = (idx + 1) * num_outputs_per_prompt
         outputs.append(
             result.__class__(
-                output=_slice_batch_value(result.output, start, stop, expected_batch_size),
+                output=_slice_rollout_output(result.output, start, stop, expected_batch_size),
                 trajectory_timesteps=_slice_batch_value(result.trajectory_timesteps, start, stop, expected_batch_size),
                 trajectory_latents=_slice_batch_value(result.trajectory_latents, start, stop, expected_batch_size),
                 trajectory_log_probs=_slice_batch_value(result.trajectory_log_probs, start, stop, expected_batch_size),

--- a/verl_omni/pipelines/rollout_artifacts.py
+++ b/verl_omni/pipelines/rollout_artifacts.py
@@ -23,11 +23,11 @@ from __future__ import annotations
 import re
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import asdict, dataclass, replace
-from typing import Any, Literal
+from typing import Any
 
 import torch
 
-from verl_omni.pipelines.rollout_media import Modality
+from verl_omni.pipelines.rollout_media import MediaSpec
 
 ARTIFACT_PREFIX = "media_artifact__"
 ARTIFACT_SPECS = "media_artifact_specs"
@@ -41,21 +41,10 @@ class ArtifactContractError(ValueError):
 
 
 @dataclass(frozen=True)
-class ArtifactSpec:
-    """One runtime artifact declaration; dtype belongs to the tensor, not config."""
-
-    modality: Modality
-    representation: Literal["decoded", "latent"]
-    layout: str
-    sample_rate: int | None = None
-    fps: float | None = None
-
-
-@dataclass(frozen=True)
 class MediaArtifact:
     """A named stream's declaration and one sample's tensor (no batch axis)."""
 
-    spec: ArtifactSpec
+    spec: MediaSpec
     data: torch.Tensor
     context: str = ""
 
@@ -135,7 +124,7 @@ def requested_artifact_names(requested: Any, *, context: str) -> list[str]:
 
 def validate_artifacts(
     items: Iterable[tuple[str, MediaArtifact]],
-    specs: Mapping[str, ArtifactSpec],
+    specs: Mapping[str, MediaSpec],
     *,
     primary: str,
     context: str,
@@ -200,7 +189,7 @@ def artifacts_from_fields(fields: Mapping[str, Any], *, context: str) -> dict[st
     if not isinstance(raw_specs, Mapping):
         raise TypeError(f"{context}: artifact declarations must be a mapping")
     try:
-        specs = {name: ArtifactSpec(**spec) for name, spec in raw_specs.items()}
+        specs = {name: MediaSpec(**spec) for name, spec in raw_specs.items()}
     except (TypeError, ValueError) as error:
         raise ValueError(f"{context}: invalid artifact declarations: {error}") from error
     unknown = tensors.keys() - specs.keys()
@@ -223,7 +212,7 @@ def validate_visual_batch(outputs: torch.Tensor, media_kind: str, *, fps: float,
         raise ArtifactContractError(
             f"{context}: expected canonical batched {media_kind}, got shape={tuple(outputs.shape)}"
         )
-    spec = ArtifactSpec(media_kind, "decoded", layout, fps=fps if media_kind == "video" else None)
+    spec = MediaSpec(media_kind, "decoded", layout, fps=fps if media_kind == "video" else None)
     for index, output in enumerate(outputs):
         MediaArtifact(spec, output).validate(context=context, name=f"preview_{index}")
 
@@ -233,9 +222,7 @@ def validate_audio(audio: Any, sample_rate: Any, *, context: str) -> None:
     if audio is not None:
         if isinstance(sample_rate, torch.Tensor):
             sample_rate = sample_rate.item()
-        artifact = MediaArtifact(
-            ArtifactSpec("audio", "decoded", "CT", sample_rate=sample_rate), torch.as_tensor(audio)
-        )
+        artifact = MediaArtifact(MediaSpec("audio", "decoded", "CT", sample_rate=sample_rate), torch.as_tensor(audio))
         artifact.validate(context=context, name="audio")
 
 

--- a/verl_omni/pipelines/rollout_artifacts.py
+++ b/verl_omni/pipelines/rollout_artifacts.py
@@ -1,0 +1,242 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Named per-sample media and its lossless TensorDict/engine projections.
+
+Decoded axes normalize once; native latent axes and floating dtype never change.
+These types are separate from the legacy primary/auxiliary ``DiffusionIOSpec``
+while adapters migrate. No model or GPU runtime is imported here.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable, Mapping
+from dataclasses import asdict, dataclass, replace
+from typing import Any, Literal
+
+import torch
+
+from verl_omni.pipelines.rollout_media import Modality
+
+ARTIFACT_PREFIX = "media_artifact__"
+ARTIFACT_SPECS = "media_artifact_specs"
+PRIMARY_ARTIFACT = "primary_artifact"
+PREVIEW_ARTIFACT = "preview_artifact"
+
+
+@dataclass(frozen=True)
+class ArtifactSpec:
+    """One runtime artifact declaration; dtype belongs to the tensor, not config."""
+
+    modality: Modality
+    representation: Literal["decoded", "latent"]
+    layout: str
+    sample_rate: int | None = None
+    fps: float | None = None
+
+
+@dataclass(frozen=True)
+class MediaArtifact:
+    """A named stream's declaration and one sample's tensor (no batch axis)."""
+
+    spec: ArtifactSpec
+    data: torch.Tensor
+
+    def validate(self, *, context: str, name: str) -> None:
+        """Fail closed on incorrect metadata, layout, shape or dtype."""
+        spec, data = self.spec, self.data
+        prefix = f"{context}, artifact={name!r}"
+        if not re.fullmatch(r"[A-Za-z][A-Za-z0-9_]*", name):
+            raise ValueError(f"{prefix}: expected an identifier artifact name")
+        if spec.modality not in ("image", "video", "audio") or spec.representation not in ("latent", "decoded"):
+            raise ValueError(f"{prefix}: invalid modality/representation {spec}")
+        if not isinstance(data, torch.Tensor):
+            raise TypeError(f"{prefix}: expected tensor, got {type(data).__name__}")
+        if not re.fullmatch(r"[A-Z]+", spec.layout) or len(set(spec.layout)) != len(spec.layout):
+            raise ValueError(f"{prefix}: expected distinct uppercase layout axes, got {spec.layout!r}")
+        if data.ndim != len(spec.layout) or any(size <= 0 for size in data.shape):
+            raise ValueError(f"{prefix}: expected layout={spec.layout}, got shape={tuple(data.shape)}")
+        if spec.representation == "latent":
+            if not data.is_floating_point():
+                raise ValueError(f"{prefix}: expected floating latent dtype, got {data.dtype}")
+        else:
+            layouts = {"image": ("CHW", "HWC"), "video": ("TCHW", "CTHW", "THWC"), "audio": ("T", "CT")}
+            if spec.layout not in layouts[spec.modality]:
+                raise ValueError(
+                    f"{prefix}: expected decoded {spec.modality} layout in {layouts[spec.modality]}, got {spec.layout}"
+                )
+            if spec.modality == "audio":
+                if not data.is_floating_point():
+                    raise ValueError(f"{prefix}: expected floating audio waveform, got {data.dtype}")
+                if isinstance(spec.sample_rate, bool) or not isinstance(spec.sample_rate, int) or spec.sample_rate <= 0:
+                    raise ValueError(f"{prefix}: expected positive audio sample_rate, got {spec.sample_rate!r}")
+            elif data.dtype != torch.uint8:
+                raise ValueError(f"{prefix}: expected uint8 decoded pixels, got {data.dtype}")
+            if "C" in spec.layout and spec.modality != "audio" and data.shape[spec.layout.index("C")] not in (1, 3, 4):
+                raise ValueError(f"{prefix}: expected 1/3/4 image channels, got shape={tuple(data.shape)}")
+        if spec.fps is not None and (
+            spec.modality != "video"
+            or isinstance(spec.fps, bool)
+            or not isinstance(spec.fps, int | float)
+            or not 0 < spec.fps < float("inf")
+        ):
+            raise ValueError(f"{prefix}: expected positive finite video fps, got {spec.fps!r}")
+        if spec.sample_rate is not None and spec.modality != "audio":
+            raise ValueError(f"{prefix}: sample_rate belongs only to audio")
+
+    def normalized(self, *, context: str, name: str) -> MediaArtifact:
+        """Normalize decoded axes to CHW/TCHW/CT without touching native latents."""
+        self.validate(context=context, name=name)
+        if self.spec.representation == "latent":
+            return self
+        target = {"image": "CHW", "video": "TCHW", "audio": "CT"}[self.spec.modality]
+        if self.spec.layout == target:
+            return self
+        if self.spec.layout == "T":
+            data = self.data.unsqueeze(0)
+        else:
+            data = self.data.permute(*(self.spec.layout.index(axis) for axis in target)).contiguous()
+        return MediaArtifact(replace(self.spec, layout=target), data)
+
+
+def validate_artifacts(
+    items: Iterable[tuple[str, MediaArtifact]],
+    specs: Mapping[str, ArtifactSpec],
+    *,
+    primary: str,
+    context: str,
+    requested: Iterable[str] | None = None,
+) -> dict[str, MediaArtifact]:
+    """Validate names and expected declarations before normalizing each artifact."""
+    artifacts = {}
+    for name, artifact in items:
+        if name in artifacts:
+            raise ValueError(f"{context}: duplicate artifact={name!r}")
+        if name not in specs:
+            raise ValueError(f"{context}: undeclared artifact={name!r}")
+        if artifact.spec != specs[name]:
+            raise ValueError(f"{context}, artifact={name!r}: expected {specs[name]}, got {artifact.spec}")
+        artifacts[name] = artifact.normalized(context=context, name=name)
+    missing = specs.keys() - artifacts.keys()
+    if missing:
+        raise ValueError(f"{context}: declared artifacts missing: {sorted(missing)}")
+    if primary not in artifacts:
+        raise ValueError(f"{context}: primary artifact={primary!r} is absent")
+    if requested is not None:
+        if isinstance(requested, str):
+            raise TypeError(f"{context}: requested_outputs must be a sequence of artifact names, not str")
+        requested = list(requested)
+        if len(set(requested)) != len(requested):
+            raise ValueError(f"{context}: duplicate requested_outputs")
+        absent = set(requested) - artifacts.keys()
+        if absent:
+            raise ValueError(f"{context}: requested artifacts absent: {sorted(absent)}")
+    return artifacts
+
+
+def artifact_fields(artifacts: Mapping[str, MediaArtifact], primary: str, preview: str | None = None) -> dict[str, Any]:
+    """Flatten tensors into regular TensorDict fields; metadata contains no tensors."""
+    if primary not in artifacts:
+        raise ValueError(f"Primary artifact {primary!r} is absent")
+    if preview is not None and (
+        preview not in artifacts
+        or artifacts[preview].spec.representation != "decoded"
+        or artifacts[preview].spec.modality not in ("image", "video")
+    ):
+        raise ValueError(f"Preview artifact={preview!r} must name decoded visual media")
+    for name, artifact in artifacts.items():
+        artifact.validate(context="artifact transport", name=name)
+    return {
+        **{ARTIFACT_PREFIX + name: artifact.data for name, artifact in artifacts.items()},
+        ARTIFACT_SPECS: {name: asdict(artifact.spec) for name, artifact in artifacts.items()},
+        PRIMARY_ARTIFACT: primary,
+        PREVIEW_ARTIFACT: preview,
+    }
+
+
+def artifacts_from_fields(fields: Mapping[str, Any], *, context: str) -> dict[str, MediaArtifact]:
+    """Restore one sample without inferring representation or dropping unknown names."""
+    raw_specs = fields.get(ARTIFACT_SPECS)
+    tensors = {key[len(ARTIFACT_PREFIX) :]: value for key, value in fields.items() if key.startswith(ARTIFACT_PREFIX)}
+    if raw_specs is None:
+        if tensors or fields.get(PRIMARY_ARTIFACT) is not None:
+            raise ValueError(f"{context}: artifact tensors/primary have no declarations")
+        return {}
+    if not isinstance(raw_specs, Mapping):
+        raise TypeError(f"{context}: artifact declarations must be a mapping")
+    try:
+        specs = {name: ArtifactSpec(**spec) for name, spec in raw_specs.items()}
+    except (TypeError, ValueError) as error:
+        raise ValueError(f"{context}: invalid artifact declarations: {error}") from error
+    unknown = tensors.keys() - specs.keys()
+    if unknown:
+        raise ValueError(f"{context}: undeclared artifact tensors: {sorted(unknown)}")
+    return validate_artifacts(
+        ((name, MediaArtifact(specs[name], tensor)) for name, tensor in tensors.items()),
+        specs,
+        primary=fields.get(PRIMARY_ARTIFACT),
+        context=context,
+    )
+
+
+def validate_previews(previews: list[MediaArtifact] | None, count: int) -> list[MediaArtifact] | None:
+    """Validate export selection synchronously, before best-effort I/O starts."""
+    if previews is None or all(preview is None for preview in previews):
+        return None
+    if len(previews) != count:
+        raise ValueError(f"Expected {count} previews, got {len(previews)}")
+    for i, preview in enumerate(previews):
+        if not isinstance(preview, MediaArtifact):
+            raise ValueError(f"Preview sample={i} is missing; cannot substitute a response/latent")
+        preview.validate(context=f"preview sample={i}", name="preview")
+        if preview.spec.representation != "decoded" or preview.spec.modality not in ("image", "video"):
+            raise ValueError(f"Preview sample={i}: expected decoded visual media, got {preview.spec}")
+    if len({preview.spec.modality for preview in previews}) != 1:
+        raise ValueError("Cannot export a mixed image/video preview batch")
+    return [preview.normalized(context="preview export", name="preview") for preview in previews]
+
+
+def previews_from_batch(batch: Any) -> list[MediaArtifact] | None:
+    """Select explicit decoded previews from DataProto rows for dump/W&B paths."""
+    if ARTIFACT_SPECS not in batch.non_tensor_batch:
+        if any(key.startswith(ARTIFACT_PREFIX) for key in batch.batch.keys()):
+            raise ValueError("Media export received artifact tensors without declarations")
+        return None
+    previews = []
+    for i in range(len(batch)):
+        row = batch[i]
+        fields = dict(row.non_tensor_batch)
+        fields.update({key: value for key, value in row.batch.items() if key.startswith(ARTIFACT_PREFIX)})
+        artifacts = artifacts_from_fields(fields, context=f"media export sample={i}")
+        name = fields.get(PREVIEW_ARTIFACT)
+        if name not in artifacts:
+            raise ValueError(f"media export sample={i}: requested decoded preview {name!r} is absent")
+        artifact = artifacts[name]
+        if artifact.spec.representation != "decoded" or artifact.spec.modality not in ("image", "video"):
+            raise ValueError(f"media export sample={i}, artifact={name!r}: expected decoded visual preview")
+        previews.append(artifact)
+    return previews
+
+
+def select_artifact(
+    artifacts: Mapping[str, MediaArtifact], *, name: str, modality: str, representation: str
+) -> MediaArtifact:
+    """Select exactly the requested stream; never substitute a latent for a preview."""
+    if name not in artifacts:
+        raise ValueError(f"Requested artifact={name!r} is absent; available={sorted(artifacts)}")
+    artifact = artifacts[name]
+    artifact.validate(context="artifact consumer", name=name)
+    if (artifact.spec.modality, artifact.spec.representation) != (modality, representation):
+        raise ValueError(f"artifact={name!r}: expected {modality}/{representation}, got {artifact.spec}")
+    return artifact

--- a/verl_omni/pipelines/rollout_artifacts.py
+++ b/verl_omni/pipelines/rollout_artifacts.py
@@ -14,14 +14,14 @@
 """Named per-sample media and its lossless TensorDict/engine projections.
 
 Decoded axes normalize once; native latent axes and floating dtype never change.
-These types are separate from the legacy primary/auxiliary ``DiffusionIOSpec``
-while adapters migrate. No model or GPU runtime is imported here.
+Adapters declare available names in ``DiffusionIOSpec``. No model or GPU runtime
+is imported here.
 """
 
 from __future__ import annotations
 
 import re
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import asdict, dataclass, replace
 from typing import Any, Literal
 
@@ -33,6 +33,11 @@ ARTIFACT_PREFIX = "media_artifact__"
 ARTIFACT_SPECS = "media_artifact_specs"
 PRIMARY_ARTIFACT = "primary_artifact"
 PREVIEW_ARTIFACT = "preview_artifact"
+ARTIFACT_CONTEXT = "media_artifact_context"
+
+
+class ArtifactContractError(ValueError):
+    """A schema/selection failure, never an optional scorer or observability failure."""
 
 
 @dataclass(frozen=True)
@@ -52,12 +57,13 @@ class MediaArtifact:
 
     spec: ArtifactSpec
     data: torch.Tensor
+    context: str = ""
 
     def validate(self, *, context: str, name: str) -> None:
         """Fail closed on incorrect metadata, layout, shape or dtype."""
         spec, data = self.spec, self.data
-        prefix = f"{context}, artifact={name!r}"
-        if not re.fullmatch(r"[A-Za-z][A-Za-z0-9_]*", name):
+        prefix = f"{self.context or context}, artifact={name!r}"
+        if not isinstance(name, str) or not re.fullmatch(r"[A-Za-z][A-Za-z0-9_]*", name):
             raise ValueError(f"{prefix}: expected an identifier artifact name")
         if spec.modality not in ("image", "video", "audio") or spec.representation not in ("latent", "decoded"):
             raise ValueError(f"{prefix}: invalid modality/representation {spec}")
@@ -85,6 +91,8 @@ class MediaArtifact:
                 raise ValueError(f"{prefix}: expected uint8 decoded pixels, got {data.dtype}")
             if "C" in spec.layout and spec.modality != "audio" and data.shape[spec.layout.index("C")] not in (1, 3, 4):
                 raise ValueError(f"{prefix}: expected 1/3/4 image channels, got shape={tuple(data.shape)}")
+        if spec.modality == "video" and spec.representation == "decoded" and spec.fps is None:
+            raise ArtifactContractError(f"{prefix}: decoded video requires explicit fps")
         if spec.fps is not None and (
             spec.modality != "video"
             or isinstance(spec.fps, bool)
@@ -107,7 +115,22 @@ class MediaArtifact:
             data = self.data.unsqueeze(0)
         else:
             data = self.data.permute(*(self.spec.layout.index(axis) for axis in target)).contiguous()
-        return MediaArtifact(replace(self.spec, layout=target), data)
+        return replace(self, spec=replace(self.spec, layout=target), data=data)
+
+
+def requested_artifact_names(requested: Any, *, context: str) -> list[str]:
+    """Validate output selection without interpreting strings/dicts as name sequences."""
+    if requested is None:
+        return []
+    if (
+        isinstance(requested, str)
+        or not isinstance(requested, Sequence)
+        or any(not isinstance(name, str) for name in requested)
+    ):
+        raise ArtifactContractError(f"{context}: requested_outputs must be a sequence of artifact names")
+    if len(set(requested)) != len(requested):
+        raise ArtifactContractError(f"{context}: duplicate requested_outputs")
+    return list(requested)
 
 
 def validate_artifacts(
@@ -127,21 +150,16 @@ def validate_artifacts(
             raise ValueError(f"{context}: undeclared artifact={name!r}")
         if artifact.spec != specs[name]:
             raise ValueError(f"{context}, artifact={name!r}: expected {specs[name]}, got {artifact.spec}")
+        artifact = replace(artifact, context=artifact.context or context)
         artifacts[name] = artifact.normalized(context=context, name=name)
     missing = specs.keys() - artifacts.keys()
     if missing:
         raise ValueError(f"{context}: declared artifacts missing: {sorted(missing)}")
     if primary not in artifacts:
         raise ValueError(f"{context}: primary artifact={primary!r} is absent")
-    if requested is not None:
-        if isinstance(requested, str):
-            raise TypeError(f"{context}: requested_outputs must be a sequence of artifact names, not str")
-        requested = list(requested)
-        if len(set(requested)) != len(requested):
-            raise ValueError(f"{context}: duplicate requested_outputs")
-        absent = set(requested) - artifacts.keys()
-        if absent:
-            raise ValueError(f"{context}: requested artifacts absent: {sorted(absent)}")
+    absent = set(requested_artifact_names(requested, context=context)) - artifacts.keys()
+    if absent:
+        raise ArtifactContractError(f"{context}: requested artifacts absent: {sorted(absent)}")
     return artifacts
 
 
@@ -162,11 +180,17 @@ def artifact_fields(artifacts: Mapping[str, MediaArtifact], primary: str, previe
         ARTIFACT_SPECS: {name: asdict(artifact.spec) for name, artifact in artifacts.items()},
         PRIMARY_ARTIFACT: primary,
         PREVIEW_ARTIFACT: preview,
+        ARTIFACT_CONTEXT: artifacts[primary].context,
     }
 
 
 def artifacts_from_fields(fields: Mapping[str, Any], *, context: str) -> dict[str, MediaArtifact]:
     """Restore one sample without inferring representation or dropping unknown names."""
+    origin = fields.get(ARTIFACT_CONTEXT)
+    if origin is not None and not isinstance(origin, str):
+        raise ArtifactContractError(f"{context}: artifact context must be a string")
+    if origin:
+        context = f"{origin}, {context}"
     raw_specs = fields.get(ARTIFACT_SPECS)
     tensors = {key[len(ARTIFACT_PREFIX) :]: value for key, value in fields.items() if key.startswith(ARTIFACT_PREFIX)}
     if raw_specs is None:
@@ -190,10 +214,39 @@ def artifacts_from_fields(fields: Mapping[str, Any], *, context: str) -> dict[st
     )
 
 
+def validate_visual_batch(outputs: torch.Tensor, media_kind: str, *, fps: float, context: str) -> None:
+    """Validate the canonical batched tensor API before starting best-effort media I/O."""
+    if media_kind not in ("image", "video"):
+        raise ArtifactContractError(f"{context}: expected visual media_kind, got {media_kind!r}")
+    layout = "CHW" if media_kind == "image" else "TCHW"
+    if outputs.ndim != len(layout) + 1:
+        raise ArtifactContractError(
+            f"{context}: expected canonical batched {media_kind}, got shape={tuple(outputs.shape)}"
+        )
+    spec = ArtifactSpec(media_kind, "decoded", layout, fps=fps if media_kind == "video" else None)
+    for index, output in enumerate(outputs):
+        MediaArtifact(spec, output).validate(context=context, name=f"preview_{index}")
+
+
+def validate_audio(audio: Any, sample_rate: Any, *, context: str) -> None:
+    """Validate the explicitly CT audio projection; no batch/axis or sample-rate fallback."""
+    if audio is not None:
+        if isinstance(sample_rate, torch.Tensor):
+            sample_rate = sample_rate.item()
+        artifact = MediaArtifact(
+            ArtifactSpec("audio", "decoded", "CT", sample_rate=sample_rate), torch.as_tensor(audio)
+        )
+        artifact.validate(context=context, name="audio")
+
+
 def validate_previews(previews: list[MediaArtifact] | None, count: int) -> list[MediaArtifact] | None:
     """Validate export selection synchronously, before best-effort I/O starts."""
-    if previews is None or all(preview is None for preview in previews):
+    if previews is None:
         return None
+    if not previews:
+        return []
+    if len(previews) == count and all(preview is None for preview in previews):
+        return []
     if len(previews) != count:
         raise ValueError(f"Expected {count} previews, got {len(previews)}")
     for i, preview in enumerate(previews):
@@ -219,7 +272,12 @@ def previews_from_batch(batch: Any) -> list[MediaArtifact] | None:
         fields = dict(row.non_tensor_batch)
         fields.update({key: value for key, value in row.batch.items() if key.startswith(ARTIFACT_PREFIX)})
         artifacts = artifacts_from_fields(fields, context=f"media export sample={i}")
-        name = fields.get(PREVIEW_ARTIFACT)
+        if PREVIEW_ARTIFACT not in fields:
+            raise ValueError(f"media export sample={i}: missing explicit preview selector")
+        name = fields[PREVIEW_ARTIFACT]
+        if name is None:
+            previews.append(None)
+            continue
         if name not in artifacts:
             raise ValueError(f"media export sample={i}: requested decoded preview {name!r} is absent")
         artifact = artifacts[name]
@@ -233,10 +291,16 @@ def select_artifact(
     artifacts: Mapping[str, MediaArtifact], *, name: str, modality: str, representation: str
 ) -> MediaArtifact:
     """Select exactly the requested stream; never substitute a latent for a preview."""
+    context = next((item.context for item in artifacts.values() if item.context), "artifact consumer")
     if name not in artifacts:
-        raise ValueError(f"Requested artifact={name!r} is absent; available={sorted(artifacts)}")
+        raise ArtifactContractError(f"{context}: Requested artifact={name!r} is absent; available={sorted(artifacts)}")
     artifact = artifacts[name]
-    artifact.validate(context="artifact consumer", name=name)
+    try:
+        artifact.validate(context="artifact consumer", name=name)
+    except (TypeError, ValueError) as error:
+        raise ArtifactContractError(str(error)) from error
     if (artifact.spec.modality, artifact.spec.representation) != (modality, representation):
-        raise ValueError(f"artifact={name!r}: expected {modality}/{representation}, got {artifact.spec}")
+        raise ArtifactContractError(
+            f"{context}, artifact={name!r}: expected {modality}/{representation}, got {artifact.spec}"
+        )
     return artifact

--- a/verl_omni/pipelines/rollout_media.py
+++ b/verl_omni/pipelines/rollout_media.py
@@ -61,10 +61,21 @@ class DiffusionIOSpec:
         primary: The main media stream. It is carried on
             ``DiffusionOutput.diffusion_output`` and, when the pipeline emits a
             media tuple, occupies position 0.
-        auxiliary: Additional media streams in tuple order, so ``auxiliary[i]``
-            describes media-tuple position ``i + 1`` (e.g. a single ``audio``
-            entry describes the joint-audio stream at position 1).
+        auxiliary: At most one audio stream, carried at position 1 of a
+            ``(visual, audio)`` tuple. Other auxiliary combinations are not
+            supported by the current rollout transport.
     """
 
     primary: MediaSpec
     auxiliary: tuple[MediaSpec, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.auxiliary and (
+            self.primary.modality not in ("image", "video")
+            or len(self.auxiliary) != 1
+            or self.auxiliary[0].modality != "audio"
+        ):
+            raise ValueError(
+                "DiffusionIOSpec supports image/video primary media with at most one auxiliary audio stream; "
+                f"got primary={self.primary.modality!r}, auxiliary={tuple(s.modality for s in self.auxiliary)!r}"
+            )

--- a/verl_omni/pipelines/rollout_media.py
+++ b/verl_omni/pipelines/rollout_media.py
@@ -17,12 +17,20 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Literal
-
-if TYPE_CHECKING:
-    from verl_omni.pipelines.rollout_artifacts import ArtifactSpec
+from typing import Literal
 
 Modality = Literal["image", "video", "audio"]
+
+
+@dataclass(frozen=True)
+class MediaSpec:
+    """One media declaration; dtype belongs to the tensor, not config."""
+
+    modality: Modality
+    representation: Literal["decoded", "latent"]
+    layout: str
+    sample_rate: int | None = None
+    fps: float | None = None
 
 
 @dataclass(frozen=True)
@@ -34,14 +42,10 @@ class DiffusionIOSpec:
     fixed rate or leave it to a model's runtime decoder configuration.
     """
 
-    artifacts: Mapping[str, ArtifactSpec]
+    artifacts: Mapping[str, MediaSpec]
 
     def __post_init__(self) -> None:
-        from verl_omni.pipelines.rollout_artifacts import ArtifactSpec
-
         if not isinstance(self.artifacts, Mapping) or not self.artifacts:
             raise ValueError("DiffusionIOSpec requires named artifacts")
-        if any(
-            not isinstance(name, str) or not isinstance(spec, ArtifactSpec) for name, spec in self.artifacts.items()
-        ):
-            raise TypeError("DiffusionIOSpec requires artifact-name to ArtifactSpec declarations")
+        if any(not isinstance(name, str) or not isinstance(spec, MediaSpec) for name, spec in self.artifacts.items()):
+            raise TypeError("DiffusionIOSpec requires artifact-name to MediaSpec declarations")

--- a/verl_omni/pipelines/rollout_media.py
+++ b/verl_omni/pipelines/rollout_media.py
@@ -11,71 +11,37 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Typed, CPU-importable contracts for diffusion rollout media.
-
-These types let a diffusion adapter *declare* what media its pipeline emits
-(primary stream plus any auxiliary streams such as joint audio) instead of the
-rollout strategy hard-coding model-specific conventions like "audio lives at
-tuple position 1" or "the audio sample rate is 32000 Hz". The diffusion
-strategy consults the adapter-owned :class:`DiffusionIOSpec` when it converts an
-engine result into a rollout output, so adding a new combination of existing
-modalities only touches the adapter, not the shared server/strategy code.
-"""
+"""Adapter-owned named diffusion output declarations; no positional media protocol."""
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Literal, Optional
+from typing import TYPE_CHECKING, Literal
 
-#: Media kinds a diffusion pipeline can emit.
+if TYPE_CHECKING:
+    from verl_omni.pipelines.rollout_artifacts import ArtifactSpec
+
 Modality = Literal["image", "video", "audio"]
 
 
 @dataclass(frozen=True)
-class MediaSpec:
-    """Declaration of a single media stream produced by a diffusion pipeline.
-
-    Attributes:
-        modality: The media kind (``"image"``, ``"video"`` or ``"audio"``).
-        sample_rate: Default audio sample rate in Hz. Audio streams only; used
-            as a fallback when the adapter does not attach a runtime sample rate
-            through the rollout metadata.
-        fps: Default frames-per-second. Video streams only; ``None`` when the
-            pipeline does not declare one.
-
-    The float-latent vs. uint8-pixel distinction is intentionally *not* declared
-    here: it is decided per request by the sampling ``output_type`` (``latent``
-    keeps floats, otherwise pixels are quantized to uint8 in ``[0, 255]``).
-    """
-
-    modality: Modality
-    sample_rate: Optional[int] = None
-    fps: Optional[int] = None
-
-
-@dataclass(frozen=True)
 class DiffusionIOSpec:
-    """Adapter-owned declaration of a diffusion pipeline's rollout outputs.
+    """Available named artifacts, with canonical decoded and native latent axes.
 
-    Attributes:
-        primary: The main media stream. It is carried on
-            ``DiffusionOutput.diffusion_output`` and, when the pipeline emits a
-            media tuple, occupies position 0.
-        auxiliary: At most one audio stream, carried at position 1 of a
-            ``(visual, audio)`` tuple. Other auxiliary combinations are not
-            supported by the current rollout transport.
+    Each request selects its primary and optional preview explicitly. Runtime
+    sample rate/FPS live on the returned artifacts; a declaration can constrain a
+    fixed rate or leave it to a model's runtime decoder configuration.
     """
 
-    primary: MediaSpec
-    auxiliary: tuple[MediaSpec, ...] = ()
+    artifacts: Mapping[str, ArtifactSpec]
 
     def __post_init__(self) -> None:
-        if self.auxiliary and (
-            self.primary.modality not in ("image", "video")
-            or len(self.auxiliary) != 1
-            or self.auxiliary[0].modality != "audio"
+        from verl_omni.pipelines.rollout_artifacts import ArtifactSpec
+
+        if not isinstance(self.artifacts, Mapping) or not self.artifacts:
+            raise ValueError("DiffusionIOSpec requires named artifacts")
+        if any(
+            not isinstance(name, str) or not isinstance(spec, ArtifactSpec) for name, spec in self.artifacts.items()
         ):
-            raise ValueError(
-                "DiffusionIOSpec supports image/video primary media with at most one auxiliary audio stream; "
-                f"got primary={self.primary.modality!r}, auxiliary={tuple(s.modality for s in self.auxiliary)!r}"
-            )
+            raise TypeError("DiffusionIOSpec requires artifact-name to ArtifactSpec declarations")

--- a/verl_omni/pipelines/rollout_media.py
+++ b/verl_omni/pipelines/rollout_media.py
@@ -24,11 +24,34 @@ modalities only touches the adapter, not the shared server/strategy code.
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import Literal, Optional
 
 #: Media kinds a diffusion pipeline can emit.
 Modality = Literal["image", "video", "audio"]
+
+
+def resolve_is_video(ndim: int, media_kind: str | None) -> bool:
+    """Prefer the declared modality, retaining rank fallback for legacy outputs."""
+    if media_kind is not None:
+        if media_kind not in ("image", "video", "audio"):
+            raise ValueError(f"Unsupported media kind: {media_kind!r}")
+        return media_kind == "video"
+    return ndim == 5
+
+
+def resolve_batch_media_kind(media_kinds: Iterable[str | None]) -> str | None:
+    """Require one declared modality per pipeline batch; ignore absent legacy metadata."""
+    resolved = None
+    for kind in media_kinds:
+        if kind is None:
+            continue
+        resolve_is_video(0, kind)
+        if resolved is not None and resolved != kind:
+            raise ValueError(f"Conflicting media kinds in one rollout batch: {resolved!r} and {kind!r}")
+        resolved = kind
+    return resolved
 
 
 @dataclass(frozen=True)

--- a/verl_omni/pipelines/rollout_request.py
+++ b/verl_omni/pipelines/rollout_request.py
@@ -20,16 +20,17 @@ every strategy re-derived the same conventions on its own. :class:`OmniRolloutRe
 gives both the AR and diffusion strategies a single typed object to consume so
 the request shape is declared in one place.
 
-This module keeps the *interpretation* of the request (how the fields map onto
-the engine ``OmniCustomPrompt`` / vLLM prompt dict) inside each strategy; it does
-not change the wire keys the pipelines already read.
+Diffusion prompts use the upstream ``prompt_ids`` spelling. Media and processor
+kwargs stay at the top level, as required by the pinned engine's MiniMax/Bagel
+implementations; extra-encoder IDs live only in ``extra_args``. AR transport
+continues to use vLLM's distinct ``prompt_token_ids`` contract.
 """
 
 from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any, Optional, get_args
+from typing import Any, Optional, TypedDict, get_args
 
 from verl_omni.pipelines.rollout_media import Modality
 
@@ -44,6 +45,33 @@ _CONDITION_IMAGE_KEYS: tuple[str, ...] = (
     "extra_args.multi_modal_data.image",
     "additional_information.condition_images",
 )
+
+
+class DiffusionEnginePrompt(TypedDict, total=False):
+    """Pinned diffusion prompt, including upstream runtime multimodal extensions."""
+
+    prompt_ids: list[int] | list[list[int]]
+    prompt_mask: Any
+    negative_prompt_ids: list[int] | list[list[int]]
+    negative_prompt_mask: Any
+    multi_modal_data: dict[str, Any]
+    mm_processor_kwargs: Mapping[str, Any]
+    extra_args: dict[str, Any]
+
+
+def prompt_ids_from_payload(payload: Mapping[str, Any], default: Any = None) -> Any:
+    """Read diffusion IDs or the token transport used by an upstream AR stage.
+
+    This is the only adapter boundary accepting the AR spelling. Two conflicting
+    spellings are an error, not a priority choice.
+    """
+    canonical = payload.get("prompt_ids")
+    tokens = payload.get("prompt_token_ids")
+    if canonical is not None and tokens is not None and not _alias_values_match(canonical, tokens):
+        raise ValueError("Conflicting prompt_ids and AR-stage prompt_token_ids")
+    if canonical is not None:
+        return canonical
+    return tokens if tokens is not None else default
 
 
 @dataclass(frozen=True)
@@ -136,6 +164,27 @@ class OmniRolloutRequest:
             ),
             media=tuple(media),
         )
+
+    def to_diffusion_prompt(self) -> DiffusionEnginePrompt:
+        """Lower to the pinned diffusion contract without duplicate media fields."""
+        result: DiffusionEnginePrompt = {"prompt_ids": self.prompt.token_ids}
+        if self.prompt.mask is not None:
+            result["prompt_mask"] = self.prompt.mask
+        if self.prompt.negative_token_ids is not None:
+            result["negative_prompt_ids"] = self.prompt.negative_token_ids
+        extra_args = {}
+        if self.prompt.extra_token_ids is not None:
+            extra_args["extra_prompt_ids"] = self.prompt.extra_token_ids
+        if self.prompt.negative_extra_token_ids is not None:
+            extra_args["negative_extra_prompt_ids"] = self.prompt.negative_extra_token_ids
+        if extra_args:
+            result["extra_args"] = extra_args
+        media = self.multi_modal_data()
+        if media:
+            result["multi_modal_data"] = media
+        if self.prompt.mm_processor_kwargs is not None:
+            result["mm_processor_kwargs"] = self.prompt.mm_processor_kwargs
+        return result
 
     def multi_modal_data(self) -> dict[str, Any]:
         """Assemble the vLLM ``multi_modal_data`` dict from the media streams.

--- a/verl_omni/pipelines/sd3_flow_grpo/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/sd3_flow_grpo/vllm_omni_rollout_adapter.py
@@ -40,6 +40,7 @@ from verl_omni.pipelines.request_batch import (
     split_diffusion_output_by_request as _split_diffusion_output_by_request,
 )
 from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
+from verl_omni.pipelines.rollout_request import prompt_ids_from_payload
 from verl_omni.pipelines.schedulers import FlowMatchSDEDiscreteScheduler
 from verl_omni.pipelines.sd3_flow_grpo.common import (
     SD3_CLIP_TOKENS_KEY,
@@ -106,7 +107,9 @@ def _extract_extra_prompt_ids(prompts: list, key: str = "extra_prompt_ids") -> d
     for prompt in prompts:
         if not isinstance(prompt, dict):
             return None
-        extra = prompt.get(key)
+        extra = (prompt.get("extra_args") or {}).get(key)
+        if prompt.get(key) is not None:
+            raise ValueError(f"SD3 {key} must be nested under extra_args, not at the prompt top level")
         if not extra:
             return None
         per_prompt.append(extra)
@@ -374,7 +377,7 @@ class StableDiffusion3PipelineWithLogProb(SD3TokenIdPromptMixin, StableDiffusion
         negative_prompt = req_negative_prompt if req_negative_prompt is not None else negative_prompt
 
         if extra_prompt_ids is None and prompt is None:
-            if any(isinstance(p, dict) and p.get("prompt_token_ids") is not None for p in req_prompts):
+            if any(isinstance(p, dict) and prompt_ids_from_payload(p) is not None for p in req_prompts):
                 raise ValueError(
                     "SD3 rollout received tokenized prompts without per-text-encoder token ids; decoding "
                     "token ids back to text inside the pipeline is not supported. Configure "

--- a/verl_omni/pipelines/sd3_flow_grpo/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/sd3_flow_grpo/vllm_omni_rollout_adapter.py
@@ -41,8 +41,7 @@ from verl_omni.pipelines.request_batch import (
 from verl_omni.pipelines.request_batch import (
     split_diffusion_output_by_request as _split_diffusion_output_by_request,
 )
-from verl_omni.pipelines.rollout_artifacts import ArtifactSpec
-from verl_omni.pipelines.rollout_media import DiffusionIOSpec
+from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
 from verl_omni.pipelines.rollout_request import prompt_ids_from_payload
 from verl_omni.pipelines.schedulers import FlowMatchSDEDiscreteScheduler
 from verl_omni.pipelines.sd3_flow_grpo.common import (
@@ -191,8 +190,8 @@ class StableDiffusion3PipelineWithLogProb(SD3TokenIdPromptMixin, StableDiffusion
 
     diffusion_io_spec = DiffusionIOSpec(
         artifacts={
-            "image_preview": ArtifactSpec("image", "decoded", "CHW"),
-            "image_latent": ArtifactSpec("image", "latent", "CHW"),
+            "image_preview": MediaSpec("image", "decoded", "CHW"),
+            "image_latent": MediaSpec("image", "latent", "CHW"),
         }
     )
 

--- a/verl_omni/pipelines/sd3_flow_grpo/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/sd3_flow_grpo/vllm_omni_rollout_adapter.py
@@ -30,16 +30,19 @@ from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
 
 from verl_omni.pipelines.diffusion_rollout_output import (
     rollout_output,
+    with_visual_artifacts,
     wrap_rollout_postprocessor,
 )
 from verl_omni.pipelines.model_base import VllmOmniPipelineBase
+from verl_omni.pipelines.request_batch import requested_outputs_for_batch
 from verl_omni.pipelines.request_batch import (
     sample_per_sample_sde_windows as _sample_per_sample_sde_windows,
 )
 from verl_omni.pipelines.request_batch import (
     split_diffusion_output_by_request as _split_diffusion_output_by_request,
 )
-from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
+from verl_omni.pipelines.rollout_artifacts import ArtifactSpec
+from verl_omni.pipelines.rollout_media import DiffusionIOSpec
 from verl_omni.pipelines.rollout_request import prompt_ids_from_payload
 from verl_omni.pipelines.schedulers import FlowMatchSDEDiscreteScheduler
 from verl_omni.pipelines.sd3_flow_grpo.common import (
@@ -155,14 +158,7 @@ _SD3_IMAGE_POST_PROCESS_FUNC = pipeline_sd3.get_sd3_image_post_process_func
 
 def get_latent_post_process_func(od_config):
     """Postprocess SD3 media while preserving rollout metadata."""
-    image_postprocess = _SD3_IMAGE_POST_PROCESS_FUNC(od_config)
-
-    def postprocess(output):
-        if isinstance(output, torch.Tensor) and output.ndim >= 3 and output.shape[-3] == 16:
-            return output
-        return image_postprocess(output)
-
-    return wrap_rollout_postprocessor(postprocess)
+    return wrap_rollout_postprocessor(_SD3_IMAGE_POST_PROCESS_FUNC(od_config))
 
 
 # vLLM-Omni resolves this module-level factory before initializing the custom
@@ -193,9 +189,12 @@ class StableDiffusion3PipelineWithLogProb(SD3TokenIdPromptMixin, StableDiffusion
 
     supports_request_batch = True
 
-    #: Declares the primary rollout media stream so downstream consumers read
-    #: the modality from the adapter instead of inferring it from tensor rank.
-    diffusion_io_spec = DiffusionIOSpec(primary=MediaSpec("image"))
+    diffusion_io_spec = DiffusionIOSpec(
+        artifacts={
+            "image_preview": ArtifactSpec("image", "decoded", "CHW"),
+            "image_latent": ArtifactSpec("image", "latent", "CHW"),
+        }
+    )
 
     def __init__(self, *, od_config: OmniDiffusionConfig, prefix: str = ""):
         super().__init__(od_config=od_config, prefix=prefix)
@@ -391,6 +390,7 @@ class StableDiffusion3PipelineWithLogProb(SD3TokenIdPromptMixin, StableDiffusion
             prompt = [prompt]
 
         sampling_params = request_batch.sampling_params_list[0]
+        requested_outputs = requested_outputs_for_batch(request_batch)
         height = sampling_params.height or self.default_sample_size * self.vae_scale_factor
         width = sampling_params.width or self.default_sample_size * self.vae_scale_factor
         num_inference_steps = sampling_params.num_inference_steps or num_inference_steps
@@ -408,6 +408,7 @@ class StableDiffusion3PipelineWithLogProb(SD3TokenIdPromptMixin, StableDiffusion
         sde_type = _coalesce_not_none(sampling_params.extra_args.get("sde_type", None), sde_type)
         logprobs = _coalesce_not_none(sampling_params.extra_args.get("logprobs", None), logprobs)
         output_type = _resolve_output_type(sampling_params, output_type)
+        decode = output_type != "latent" or "image_preview" in requested_outputs
 
         req_num_outputs = getattr(sampling_params, "num_outputs_per_prompt", None)
         if req_num_outputs and req_num_outputs > 0:
@@ -497,8 +498,16 @@ class StableDiffusion3PipelineWithLogProb(SD3TokenIdPromptMixin, StableDiffusion
         )
 
         if request_batch.requests[0].request_id == DUMMY_DIFFUSION_REQUEST_ID and sde_window[0][0] == sde_window[0][1]:
-            output = self._decode_latents(latents, output_type)
-            result = DiffusionOutput(output=output, to_cpu=True)
+            output = self._decode_latents(latents, "image") if decode else None
+            result = with_visual_artifacts(
+                DiffusionOutput(output=output, to_cpu=True),
+                decoded=output,
+                latents=latents,
+                latent_layout="CHW",
+                output_type=output_type,
+                context=f"pipeline={type(self).__name__}, request_id={request_batch.requests[0].request_id}",
+                requested=requested_outputs,
+            )
             outputs = _split_diffusion_output_by_request(
                 result,
                 request_batch,
@@ -523,7 +532,7 @@ class StableDiffusion3PipelineWithLogProb(SD3TokenIdPromptMixin, StableDiffusion
         )
 
         self._current_timestep = None
-        output = self._decode_latents(latents, output_type)
+        output = self._decode_latents(latents, "image") if decode else None
         rl = {}
         if output_type == "both":
             rl["latents_clean"] = latents.float()
@@ -543,6 +552,15 @@ class StableDiffusion3PipelineWithLogProb(SD3TokenIdPromptMixin, StableDiffusion
             },
             rl=rl,
             to_cpu=True,
+        )
+        result = with_visual_artifacts(
+            result,
+            decoded=output,
+            latents=latents,
+            latent_layout="CHW",
+            output_type=output_type,
+            context=f"pipeline={type(self).__name__}, request_id={[r.request_id for r in request_batch.requests]}",
+            requested=requested_outputs,
         )
         outputs = _split_diffusion_output_by_request(
             result,

--- a/verl_omni/pipelines/wan22_dance_grpo/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/wan22_dance_grpo/vllm_omni_rollout_adapter.py
@@ -44,8 +44,7 @@ from verl_omni.pipelines.diffusion_rollout_output import (
     wrap_rollout_postprocessor,
 )
 from verl_omni.pipelines.model_base import VllmOmniPipelineBase
-from verl_omni.pipelines.rollout_artifacts import ArtifactSpec
-from verl_omni.pipelines.rollout_media import DiffusionIOSpec
+from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
 from verl_omni.pipelines.rollout_request import prompt_ids_from_payload
 from verl_omni.pipelines.schedulers import FlowMatchSDEDiscreteScheduler
 
@@ -117,8 +116,8 @@ class Wan22DanceGRPOPipelineWithLogProb(Wan22Pipeline):
     #: the modality from the adapter instead of inferring it from tensor rank.
     diffusion_io_spec = DiffusionIOSpec(
         artifacts={
-            "video_preview": ArtifactSpec("video", "decoded", "TCHW"),
-            "video_latent": ArtifactSpec("video", "latent", "CTHW"),
+            "video_preview": MediaSpec("video", "decoded", "TCHW"),
+            "video_latent": MediaSpec("video", "latent", "CTHW"),
         }
     )
 

--- a/verl_omni/pipelines/wan22_dance_grpo/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/wan22_dance_grpo/vllm_omni_rollout_adapter.py
@@ -39,10 +39,13 @@ from vllm_omni.platforms import current_omni_platform
 
 from verl_omni.pipelines.diffusion_rollout_output import (
     rollout_output,
+    wants_decoded_preview,
+    with_visual_artifacts,
     wrap_rollout_postprocessor,
 )
 from verl_omni.pipelines.model_base import VllmOmniPipelineBase
-from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
+from verl_omni.pipelines.rollout_artifacts import ArtifactSpec
+from verl_omni.pipelines.rollout_media import DiffusionIOSpec
 from verl_omni.pipelines.rollout_request import prompt_ids_from_payload
 from verl_omni.pipelines.schedulers import FlowMatchSDEDiscreteScheduler
 
@@ -112,7 +115,12 @@ class Wan22DanceGRPOPipelineWithLogProb(Wan22Pipeline):
 
     #: Declares the primary rollout media stream so downstream consumers read
     #: the modality from the adapter instead of inferring it from tensor rank.
-    diffusion_io_spec = DiffusionIOSpec(primary=MediaSpec("video"))
+    diffusion_io_spec = DiffusionIOSpec(
+        artifacts={
+            "video_preview": ArtifactSpec("video", "decoded", "TCHW"),
+            "video_latent": ArtifactSpec("video", "latent", "CTHW"),
+        }
+    )
 
     def __init__(self, *, od_config: OmniDiffusionConfig, prefix: str = ""):
         super().__init__(od_config=od_config, prefix=prefix)
@@ -676,8 +684,9 @@ class Wan22DanceGRPOPipelineWithLogProb(Wan22Pipeline):
             latents = (1 - first_frame_mask) * latent_condition + first_frame_mask * latents
 
         # Decode latents
-        if output_type == "latent":
-            output = latents
+        native_latents = latents
+        if not wants_decoded_preview(output_type, sampling_params, modality="video"):
+            output = None
         else:
             latents = latents.to(self.vae.dtype)
             latents_mean = (
@@ -691,7 +700,16 @@ class Wan22DanceGRPOPipelineWithLogProb(Wan22Pipeline):
             latents = latents / latents_std + latents_mean
             output = self.vae.decode(latents, return_dict=False)[0]
 
-        return rollout_output(
+        fps = sampling_params.frame_rate
+        if output is not None and sampling_params.enable_frame_interpolation:
+            output, multiplier = pipeline_wan2_2.interpolate_video_tensor(
+                output,
+                exp=sampling_params.frame_interpolation_exp,
+                scale=sampling_params.frame_interpolation_scale,
+                model_path=sampling_params.frame_interpolation_model_path,
+            )
+            fps = fps * multiplier if fps is not None else None
+        result = rollout_output(
             media=output,
             media_key="video",
             trajectory_latents=all_latents,
@@ -704,6 +722,18 @@ class Wan22DanceGRPOPipelineWithLogProb(Wan22Pipeline):
                 "negative_prompt_embeds_mask": negative_prompt_embeds_mask,
             },
             to_cpu=True,
+        )
+        return with_visual_artifacts(
+            result,
+            decoded=output,
+            latents=native_latents,
+            latent_layout="CTHW",
+            modality="video",
+            decoded_layout="CTHW",
+            fps=fps,
+            output_type=output_type,
+            context=f"pipeline={type(self).__name__}, request_id={req.request_id}",
+            requested=(sampling_params.extra_args or {}).get("requested_outputs"),
         )
 
     def check_inputs(

--- a/verl_omni/pipelines/wan22_dance_grpo/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/wan22_dance_grpo/vllm_omni_rollout_adapter.py
@@ -43,6 +43,7 @@ from verl_omni.pipelines.diffusion_rollout_output import (
 )
 from verl_omni.pipelines.model_base import VllmOmniPipelineBase
 from verl_omni.pipelines.rollout_media import DiffusionIOSpec, MediaSpec
+from verl_omni.pipelines.rollout_request import prompt_ids_from_payload
 from verl_omni.pipelines.schedulers import FlowMatchSDEDiscreteScheduler
 
 from .common import sd3_time_shift, seed_from_prompt_ids
@@ -410,16 +411,12 @@ class Wan22DanceGRPOPipelineWithLogProb(Wan22Pipeline):
         # --- Extract parameters from request ---
         custom_prompt = req.prompt if isinstance(req.prompt, dict) else {}
         if isinstance(custom_prompt, dict):
-            prompt_ids = custom_prompt.get("prompt_token_ids", prompt_ids)
+            prompt_ids = prompt_ids_from_payload(custom_prompt, prompt_ids)
             prompt_mask = custom_prompt.get("prompt_mask", prompt_mask)
             negative_prompt_ids = custom_prompt.get("negative_prompt_ids", negative_prompt_ids)
             negative_prompt_mask = custom_prompt.get("negative_prompt_mask", negative_prompt_mask)
             if image is None:
-                # Check both top-level and extra_args for multi_modal_data
-                multi_modal_data = custom_prompt.get("multi_modal_data", None)
-                if multi_modal_data is None:
-                    extra_args = custom_prompt.get("extra_args", {})
-                    multi_modal_data = extra_args.get("multi_modal_data", {}) if isinstance(extra_args, dict) else {}
+                multi_modal_data = custom_prompt.get("multi_modal_data")
                 raw_image = multi_modal_data.get("image", None) if multi_modal_data else None
                 image = raw_image if raw_image is not None else image
 

--- a/verl_omni/reward_loop/reward_manager/audio.py
+++ b/verl_omni/reward_loop/reward_manager/audio.py
@@ -16,7 +16,6 @@
 import asyncio
 import inspect
 import math
-from collections.abc import Mapping
 from functools import partial
 
 import numpy as np
@@ -24,6 +23,8 @@ import torch
 from verl import DataProto
 from verl.experimental.reward_loop.reward_manager.base import RewardManagerBase
 from verl.utils.reward_score import default_compute_score as _upstream_default_compute_score
+
+from verl_omni.reward_loop.reward_manager.media import _reward_extra_info
 
 
 class AudioRewardManager(RewardManagerBase):
@@ -40,16 +41,6 @@ class AudioRewardManager(RewardManagerBase):
         self.is_async_reward_score = inspect.iscoroutinefunction(compute_score)
         self.reward_router_address = reward_router_address
         self.reward_model_tokenizer = reward_model_tokenizer
-
-    @staticmethod
-    def _mapping(value):
-        if isinstance(value, np.ndarray) and value.shape == ():
-            value = value.item()
-        if value is None:
-            return {}
-        if not isinstance(value, Mapping):
-            raise TypeError(f"Audio reward metadata must be a mapping, got {type(value).__name__}.")
-        return dict(value)
 
     @classmethod
     def _extract_audio(cls, extra_info):
@@ -94,11 +85,7 @@ class AudioRewardManager(RewardManagerBase):
             raise ValueError(f"AudioRewardManager scores one sample at a time, got batch size {len(data)}.")
         item = data[0]
         batch = item.non_tensor_batch
-        extra_info = self._mapping(batch.get("extra_info", {}))
-        extra_info.update(self._mapping(batch.get("tool_extra_fields")))
-        for key in ("audio", "audio_sample_rate"):
-            if key in batch and batch[key] is not None:
-                extra_info[key] = batch[key]
+        extra_info = _reward_extra_info(item)
         if "__num_turns__" in batch:
             extra_info["num_turns"] = batch["__num_turns__"]
         if "global_steps" in batch:

--- a/verl_omni/reward_loop/reward_manager/media.py
+++ b/verl_omni/reward_loop/reward_manager/media.py
@@ -1,0 +1,53 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Shared generated-media projection for visual and audio reward managers."""
+
+from collections.abc import Mapping
+
+import numpy as np
+import torch
+
+
+def _metadata_mapping(value):
+    if isinstance(value, np.ndarray) and value.shape == ():
+        value = value.item()
+    if value is None:
+        return {}
+    if not isinstance(value, Mapping):
+        raise TypeError(f"Reward media metadata must be a mapping, got {type(value).__name__}.")
+    return dict(value)
+
+
+def _reward_extra_info(data_item) -> dict:
+    """Copy metadata and project generated media, rejecting conflicting sources."""
+    extra_info = _metadata_mapping(data_item.non_tensor_batch.get("extra_info"))
+    tool_extra_fields = _metadata_mapping(data_item.non_tensor_batch.get("tool_extra_fields"))
+    extra_info.update(tool_extra_fields)
+    tensor_fields = data_item.batch if data_item.batch is not None else {}
+    for key in ("audio", "audio_sample_rate", "media_kind"):
+        value = tensor_fields.get(key)
+        if value is None:
+            value = data_item.non_tensor_batch.get(key)
+        if value is None:
+            continue
+        tool_value = tool_extra_fields.get(key)
+        if tool_value is not None and tool_value is not value:
+            if isinstance(value, torch.Tensor) and isinstance(tool_value, torch.Tensor):
+                matches = value.device == tool_value.device and torch.equal(value, tool_value)
+            else:
+                matches = np.array_equal(value, tool_value)
+            if not matches:
+                raise ValueError(f"Conflicting rollout media field {key!r} in batch and tool_extra_fields")
+        extra_info[key] = value
+    return extra_info

--- a/verl_omni/reward_loop/reward_manager/multi.py
+++ b/verl_omni/reward_loop/reward_manager/multi.py
@@ -19,7 +19,8 @@ import logging
 from verl import DataProto
 from verl.utils.import_utils import load_extern_object
 
-from .visual import VisualRewardManager, _reward_extra_info, _validate_visual_response
+from .media import _reward_extra_info
+from .visual import VisualRewardManager, _validate_visual_response
 
 logger = logging.getLogger(__name__)
 

--- a/verl_omni/reward_loop/reward_manager/multi.py
+++ b/verl_omni/reward_loop/reward_manager/multi.py
@@ -19,7 +19,7 @@ import logging
 from verl import DataProto
 from verl.utils.import_utils import load_extern_object
 
-from .visual import VisualRewardManager, _validate_visual_response
+from .visual import VisualRewardManager, _reward_extra_info, _validate_visual_response
 
 logger = logging.getLogger(__name__)
 
@@ -118,10 +118,7 @@ class MultiVisualRewardManager(VisualRewardManager):
         _validate_visual_response(response_visual, self.config, is_validate=data_item.meta_info.get("validate", False))
         data_source = data_item.non_tensor_batch["data_source"]
         ground_truth = data_item.non_tensor_batch["reward_model"]["ground_truth"]
-        extra_info = data_item.non_tensor_batch.get("extra_info", {})
-        tool_extra_fields = data_item.non_tensor_batch.get("tool_extra_fields", None)
-        if tool_extra_fields is not None:
-            extra_info.update(tool_extra_fields.items())
+        extra_info = _reward_extra_info(data_item)
 
         num_turns = data_item.non_tensor_batch.get("__num_turns__", None)
         rollout_reward_scores = data_item.non_tensor_batch.get("reward_scores", {})

--- a/verl_omni/reward_loop/reward_manager/multi.py
+++ b/verl_omni/reward_loop/reward_manager/multi.py
@@ -19,6 +19,8 @@ import logging
 from verl import DataProto
 from verl.utils.import_utils import load_extern_object
 
+from verl_omni.pipelines.rollout_artifacts import ArtifactContractError
+
 from .visual import VisualRewardManager, _reward_extra_info, _validate_visual_response
 
 logger = logging.getLogger(__name__)
@@ -115,10 +117,15 @@ class MultiVisualRewardManager(VisualRewardManager):
         assert len(data) == 1, "Only support single data item"
         data_item = data[0]
         response_visual = data_item.batch["responses"]
-        _validate_visual_response(response_visual, self.config, is_validate=data_item.meta_info.get("validate", False))
+        extra_info = _reward_extra_info(data_item)
+        _validate_visual_response(
+            response_visual,
+            self.config,
+            is_validate=data_item.meta_info.get("validate", False),
+            extra_info=extra_info,
+        )
         data_source = data_item.non_tensor_batch["data_source"]
         ground_truth = data_item.non_tensor_batch["reward_model"]["ground_truth"]
-        extra_info = _reward_extra_info(data_item)
 
         num_turns = data_item.non_tensor_batch.get("__num_turns__", None)
         rollout_reward_scores = data_item.non_tensor_batch.get("reward_scores", {})
@@ -175,6 +182,8 @@ class MultiVisualRewardManager(VisualRewardManager):
                 else:
                     score = float(result)
 
+            except ArtifactContractError:
+                raise
             except Exception as e:
                 if required:
                     raise RuntimeError(f"Required sub-reward '{key}' failed: {e}") from e

--- a/verl_omni/reward_loop/reward_manager/visual.py
+++ b/verl_omni/reward_loop/reward_manager/visual.py
@@ -21,15 +21,34 @@ from verl.experimental.reward_loop.reward_manager.base import RewardManagerBase
 from verl.utils.reward_score import default_compute_score as _upstream_default_compute_score
 
 from verl_omni.pipelines.rollout_artifacts import (
+    ARTIFACT_CONTEXT,
     ARTIFACT_PREFIX,
     ARTIFACT_SPECS,
+    PREVIEW_ARTIFACT,
     PRIMARY_ARTIFACT,
+    ArtifactContractError,
     artifacts_from_fields,
 )
 from verl_omni.utils.reward_score import default_compute_score_image
 
 
-def _validate_visual_response(response_visual, config, *, is_validate: bool) -> None:
+def _validate_visual_response(response_visual, config, *, is_validate: bool, extra_info=None) -> None:
+    if extra_info is not None and "media_artifacts" in extra_info:
+        artifacts = extra_info["media_artifacts"]
+        primary = extra_info.get(PRIMARY_ARTIFACT)
+        if primary not in artifacts:
+            raise ArtifactContractError(f"Reward entry requires an explicit primary artifact, got {primary!r}")
+        artifact = artifacts[primary]
+        if (
+            not isinstance(response_visual, torch.Tensor)
+            or response_visual.dtype != artifact.data.dtype
+            or response_visual.shape != artifact.data.shape
+            or not torch.equal(response_visual, artifact.data)
+        ):
+            raise ArtifactContractError(
+                f"{artifact.context}, artifact={primary!r}: responses projection does not match declared primary"
+            )
+        return
     rollout_config = config.actor_rollout_ref.rollout
     pipeline_config = rollout_config.val_kwargs.pipeline if is_validate else rollout_config.pipeline
     output_type = pipeline_config.get("output_type", "image")
@@ -48,7 +67,15 @@ def _reward_extra_info(data_item) -> dict:
     extra_info = data_item.non_tensor_batch.get("extra_info", {})
     tool_extra_fields = data_item.non_tensor_batch.get("tool_extra_fields") or {}
     extra_info.update(tool_extra_fields)
-    media_keys = {"audio", "audio_sample_rate", "media_kind", ARTIFACT_SPECS, PRIMARY_ARTIFACT}
+    media_keys = {
+        "audio",
+        "audio_sample_rate",
+        "media_kind",
+        ARTIFACT_SPECS,
+        PRIMARY_ARTIFACT,
+        PREVIEW_ARTIFACT,
+        ARTIFACT_CONTEXT,
+    }
     media_keys.update(key for key in data_item.batch.keys() if key.startswith(ARTIFACT_PREFIX))
     for key in media_keys:
         value = data_item.batch.get(key)
@@ -95,10 +122,15 @@ class VisualRewardManager(RewardManagerBase):
         assert len(data) == 1, "Only support single data item"
         data_item = data[0]
         response_visual = data_item.batch["responses"]
-        _validate_visual_response(response_visual, self.config, is_validate=data_item.meta_info.get("validate", False))
+        extra_info = _reward_extra_info(data_item)
+        _validate_visual_response(
+            response_visual,
+            self.config,
+            is_validate=data_item.meta_info.get("validate", False),
+            extra_info=extra_info,
+        )
         data_source = data_item.non_tensor_batch["data_source"]
         ground_truth = data_item.non_tensor_batch["reward_model"]["ground_truth"]
-        extra_info = _reward_extra_info(data_item)
 
         num_turns = data_item.non_tensor_batch.get("__num_turns__", None)
         rollout_reward_scores = data_item.non_tensor_batch.get("reward_scores", {})

--- a/verl_omni/reward_loop/reward_manager/visual.py
+++ b/verl_omni/reward_loop/reward_manager/visual.py
@@ -14,6 +14,7 @@
 
 import inspect
 
+import numpy as np
 import torch
 from verl import DataProto
 from verl.experimental.reward_loop.reward_manager.base import RewardManagerBase
@@ -34,6 +35,29 @@ def _validate_visual_response(response_visual, config, *, is_validate: bool) -> 
     elif not isinstance(response_visual, torch.Tensor) or response_visual.dtype != torch.uint8:
         dtype = getattr(response_visual, "dtype", type(response_visual))
         raise ValueError(f"Expected uint8 pixel responses for output_type={output_type!r}, got {dtype}.")
+
+
+def _reward_extra_info(data_item) -> dict:
+    """Project generated media from ordinary/TQ batches into scorer metadata."""
+    extra_info = data_item.non_tensor_batch.get("extra_info", {})
+    tool_extra_fields = data_item.non_tensor_batch.get("tool_extra_fields") or {}
+    extra_info.update(tool_extra_fields)
+    for key in ("audio", "audio_sample_rate", "media_kind"):
+        value = data_item.batch.get(key)
+        if value is None:
+            value = data_item.non_tensor_batch.get(key)
+        if value is None:
+            continue
+        tool_value = tool_extra_fields.get(key)
+        if tool_value is not None and tool_value is not value:
+            if isinstance(value, torch.Tensor) and isinstance(tool_value, torch.Tensor):
+                matches = value.device == tool_value.device and torch.equal(value, tool_value)
+            else:
+                matches = np.array_equal(value, tool_value)
+            if not matches:
+                raise ValueError(f"Conflicting rollout media field {key!r} in batch and tool_extra_fields")
+        extra_info[key] = value
+    return extra_info
 
 
 class VisualRewardManager(RewardManagerBase):
@@ -63,10 +87,7 @@ class VisualRewardManager(RewardManagerBase):
         _validate_visual_response(response_visual, self.config, is_validate=data_item.meta_info.get("validate", False))
         data_source = data_item.non_tensor_batch["data_source"]
         ground_truth = data_item.non_tensor_batch["reward_model"]["ground_truth"]
-        extra_info = data_item.non_tensor_batch.get("extra_info", {})
-        tool_extra_fields = data_item.non_tensor_batch.get("tool_extra_fields", None)
-        if tool_extra_fields is not None:
-            extra_info.update(tool_extra_fields.items())
+        extra_info = _reward_extra_info(data_item)
 
         num_turns = data_item.non_tensor_batch.get("__num_turns__", None)
         rollout_reward_scores = data_item.non_tensor_batch.get("reward_scores", {})

--- a/verl_omni/reward_loop/reward_manager/visual.py
+++ b/verl_omni/reward_loop/reward_manager/visual.py
@@ -20,6 +20,12 @@ from verl import DataProto
 from verl.experimental.reward_loop.reward_manager.base import RewardManagerBase
 from verl.utils.reward_score import default_compute_score as _upstream_default_compute_score
 
+from verl_omni.pipelines.rollout_artifacts import (
+    ARTIFACT_PREFIX,
+    ARTIFACT_SPECS,
+    PRIMARY_ARTIFACT,
+    artifacts_from_fields,
+)
 from verl_omni.utils.reward_score import default_compute_score_image
 
 
@@ -42,7 +48,9 @@ def _reward_extra_info(data_item) -> dict:
     extra_info = data_item.non_tensor_batch.get("extra_info", {})
     tool_extra_fields = data_item.non_tensor_batch.get("tool_extra_fields") or {}
     extra_info.update(tool_extra_fields)
-    for key in ("audio", "audio_sample_rate", "media_kind"):
+    media_keys = {"audio", "audio_sample_rate", "media_kind", ARTIFACT_SPECS, PRIMARY_ARTIFACT}
+    media_keys.update(key for key in data_item.batch.keys() if key.startswith(ARTIFACT_PREFIX))
+    for key in media_keys:
         value = data_item.batch.get(key)
         if value is None:
             value = data_item.non_tensor_batch.get(key)
@@ -57,6 +65,9 @@ def _reward_extra_info(data_item) -> dict:
             if not matches:
                 raise ValueError(f"Conflicting rollout media field {key!r} in batch and tool_extra_fields")
         extra_info[key] = value
+    artifacts = artifacts_from_fields(extra_info, context="reward entry")
+    if artifacts:
+        extra_info["media_artifacts"] = artifacts
     return extra_info
 
 

--- a/verl_omni/reward_loop/reward_manager/visual.py
+++ b/verl_omni/reward_loop/reward_manager/visual.py
@@ -14,13 +14,14 @@
 
 import inspect
 
-import numpy as np
 import torch
 from verl import DataProto
 from verl.experimental.reward_loop.reward_manager.base import RewardManagerBase
 from verl.utils.reward_score import default_compute_score as _upstream_default_compute_score
 
 from verl_omni.utils.reward_score import default_compute_score_image
+
+from .media import _reward_extra_info
 
 
 def _validate_visual_response(response_visual, config, *, is_validate: bool) -> None:
@@ -35,29 +36,6 @@ def _validate_visual_response(response_visual, config, *, is_validate: bool) -> 
     elif not isinstance(response_visual, torch.Tensor) or response_visual.dtype != torch.uint8:
         dtype = getattr(response_visual, "dtype", type(response_visual))
         raise ValueError(f"Expected uint8 pixel responses for output_type={output_type!r}, got {dtype}.")
-
-
-def _reward_extra_info(data_item) -> dict:
-    """Project generated media from ordinary/TQ batches into scorer metadata."""
-    extra_info = data_item.non_tensor_batch.get("extra_info", {})
-    tool_extra_fields = data_item.non_tensor_batch.get("tool_extra_fields") or {}
-    extra_info.update(tool_extra_fields)
-    for key in ("audio", "audio_sample_rate", "media_kind"):
-        value = data_item.batch.get(key)
-        if value is None:
-            value = data_item.non_tensor_batch.get(key)
-        if value is None:
-            continue
-        tool_value = tool_extra_fields.get(key)
-        if tool_value is not None and tool_value is not value:
-            if isinstance(value, torch.Tensor) and isinstance(tool_value, torch.Tensor):
-                matches = value.device == tool_value.device and torch.equal(value, tool_value)
-            else:
-                matches = np.array_equal(value, tool_value)
-            if not matches:
-                raise ValueError(f"Conflicting rollout media field {key!r} in batch and tool_extra_fields")
-        extra_info[key] = value
-    return extra_info
 
 
 class VisualRewardManager(RewardManagerBase):

--- a/verl_omni/trainer/config/_generated_diffusion_trainer.yaml
+++ b/verl_omni/trainer/config/_generated_diffusion_trainer.yaml
@@ -224,6 +224,7 @@ actor_rollout_ref:
         height: ${oc.select:actor_rollout_ref.rollout.pipeline.height,512}
         width: ${oc.select:actor_rollout_ref.rollout.pipeline.width,512}
         num_inference_steps: 50
+        requested_outputs: ${oc.select:actor_rollout_ref.rollout.pipeline.requested_outputs,null}
         true_cfg_scale: ${oc.select:actor_rollout_ref.rollout.pipeline.true_cfg_scale,1.0}
         max_sequence_length: ${oc.select:actor_rollout_ref.rollout.pipeline.max_sequence_length,512}
         guidance_scale: ${oc.select:actor_rollout_ref.rollout.pipeline.guidance_scale,null}
@@ -256,6 +257,7 @@ actor_rollout_ref:
       height: 512
       width: 512
       num_inference_steps: 10
+      requested_outputs: null
       true_cfg_scale: 1.0
       max_sequence_length: 512
       guidance_scale: null
@@ -331,6 +333,7 @@ actor_rollout_ref:
       height: ${oc.select:actor_rollout_ref.rollout.pipeline.height,512}
       width: ${oc.select:actor_rollout_ref.rollout.pipeline.width,512}
       num_inference_steps: ${oc.select:actor_rollout_ref.rollout.pipeline.num_inference_steps,10}
+      requested_outputs: ${oc.select:actor_rollout_ref.rollout.pipeline.requested_outputs,null}
       true_cfg_scale: ${oc.select:actor_rollout_ref.rollout.pipeline.true_cfg_scale,1.0}
       max_sequence_length: ${oc.select:actor_rollout_ref.rollout.pipeline.max_sequence_length,512}
       guidance_scale: ${oc.select:actor_rollout_ref.rollout.pipeline.guidance_scale,null}

--- a/verl_omni/trainer/config/_generated_diffusion_veomni_trainer.yaml
+++ b/verl_omni/trainer/config/_generated_diffusion_veomni_trainer.yaml
@@ -265,6 +265,7 @@ actor_rollout_ref:
         height: ${oc.select:actor_rollout_ref.rollout.pipeline.height,512}
         width: ${oc.select:actor_rollout_ref.rollout.pipeline.width,512}
         num_inference_steps: 50
+        requested_outputs: ${oc.select:actor_rollout_ref.rollout.pipeline.requested_outputs,null}
         true_cfg_scale: ${oc.select:actor_rollout_ref.rollout.pipeline.true_cfg_scale,1.0}
         max_sequence_length: ${oc.select:actor_rollout_ref.rollout.pipeline.max_sequence_length,512}
         guidance_scale: ${oc.select:actor_rollout_ref.rollout.pipeline.guidance_scale,null}
@@ -297,6 +298,7 @@ actor_rollout_ref:
       height: 512
       width: 512
       num_inference_steps: 10
+      requested_outputs: null
       true_cfg_scale: 1.0
       max_sequence_length: 512
       guidance_scale: null
@@ -372,6 +374,7 @@ actor_rollout_ref:
       height: ${oc.select:actor_rollout_ref.rollout.pipeline.height,512}
       width: ${oc.select:actor_rollout_ref.rollout.pipeline.width,512}
       num_inference_steps: ${oc.select:actor_rollout_ref.rollout.pipeline.num_inference_steps,10}
+      requested_outputs: ${oc.select:actor_rollout_ref.rollout.pipeline.requested_outputs,null}
       true_cfg_scale: ${oc.select:actor_rollout_ref.rollout.pipeline.true_cfg_scale,1.0}
       max_sequence_length: ${oc.select:actor_rollout_ref.rollout.pipeline.max_sequence_length,512}
       guidance_scale: ${oc.select:actor_rollout_ref.rollout.pipeline.guidance_scale,null}

--- a/verl_omni/trainer/config/diffusion/model/diffusion_model.yaml
+++ b/verl_omni/trainer/config/diffusion/model/diffusion_model.yaml
@@ -106,6 +106,9 @@ pipeline:
   # inference steps
   num_inference_steps: ${oc.select:actor_rollout_ref.rollout.pipeline.num_inference_steps,10}
 
+  # Additional named rollout artifacts required by rewards/logging
+  requested_outputs: ${oc.select:actor_rollout_ref.rollout.pipeline.requested_outputs,null}
+
   # Classifier-free guidance scale
   true_cfg_scale: ${oc.select:actor_rollout_ref.rollout.pipeline.true_cfg_scale,1.0}
 

--- a/verl_omni/trainer/config/diffusion/rollout/diffusion_rollout.yaml
+++ b/verl_omni/trainer/config/diffusion/rollout/diffusion_rollout.yaml
@@ -167,6 +167,9 @@ val_kwargs:
     # number of inference steps for diffusion model validation
     num_inference_steps: 50
 
+    # Additional named artifacts required during validation
+    requested_outputs: ${oc.select:actor_rollout_ref.rollout.pipeline.requested_outputs,null}
+
     # Classifier-free guidance scale (true CFG); values > 1.0 enable CFG with negative prompt
     true_cfg_scale: ${oc.select:actor_rollout_ref.rollout.pipeline.true_cfg_scale,1.0}
 
@@ -265,6 +268,9 @@ pipeline:
 
   # number of inference steps for diffusion model rollout
   num_inference_steps: 10
+
+  # Additional named artifacts required by rewards/logging (for example a decoded preview with latent primary)
+  requested_outputs: null
 
   # Classifier-free guidance scale (true CFG); values > 1.0 enable CFG with negative prompt
   true_cfg_scale: 1.0

--- a/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
+++ b/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
@@ -81,10 +81,29 @@ from verl_omni.trainer.diffusion.rollout_correction import (
     rollout_correction_enabled,
 )
 from verl_omni.trainer.diffusion.teacher_manager import DiffusionTeacherManager
-from verl_omni.utils.tracking import _export_video, batch_items, log_wandb_media, wrap_val_samples_for_wandb
+from verl_omni.utils.tracking import (
+    _export_video,
+    batch_items,
+    log_wandb_media,
+    resolve_is_video,
+    wrap_val_samples_for_wandb,
+)
 from verl_omni.workers.utils.padding import embeds_padding_2_no_padding
 
 sys_logger = logging.getLogger(__name__)
+
+
+def _json_encode_default(obj):
+    """Encode NumPy values retained in rollout metadata for JSONL dumps."""
+    if isinstance(obj, np.integer):
+        return int(obj)
+    if isinstance(obj, np.floating):
+        return float(obj)
+    if isinstance(obj, np.bool_):
+        return bool(obj)
+    if hasattr(obj, "tolist"):
+        return obj.tolist()
+    raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
 
 
 def validate_separate_config(config) -> None:
@@ -363,6 +382,7 @@ class BaseRayDiffusionTrainer(ABC):
         fps=24,
         audios=None,
         audio_sample_rates=None,
+        media_kind=None,
     ):
         """Dump samples to disk as media files plus a JSONL index.
 
@@ -387,9 +407,11 @@ class BaseRayDiffusionTrainer(ABC):
             # Per-sample batch dim from single-seq rollouts: [N, 1, T, C, H, W].
             outputs = outputs.squeeze(1)
         if outputs.ndim == 5 and outputs.shape[1] == 3 and outputs.shape[2] != 3:
-            # Channels-first [N, C, T, H, W] -> [N, T, C, H, W].
+            # Channels-first [N, C, T, H, W] -> [N, T, C, H, W]. Layout normalization
+            # is still heuristic; declaring/normalizing it is deferred to the layout PR.
             outputs = outputs.permute(0, 2, 1, 3, 4)
-        is_video = outputs.ndim == 5  # [N, T, C, H, W] vs image [N, C, H, W]
+        # Prefer the adapter-declared media kind over the tensor rank.
+        is_video = resolve_is_video(outputs.ndim, media_kind)
 
         output_paths = []
         output_fallback_paths = [None] * n
@@ -464,7 +486,7 @@ class BaseRayDiffusionTrainer(ABC):
         lines = []
         for i in range(n):
             entry = {k: v[i] for k, v in base_data.items()}
-            lines.append(json.dumps(entry, ensure_ascii=False))
+            lines.append(json.dumps(entry, ensure_ascii=False, default=_json_encode_default))
 
         with open(filename, "w", encoding="utf-8") as f:
             f.write("\n".join(lines) + "\n")
@@ -510,6 +532,28 @@ class BaseRayDiffusionTrainer(ABC):
                     "audio_sample_rate", batch.batch.get("audio_sample_rate")
                 )
 
+            # The primary media kind is declared per adapter and is uniform across a
+            # rollout batch (one pipeline); take the first declared value. Direct
+            # diffusion loops project it as a top-level non-tensor field, while
+            # composite loops may retain the tool-extra envelope.
+            media_kind_values = batch.non_tensor_batch.get("media_kind")
+            if media_kind_values is not None:
+                media_kind = next(
+                    (value for value in batch_items(media_kind_values, len(batch), "media_kind") if value is not None),
+                    None,
+                )
+            elif tool_extra is not None:
+                media_kind = next(
+                    (
+                        item.get("media_kind")
+                        for item in tool_extra
+                        if isinstance(item, dict) and item.get("media_kind")
+                    ),
+                    None,
+                )
+            else:
+                media_kind = None
+
             self._dump_generations(
                 inputs=inputs,
                 outputs=outputs,
@@ -521,10 +565,19 @@ class BaseRayDiffusionTrainer(ABC):
                 fps=int(self.config.trainer.get("video_fps", 24)),
                 audios=audios_to_dump,
                 audio_sample_rates=audio_rates_to_dump,
+                media_kind=media_kind,
             )
 
-    def _maybe_log_val_generations(self, inputs, outputs, scores, audios=None, audio_sample_rates=None):
-        """Log a table of validation samples to the configured logger (wandb or swanlab)"""
+    def _maybe_log_val_generations(
+        self,
+        inputs,
+        outputs,
+        scores,
+        audios=None,
+        audio_sample_rates=None,
+        media_kinds=None,
+    ):
+        """Log a table of validation samples to the configured logger (wandb or swanlab)."""
 
         generations_to_log = self.config.trainer.log_val_generations
 
@@ -537,7 +590,8 @@ class BaseRayDiffusionTrainer(ABC):
 
         audios = batch_items(audios, len(inputs), "audio")
         audio_sample_rates = batch_items(audio_sample_rates, len(inputs), "audio_sample_rate")
-        samples = list(zip(inputs, list(outputs), scores, audios, audio_sample_rates, strict=True))
+        media_kinds = batch_items(media_kinds, len(inputs), "media_kind")
+        samples = list(zip(inputs, list(outputs), scores, audios, audio_sample_rates, media_kinds, strict=True))
         samples.sort(key=lambda x: x[0])  # Sort by input text
 
         # Use fixed random seed for deterministic shuffling
@@ -557,10 +611,13 @@ class BaseRayDiffusionTrainer(ABC):
             if wandb_video_dir:
                 wandb_video_dir = os.path.join(wandb_video_dir, "wandb_val_media", f"global_step_{self.global_steps}")
             samples, video_tmp_dir, wandb_media = wrap_val_samples_for_wandb(
-                samples, fps=int(self.config.trainer.get("video_fps", 24)), output_dir=wandb_video_dir
+                samples,
+                fps=int(self.config.trainer.get("video_fps", 24)),
+                output_dir=wandb_video_dir,
+                media_kinds=[sample[5] for sample in samples],
             )
         else:
-            samples = [(input_, output, score) for input_, output, score, _, _ in samples]
+            samples = [(input_, output, score) for input_, output, score, *_ in samples]
 
         # Log to each configured logger
         try:
@@ -603,6 +660,7 @@ class BaseRayDiffusionTrainer(ABC):
         sample_outputs = []
         sample_audios = []
         sample_audio_sample_rates = []
+        sample_media_kinds = []
         sample_gts = []
         sample_scores = []
         sample_turns = []
@@ -668,6 +726,9 @@ class BaseRayDiffusionTrainer(ABC):
                     "audio_sample_rate",
                 )
             )
+            sample_media_kinds.extend(
+                batch_items(test_output_gen_batch.non_tensor_batch.get("media_kind"), batch_size, "media_kind")
+            )
 
             test_batch = test_batch.union(test_output_gen_batch)
             test_batch.meta_info["validate"] = True
@@ -706,6 +767,7 @@ class BaseRayDiffusionTrainer(ABC):
             scores=sample_scores,
             audios=sample_audios,
             audio_sample_rates=sample_audio_sample_rates,
+            media_kinds=sample_media_kinds,
         )
 
         # dump generations
@@ -722,6 +784,7 @@ class BaseRayDiffusionTrainer(ABC):
                 fps=int(self.config.trainer.get("video_fps", 24)),
                 audios=sample_audios,
                 audio_sample_rates=sample_audio_sample_rates,
+                media_kind=next((kind for kind in sample_media_kinds if kind is not None), None),
             )
 
         for key_info, lst in reward_extra_infos_dict.items():

--- a/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
+++ b/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
@@ -54,6 +54,7 @@ from verl.utils.py_functional import rename_dict
 from verl.utils.tracking import ValidationGenerationsLogger
 from verl.workers.rollout.llm_server import LLMServerManager
 
+from verl_omni.pipelines.rollout_artifacts import previews_from_batch, validate_previews
 from verl_omni.trainer.config import DiffusionAlgoConfig
 from verl_omni.trainer.diffusion.diffusion_algos import (
     DiffusionAdvantageEstimator,
@@ -383,6 +384,7 @@ class BaseRayDiffusionTrainer(ABC):
         audios=None,
         audio_sample_rates=None,
         media_kind=None,
+        previews=None,
     ):
         """Dump samples to disk as media files plus a JSONL index.
 
@@ -392,18 +394,25 @@ class BaseRayDiffusionTrainer(ABC):
         Failed video exports are preserved as ``{i}.pt`` fallback payloads when possible.
         Media failures are recorded in JSONL; filesystem failures warn and skip the dump.
         """
+        previews = validate_previews(previews, len(inputs))
+        if previews is not None:
+            retained = previews if max_samples is None else previews[:max_samples]
+            outputs = (
+                torch.stack([preview.data for preview in retained]) if retained else previews[0].data.unsqueeze(0)[:0]
+            )
+            media_kind = previews[0].spec.modality
         if not isinstance(outputs, torch.Tensor) or outputs.dtype != torch.uint8:
             dtype = getattr(outputs, "dtype", type(outputs))
             raise ValueError(f"Expected generation outputs to be a uint8 tensor, got {dtype}.")
 
         visual_folder = os.path.join(dump_path, f"{self.global_steps}")
 
-        n_full = outputs.shape[0]
+        n_full = len(previews) if previews is not None else outputs.shape[0]
         n = n_full if max_samples is None else min(max_samples, n_full)
-        if outputs.ndim == 6:
+        if previews is None and outputs.ndim == 6:
             # Per-sample batch dim from single-seq rollouts: [N, 1, T, C, H, W].
             outputs = outputs.squeeze(1)
-        if outputs.ndim == 5 and outputs.shape[1] == 3 and outputs.shape[2] != 3:
+        if previews is None and outputs.ndim == 5 and outputs.shape[1] == 3 and outputs.shape[2] != 3:
             # Channels-first [N, C, T, H, W] -> [N, T, C, H, W]. Layout normalization
             # is still heuristic; declaring/normalizing it is deferred to the layout PR.
             outputs = outputs.permute(0, 2, 1, 3, 4)
@@ -427,7 +436,7 @@ class BaseRayDiffusionTrainer(ABC):
                 video_path = os.path.join(visual_folder, f"{i}.mp4")
                 try:
                     _export_video(
-                        outputs[i],
+                        previews[i] if previews is not None else outputs[i],
                         video_path,
                         fps=fps,
                         audio=audios[i],
@@ -585,6 +594,7 @@ class BaseRayDiffusionTrainer(ABC):
                 audios=audios_to_dump,
                 audio_sample_rates=audio_rates_to_dump,
                 media_kind=media_kind,
+                previews=previews_from_batch(batch),
             )
 
     def _maybe_log_val_generations(
@@ -595,6 +605,7 @@ class BaseRayDiffusionTrainer(ABC):
         audios=None,
         audio_sample_rates=None,
         media_kinds=None,
+        previews=None,
     ):
         """Log a table of validation samples to the configured logger (wandb or swanlab)."""
 
@@ -607,6 +618,10 @@ class BaseRayDiffusionTrainer(ABC):
 
         import numpy as np
 
+        previews = validate_previews(previews, len(inputs))
+        if previews is not None:
+            outputs = previews
+            media_kinds = [preview.spec.modality for preview in previews]
         audios = batch_items(audios, len(inputs), "audio")
         audio_sample_rates = batch_items(audio_sample_rates, len(inputs), "audio_sample_rate")
         media_kinds = batch_items(media_kinds, len(inputs), "media_kind")
@@ -636,7 +651,10 @@ class BaseRayDiffusionTrainer(ABC):
                 media_kinds=[sample[5] for sample in samples],
             )
         else:
-            samples = [(input_, output, score) for input_, output, score, *_ in samples]
+            samples = [
+                (input_, output.data if previews is not None else output, score)
+                for input_, output, score, *_ in samples
+            ]
 
         # Log to each configured logger
         try:
@@ -686,6 +704,7 @@ class BaseRayDiffusionTrainer(ABC):
         sample_audios = []
         sample_audio_sample_rates = []
         sample_media_kinds = []
+        sample_previews = []
         sample_gts = []
         sample_scores = []
         sample_turns = []
@@ -742,6 +761,7 @@ class BaseRayDiffusionTrainer(ABC):
             # Store generated outputs
             output_images = test_output_gen_batch.batch["responses"]
             sample_outputs.append(output_images)
+            sample_previews.extend(previews_from_batch(test_output_gen_batch) or [None] * len(output_images))
             batch_size = len(output_images)
             sample_audios.extend(batch_items(test_output_gen_batch.batch.get("audio"), batch_size, "audio"))
             sample_audio_sample_rates.extend(
@@ -793,6 +813,7 @@ class BaseRayDiffusionTrainer(ABC):
             audios=sample_audios,
             audio_sample_rates=sample_audio_sample_rates,
             media_kinds=sample_media_kinds,
+            previews=sample_previews,
         )
 
         # dump generations
@@ -810,6 +831,7 @@ class BaseRayDiffusionTrainer(ABC):
                 audios=sample_audios,
                 audio_sample_rates=sample_audio_sample_rates,
                 media_kind=next((kind for kind in sample_media_kinds if kind is not None), None),
+                previews=sample_previews,
             )
 
         for key_info, lst in reward_extra_infos_dict.items():

--- a/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
+++ b/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
@@ -389,17 +389,14 @@ class BaseRayDiffusionTrainer(ABC):
         ``outputs`` is a batch of images ``[N, C, H, W]`` (-> ``{i}.jpg``) or videos
         ``[N, T, C, H, W]`` (-> ``{i}.mp4`` at ``fps``). ``max_samples`` caps how many
         are written (``None`` = all). Optional generated audio is muxed into video files.
-        Failed video exports are preserved as ``{i}.pt`` fallback payloads and recorded
-        in the JSONL instead of terminating training.
+        Failed video exports are preserved as ``{i}.pt`` fallback payloads when possible.
+        Media failures are recorded in JSONL; filesystem failures warn and skip the dump.
         """
         if not isinstance(outputs, torch.Tensor) or outputs.dtype != torch.uint8:
             dtype = getattr(outputs, "dtype", type(outputs))
             raise ValueError(f"Expected generation outputs to be a uint8 tensor, got {dtype}.")
 
-        os.makedirs(dump_path, exist_ok=True)
-
         visual_folder = os.path.join(dump_path, f"{self.global_steps}")
-        os.makedirs(visual_folder, exist_ok=True)
 
         n_full = outputs.shape[0]
         n = n_full if max_samples is None else min(max_samples, n_full)
@@ -413,9 +410,16 @@ class BaseRayDiffusionTrainer(ABC):
         # Prefer the adapter-declared media kind over the tensor rank.
         is_video = resolve_is_video(outputs.ndim, media_kind)
 
+        try:
+            os.makedirs(visual_folder, exist_ok=True)
+        except OSError as error:
+            sys_logger.warning("Skipping media dump at step %s: %s", self.global_steps, error)
+            return
+
         output_paths = []
         output_fallback_paths = [None] * n
         video_export_errors = [None] * n
+        image_export_errors = [None] * n
         if is_video:
             audios = batch_items(audios, n_full, "audio")
             audio_sample_rates = batch_items(audio_sample_rates, n_full, "audio_sample_rate")
@@ -463,8 +467,16 @@ class BaseRayDiffusionTrainer(ABC):
             images_pil = outputs[:n].cpu().permute(0, 2, 3, 1).numpy()
             for i, image in enumerate(images_pil):
                 image_path = os.path.join(visual_folder, f"{i}.jpg")
-                Image.fromarray(image).save(image_path)
-                output_paths.append(image_path)
+                try:
+                    Image.fromarray(image).save(image_path)
+                except (OSError, ValueError) as error:
+                    image_export_errors[i] = f"{type(error).__name__}: {error}"
+                    sys_logger.warning(
+                        "Failed to export rollout image at step %s sample %s: %s", self.global_steps, i, error
+                    )
+                    output_paths.append(None)
+                else:
+                    output_paths.append(image_path)
 
         filename = os.path.join(dump_path, f"{self.global_steps}.jsonl")
 
@@ -483,13 +495,20 @@ class BaseRayDiffusionTrainer(ABC):
             base_data["output_fallback"] = output_fallback_paths
             base_data["video_export_error"] = video_export_errors
 
-        lines = []
-        for i in range(n):
-            entry = {k: v[i] for k, v in base_data.items()}
-            lines.append(json.dumps(entry, ensure_ascii=False, default=_json_encode_default))
+        if any(image_export_errors):
+            base_data["image_export_error"] = image_export_errors
 
-        with open(filename, "w", encoding="utf-8") as f:
-            f.write("\n".join(lines) + "\n")
+        try:
+            lines = []
+            for i in range(n):
+                entry = {k: v[i] for k, v in base_data.items()}
+                lines.append(json.dumps(entry, ensure_ascii=False, default=_json_encode_default))
+
+            with open(filename, "w", encoding="utf-8") as f:
+                f.write("\n".join(lines) + "\n")
+        except (OSError, TypeError, ValueError) as error:
+            sys_logger.warning("Skipping media index at step %s (%s): %s", self.global_steps, filename, error)
+            return
 
         print(f"Dumped generations to {filename}")
 
@@ -621,8 +640,14 @@ class BaseRayDiffusionTrainer(ABC):
 
         # Log to each configured logger
         try:
-            log_wandb_media(wandb_media, self.global_steps)
-            self.validation_generations_logger.log(self.config.trainer.logger, samples, self.global_steps)
+            try:
+                log_wandb_media(wandb_media, self.global_steps)
+            except Exception as error:
+                sys_logger.warning("Skipping validation media log at step %s: %s", self.global_steps, error)
+            try:
+                self.validation_generations_logger.log(self.config.trainer.logger, samples, self.global_steps)
+            except Exception as error:
+                sys_logger.warning("Skipping validation table log at step %s: %s", self.global_steps, error)
         finally:
             if video_tmp_dir is not None:
                 shutil.rmtree(video_tmp_dir, ignore_errors=True)

--- a/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
+++ b/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
@@ -54,6 +54,7 @@ from verl.utils.py_functional import rename_dict
 from verl.utils.tracking import ValidationGenerationsLogger
 from verl.workers.rollout.llm_server import LLMServerManager
 
+from verl_omni.pipelines.rollout_media import resolve_batch_media_kind, resolve_is_video
 from verl_omni.trainer.config import DiffusionAlgoConfig
 from verl_omni.trainer.diffusion.diffusion_algos import (
     DiffusionAdvantageEstimator,
@@ -85,7 +86,6 @@ from verl_omni.utils.tracking import (
     _export_video,
     batch_items,
     log_wandb_media,
-    resolve_is_video,
     wrap_val_samples_for_wandb,
 )
 from verl_omni.workers.utils.padding import embeds_padding_2_no_padding
@@ -187,6 +187,146 @@ def compute_advantage(
     data.batch["advantages"] = advantages
     data.batch["returns"] = returns
     return data
+
+
+def _validate_generation_outputs(outputs) -> None:
+    """Reject non-pixel outputs before best-effort logging or async submission."""
+    if not isinstance(outputs, torch.Tensor) or outputs.dtype != torch.uint8:
+        dtype = getattr(outputs, "dtype", type(outputs))
+        raise ValueError(f"Expected generation outputs to be a uint8 tensor, got {dtype}.")
+
+
+def dump_generations(
+    global_steps,
+    inputs,
+    outputs,
+    gts,
+    scores,
+    reward_extra_infos_dict,
+    dump_path,
+    max_samples=None,
+    fps=24,
+    audios=None,
+    audio_sample_rates=None,
+    media_kind=None,
+):
+    """Dump samples to disk as media files plus a JSONL index.
+
+    ``outputs`` is a batch of images ``[N, C, H, W]`` (-> ``{i}.jpg``) or videos
+    ``[N, T, C, H, W]`` (-> ``{i}.mp4`` at ``fps``). ``max_samples`` caps how many
+    are written (``None`` = all). Optional generated audio is muxed into video files.
+    Failed video exports are preserved as ``{i}.pt`` fallback payloads when possible.
+    Media failures are recorded in JSONL; filesystem failures warn and skip the dump.
+    """
+    _validate_generation_outputs(outputs)
+    visual_folder = os.path.join(dump_path, f"{global_steps}")
+
+    n_full = outputs.shape[0]
+    n = n_full if max_samples is None else min(max_samples, n_full)
+    if outputs.ndim == 6:
+        # Per-sample batch dim from single-seq rollouts: [N, 1, T, C, H, W].
+        outputs = outputs.squeeze(1)
+    if outputs.ndim == 5 and outputs.shape[1] == 3 and outputs.shape[2] != 3:
+        # Channels-first [N, C, T, H, W] -> [N, T, C, H, W]. Layout normalization
+        # is still heuristic; declaring/normalizing it is deferred to the layout PR.
+        outputs = outputs.permute(0, 2, 1, 3, 4)
+    # Prefer the adapter-declared media kind over the tensor rank.
+    is_video = resolve_is_video(outputs.ndim, media_kind)
+
+    try:
+        os.makedirs(visual_folder, exist_ok=True)
+    except OSError as error:
+        sys_logger.warning("Skipping media dump at step %s: %s", global_steps, error)
+        return
+
+    output_paths = []
+    output_fallback_paths = [None] * n
+    video_export_errors = [None] * n
+    image_export_errors = [None] * n
+    if is_video:
+        audios = batch_items(audios, n_full, "audio")
+        audio_sample_rates = batch_items(audio_sample_rates, n_full, "audio_sample_rate")
+        for i in range(n):
+            video_path = os.path.join(visual_folder, f"{i}.mp4")
+            try:
+                _export_video(
+                    outputs[i],
+                    video_path,
+                    fps=fps,
+                    audio=audios[i],
+                    audio_sample_rate=audio_sample_rates[i],
+                )
+            except (OSError, subprocess.SubprocessError, ValueError) as error:
+                error_message = f"{type(error).__name__}: {error}"
+                fallback_path = os.path.join(visual_folder, f"{i}.pt")
+                fallback_audio = audios[i]
+                if isinstance(fallback_audio, torch.Tensor):
+                    fallback_audio = fallback_audio.detach().cpu()
+                fallback = {
+                    "video": outputs[i].detach().cpu(),
+                    "audio": fallback_audio,
+                    "audio_sample_rate": audio_sample_rates[i],
+                }
+                try:
+                    torch.save(fallback, fallback_path)
+                except Exception as fallback_error:
+                    fallback_path = None
+                    error_message = (
+                        f"{error_message}; fallback save failed: {type(fallback_error).__name__}: {fallback_error}"
+                    )
+                else:
+                    output_fallback_paths[i] = fallback_path
+                video_export_errors[i] = error_message
+                sys_logger.warning(
+                    "Failed to export rollout video at step %s sample %s: %s",
+                    global_steps,
+                    i,
+                    error_message,
+                )
+                output_paths.append(None)
+            else:
+                output_paths.append(video_path)
+    else:
+        images_pil = outputs[:n].cpu().permute(0, 2, 3, 1).numpy()
+        for i, image in enumerate(images_pil):
+            image_path = os.path.join(visual_folder, f"{i}.jpg")
+            try:
+                Image.fromarray(image).save(image_path)
+            except (OSError, ValueError) as error:
+                image_export_errors[i] = f"{type(error).__name__}: {error}"
+                sys_logger.warning("Failed to export rollout image at step %s sample %s: %s", global_steps, i, error)
+                output_paths.append(None)
+            else:
+                output_paths.append(image_path)
+
+    filename = os.path.join(dump_path, f"{global_steps}.jsonl")
+    base_data = {
+        "input": list(inputs)[:n],
+        "output": output_paths,
+        "gts": list(gts)[:n],
+        "score": list(scores)[:n],
+        "step": [global_steps] * n,
+    }
+    for k, v in reward_extra_infos_dict.items():
+        if len(v) == n_full:
+            base_data[k] = list(v)[:n]
+    if any(video_export_errors):
+        base_data["output_fallback"] = output_fallback_paths
+        base_data["video_export_error"] = video_export_errors
+    if any(image_export_errors):
+        base_data["image_export_error"] = image_export_errors
+
+    try:
+        lines = []
+        for i in range(n):
+            entry = {k: v[i] for k, v in base_data.items()}
+            lines.append(json.dumps(entry, ensure_ascii=False, default=_json_encode_default))
+        with open(filename, "w", encoding="utf-8") as f:
+            f.write("\n".join(lines) + "\n")
+    except (OSError, TypeError, ValueError) as error:
+        sys_logger.warning("Skipping media index at step %s (%s): %s", global_steps, filename, error)
+        return
+    print(f"Dumped generations to {filename}")
 
 
 class BaseRayDiffusionTrainer(ABC):
@@ -384,133 +524,21 @@ class BaseRayDiffusionTrainer(ABC):
         audio_sample_rates=None,
         media_kind=None,
     ):
-        """Dump samples to disk as media files plus a JSONL index.
-
-        ``outputs`` is a batch of images ``[N, C, H, W]`` (-> ``{i}.jpg``) or videos
-        ``[N, T, C, H, W]`` (-> ``{i}.mp4`` at ``fps``). ``max_samples`` caps how many
-        are written (``None`` = all). Optional generated audio is muxed into video files.
-        Failed video exports are preserved as ``{i}.pt`` fallback payloads when possible.
-        Media failures are recorded in JSONL; filesystem failures warn and skip the dump.
-        """
-        if not isinstance(outputs, torch.Tensor) or outputs.dtype != torch.uint8:
-            dtype = getattr(outputs, "dtype", type(outputs))
-            raise ValueError(f"Expected generation outputs to be a uint8 tensor, got {dtype}.")
-
-        visual_folder = os.path.join(dump_path, f"{self.global_steps}")
-
-        n_full = outputs.shape[0]
-        n = n_full if max_samples is None else min(max_samples, n_full)
-        if outputs.ndim == 6:
-            # Per-sample batch dim from single-seq rollouts: [N, 1, T, C, H, W].
-            outputs = outputs.squeeze(1)
-        if outputs.ndim == 5 and outputs.shape[1] == 3 and outputs.shape[2] != 3:
-            # Channels-first [N, C, T, H, W] -> [N, T, C, H, W]. Layout normalization
-            # is still heuristic; declaring/normalizing it is deferred to the layout PR.
-            outputs = outputs.permute(0, 2, 1, 3, 4)
-        # Prefer the adapter-declared media kind over the tensor rank.
-        is_video = resolve_is_video(outputs.ndim, media_kind)
-
-        try:
-            os.makedirs(visual_folder, exist_ok=True)
-        except OSError as error:
-            sys_logger.warning("Skipping media dump at step %s: %s", self.global_steps, error)
-            return
-
-        output_paths = []
-        output_fallback_paths = [None] * n
-        video_export_errors = [None] * n
-        image_export_errors = [None] * n
-        if is_video:
-            audios = batch_items(audios, n_full, "audio")
-            audio_sample_rates = batch_items(audio_sample_rates, n_full, "audio_sample_rate")
-            for i in range(n):
-                video_path = os.path.join(visual_folder, f"{i}.mp4")
-                try:
-                    _export_video(
-                        outputs[i],
-                        video_path,
-                        fps=fps,
-                        audio=audios[i],
-                        audio_sample_rate=audio_sample_rates[i],
-                    )
-                except (OSError, subprocess.SubprocessError, ValueError) as error:
-                    error_message = f"{type(error).__name__}: {error}"
-                    fallback_path = os.path.join(visual_folder, f"{i}.pt")
-                    fallback_audio = audios[i]
-                    if isinstance(fallback_audio, torch.Tensor):
-                        fallback_audio = fallback_audio.detach().cpu()
-                    fallback = {
-                        "video": outputs[i].detach().cpu(),
-                        "audio": fallback_audio,
-                        "audio_sample_rate": audio_sample_rates[i],
-                    }
-                    try:
-                        torch.save(fallback, fallback_path)
-                    except Exception as fallback_error:
-                        fallback_path = None
-                        error_message = (
-                            f"{error_message}; fallback save failed: {type(fallback_error).__name__}: {fallback_error}"
-                        )
-                    else:
-                        output_fallback_paths[i] = fallback_path
-                    video_export_errors[i] = error_message
-                    sys_logger.warning(
-                        "Failed to export rollout video at step %s sample %s: %s",
-                        self.global_steps,
-                        i,
-                        error_message,
-                    )
-                    output_paths.append(None)
-                else:
-                    output_paths.append(video_path)
-        else:
-            images_pil = outputs[:n].cpu().permute(0, 2, 3, 1).numpy()
-            for i, image in enumerate(images_pil):
-                image_path = os.path.join(visual_folder, f"{i}.jpg")
-                try:
-                    Image.fromarray(image).save(image_path)
-                except (OSError, ValueError) as error:
-                    image_export_errors[i] = f"{type(error).__name__}: {error}"
-                    sys_logger.warning(
-                        "Failed to export rollout image at step %s sample %s: %s", self.global_steps, i, error
-                    )
-                    output_paths.append(None)
-                else:
-                    output_paths.append(image_path)
-
-        filename = os.path.join(dump_path, f"{self.global_steps}.jsonl")
-
-        base_data = {
-            "input": list(inputs)[:n],
-            "output": output_paths,
-            "gts": list(gts)[:n],
-            "score": list(scores)[:n],
-            "step": [self.global_steps] * n,
-        }
-
-        for k, v in reward_extra_infos_dict.items():
-            if len(v) == n_full:
-                base_data[k] = list(v)[:n]
-        if any(video_export_errors):
-            base_data["output_fallback"] = output_fallback_paths
-            base_data["video_export_error"] = video_export_errors
-
-        if any(image_export_errors):
-            base_data["image_export_error"] = image_export_errors
-
-        try:
-            lines = []
-            for i in range(n):
-                entry = {k: v[i] for k, v in base_data.items()}
-                lines.append(json.dumps(entry, ensure_ascii=False, default=_json_encode_default))
-
-            with open(filename, "w", encoding="utf-8") as f:
-                f.write("\n".join(lines) + "\n")
-        except (OSError, TypeError, ValueError) as error:
-            sys_logger.warning("Skipping media index at step %s (%s): %s", self.global_steps, filename, error)
-            return
-
-        print(f"Dumped generations to {filename}")
+        """Dump media with the shared exporter at the current training step."""
+        return dump_generations(
+            self.global_steps,
+            inputs,
+            outputs,
+            gts,
+            scores,
+            reward_extra_infos_dict,
+            dump_path,
+            max_samples=max_samples,
+            fps=fps,
+            audios=audios,
+            audio_sample_rates=audio_sample_rates,
+            media_kind=media_kind,
+        )
 
     def _log_rollout_data(
         self, batch: DataProto, reward_extra_infos_dict: dict, timing_raw: dict, rollout_data_dir: str
@@ -551,27 +579,12 @@ class BaseRayDiffusionTrainer(ABC):
                     "audio_sample_rate", batch.batch.get("audio_sample_rate")
                 )
 
-            # The primary media kind is declared per adapter and is uniform across a
-            # rollout batch (one pipeline); take the first declared value. Direct
-            # diffusion loops project it as a top-level non-tensor field, while
-            # composite loops may retain the tool-extra envelope.
+            # One pipeline owns the batch; validate rather than silently choosing
+            # one sample's kind. Composite loops may retain the tool-extra envelope.
             media_kind_values = batch.non_tensor_batch.get("media_kind")
-            if media_kind_values is not None:
-                media_kind = next(
-                    (value for value in batch_items(media_kind_values, len(batch), "media_kind") if value is not None),
-                    None,
-                )
-            elif tool_extra is not None:
-                media_kind = next(
-                    (
-                        item.get("media_kind")
-                        for item in tool_extra
-                        if isinstance(item, dict) and item.get("media_kind")
-                    ),
-                    None,
-                )
-            else:
-                media_kind = None
+            if media_kind_values is None and tool_extra is not None:
+                media_kind_values = [item.get("media_kind") if isinstance(item, dict) else None for item in tool_extra]
+            media_kind = resolve_batch_media_kind(batch_items(media_kind_values, len(batch), "media_kind"))
 
             self._dump_generations(
                 inputs=inputs,
@@ -602,6 +615,7 @@ class BaseRayDiffusionTrainer(ABC):
 
         if generations_to_log == 0:
             return
+        _validate_generation_outputs(outputs)
 
         import shutil
 
@@ -610,6 +624,7 @@ class BaseRayDiffusionTrainer(ABC):
         audios = batch_items(audios, len(inputs), "audio")
         audio_sample_rates = batch_items(audio_sample_rates, len(inputs), "audio_sample_rate")
         media_kinds = batch_items(media_kinds, len(inputs), "media_kind")
+        resolve_batch_media_kind(media_kinds)
         samples = list(zip(inputs, list(outputs), scores, audios, audio_sample_rates, media_kinds, strict=True))
         samples.sort(key=lambda x: x[0])  # Sort by input text
 
@@ -809,7 +824,7 @@ class BaseRayDiffusionTrainer(ABC):
                 fps=int(self.config.trainer.get("video_fps", 24)),
                 audios=sample_audios,
                 audio_sample_rates=sample_audio_sample_rates,
-                media_kind=next((kind for kind in sample_media_kinds if kind is not None), None),
+                media_kind=resolve_batch_media_kind(sample_media_kinds),
             )
 
         for key_info, lst in reward_extra_infos_dict.items():

--- a/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
+++ b/verl_omni/trainer/diffusion/ray_diffusion_trainer.py
@@ -54,7 +54,12 @@ from verl.utils.py_functional import rename_dict
 from verl.utils.tracking import ValidationGenerationsLogger
 from verl.workers.rollout.llm_server import LLMServerManager
 
-from verl_omni.pipelines.rollout_artifacts import previews_from_batch, validate_previews
+from verl_omni.pipelines.rollout_artifacts import (
+    previews_from_batch,
+    validate_audio,
+    validate_previews,
+    validate_visual_batch,
+)
 from verl_omni.trainer.config import DiffusionAlgoConfig
 from verl_omni.trainer.diffusion.diffusion_algos import (
     DiffusionAdvantageEstimator,
@@ -380,7 +385,7 @@ class BaseRayDiffusionTrainer(ABC):
         reward_extra_infos_dict,
         dump_path,
         max_samples=None,
-        fps=24,
+        fps=None,
         audios=None,
         audio_sample_rates=None,
         media_kind=None,
@@ -395,6 +400,9 @@ class BaseRayDiffusionTrainer(ABC):
         Media failures are recorded in JSONL; filesystem failures warn and skip the dump.
         """
         previews = validate_previews(previews, len(inputs))
+        if previews == []:
+            sys_logger.warning("Skipping media dump: no decoded preview was requested")
+            return
         if previews is not None:
             retained = previews if max_samples is None else previews[:max_samples]
             outputs = (
@@ -409,15 +417,14 @@ class BaseRayDiffusionTrainer(ABC):
 
         n_full = len(previews) if previews is not None else outputs.shape[0]
         n = n_full if max_samples is None else min(max_samples, n_full)
-        if previews is None and outputs.ndim == 6:
-            # Per-sample batch dim from single-seq rollouts: [N, 1, T, C, H, W].
-            outputs = outputs.squeeze(1)
-        if previews is None and outputs.ndim == 5 and outputs.shape[1] == 3 and outputs.shape[2] != 3:
-            # Channels-first [N, C, T, H, W] -> [N, T, C, H, W]. Layout normalization
-            # is still heuristic; declaring/normalizing it is deferred to the layout PR.
-            outputs = outputs.permute(0, 2, 1, 3, 4)
-        # Prefer the adapter-declared media kind over the tensor rank.
         is_video = resolve_is_video(outputs.ndim, media_kind)
+        if previews is None:
+            validate_visual_batch(outputs, media_kind, fps=fps, context="media dump")
+        if is_video:
+            audios = batch_items(audios, n_full, "audio")
+            audio_sample_rates = batch_items(audio_sample_rates, n_full, "audio_sample_rate")
+            for i in range(n):
+                validate_audio(audios[i], audio_sample_rates[i], context=f"media dump sample={i}")
 
         try:
             os.makedirs(visual_folder, exist_ok=True)
@@ -430,8 +437,6 @@ class BaseRayDiffusionTrainer(ABC):
         video_export_errors = [None] * n
         image_export_errors = [None] * n
         if is_video:
-            audios = batch_items(audios, n_full, "audio")
-            audio_sample_rates = batch_items(audio_sample_rates, n_full, "audio_sample_rate")
             for i in range(n):
                 video_path = os.path.join(visual_folder, f"{i}.mp4")
                 try:
@@ -619,6 +624,8 @@ class BaseRayDiffusionTrainer(ABC):
         import numpy as np
 
         previews = validate_previews(previews, len(inputs))
+        if previews == []:
+            return
         if previews is not None:
             outputs = previews
             media_kinds = [preview.spec.modality for preview in previews]

--- a/verl_omni/trainer/diffusion/v1/tq_utils.py
+++ b/verl_omni/trainer/diffusion/v1/tq_utils.py
@@ -136,7 +136,7 @@ def diffusion_tq_batch_to_dataproto(
                 continue
             for k, v in extra.items():
                 if k not in non_tensor_batch:
-                    non_tensor_batch[k] = np.empty(len(extra_fields_arr), dtype=object)
+                    non_tensor_batch[k] = np.full(len(extra_fields_arr), None, dtype=object)
                 non_tensor_batch[k][i] = v
 
     batch = TensorDict(batch_dict, batch_size=len(keys))

--- a/verl_omni/trainer/diffusion/v1/trainer_base.py
+++ b/verl_omni/trainer/diffusion/v1/trainer_base.py
@@ -20,7 +20,6 @@ from abc import ABC, abstractmethod
 from collections import Counter, defaultdict
 from concurrent.futures import ThreadPoolExecutor
 from pprint import pprint
-from types import SimpleNamespace
 
 import numpy as np
 import ray
@@ -57,6 +56,7 @@ from verl.utils.skip import SkipManager
 from verl.utils.tracking import Tracking, ValidationGenerationsLogger
 from verl.workers.rollout.llm_server import LLMServerManager
 
+from verl_omni.pipelines.rollout_media import resolve_batch_media_kind, resolve_is_video
 from verl_omni.trainer.diffusion.diffusion_algos import get_diffusion_loss_fn
 from verl_omni.trainer.diffusion.diffusion_metric_utils import (
     compute_data_metrics_diffusion,
@@ -73,7 +73,9 @@ from verl_omni.trainer.diffusion.diffusion_trainer_utils import (
 from verl_omni.trainer.diffusion.ray_diffusion_trainer import (
     BaseRayDiffusionTrainer,
     _to_diffusion_worker_tensordict,
+    _validate_generation_outputs,
     compute_advantage,
+    dump_generations,
 )
 from verl_omni.trainer.diffusion.rollout_correction import (
     apply_bypass_mode_to_diffusion_batch,
@@ -87,7 +89,7 @@ from verl_omni.trainer.diffusion.v1.tq_utils import (
     put_dataproto_fields_to_tq,
     sort_diffusion_tq_keys,
 )
-from verl_omni.utils.tracking import batch_items, resolve_is_video
+from verl_omni.utils.tracking import batch_items
 from verl_omni.workers.engine_workers import ActorRolloutRefWorker, resolve_teacher_infer_micro_batch_size
 from verl_omni.workers.utils.padding import embeds_padding_2_no_padding
 
@@ -1382,7 +1384,7 @@ class PolicyGradientDiffusionTrainerV1(ABC):
                 fps=int(self.config.trainer.get("video_fps", 24)),
                 audios=sample_audios,
                 audio_sample_rates=sample_audio_sample_rates,
-                media_kind=next((kind for kind in sample_media_kinds if kind is not None), None),
+                media_kind=resolve_batch_media_kind(sample_media_kinds),
             )
 
         data_sources_arr = np.concatenate(data_sources, axis=0) if data_sources else np.array([])
@@ -1422,18 +1424,19 @@ class PolicyGradientDiffusionTrainerV1(ABC):
         audio_sample_rates=None,
         media_kind=None,
     ):
-        """Submit a best-effort image/video dump to the background executor."""
+        """Validate media synchronously, then submit best-effort I/O with a step snapshot."""
+        _validate_generation_outputs(outputs)
         resolve_is_video(outputs.ndim, media_kind)
         global_step = self.global_steps
         future = self._dump_executor.submit(
-            self._write_generations,
+            dump_generations,
+            global_step,
             inputs,
             outputs,
             gts,
             scores,
             reward_extra_infos_dict,
             dump_path,
-            global_step,
             max_samples,
             fps,
             audios,
@@ -1442,38 +1445,6 @@ class PolicyGradientDiffusionTrainerV1(ABC):
         )
         self._dump_futures.append((future, global_step))
         self._drain_dump_futures()
-
-    @staticmethod
-    def _write_generations(
-        inputs,
-        outputs,
-        gts,
-        scores,
-        reward_extra_infos_dict,
-        dump_path,
-        global_step,
-        max_samples,
-        fps,
-        audios,
-        audio_sample_rates,
-        media_kind,
-    ):
-        """Reuse the V0 media exporter with a step snapshot for thread safety."""
-        dump_context = SimpleNamespace(global_steps=global_step)
-        BaseRayDiffusionTrainer._dump_generations(
-            dump_context,
-            inputs,
-            outputs,
-            gts,
-            scores,
-            reward_extra_infos_dict,
-            dump_path,
-            max_samples=max_samples,
-            fps=fps,
-            audios=audios,
-            audio_sample_rates=audio_sample_rates,
-            media_kind=media_kind,
-        )
 
     def _log_rollout_data(self, batch_meta: KVBatchMeta, timing_raw: dict, rollout_data_dir: str):
         """Fetch rollout rows from TQ and dump sorted by uid."""
@@ -1522,7 +1493,7 @@ class PolicyGradientDiffusionTrainerV1(ABC):
                 fps=int(self.config.trainer.get("video_fps", 24)),
                 audios=audios,
                 audio_sample_rates=audio_sample_rates,
-                media_kind=next((kind for kind in media_kinds if kind is not None), None),
+                media_kind=resolve_batch_media_kind(media_kinds),
             )
 
     def _val_metrics_update(self, data_sources, sample_uids, reward_extra_infos_dict, sample_turns) -> dict:

--- a/verl_omni/trainer/diffusion/v1/trainer_base.py
+++ b/verl_omni/trainer/diffusion/v1/trainer_base.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
 import logging
 import math
 import os
@@ -21,13 +20,13 @@ from abc import ABC, abstractmethod
 from collections import Counter, defaultdict
 from concurrent.futures import ThreadPoolExecutor
 from pprint import pprint
+from types import SimpleNamespace
 
 import numpy as np
 import ray
 import torch
 import transfer_queue as tq
 from omegaconf import OmegaConf, open_dict
-from PIL import Image
 from torchdata.stateful_dataloader import StatefulDataLoader
 from tqdm import tqdm
 from transfer_queue import KVBatchMeta
@@ -71,7 +70,11 @@ from verl_omni.trainer.diffusion.diffusion_trainer_utils import (
     validate_distillation_config,
     worker_group_port_ranges,
 )
-from verl_omni.trainer.diffusion.ray_diffusion_trainer import _to_diffusion_worker_tensordict, compute_advantage
+from verl_omni.trainer.diffusion.ray_diffusion_trainer import (
+    BaseRayDiffusionTrainer,
+    _to_diffusion_worker_tensordict,
+    compute_advantage,
+)
 from verl_omni.trainer.diffusion.rollout_correction import (
     apply_bypass_mode_to_diffusion_batch,
     apply_rollout_correction_to_diffusion_batch,
@@ -84,6 +87,7 @@ from verl_omni.trainer.diffusion.v1.tq_utils import (
     put_dataproto_fields_to_tq,
     sort_diffusion_tq_keys,
 )
+from verl_omni.utils.tracking import batch_items
 from verl_omni.workers.engine_workers import ActorRolloutRefWorker, resolve_teacher_infer_micro_batch_size
 from verl_omni.workers.utils.padding import embeds_padding_2_no_padding
 
@@ -255,7 +259,8 @@ class PolicyGradientDiffusionTrainerV1(ABC):
             self._compute_metrics(batch, metrics, self.timing_raw, self.global_steps, current_epoch)
 
             rollout_data_dir = self.config.trainer.get("rollout_data_dir", None)
-            if rollout_data_dir:
+            rollout_data_save_freq = self.config.trainer.get("rollout_data_save_freq", 1)
+            if rollout_data_dir and rollout_data_save_freq > 0 and self.global_steps % rollout_data_save_freq == 0:
                 self._log_rollout_data(batch, self.timing_raw, rollout_data_dir)
 
             tq.kv_clear(keys=batch.keys, partition_id=batch.partition_id)
@@ -756,11 +761,33 @@ class PolicyGradientDiffusionTrainerV1(ABC):
         self._dump_executor = ThreadPoolExecutor(max_workers=1)
         self._dump_futures = []
 
+    @staticmethod
+    def _report_dump_failure(future, global_step: int) -> None:
+        """Log a completed media-dump failure without interrupting training."""
+        try:
+            future.result()
+        except Exception as error:
+            logger.warning(
+                "Ignoring background media dump failure at step %s: %s",
+                global_step,
+                error,
+                exc_info=(type(error), error, error.__traceback__),
+            )
+
+    def _drain_dump_futures(self) -> None:
+        still_pending = []
+        for future, global_step in self._dump_futures:
+            if future.done():
+                self._report_dump_failure(future, global_step)
+            else:
+                still_pending.append((future, global_step))
+        self._dump_futures = still_pending
+
     def _shutdown_dump_executor(self):
-        for f in self._dump_futures:
-            f.result()
-        self._dump_futures.clear()
         self._dump_executor.shutdown(wait=True)
+        for future, global_step in self._dump_futures:
+            self._report_dump_failure(future, global_step)
+        self._dump_futures.clear()
 
     def _shutdown_dataloaders(self):
         for attr in ("train_dataloader", "val_dataloader"):
@@ -1230,9 +1257,12 @@ class PolicyGradientDiffusionTrainerV1(ABC):
         return DataProto.from_single_dict(data={}, meta_info={"metrics": actor_output})
 
     def _validate(self) -> dict:
-        """Validation via TransferQueue: dispatch, sample, convert, reward, dump images."""
+        """Validation via TransferQueue: dispatch, sample, convert, reward, dump media."""
         sample_inputs: list[str] = []
         sample_outputs: list[torch.Tensor] = []
+        sample_audios: list = []
+        sample_audio_sample_rates: list = []
+        sample_media_kinds: list = []
         sample_gts: list = []
         sample_scores: list[float] = []
         sample_turns: list = []
@@ -1286,7 +1316,7 @@ class PolicyGradientDiffusionTrainerV1(ABC):
                 else 0
             )
             logger.info(
-                "Validation batch (step=%d): %d trajectories, responses shape=%s, real_images=%s",
+                "Validation batch (step=%d): %d trajectories, responses shape=%s, real_media=%s",
                 self.global_steps,
                 len(data),
                 tuple(output_images.shape) if isinstance(output_images, torch.Tensor) else None,
@@ -1294,6 +1324,16 @@ class PolicyGradientDiffusionTrainerV1(ABC):
             )
             sample_inputs.extend(input_texts)
             sample_outputs.append(output_images)
+            batch_size = len(output_images)
+            sample_audios.extend(batch_items(data.batch.get("audio"), batch_size, "audio"))
+            sample_audio_sample_rates.extend(
+                batch_items(
+                    data.non_tensor_batch.get("audio_sample_rate", data.batch.get("audio_sample_rate")),
+                    batch_size,
+                    "audio_sample_rate",
+                )
+            )
+            sample_media_kinds.extend(batch_items(data.non_tensor_batch.get("media_kind"), batch_size, "media_kind"))
             uids = data.non_tensor_batch.get("uid")
             sample_uids.extend(list(uids) if uids is not None else [None] * len(data))
 
@@ -1320,7 +1360,14 @@ class PolicyGradientDiffusionTrainerV1(ABC):
             tq.kv_clear(keys=batch_meta.keys, partition_id=batch_meta.partition_id)
 
         sample_outputs = torch.cat(sample_outputs, dim=0) if sample_outputs else torch.empty(0)
-        self._maybe_log_val_generations(inputs=sample_inputs, outputs=sample_outputs, scores=sample_scores)
+        self._maybe_log_val_generations(
+            inputs=sample_inputs,
+            outputs=sample_outputs,
+            scores=sample_scores,
+            audios=sample_audios,
+            audio_sample_rates=sample_audio_sample_rates,
+            media_kinds=sample_media_kinds,
+        )
 
         val_data_dir = self.config.trainer.get("validation_data_dir", None)
         if val_data_dir and len(sample_outputs) > 0:
@@ -1331,35 +1378,52 @@ class PolicyGradientDiffusionTrainerV1(ABC):
                 scores=sample_scores,
                 reward_extra_infos_dict=reward_extra_infos_dict,
                 dump_path=val_data_dir,
+                max_samples=self.config.trainer.get("validation_data_max_samples", None),
+                fps=int(self.config.trainer.get("video_fps", 24)),
+                audios=sample_audios,
+                audio_sample_rates=sample_audio_sample_rates,
+                media_kind=next((kind for kind in sample_media_kinds if kind is not None), None),
             )
 
         data_sources_arr = np.concatenate(data_sources, axis=0) if data_sources else np.array([])
         return self._val_metrics_update(data_sources_arr, sample_uids, reward_extra_infos_dict, sample_turns)
 
-    def _maybe_log_val_generations(self, inputs, outputs, scores):
-        generations_to_log = self.config.trainer.log_val_generations
-        if generations_to_log == 0:
-            return
-        if "wandb" in self.config.trainer.logger:
-            for image in outputs:
-                if not isinstance(image, torch.Tensor) or image.dtype != torch.uint8:
-                    raise ValueError(f"Expected a uint8 image tensor, got {getattr(image, 'dtype', type(image))}.")
-            import wandb
+    def _maybe_log_val_generations(
+        self,
+        inputs,
+        outputs,
+        scores,
+        audios=None,
+        audio_sample_rates=None,
+        media_kinds=None,
+    ):
+        """Use the shared image/video W&B path with declared media metadata."""
+        return BaseRayDiffusionTrainer._maybe_log_val_generations(
+            self,
+            inputs,
+            outputs,
+            scores,
+            audios=audios,
+            audio_sample_rates=audio_sample_rates,
+            media_kinds=media_kinds,
+        )
 
-            outputs = [wandb.Image(image, file_type="jpg") for image in outputs]
-        samples = list(zip(inputs, outputs, scores, strict=True))
-        samples.sort(key=lambda x: x[0])
-        rng = np.random.RandomState(42)
-        rng.shuffle(samples)
-        samples = samples[:generations_to_log]
-        self.validation_generations_logger.log(self.config.trainer.logger, samples, self.global_steps)
-
-    def _dump_generations(self, inputs, outputs, gts, scores, reward_extra_infos_dict, dump_path):
-        """Dump validation/rollout samples as images + JSONL (runs in background)."""
-        if not isinstance(outputs, torch.Tensor) or outputs.dtype != torch.uint8:
-            dtype = getattr(outputs, "dtype", type(outputs))
-            raise ValueError(f"Expected generation outputs to be a uint8 tensor, got {dtype}.")
-
+    def _dump_generations(
+        self,
+        inputs,
+        outputs,
+        gts,
+        scores,
+        reward_extra_infos_dict,
+        dump_path,
+        max_samples=None,
+        fps=24,
+        audios=None,
+        audio_sample_rates=None,
+        media_kind=None,
+    ):
+        """Submit a best-effort image/video dump to the background executor."""
+        global_step = self.global_steps
         future = self._dump_executor.submit(
             self._write_generations,
             inputs,
@@ -1368,64 +1432,47 @@ class PolicyGradientDiffusionTrainerV1(ABC):
             scores,
             reward_extra_infos_dict,
             dump_path,
-            self.global_steps,
+            global_step,
+            max_samples,
+            fps,
+            audios,
+            audio_sample_rates,
+            media_kind,
         )
-        self._dump_futures.append(future)
-        still_pending = []
-        for f in self._dump_futures:
-            if f.done():
-                f.result()
-            else:
-                still_pending.append(f)
-        self._dump_futures = still_pending
+        self._dump_futures.append((future, global_step))
+        self._drain_dump_futures()
 
     @staticmethod
-    def _write_generations(inputs, outputs, gts, scores, reward_extra_infos_dict, dump_path, global_steps):
-        os.makedirs(dump_path, exist_ok=True)
-        visual_folder = os.path.join(dump_path, f"{global_steps}")
-        os.makedirs(visual_folder, exist_ok=True)
-
-        output_paths = []
-        images_pil = outputs.cpu()
-        # images: [N, C, H, W] -> [N, H, W, C]
-        if images_pil.dim() == 4:
-            images_pil = images_pil.permute(0, 2, 3, 1).numpy()
-        else:
-            images_pil = images_pil.numpy()
-        for i, image in enumerate(images_pil):
-            image_path = os.path.join(visual_folder, f"{i}.jpg")
-            Image.fromarray(image).save(image_path)
-            output_paths.append(image_path)
-
-        filename = os.path.join(dump_path, f"{global_steps}.jsonl")
-        n = len(inputs)
-        base_data = {
-            "input": inputs,
-            "output": output_paths,
-            "gts": gts,
-            "score": scores,
-            "step": [global_steps] * n,
-        }
-        for k, v in reward_extra_infos_dict.items():
-            if len(v) == n:
-                base_data[k] = v
-
-        def json_encode_default(obj):
-            if isinstance(obj, np.integer):
-                return int(obj)
-            if isinstance(obj, np.floating):
-                return float(obj)
-            if isinstance(obj, np.bool_):
-                return bool(obj)
-            if hasattr(obj, "tolist"):
-                return obj.tolist()
-            raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
-
-        with open(filename, "w") as f:
-            for i in range(n):
-                entry = {k: v[i] for k, v in base_data.items()}
-                f.write(json.dumps(entry, ensure_ascii=False, default=json_encode_default) + "\n")
-        print(f"Dumped diffusion generations to {filename}")
+    def _write_generations(
+        inputs,
+        outputs,
+        gts,
+        scores,
+        reward_extra_infos_dict,
+        dump_path,
+        global_step,
+        max_samples,
+        fps,
+        audios,
+        audio_sample_rates,
+        media_kind,
+    ):
+        """Reuse the V0 media exporter with a step snapshot for thread safety."""
+        dump_context = SimpleNamespace(global_steps=global_step)
+        BaseRayDiffusionTrainer._dump_generations(
+            dump_context,
+            inputs,
+            outputs,
+            gts,
+            scores,
+            reward_extra_infos_dict,
+            dump_path,
+            max_samples=max_samples,
+            fps=fps,
+            audios=audios,
+            audio_sample_rates=audio_sample_rates,
+            media_kind=media_kind,
+        )
 
     def _log_rollout_data(self, batch_meta: KVBatchMeta, timing_raw: dict, rollout_data_dir: str):
         """Fetch rollout rows from TQ and dump sorted by uid."""
@@ -1446,12 +1493,22 @@ class PolicyGradientDiffusionTrainerV1(ABC):
                 if rm_meta is not None
                 else [None] * len(data)
             )
+            audios = batch_items(data.batch.get("audio"), len(data), "audio")
+            audio_sample_rates = batch_items(
+                data.non_tensor_batch.get("audio_sample_rate", data.batch.get("audio_sample_rate")),
+                len(data),
+                "audio_sample_rate",
+            )
+            media_kinds = batch_items(data.non_tensor_batch.get("media_kind"), len(data), "media_kind")
 
             sort_idx = sort_diffusion_tq_keys(list(batch_meta.keys))
             inputs = [inputs[i] for i in sort_idx]
             outputs = outputs[torch.tensor(sort_idx)]
             gts = [gts[i] for i in sort_idx]
             scores = [scores[i] for i in sort_idx]
+            audios = [audios[i] for i in sort_idx]
+            audio_sample_rates = [audio_sample_rates[i] for i in sort_idx]
+            media_kinds = [media_kinds[i] for i in sort_idx]
             reward_extra_infos_dict = {"uid": [batch_meta.keys[i] for i in sort_idx]}
             self._dump_generations(
                 inputs=inputs,
@@ -1460,6 +1517,11 @@ class PolicyGradientDiffusionTrainerV1(ABC):
                 scores=scores,
                 reward_extra_infos_dict=reward_extra_infos_dict,
                 dump_path=rollout_data_dir,
+                max_samples=self.config.trainer.get("rollout_data_max_samples", None),
+                fps=int(self.config.trainer.get("video_fps", 24)),
+                audios=audios,
+                audio_sample_rates=audio_sample_rates,
+                media_kind=next((kind for kind in media_kinds if kind is not None), None),
             )
 
     def _val_metrics_update(self, data_sources, sample_uids, reward_extra_infos_dict, sample_turns) -> dict:

--- a/verl_omni/trainer/diffusion/v1/trainer_base.py
+++ b/verl_omni/trainer/diffusion/v1/trainer_base.py
@@ -87,7 +87,7 @@ from verl_omni.trainer.diffusion.v1.tq_utils import (
     put_dataproto_fields_to_tq,
     sort_diffusion_tq_keys,
 )
-from verl_omni.utils.tracking import batch_items
+from verl_omni.utils.tracking import batch_items, resolve_is_video
 from verl_omni.workers.engine_workers import ActorRolloutRefWorker, resolve_teacher_infer_micro_batch_size
 from verl_omni.workers.utils.padding import embeds_padding_2_no_padding
 
@@ -1423,6 +1423,7 @@ class PolicyGradientDiffusionTrainerV1(ABC):
         media_kind=None,
     ):
         """Submit a best-effort image/video dump to the background executor."""
+        resolve_is_video(outputs.ndim, media_kind)
         global_step = self.global_steps
         future = self._dump_executor.submit(
             self._write_generations,

--- a/verl_omni/trainer/diffusion/v1/trainer_base.py
+++ b/verl_omni/trainer/diffusion/v1/trainer_base.py
@@ -57,6 +57,7 @@ from verl.utils.skip import SkipManager
 from verl.utils.tracking import Tracking, ValidationGenerationsLogger
 from verl.workers.rollout.llm_server import LLMServerManager
 
+from verl_omni.pipelines.rollout_artifacts import previews_from_batch, validate_previews
 from verl_omni.trainer.diffusion.diffusion_algos import get_diffusion_loss_fn
 from verl_omni.trainer.diffusion.diffusion_metric_utils import (
     compute_data_metrics_diffusion,
@@ -1263,6 +1264,7 @@ class PolicyGradientDiffusionTrainerV1(ABC):
         sample_audios: list = []
         sample_audio_sample_rates: list = []
         sample_media_kinds: list = []
+        sample_previews: list = []
         sample_gts: list = []
         sample_scores: list[float] = []
         sample_turns: list = []
@@ -1324,6 +1326,7 @@ class PolicyGradientDiffusionTrainerV1(ABC):
             )
             sample_inputs.extend(input_texts)
             sample_outputs.append(output_images)
+            sample_previews.extend(previews_from_batch(data) or [None] * len(output_images))
             batch_size = len(output_images)
             sample_audios.extend(batch_items(data.batch.get("audio"), batch_size, "audio"))
             sample_audio_sample_rates.extend(
@@ -1367,6 +1370,7 @@ class PolicyGradientDiffusionTrainerV1(ABC):
             audios=sample_audios,
             audio_sample_rates=sample_audio_sample_rates,
             media_kinds=sample_media_kinds,
+            previews=sample_previews,
         )
 
         val_data_dir = self.config.trainer.get("validation_data_dir", None)
@@ -1383,6 +1387,7 @@ class PolicyGradientDiffusionTrainerV1(ABC):
                 audios=sample_audios,
                 audio_sample_rates=sample_audio_sample_rates,
                 media_kind=next((kind for kind in sample_media_kinds if kind is not None), None),
+                previews=sample_previews,
             )
 
         data_sources_arr = np.concatenate(data_sources, axis=0) if data_sources else np.array([])
@@ -1396,6 +1401,7 @@ class PolicyGradientDiffusionTrainerV1(ABC):
         audios=None,
         audio_sample_rates=None,
         media_kinds=None,
+        previews=None,
     ):
         """Use the shared image/video W&B path with declared media metadata."""
         return BaseRayDiffusionTrainer._maybe_log_val_generations(
@@ -1406,6 +1412,7 @@ class PolicyGradientDiffusionTrainerV1(ABC):
             audios=audios,
             audio_sample_rates=audio_sample_rates,
             media_kinds=media_kinds,
+            previews=previews,
         )
 
     def _dump_generations(
@@ -1421,8 +1428,10 @@ class PolicyGradientDiffusionTrainerV1(ABC):
         audios=None,
         audio_sample_rates=None,
         media_kind=None,
+        previews=None,
     ):
         """Submit a best-effort image/video dump to the background executor."""
+        previews = validate_previews(previews, len(inputs))
         resolve_is_video(outputs.ndim, media_kind)
         global_step = self.global_steps
         future = self._dump_executor.submit(
@@ -1439,6 +1448,7 @@ class PolicyGradientDiffusionTrainerV1(ABC):
             audios,
             audio_sample_rates,
             media_kind,
+            previews,
         )
         self._dump_futures.append((future, global_step))
         self._drain_dump_futures()
@@ -1457,6 +1467,7 @@ class PolicyGradientDiffusionTrainerV1(ABC):
         audios,
         audio_sample_rates,
         media_kind,
+        previews=None,
     ):
         """Reuse the V0 media exporter with a step snapshot for thread safety."""
         dump_context = SimpleNamespace(global_steps=global_step)
@@ -1473,6 +1484,7 @@ class PolicyGradientDiffusionTrainerV1(ABC):
             audios=audios,
             audio_sample_rates=audio_sample_rates,
             media_kind=media_kind,
+            previews=previews,
         )
 
     def _log_rollout_data(self, batch_meta: KVBatchMeta, timing_raw: dict, rollout_data_dir: str):
@@ -1502,7 +1514,10 @@ class PolicyGradientDiffusionTrainerV1(ABC):
             )
             media_kinds = batch_items(data.non_tensor_batch.get("media_kind"), len(data), "media_kind")
 
+            previews = previews_from_batch(data)
             sort_idx = sort_diffusion_tq_keys(list(batch_meta.keys))
+            if previews is not None:
+                previews = [previews[i] for i in sort_idx]
             inputs = [inputs[i] for i in sort_idx]
             outputs = outputs[torch.tensor(sort_idx)]
             gts = [gts[i] for i in sort_idx]
@@ -1523,6 +1538,7 @@ class PolicyGradientDiffusionTrainerV1(ABC):
                 audios=audios,
                 audio_sample_rates=audio_sample_rates,
                 media_kind=next((kind for kind in media_kinds if kind is not None), None),
+                previews=previews,
             )
 
     def _val_metrics_update(self, data_sources, sample_uids, reward_extra_infos_dict, sample_turns) -> dict:

--- a/verl_omni/trainer/diffusion/v1/trainer_base.py
+++ b/verl_omni/trainer/diffusion/v1/trainer_base.py
@@ -19,6 +19,7 @@ import uuid
 from abc import ABC, abstractmethod
 from collections import Counter, defaultdict
 from concurrent.futures import ThreadPoolExecutor
+from dataclasses import replace
 from pprint import pprint
 from types import SimpleNamespace
 
@@ -57,7 +58,12 @@ from verl.utils.skip import SkipManager
 from verl.utils.tracking import Tracking, ValidationGenerationsLogger
 from verl.workers.rollout.llm_server import LLMServerManager
 
-from verl_omni.pipelines.rollout_artifacts import previews_from_batch, validate_previews
+from verl_omni.pipelines.rollout_artifacts import (
+    previews_from_batch,
+    validate_audio,
+    validate_previews,
+    validate_visual_batch,
+)
 from verl_omni.trainer.diffusion.diffusion_algos import get_diffusion_loss_fn
 from verl_omni.trainer.diffusion.diffusion_metric_utils import (
     compute_data_metrics_diffusion,
@@ -1424,7 +1430,7 @@ class PolicyGradientDiffusionTrainerV1(ABC):
         reward_extra_infos_dict,
         dump_path,
         max_samples=None,
-        fps=24,
+        fps=None,
         audios=None,
         audio_sample_rates=None,
         media_kind=None,
@@ -1432,14 +1438,49 @@ class PolicyGradientDiffusionTrainerV1(ABC):
     ):
         """Submit a best-effort image/video dump to the background executor."""
         previews = validate_previews(previews, len(inputs))
-        resolve_is_video(outputs.ndim, media_kind)
+        if previews == []:
+            return
+        if previews is None:
+            is_video = resolve_is_video(outputs.ndim, media_kind)
+            validate_visual_batch(outputs, media_kind, fps=fps, context="V1 media dump")
+        else:
+            is_video = previews[0].spec.modality == "video"
+        if is_video:
+            audio_rows = batch_items(audios, len(inputs), "audio")
+            rates = batch_items(audio_sample_rates, len(inputs), "audio_sample_rate")
+            for i, (audio, rate) in enumerate(zip(audio_rows, rates, strict=True)):
+                validate_audio(audio, rate, context=f"V1 media dump sample={i}")
         global_step = self.global_steps
+        self._drain_dump_futures()
+        if self._dump_futures:
+            logger.warning("Skipping media dump at step %s: previous dump is still running", global_step)
+            return
+        count = len(inputs)
+        retained = count if max_samples is None else min(max_samples, count)
+        if retained == 0:
+            return
+        # A row view retains the whole batch storage. Copy only retained previews,
+        # and never queue the unused primary latent/training tensors alongside them.
+        if previews is not None:
+            previews = [replace(item, data=item.data.detach().to("cpu", copy=True)) for item in previews[:retained]]
+            outputs = None
+        else:
+            outputs = outputs[:retained].detach().to("cpu", copy=True)
+        if is_video:
+            audios = [
+                None if audio is None else torch.as_tensor(audio).detach().to("cpu", copy=True)
+                for audio in audio_rows[:retained]
+            ]
+            audio_sample_rates = rates[:retained]
+        reward_extra_infos_dict = {
+            key: value[:retained] if len(value) == count else value for key, value in reward_extra_infos_dict.items()
+        }
         future = self._dump_executor.submit(
             self._write_generations,
-            inputs,
+            inputs[:retained],
             outputs,
-            gts,
-            scores,
+            gts[:retained],
+            scores[:retained],
             reward_extra_infos_dict,
             dump_path,
             global_step,

--- a/verl_omni/utils/reward_score/__init__.py
+++ b/verl_omni/utils/reward_score/__init__.py
@@ -42,7 +42,7 @@ def default_compute_score_image(
     if data_source == "jpeg_compressibility":
         from verl_omni.utils.reward_score import jpeg_compressibility
 
-        res = jpeg_compressibility.compute_score(solution_image)
+        res = jpeg_compressibility.compute_score(solution_image, extra_info=extra_info)
     else:
         raise NotImplementedError(f"Reward function is not implemented for {data_source=}")
 

--- a/verl_omni/utils/reward_score/clap.py
+++ b/verl_omni/utils/reward_score/clap.py
@@ -53,31 +53,14 @@ def _get_batching_state() -> _BatchingState:
 
 
 def _get_audio(extra_info: dict) -> tuple[torch.Tensor, int]:
-    if "media_artifacts" in extra_info:
-        from verl_omni.pipelines.rollout_artifacts import select_artifact
+    from verl_omni.pipelines.rollout_artifacts import ArtifactContractError, select_artifact
 
-        artifact = select_artifact(
-            extra_info["media_artifacts"], name="audio", modality="audio", representation="decoded"
-        )
-        artifact = artifact.normalized(context="CLAP", name="audio")
-        return artifact.data.detach().float().cpu().mean(dim=0), artifact.spec.sample_rate
-    audio = extra_info.get("audio")
-    if audio is None:
-        raise KeyError("CLAP reward requires decoded audio in extra_info['audio'].")
-    audio = torch.as_tensor(audio).detach().float().cpu()
-    while audio.ndim > 2 and audio.shape[0] == 1:
-        audio = audio[0]
-    if audio.ndim == 2:
-        audio = audio.mean(dim=0)
-    elif audio.ndim != 1:
-        raise ValueError(f"Expected audio shape (T,) or (C,T), got {tuple(audio.shape)}.")
-
-    sample_rate = extra_info.get("audio_sample_rate", _CLAP_SAMPLE_RATE)
-    if isinstance(sample_rate, torch.Tensor):
-        sample_rate = sample_rate.item()
-    if sample_rate is None:
-        raise KeyError("CLAP reward requires extra_info['audio_sample_rate'].")
-    return audio, int(sample_rate)
+    artifact = select_artifact(
+        extra_info.get("media_artifacts", {}), name="audio", modality="audio", representation="decoded"
+    )
+    if artifact.spec.layout != "CT":
+        raise ArtifactContractError(f"CLAP requires canonical CT audio, got {artifact.spec.layout}")
+    return artifact.data.detach().float().cpu().mean(dim=0), artifact.spec.sample_rate
 
 
 def _load_clap(model_name_or_path: str, device: str):

--- a/verl_omni/utils/reward_score/clap.py
+++ b/verl_omni/utils/reward_score/clap.py
@@ -53,6 +53,14 @@ def _get_batching_state() -> _BatchingState:
 
 
 def _get_audio(extra_info: dict) -> tuple[torch.Tensor, int]:
+    if "media_artifacts" in extra_info:
+        from verl_omni.pipelines.rollout_artifacts import select_artifact
+
+        artifact = select_artifact(
+            extra_info["media_artifacts"], name="audio", modality="audio", representation="decoded"
+        )
+        artifact = artifact.normalized(context="CLAP", name="audio")
+        return artifact.data.detach().float().cpu().mean(dim=0), artifact.spec.sample_rate
     audio = extra_info.get("audio")
     if audio is None:
         raise KeyError("CLAP reward requires decoded audio in extra_info['audio'].")

--- a/verl_omni/utils/reward_score/genrm_ocr.py
+++ b/verl_omni/utils/reward_score/genrm_ocr.py
@@ -126,42 +126,9 @@ async def compute_score_ocr(
     """
     from verl.utils.ray_utils import get_event_loop
 
-    from verl_omni.utils.reward_score.reward_utils import pil_image_to_base64
+    from verl_omni.utils.reward_score.reward_utils import pil_image_to_base64, visual_reward_frames
 
-    # Normalize any input format to [N, C, H, W] (frames × channels × height × width).
-    # Detected formats:
-    #   3D:        [C, H, W]             — single image (QwenImage FlowGRPO)
-    #   4D:        [C, F, H, W]          — channels-first video (raw VAE)
-    #              [F, H, W, C]          — channels-last video (engine postprocess)
-    #   5D:        [B, C, F, H, W]       — batched channels-first
-    #              [B, F, H, W, C]       — batched channels-last (Wan22 DanceGRPO)
-    is_channels_last = solution_image.shape[-1] in (1, 3)
-
-    if solution_image.ndim == 3:
-        frame_interval = extra_info.get("frame_interval", 1)
-        # [C, H, W] → [1, C, H, W]
-        solution_image = solution_image.unsqueeze(0)
-
-    elif solution_image.ndim == 4:
-        frame_interval = extra_info.get("frame_interval", 4)
-        if is_channels_last:
-            # [F, H, W, C] → [C, F, H, W]
-            solution_image = solution_image.permute(3, 0, 1, 2)
-        # Now [C, F, H, W]: subsample frames, then frame-dim first
-        solution_image = solution_image[:, ::frame_interval]  # [C, F', H, W]
-        solution_image = solution_image.permute(1, 0, 2, 3)  # [F', C, H, W]
-
-    elif solution_image.ndim == 5:
-        frame_interval = extra_info.get(
-            "frame_interval",
-        )
-        if is_channels_last:
-            # [B, F, H, W, C] → [B, C, F, H, W]
-            solution_image = solution_image.permute(0, 4, 1, 2, 3)
-        # Now [B, C, F, H, W]: subsample frames, flatten batch + frames
-        solution_image = solution_image[:, :, ::frame_interval]  # [B, C, F', H, W]
-        solution_image = solution_image.permute(0, 2, 1, 3, 4)  # [B, F', C, H, W]
-        solution_image = solution_image.reshape(-1, *solution_image.shape[2:])  # [B*F', C, H, W]
+    solution_image = visual_reward_frames(solution_image, extra_info, extra_info.get("frame_interval", 4))
 
     model_name = model_name or os.path.expanduser(DEFAULT_GRM_MODEL_PATH)
     loop = get_event_loop()

--- a/verl_omni/utils/reward_score/hpsv3_reward.py
+++ b/verl_omni/utils/reward_score/hpsv3_reward.py
@@ -17,7 +17,6 @@ import math
 import os
 import threading
 
-import numpy as np
 import torch
 import torch.nn as nn
 from PIL import Image
@@ -374,38 +373,15 @@ def _get_inferencer(checkpoint_path: str, device: str):
 
 
 def _to_pil_hwc(image) -> Image.Image:
-    if isinstance(image, torch.Tensor):
-        image = image.cpu().numpy()
-    if isinstance(image, np.ndarray):
-        if image.ndim == 3 and image.shape[0] in (1, 3):
-            image = image.transpose(1, 2, 0)
-        image = Image.fromarray(image)
-    assert isinstance(image, Image.Image)
-    return image
+    from verl_omni.utils.reward_score.reward_utils import image_tensor_to_pil
+
+    return image_tensor_to_pil(image)
 
 
-def _extract_frames(solution_image, frame_interval: int = 1) -> list[Image.Image]:
-    is_channels_last = solution_image.shape[-1] in (1, 3) if solution_image.ndim >= 3 else False
+def _extract_frames(solution_image, frame_interval: int = 1, *, extra_info: dict) -> list[Image.Image]:
+    from verl_omni.utils.reward_score.reward_utils import visual_reward_frames
 
-    if solution_image.ndim == 3:
-        if is_channels_last:
-            solution_image = solution_image.permute(2, 0, 1)
-        solution_image = solution_image.unsqueeze(0)
-
-    elif solution_image.ndim == 4:
-        if is_channels_last:
-            solution_image = solution_image.permute(3, 0, 1, 2)
-        solution_image = solution_image[:, ::frame_interval]
-        solution_image = solution_image.permute(1, 0, 2, 3)
-
-    elif solution_image.ndim == 5:
-        if is_channels_last:
-            solution_image = solution_image.permute(0, 4, 1, 2, 3)
-        solution_image = solution_image[:, :, ::frame_interval]
-        solution_image = solution_image.permute(0, 2, 1, 3, 4)
-        solution_image = solution_image.reshape(-1, *solution_image.shape[2:])
-
-    return [_to_pil_hwc(frame) for frame in solution_image]
+    return [_to_pil_hwc(frame) for frame in visual_reward_frames(solution_image, extra_info, frame_interval)]
 
 
 def compute_score_hpsv3(
@@ -424,7 +400,7 @@ def compute_score_hpsv3(
     inferencer = _get_inferencer(checkpoint_path, device)
 
     frame_interval = extra_info.get("frame_interval", 4)
-    pil_images = _extract_frames(solution_image, frame_interval=frame_interval)
+    pil_images = _extract_frames(solution_image, frame_interval=frame_interval, extra_info=extra_info)
 
     prompt = ground_truth if ground_truth else ""
     with _lock:

--- a/verl_omni/utils/reward_score/http_scorer_client.py
+++ b/verl_omni/utils/reward_score/http_scorer_client.py
@@ -33,10 +33,9 @@ from PIL import Image
 
 def _tensor_to_pil(image: torch.Tensor) -> Image.Image:
     """Convert a CHW uint8 tensor to an RGB PIL image."""
-    if image.ndim == 4:
-        image = image[0]
-    image = image.permute(1, 2, 0).cpu().numpy()
-    return Image.fromarray(image)
+    from verl_omni.utils.reward_score.reward_utils import image_tensor_to_pil
+
+    return image_tensor_to_pil(image)
 
 
 def _serialize_image(pil_image: Image.Image) -> bytes:
@@ -93,8 +92,13 @@ async def compute_score(
     if retry_backoff < 0:
         raise ValueError(f"retry_backoff must be non-negative, got {retry_backoff}")
 
+    from verl_omni.utils.reward_score.reward_utils import visual_reward_frames
+
+    frames = visual_reward_frames(solution_image, kwargs.get("extra_info") or {"media_kind": "image"})
+    if len(frames) != 1:
+        raise ValueError("HTTP image scorer requires one decoded image")
     loop = asyncio.get_running_loop()
-    image_bytes = await loop.run_in_executor(None, _prepare_image_bytes, solution_image)
+    image_bytes = await loop.run_in_executor(None, _prepare_image_bytes, frames[0])
 
     payload = pickle.dumps(
         {

--- a/verl_omni/utils/reward_score/imagebind.py
+++ b/verl_omni/utils/reward_score/imagebind.py
@@ -137,6 +137,13 @@ def _preprocess_audio(audio, source_rate: int, device: str) -> torch.Tensor:
 
 
 def _to_tchw(video) -> torch.Tensor:
+    from verl_omni.pipelines.rollout_artifacts import MediaArtifact
+
+    if isinstance(video, MediaArtifact):
+        if (video.spec.modality, video.spec.representation) != ("video", "decoded"):
+            raise ValueError(f"ImageBind requires decoded video, got {video.spec}")
+        video = video.normalized(context="ImageBind", name="video")
+        return video.data.detach().float().cpu() / 255.0
     video = torch.as_tensor(video)
     if video.dtype != torch.uint8:
         raise ValueError(f"Expected uint8 video input, got {video.dtype}.")
@@ -247,6 +254,21 @@ def compute_score(
     need_audio = mode in {"audio_video", "text_audio", "all"}
     need_video = mode in {"audio_video", "text_video", "all"}
 
+    artifacts = extra_info.get("media_artifacts")
+    if artifacts is not None:
+        from verl_omni.pipelines.rollout_artifacts import select_artifact
+
+        if need_video:
+            solution_image = select_artifact(
+                artifacts, name="video_preview", modality="video", representation="decoded"
+            )
+        if need_audio:
+            audio_artifact = select_artifact(artifacts, name="audio", modality="audio", representation="decoded")
+            extra_info = {
+                **extra_info,
+                "audio": audio_artifact.data,
+                "audio_sample_rate": audio_artifact.spec.sample_rate,
+            }
     inputs = {}
     if need_text:
         inputs[ModalityType.TEXT] = _preprocess_text(ground_truth or "", device)

--- a/verl_omni/utils/reward_score/imagebind.py
+++ b/verl_omni/utils/reward_score/imagebind.py
@@ -85,14 +85,9 @@ def _normalize_audio(audio, source_rate: int) -> torch.Tensor:
     import torchaudio.functional as audio_functional
 
     waveform = torch.as_tensor(audio).detach().float().cpu()
-    while waveform.ndim > 2 and waveform.shape[0] == 1:
-        waveform = waveform[0]
-    if waveform.ndim == 1:
-        waveform = waveform.unsqueeze(0)
-    elif waveform.ndim == 2 and waveform.shape[0] > 1:
-        waveform = waveform.mean(dim=0, keepdim=True)
     if waveform.ndim != 2:
-        raise ValueError(f"Expected audio shape (T,) or (C,T), got {tuple(waveform.shape)}.")
+        raise ValueError(f"Expected canonical CT audio, got {tuple(waveform.shape)}.")
+    waveform = waveform.mean(dim=0, keepdim=True)
     if source_rate != _AUDIO_SAMPLE_RATE:
         waveform = audio_functional.resample(waveform, source_rate, _AUDIO_SAMPLE_RATE)
     return waveform
@@ -142,25 +137,13 @@ def _to_tchw(video) -> torch.Tensor:
     if isinstance(video, MediaArtifact):
         if (video.spec.modality, video.spec.representation) != ("video", "decoded"):
             raise ValueError(f"ImageBind requires decoded video, got {video.spec}")
-        video = video.normalized(context="ImageBind", name="video")
-        return video.data.detach().float().cpu() / 255.0
-    video = torch.as_tensor(video)
-    if video.dtype != torch.uint8:
-        raise ValueError(f"Expected uint8 video input, got {video.dtype}.")
-    video = video.detach().float().cpu() / 255.0
-    while video.ndim > 4 and video.shape[0] == 1:
-        video = video[0]
-    if video.ndim != 4:
-        raise ValueError(f"Expected a four-dimensional video, got {tuple(video.shape)}.")
-    if video.shape[1] in (1, 3):
-        pass
-    elif video.shape[-1] in (1, 3):
-        video = video.permute(0, 3, 1, 2)
-    elif video.shape[0] in (1, 3):
-        video = video.permute(1, 0, 2, 3)
-    else:
-        raise ValueError(f"Could not infer video channel dimension from {tuple(video.shape)}.")
-    return video
+        video.validate(context="ImageBind", name="video")
+        if video.spec.layout != "TCHW":
+            raise ValueError(f"ImageBind requires canonical TCHW, got {video.spec.layout}")
+        video = video.data
+    from verl_omni.utils.reward_score.reward_utils import normalize_video_tensor
+
+    return normalize_video_tensor(video).detach().float().cpu() / 255.0
 
 
 def _preprocess_video(video, device: str) -> torch.Tensor:
@@ -254,34 +237,20 @@ def compute_score(
     need_audio = mode in {"audio_video", "text_audio", "all"}
     need_video = mode in {"audio_video", "text_video", "all"}
 
-    artifacts = extra_info.get("media_artifacts")
-    if artifacts is not None:
-        from verl_omni.pipelines.rollout_artifacts import select_artifact
+    from verl_omni.pipelines.rollout_artifacts import select_artifact
 
-        if need_video:
-            solution_image = select_artifact(
-                artifacts, name="video_preview", modality="video", representation="decoded"
-            )
-        if need_audio:
-            audio_artifact = select_artifact(artifacts, name="audio", modality="audio", representation="decoded")
-            extra_info = {
-                **extra_info,
-                "audio": audio_artifact.data,
-                "audio_sample_rate": audio_artifact.spec.sample_rate,
-            }
+    artifacts = extra_info.get("media_artifacts", {})
+    if need_video:
+        solution_image = select_artifact(artifacts, name="video_preview", modality="video", representation="decoded")
+    if need_audio:
+        audio_artifact = select_artifact(artifacts, name="audio", modality="audio", representation="decoded")
+        if audio_artifact.spec.layout != "CT":
+            raise ValueError(f"ImageBind requires canonical CT audio, got {audio_artifact.spec.layout}")
     inputs = {}
     if need_text:
         inputs[ModalityType.TEXT] = _preprocess_text(ground_truth or "", device)
     if need_audio:
-        audio = extra_info.get("audio")
-        if audio is None:
-            raise KeyError("ImageBind reward requires decoded audio in extra_info['audio'].")
-        sample_rate = extra_info.get("audio_sample_rate", _AUDIO_SAMPLE_RATE)
-        if isinstance(sample_rate, torch.Tensor):
-            sample_rate = sample_rate.item()
-        if sample_rate is None:
-            raise KeyError("ImageBind reward requires extra_info['audio_sample_rate'].")
-        inputs[ModalityType.AUDIO] = _preprocess_audio(audio, int(sample_rate), device)
+        inputs[ModalityType.AUDIO] = _preprocess_audio(audio_artifact.data, audio_artifact.spec.sample_rate, device)
     if need_video:
         if solution_image is None:
             raise ValueError("ImageBind reward requires video in solution_image.")

--- a/verl_omni/utils/reward_score/jpeg_compressibility.py
+++ b/verl_omni/utils/reward_score/jpeg_compressibility.py
@@ -49,13 +49,14 @@ def jpeg_compressibility():
     return _fn
 
 
-def compute_score(solution_image):
+def compute_score(solution_image, extra_info=None):
     """The scoring function for JPEG compressibility.
 
     Args:
         solution_image: the solution image or video, in shape (C, H, W) or (N, C, H, W).
     """
-    if isinstance(solution_image, torch.Tensor) and solution_image.ndim == 3:
-        solution_image = solution_image.unsqueeze(0)
-    score = jpeg_compressibility()(solution_image, None)[0]
-    return float(score[0])
+    from verl_omni.utils.reward_score.reward_utils import visual_reward_frames
+
+    frames = visual_reward_frames(solution_image, extra_info or {})
+    scores = jpeg_compressibility()(frames, None)[0]
+    return float(scores.mean())

--- a/verl_omni/utils/reward_score/latent_http_scorer_client.py
+++ b/verl_omni/utils/reward_score/latent_http_scorer_client.py
@@ -50,19 +50,14 @@ def _serialize_request(
     noise_level: float,
     noise_seed: int | None,
 ) -> bytes:
-    if "media_artifacts" in extra_info:
-        from verl_omni.pipelines.rollout_artifacts import select_artifact
+    from verl_omni.pipelines.rollout_artifacts import ArtifactContractError, select_artifact
 
-        artifact = select_artifact(
-            extra_info["media_artifacts"], name="image_latent", modality="image", representation="latent"
-        )
-        if artifact.spec.layout != "CHW":
-            raise ValueError(f"SD3 latent scorer expects native CHW, got {artifact.spec.layout}")
-        latents = artifact.data
-    else:
-        latents = extra_info.get("latents_clean")
-        if latents is None and isinstance(solution_image, torch.Tensor) and solution_image.shape[-3] == 16:
-            latents = solution_image
+    artifact = select_artifact(
+        extra_info.get("media_artifacts", {}), name="image_latent", modality="image", representation="latent"
+    )
+    if artifact.spec.layout != "CHW":
+        raise ArtifactContractError(f"SD3 latent scorer expects native CHW, got {artifact.spec.layout}")
+    latents = artifact.data
 
     tensors = {
         "latents": _batched_tensor(latents, "latents_clean", expected_rank=4),

--- a/verl_omni/utils/reward_score/latent_http_scorer_client.py
+++ b/verl_omni/utils/reward_score/latent_http_scorer_client.py
@@ -50,9 +50,19 @@ def _serialize_request(
     noise_level: float,
     noise_seed: int | None,
 ) -> bytes:
-    latents = extra_info.get("latents_clean")
-    if latents is None and isinstance(solution_image, torch.Tensor) and solution_image.shape[-3] == 16:
-        latents = solution_image
+    if "media_artifacts" in extra_info:
+        from verl_omni.pipelines.rollout_artifacts import select_artifact
+
+        artifact = select_artifact(
+            extra_info["media_artifacts"], name="image_latent", modality="image", representation="latent"
+        )
+        if artifact.spec.layout != "CHW":
+            raise ValueError(f"SD3 latent scorer expects native CHW, got {artifact.spec.layout}")
+        latents = artifact.data
+    else:
+        latents = extra_info.get("latents_clean")
+        if latents is None and isinstance(solution_image, torch.Tensor) and solution_image.shape[-3] == 16:
+            latents = solution_image
 
     tensors = {
         "latents": _batched_tensor(latents, "latents_clean", expected_rank=4),

--- a/verl_omni/utils/reward_score/pickscore_reward.py
+++ b/verl_omni/utils/reward_score/pickscore_reward.py
@@ -16,7 +16,6 @@ import asyncio
 import logging
 import os
 
-import numpy as np
 import torch
 from PIL import Image
 from transformers import CLIPModel, CLIPProcessor
@@ -98,14 +97,9 @@ class _PickScoreInferencer:
 
 
 def _to_pil_hwc(image) -> Image.Image:
-    if isinstance(image, torch.Tensor):
-        image = image.cpu().numpy()
-    if isinstance(image, np.ndarray):
-        if image.ndim == 3 and image.shape[0] in (1, 3):
-            image = image.transpose(1, 2, 0)
-        image = Image.fromarray(image)
-    assert isinstance(image, Image.Image)
-    return image
+    from verl_omni.utils.reward_score.reward_utils import image_tensor_to_pil
+
+    return image if isinstance(image, Image.Image) else image_tensor_to_pil(image)
 
 
 def _score_batch(requests) -> list[float | Exception]:
@@ -190,6 +184,12 @@ async def compute_score_pickscore(
     device: str | None = None,
     **kwargs,
 ) -> dict:
+    from verl_omni.utils.reward_score.reward_utils import visual_reward_frames
+
+    frames = visual_reward_frames(solution_image, extra_info)
+    if len(frames) != 1:
+        raise ValueError("PickScore requires a single decoded image")
+    solution_image = frames[0]
     await _ensure_consumer(device)
 
     prompt = ground_truth if ground_truth else ""

--- a/verl_omni/utils/reward_score/reward_utils.py
+++ b/verl_omni/utils/reward_score/reward_utils.py
@@ -22,31 +22,66 @@ from PIL import Image
 
 
 def normalize_video_tensor(video: torch.Tensor) -> torch.Tensor:
-    """Normalize an RGB uint8 video to the ``[T, 3, H, W]`` layout.
-
-    Accepted layouts are time-first channels-first ``[T, 3, H, W]``,
-    channels-first temporal ``[3, T, H, W]``, and channels-last
-    ``[T, H, W, 3]``. Ambiguous shapes such as ``[3, 3, H, W]`` retain the
-    canonical time-first interpretation.
-    """
+    """Validate canonical RGB uint8 TCHW; layout conversion belongs to the adapter."""
     if not isinstance(video, torch.Tensor) or video.dtype != torch.uint8:
         dtype = video.dtype if isinstance(video, torch.Tensor) else type(video)
         raise ValueError(f"Expected a uint8 video tensor, got {dtype}")
     if video.ndim != 4:
         raise ValueError(f"Expected an RGB video tensor with shape [T, 3, H, W], got {tuple(video.shape)}")
 
-    if video.shape[1] == 3:
-        normalized = video
-    elif video.shape[0] == 3:
-        normalized = video.permute(1, 0, 2, 3)
-    elif video.shape[-1] == 3:
-        normalized = video.permute(0, 3, 1, 2)
-    else:
-        raise ValueError(f"Expected an RGB video tensor with shape [T, 3, H, W], got {tuple(video.shape)}")
+    if video.shape[1] != 3 or any(size <= 0 for size in video.shape):
+        raise ValueError(f"Expected a nonempty RGB video with shape [T, 3, H, W], got {tuple(video.shape)}")
+    return video
 
-    if normalized.shape[0] == 0 or normalized.shape[2] == 0 or normalized.shape[3] == 0:
-        raise ValueError(f"Expected a video with non-empty time and spatial dimensions, got {tuple(video.shape)}")
-    return normalized
+
+def visual_reward_frames(solution_image, extra_info: dict, frame_interval: int = 1) -> torch.Tensor:
+    """Select decoded visual media and return NCHW frames using declared modality, never rank."""
+    from verl_omni.pipelines.rollout_artifacts import (
+        PREVIEW_ARTIFACT,
+        ArtifactContractError,
+        ArtifactSpec,
+        MediaArtifact,
+    )
+
+    if isinstance(frame_interval, bool) or not isinstance(frame_interval, int) or frame_interval < 1:
+        raise ValueError("frame_interval must be a positive integer")
+    artifacts = extra_info.get("media_artifacts")
+    if artifacts is not None:
+        name = extra_info.get(PREVIEW_ARTIFACT)
+        if name not in artifacts:
+            raise ArtifactContractError(
+                f"Decoded preview artifact={name!r} is absent; cannot score latent responses as pixels"
+            )
+        artifact = artifacts[name]
+    else:
+        kind = extra_info.get("media_kind")
+        if kind not in ("image", "video"):
+            raise ArtifactContractError("Visual rewards require named artifacts or an explicit media_kind")
+        artifact = MediaArtifact(
+            ArtifactSpec(kind, "decoded", "CHW" if kind == "image" else "TCHW", fps=extra_info.get("fps")),
+            solution_image,
+        )
+    try:
+        artifact.validate(context="visual reward", name="preview")
+    except (TypeError, ValueError) as error:
+        raise ArtifactContractError(str(error)) from error
+    expected_layout = {"image": "CHW", "video": "TCHW"}.get(artifact.spec.modality)
+    if artifact.spec.representation != "decoded" or artifact.spec.layout != expected_layout:
+        raise ArtifactContractError(f"Visual rewards require canonical decoded media, got {artifact.spec}")
+    if artifact.spec.modality == "image":
+        return artifact.data.unsqueeze(0)
+    return artifact.data[::frame_interval]
+
+
+def image_tensor_to_pil(image: torch.Tensor) -> Image.Image:
+    """Convert an explicitly canonical uint8 CHW image to RGB PIL."""
+    from verl_omni.pipelines.rollout_artifacts import ArtifactSpec, MediaArtifact
+
+    MediaArtifact(ArtifactSpec("image", "decoded", "CHW"), image).validate(context="PIL conversion", name="image")
+    array = image.detach().permute(1, 2, 0).cpu().numpy()
+    if image.shape[0] == 1:
+        array = array[:, :, 0]
+    return Image.fromarray(array).convert("RGB")
 
 
 def video_tensor_to_pil_frames(video: torch.Tensor) -> list[Image.Image]:

--- a/verl_omni/utils/reward_score/reward_utils.py
+++ b/verl_omni/utils/reward_score/reward_utils.py
@@ -36,12 +36,8 @@ def normalize_video_tensor(video: torch.Tensor) -> torch.Tensor:
 
 def visual_reward_frames(solution_image, extra_info: dict, frame_interval: int = 1) -> torch.Tensor:
     """Select decoded visual media and return NCHW frames using declared modality, never rank."""
-    from verl_omni.pipelines.rollout_artifacts import (
-        PREVIEW_ARTIFACT,
-        ArtifactContractError,
-        ArtifactSpec,
-        MediaArtifact,
-    )
+    from verl_omni.pipelines.rollout_artifacts import PREVIEW_ARTIFACT, ArtifactContractError, MediaArtifact
+    from verl_omni.pipelines.rollout_media import MediaSpec
 
     if isinstance(frame_interval, bool) or not isinstance(frame_interval, int) or frame_interval < 1:
         raise ValueError("frame_interval must be a positive integer")
@@ -58,7 +54,7 @@ def visual_reward_frames(solution_image, extra_info: dict, frame_interval: int =
         if kind not in ("image", "video"):
             raise ArtifactContractError("Visual rewards require named artifacts or an explicit media_kind")
         artifact = MediaArtifact(
-            ArtifactSpec(kind, "decoded", "CHW" if kind == "image" else "TCHW", fps=extra_info.get("fps")),
+            MediaSpec(kind, "decoded", "CHW" if kind == "image" else "TCHW", fps=extra_info.get("fps")),
             solution_image,
         )
     try:
@@ -75,9 +71,10 @@ def visual_reward_frames(solution_image, extra_info: dict, frame_interval: int =
 
 def image_tensor_to_pil(image: torch.Tensor) -> Image.Image:
     """Convert an explicitly canonical uint8 CHW image to RGB PIL."""
-    from verl_omni.pipelines.rollout_artifacts import ArtifactSpec, MediaArtifact
+    from verl_omni.pipelines.rollout_artifacts import MediaArtifact
+    from verl_omni.pipelines.rollout_media import MediaSpec
 
-    MediaArtifact(ArtifactSpec("image", "decoded", "CHW"), image).validate(context="PIL conversion", name="image")
+    MediaArtifact(MediaSpec("image", "decoded", "CHW"), image).validate(context="PIL conversion", name="image")
     array = image.detach().permute(1, 2, 0).cpu().numpy()
     if image.shape[0] == 1:
         array = array[:, :, 0]

--- a/verl_omni/utils/reward_score/unified_reward.py
+++ b/verl_omni/utils/reward_score/unified_reward.py
@@ -64,15 +64,11 @@ def _to_pil(image) -> Image.Image:
     return image
 
 
-def _prepare_solution_frames(solution_image: np.ndarray | torch.Tensor, frame_interval: int):
-    """Normalize an image/video tensor or array into an iterable of frames."""
-    if solution_image.ndim == 3:  # image
-        if isinstance(solution_image, torch.Tensor):
-            return solution_image.unsqueeze(0)
-        return np.expand_dims(solution_image, axis=0)
-    if solution_image.ndim == 4:  # video
-        return solution_image[::frame_interval]
-    raise ValueError(f"Expected image/video with 3 or 4 dimensions, got shape {solution_image.shape}")
+def _prepare_solution_frames(solution_image, frame_interval: int, *, extra_info: dict):
+    """Select canonical frames from the declared decoded visual artifact."""
+    from verl_omni.utils.reward_score.reward_utils import visual_reward_frames
+
+    return visual_reward_frames(solution_image, extra_info, frame_interval)
 
 
 def _build_unified_reward_prompt(caption: str) -> str:
@@ -181,7 +177,7 @@ async def compute_score_unified_reward(
     extra_info = extra_info or {}
     caption = extra_info.get("prompt") or extra_info.get("raw_prompt") or ground_truth or ""
     frame_interval = extra_info.get("frame_interval", 1)
-    solution_image = _prepare_solution_frames(solution_image, frame_interval)
+    solution_image = _prepare_solution_frames(solution_image, frame_interval, extra_info=extra_info)
 
     model_name = model_name or DEFAULT_UNIFIED_REWARD_MODEL_PATH
     loop = get_event_loop()

--- a/verl_omni/utils/tracking.py
+++ b/verl_omni/utils/tracking.py
@@ -81,6 +81,19 @@ def _video_tensor_to_rgb24(video: torch.Tensor) -> tuple[np.ndarray, int, int]:
     return frames, int(frames.shape[2]), int(frames.shape[1])
 
 
+def resolve_is_video(ndim: int, media_kind: str | None) -> bool:
+    """Decide whether a rollout output is a video.
+
+    Prefers the adapter-declared media kind (from ``DiffusionIOSpec``); the tensor
+    rank is only a fallback for outputs that do not carry a declared kind. This
+    avoids misclassifying, e.g., a short 3-frame video whose rank happens to match
+    an image batch.
+    """
+    if media_kind is not None:
+        return media_kind == "video"
+    return ndim == 5
+
+
 def _export_video(
     output: torch.Tensor,
     output_path: str,
@@ -165,31 +178,36 @@ def _export_video(
             audio_path.unlink(missing_ok=True)
 
 
-def wrap_val_samples_for_wandb(samples, fps=24, output_dir=None):
-    """Wrap validation samples and prepare top-level ``wandb`` video media.
+def wrap_val_samples_for_wandb(samples, fps=24, output_dir=None, media_kinds=None):
+    """Wrap validation samples and prepare top-level ``wandb`` media.
 
-    Video outputs in ``[T, C, H, W]``, ``[C, T, H, W]``, or ``[T, H, W, C]``
-    layouts are encoded to mp4 and passed to
-    ``wandb.Video`` by path. Provide ``output_dir`` to keep the media available
-    for asynchronous upload; otherwise a temp dir is returned for cleanup.
-    Optional tuple elements four and five carry audio and its sample rate. The
-    table stores a stable media key because offline ``wandb`` tables do not
-    reliably persist nested videos. Other outputs become ``wandb.Image``.
+    Declared ``media_kinds`` decide whether each output is an image or video;
+    tensor rank is retained only as a compatibility fallback. Video outputs in
+    ``[T, C, H, W]``, ``[C, T, H, W]``, or ``[T, H, W, C]`` layouts are encoded
+    to mp4 and passed to ``wandb.Video`` by path. Provide ``output_dir`` to keep
+    the media available for asynchronous upload; otherwise a temp dir is
+    returned for cleanup. Optional tuple elements four and five carry audio and
+    its sample rate. Media conversion failures are represented in the table and
+    logged instead of propagating into the training loop.
     """
     import wandb
 
+    samples = list(samples)
+    media_kinds = batch_items(media_kinds, len(samples), "media_kind")
     video_dir = output_dir
     video_tmp_dir = None
     wrapped = []
     media_to_log = {}
-    for sample in samples:
+    for sample, media_kind in zip(samples, media_kinds, strict=True):
         inp, out, score = sample[:3]
         audio = sample[3] if len(sample) > 3 else None
         audio_sample_rate = sample[4] if len(sample) > 4 else None
-        if hasattr(out, "ndim") and out.ndim == 5:
+        output_ndim = getattr(out, "ndim", -1)
+        is_video = media_kind == "video" if media_kind is not None else output_ndim in (4, 5)
+        if is_video and output_ndim == 5:
             # Batched video [B, T, C, H, W], [B, C, T, H, W], or [B, T, H, W, C].
             out = out[0]
-        if hasattr(out, "ndim") and out.ndim == 4:
+        if is_video:
             try:
                 if video_dir is None:
                     video_tmp_dir = tempfile.mkdtemp(prefix="val_video_")
@@ -205,9 +223,13 @@ def wrap_val_samples_for_wandb(samples, fps=24, output_dir=None):
                 logger.warning("Could not log validation sample %d video: %s", len(wrapped), error)
                 media = f"[validation media unavailable: {type(error).__name__}: {error}]"
         else:
-            if not isinstance(out, torch.Tensor) or out.dtype != torch.uint8:
-                raise ValueError(f"Expected a uint8 image tensor, got {getattr(out, 'dtype', type(out))}.")
-            media = wandb.Image(out, file_type="jpg")
+            try:
+                if not isinstance(out, torch.Tensor) or out.dtype != torch.uint8:
+                    raise ValueError(f"Expected a uint8 image tensor, got {getattr(out, 'dtype', type(out))}.")
+                media = wandb.Image(out, file_type="jpg")
+            except Exception as error:
+                logger.warning("Could not log validation sample %d image: %s", len(wrapped), error)
+                media = f"[validation media unavailable: {type(error).__name__}: {error}]"
         wrapped.append((inp, media, score))
     return wrapped, video_tmp_dir, media_to_log
 

--- a/verl_omni/utils/tracking.py
+++ b/verl_omni/utils/tracking.py
@@ -90,6 +90,8 @@ def resolve_is_video(ndim: int, media_kind: str | None) -> bool:
     an image batch.
     """
     if media_kind is not None:
+        if media_kind not in ("image", "video", "audio"):
+            raise ValueError(f"Unsupported media kind: {media_kind!r}")
         return media_kind == "video"
     return ndim == 5
 
@@ -203,7 +205,7 @@ def wrap_val_samples_for_wandb(samples, fps=24, output_dir=None, media_kinds=Non
         audio = sample[3] if len(sample) > 3 else None
         audio_sample_rate = sample[4] if len(sample) > 4 else None
         output_ndim = getattr(out, "ndim", -1)
-        is_video = media_kind == "video" if media_kind is not None else output_ndim in (4, 5)
+        is_video = resolve_is_video(output_ndim, media_kind) if media_kind is not None else output_ndim in (4, 5)
         if is_video and output_ndim == 5:
             # Batched video [B, T, C, H, W], [B, C, T, H, W], or [B, T, H, W, C].
             out = out[0]

--- a/verl_omni/utils/tracking.py
+++ b/verl_omni/utils/tracking.py
@@ -26,6 +26,7 @@ from typing import Any
 import numpy as np
 import torch
 
+from verl_omni.pipelines.rollout_media import resolve_is_video
 from verl_omni.utils.reward_score.reward_utils import normalize_video_tensor
 
 logger = logging.getLogger(__name__)
@@ -79,21 +80,6 @@ def _video_tensor_to_rgb24(video: torch.Tensor) -> tuple[np.ndarray, int, int]:
     video = normalize_video_tensor(video)
     frames = video.detach().permute(0, 2, 3, 1).to(device="cpu").contiguous().numpy()
     return frames, int(frames.shape[2]), int(frames.shape[1])
-
-
-def resolve_is_video(ndim: int, media_kind: str | None) -> bool:
-    """Decide whether a rollout output is a video.
-
-    Prefers the adapter-declared media kind (from ``DiffusionIOSpec``); the tensor
-    rank is only a fallback for outputs that do not carry a declared kind. This
-    avoids misclassifying, e.g., a short 3-frame video whose rank happens to match
-    an image batch.
-    """
-    if media_kind is not None:
-        if media_kind not in ("image", "video", "audio"):
-            raise ValueError(f"Unsupported media kind: {media_kind!r}")
-        return media_kind == "video"
-    return ndim == 5
 
 
 def _export_video(

--- a/verl_omni/utils/tracking.py
+++ b/verl_omni/utils/tracking.py
@@ -26,7 +26,7 @@ from typing import Any
 import numpy as np
 import torch
 
-from verl_omni.pipelines.rollout_artifacts import MediaArtifact
+from verl_omni.pipelines.rollout_artifacts import ArtifactSpec, MediaArtifact, validate_audio
 from verl_omni.utils.reward_score.reward_utils import normalize_video_tensor
 
 logger = logging.getLogger(__name__)
@@ -53,14 +53,8 @@ def batch_items(values: Any, batch_size: int, name: str) -> list[Any]:
 
 def _write_wav(audio: Any, sample_rate: Any, path: Path) -> None:
     waveform = torch.as_tensor(audio).detach().cpu().float()
-    while waveform.ndim > 2 and waveform.shape[0] == 1:
-        waveform = waveform[0]
-    if waveform.ndim == 1:
-        waveform = waveform.unsqueeze(0)
-    elif waveform.ndim != 2:
-        raise ValueError(f"Expected audio shape [T] or [C, T], got {tuple(waveform.shape)}.")
-    if waveform.shape[0] > 8 and waveform.shape[1] <= 8:
-        waveform = waveform.transpose(0, 1)
+    if waveform.ndim != 2 or any(size <= 0 for size in waveform.shape):
+        raise ValueError(f"Expected canonical audio shape [C, T], got {tuple(waveform.shape)}.")
     if waveform.shape[0] > 2:
         waveform = waveform.mean(dim=0, keepdim=True)
 
@@ -92,25 +86,17 @@ def _video_tensor_to_rgb24(video: torch.Tensor) -> tuple[np.ndarray, int, int]:
 
 
 def resolve_is_video(ndim: int, media_kind: str | None) -> bool:
-    """Decide whether a rollout output is a video.
-
-    Prefers the adapter-declared media kind (from ``DiffusionIOSpec``); the tensor
-    rank is only a fallback for outputs that do not carry a declared kind. This
-    avoids misclassifying, e.g., a short 3-frame video whose rank happens to match
-    an image batch.
-    """
-    if media_kind is not None:
-        if media_kind not in ("image", "video", "audio"):
-            raise ValueError(f"Unsupported media kind: {media_kind!r}")
-        return media_kind == "video"
-    return ndim == 5
+    """Read the declared modality; rank is never a modality discriminator."""
+    if media_kind not in ("image", "video", "audio"):
+        raise ValueError(f"Explicit media_kind required, got {media_kind!r}")
+    return media_kind == "video"
 
 
 def _export_video(
     output: torch.Tensor,
     output_path: str,
     *,
-    fps: int,
+    fps: float | None = None,
     audio: Any = None,
     audio_sample_rate: Any = None,
     ffmpeg_exe: str | None = None,
@@ -122,19 +108,16 @@ def _export_video(
     direct ``stdin.write`` path, which can silently truncate a raw-video frame
     without materializing another full-video ``bytes`` copy.
     """
+    if isinstance(output, MediaArtifact):
+        fps = output.spec.fps
+    if isinstance(fps, bool) or not isinstance(fps, int | float) or not 0 < fps < float("inf"):
+        raise ValueError(f"Video export requires explicit positive finite fps, got {fps!r}")
+    validate_audio(audio, audio_sample_rate, context="video export")
+    frames, width, height = _video_tensor_to_rgb24(output)
     if ffmpeg_exe is None:
         from imageio_ffmpeg import get_ffmpeg_exe
 
         ffmpeg_exe = get_ffmpeg_exe()
-
-    if isinstance(output, MediaArtifact) and output.spec.fps is not None:
-        fps = output.spec.fps
-    else:
-        fps = int(fps)
-    if fps <= 0:
-        raise ValueError(f"fps must be positive, got {fps}.")
-
-    frames, width, height = _video_tensor_to_rgb24(output)
     output_path = Path(output_path)
     audio_path = None
     command = [
@@ -193,17 +176,17 @@ def _export_video(
             audio_path.unlink(missing_ok=True)
 
 
-def wrap_val_samples_for_wandb(samples, fps=24, output_dir=None, media_kinds=None):
+def wrap_val_samples_for_wandb(samples, fps=None, output_dir=None, media_kinds=None):
     """Wrap validation samples and prepare top-level ``wandb`` media.
 
-    Declared ``media_kinds`` decide whether each output is an image or video;
-    tensor rank is retained only as a compatibility fallback. Video outputs in
-    ``[T, C, H, W]``, ``[C, T, H, W]``, or ``[T, H, W, C]`` layouts are encoded
-    to mp4 and passed to ``wandb.Video`` by path. Provide ``output_dir`` to keep
+    Named decoded artifacts carry modality/layout/FPS. The explicit tensor API
+    requires ``media_kinds``, canonical CHW/TCHW and video FPS; it never guesses
+    axes or representation. Videos are passed to ``wandb.Video`` by path.
+    Provide ``output_dir`` to keep
     the media available for asynchronous upload; otherwise a temp dir is
     returned for cleanup. Optional tuple elements four and five carry audio and
-    its sample rate. Media conversion failures are represented in the table and
-    logged instead of propagating into the training loop.
+    its sample rate. Schema errors fail before I/O; encoder/filesystem/W&B
+    failures are represented in the table without failing training.
     """
     import wandb
 
@@ -225,11 +208,14 @@ def wrap_val_samples_for_wandb(samples, fps=24, output_dir=None, media_kinds=Non
             if media_kind == "image":
                 out = out.normalized(context="W&B", name="preview").data
         output_ndim = getattr(out, "ndim", -1)
-        is_video = resolve_is_video(output_ndim, media_kind) if media_kind is not None else output_ndim in (4, 5)
-        if is_video and output_ndim == 5:
-            # Batched video [B, T, C, H, W], [B, C, T, H, W], or [B, T, H, W, C].
-            out = out[0]
+        is_video = resolve_is_video(output_ndim, media_kind)
+        if not isinstance(out, MediaArtifact):
+            MediaArtifact(
+                ArtifactSpec(media_kind, "decoded", "TCHW" if is_video else "CHW", fps=fps if is_video else None),
+                out,
+            ).validate(context="W&B", name="preview")
         if is_video:
+            validate_audio(audio, audio_sample_rate, context="W&B")
             try:
                 if video_dir is None:
                     video_tmp_dir = tempfile.mkdtemp(prefix="val_video_")
@@ -246,8 +232,6 @@ def wrap_val_samples_for_wandb(samples, fps=24, output_dir=None, media_kinds=Non
                 media = f"[validation media unavailable: {type(error).__name__}: {error}]"
         else:
             try:
-                if not isinstance(out, torch.Tensor) or out.dtype != torch.uint8:
-                    raise ValueError(f"Expected a uint8 image tensor, got {getattr(out, 'dtype', type(out))}.")
                 media = wandb.Image(out, file_type="jpg")
             except Exception as error:
                 logger.warning("Could not log validation sample %d image: %s", len(wrapped), error)

--- a/verl_omni/utils/tracking.py
+++ b/verl_omni/utils/tracking.py
@@ -26,6 +26,7 @@ from typing import Any
 import numpy as np
 import torch
 
+from verl_omni.pipelines.rollout_artifacts import MediaArtifact
 from verl_omni.utils.reward_score.reward_utils import normalize_video_tensor
 
 logger = logging.getLogger(__name__)
@@ -76,7 +77,16 @@ def _write_wav(audio: Any, sample_rate: Any, path: Path) -> None:
 
 def _video_tensor_to_rgb24(video: torch.Tensor) -> tuple[np.ndarray, int, int]:
     """Return a contiguous RGB24 array from a supported RGB video layout."""
-    video = normalize_video_tensor(video)
+    if isinstance(video, MediaArtifact):
+        if (video.spec.modality, video.spec.representation) != ("video", "decoded"):
+            raise ValueError(f"Video export requires a decoded video artifact, got {video.spec}")
+        video = video.normalized(context="video export", name="preview").data
+        if video.shape[1] == 1:
+            video = video.expand(-1, 3, -1, -1)
+        elif video.shape[1] == 4:
+            video = video[:, :3]  # RGB24 has no alpha channel.
+    else:
+        video = normalize_video_tensor(video)
     frames = video.detach().permute(0, 2, 3, 1).to(device="cpu").contiguous().numpy()
     return frames, int(frames.shape[2]), int(frames.shape[1])
 
@@ -117,7 +127,10 @@ def _export_video(
 
         ffmpeg_exe = get_ffmpeg_exe()
 
-    fps = int(fps)
+    if isinstance(output, MediaArtifact) and output.spec.fps is not None:
+        fps = output.spec.fps
+    else:
+        fps = int(fps)
     if fps <= 0:
         raise ValueError(f"fps must be positive, got {fps}.")
 
@@ -204,6 +217,13 @@ def wrap_val_samples_for_wandb(samples, fps=24, output_dir=None, media_kinds=Non
         inp, out, score = sample[:3]
         audio = sample[3] if len(sample) > 3 else None
         audio_sample_rate = sample[4] if len(sample) > 4 else None
+        if isinstance(out, MediaArtifact):
+            out.validate(context="W&B", name="preview")
+            if out.spec.representation != "decoded" or out.spec.modality not in ("image", "video"):
+                raise ValueError(f"W&B requires a decoded visual artifact, got {out.spec}")
+            media_kind = out.spec.modality
+            if media_kind == "image":
+                out = out.normalized(context="W&B", name="preview").data
         output_ndim = getattr(out, "ndim", -1)
         is_video = resolve_is_video(output_ndim, media_kind) if media_kind is not None else output_ndim in (4, 5)
         if is_video and output_ndim == 5:

--- a/verl_omni/utils/tracking.py
+++ b/verl_omni/utils/tracking.py
@@ -26,7 +26,8 @@ from typing import Any
 import numpy as np
 import torch
 
-from verl_omni.pipelines.rollout_artifacts import ArtifactSpec, MediaArtifact, validate_audio
+from verl_omni.pipelines.rollout_artifacts import MediaArtifact, validate_audio
+from verl_omni.pipelines.rollout_media import MediaSpec
 from verl_omni.utils.reward_score.reward_utils import normalize_video_tensor
 
 logger = logging.getLogger(__name__)
@@ -211,7 +212,7 @@ def wrap_val_samples_for_wandb(samples, fps=None, output_dir=None, media_kinds=N
         is_video = resolve_is_video(output_ndim, media_kind)
         if not isinstance(out, MediaArtifact):
             MediaArtifact(
-                ArtifactSpec(media_kind, "decoded", "TCHW" if is_video else "CHW", fps=fps if is_video else None),
+                MediaSpec(media_kind, "decoded", "TCHW" if is_video else "CHW", fps=fps if is_video else None),
                 out,
             ).validate(context="W&B", name="preview")
         if is_video:

--- a/verl_omni/workers/config/diffusion/rollout.py
+++ b/verl_omni/workers/config/diffusion/rollout.py
@@ -63,6 +63,8 @@ class DiffusionPipelineConfig(BaseConfig):
     width: int = 512
     num_inference_steps: int = 10
     output_type: str = "image"
+    # Additional named artifacts required by rewards/logging, including previews with a latent primary.
+    requested_outputs: Optional[list[str]] = None
     true_cfg_scale: float = 1.0
     max_sequence_length: int = 512
     guidance_scale: Optional[float] = None

--- a/verl_omni/workers/rollout/replica.py
+++ b/verl_omni/workers/rollout/replica.py
@@ -13,13 +13,21 @@
 # limitations under the License.
 from typing import Any, Optional
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 from verl.workers.rollout.replica import RolloutReplicaRegistry
+
+from verl_omni.pipelines.rollout_artifacts import MediaArtifact
 
 
 class DiffusionOutput(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
+    artifacts: dict[str, MediaArtifact] = Field(default_factory=dict)
+    """Named per-sample media; empty only for legacy adapters or aborts."""
+    preview_artifact: str | None = None
+    """Explicit decoded preview selection for dump/W&B consumers."""
+    primary_artifact: str | None = None
+    """Explicit compatibility response selection (never inferred from shape)."""
     diffusion_output: Any
     """Generated uint8 pixel tensor (CHW/TCHW) in [0, 255], or floating-point latents."""
     log_probs: Optional[Any] = None

--- a/verl_omni/workers/rollout/vllm_rollout/vllm_omni_diffusion_strategy.py
+++ b/verl_omni/workers/rollout/vllm_rollout/vllm_omni_diffusion_strategy.py
@@ -288,6 +288,10 @@ class DiffusionStrategy(OmniStrategyBase):
             # default lives in this shared strategy.
             if audio_sample_rate is not None:
                 extra_fields.setdefault("audio_sample_rate", audio_sample_rate)
+        # Surface the adapter-declared primary media kind so downstream consumers
+        # read the modality instead of inferring it from the response tensor rank.
+        if io_spec is not None:
+            extra_fields.setdefault("media_kind", io_spec.primary.modality)
 
         req_output = getattr(final_res, "request_output", None) or final_res
         if hasattr(req_output, "outputs") and req_output.outputs:

--- a/verl_omni/workers/rollout/vllm_rollout/vllm_omni_diffusion_strategy.py
+++ b/verl_omni/workers/rollout/vllm_rollout/vllm_omni_diffusion_strategy.py
@@ -141,8 +141,8 @@ class DiffusionStrategy(OmniStrategyBase):
     ) -> tuple[dict[str, Any], list[Any]]:
         default_params_list = self.server.engine.default_sampling_params_list
         custom_prompt = dict(request.to_diffusion_prompt())
-        if len(default_params_list) > 1:
-            # The initial AR stage uses vLLM token preprocessing, not OmniCustomPrompt.
+        if self.server.engine.engine.get_stage_metadata(0).stage_type != "diffusion":
+            # Match AsyncOmniEngine's stage-0 preprocessing gate, independently of stage count.
             custom_prompt["prompt_token_ids"] = custom_prompt.pop("prompt_ids")
             custom_prompt["modalities"] = ["image"]
 

--- a/verl_omni/workers/rollout/vllm_rollout/vllm_omni_diffusion_strategy.py
+++ b/verl_omni/workers/rollout/vllm_rollout/vllm_omni_diffusion_strategy.py
@@ -24,8 +24,16 @@ from vllm_omni.inputs.data import OmniDiffusionSamplingParams
 from vllm_omni.lora.request import LoRARequest
 
 from verl_omni.pipelines.model_base import VllmOmniPipelineBase
+from verl_omni.pipelines.rollout_artifacts import (
+    ARTIFACT_PREFIX,
+    ARTIFACT_SPECS,
+    PRIMARY_ARTIFACT,
+    artifacts_from_fields,
+    select_artifact,
+    validate_artifacts,
+)
 from verl_omni.pipelines.rollout_media import DiffusionIOSpec
-from verl_omni.pipelines.rollout_request import OmniRolloutRequest
+from verl_omni.pipelines.rollout_request import OmniRolloutRequest, _alias_values_match
 from verl_omni.workers.config import DiffusionModelConfig, DiffusionRolloutConfig
 from verl_omni.workers.rollout.replica import DiffusionOutput
 from verl_omni.workers.rollout.vllm_rollout.vllm_omni_strategy_base import OmniStrategyBase
@@ -147,8 +155,17 @@ class DiffusionStrategy(OmniStrategyBase):
             custom_prompt["modalities"] = ["image"]
 
         sampling_kwargs: dict[str, Any] = {}
-        extra_args: dict[str, Any] = {}
+        explicit_extra = sampling_params.get("extra_args") or {}
+        if not isinstance(explicit_extra, Mapping):
+            raise TypeError("Diffusion sampling extra_args must be a mapping")
+        extra_args: dict[str, Any] = dict(explicit_extra)
         for key, value in sampling_params.items():
+            if key == "extra_args":
+                continue
+            if key in extra_args:
+                if not _alias_values_match(value, extra_args[key]):
+                    raise ValueError(f"Conflicting diffusion sampling field {key!r} and extra_args.{key}")
+                del extra_args[key]
             if hasattr(OmniDiffusionSamplingParams, key):
                 sampling_kwargs[key] = value
             else:
@@ -196,7 +213,24 @@ class DiffusionStrategy(OmniStrategyBase):
 
     def process_output(self, final_res: Any, params: Any, sampling_params: dict[str, Any]) -> DiffusionOutput:
         output_type = _diffusion_output_type(sampling_params)
-        if final_res is None or not final_res.images:
+        multimodal = getattr(final_res, "multimodal_output", None)
+        metadata = multimodal.get("metadata", {}) if isinstance(multimodal, Mapping) else {}
+        artifact_header = metadata.get("media_artifacts") if isinstance(metadata, Mapping) else None
+        artifact_payload = None
+        if artifact_header is not None:
+            if not isinstance(artifact_header, Mapping) or not {"primary", "specs"} <= artifact_header.keys():
+                raise ValueError(
+                    f"request_id={getattr(final_res, 'request_id', 'unknown')}: invalid media_artifacts header"
+                )
+            if len(final_res.images) == 1:
+                artifact_payload = final_res.images[0]
+            elif not final_res.images:
+                artifact_payload = multimodal.get("audio")
+            if not isinstance(artifact_payload, Mapping):
+                raise ValueError(
+                    f"request_id={getattr(final_res, 'request_id', 'unknown')}: expected one named artifact payload"
+                )
+        if artifact_header is None and (final_res is None or not final_res.images):
             finish_reason = "abort"
             if final_res is not None:
                 req_out = getattr(final_res, "request_output", None) or final_res
@@ -219,12 +253,7 @@ class DiffusionStrategy(OmniStrategyBase):
                 extra_fields={"global_steps": self.server.global_steps},
             )
 
-        diffusion_output = final_res.images[0]
-        if isinstance(diffusion_output, dict):
-            for key in ("video", "image", "output", "audio"):
-                if key in diffusion_output and diffusion_output[key] is not None:
-                    diffusion_output = diffusion_output[key]
-                    break
+        diffusion_output = artifact_payload if artifact_header is not None else final_res.images[0]
         io_spec = self._diffusion_io_spec()
         req_output = getattr(final_res, "request_output", None) or final_res
         request_id = getattr(req_output, "request_id", getattr(final_res, "request_id", "unknown"))
@@ -233,9 +262,56 @@ class DiffusionStrategy(OmniStrategyBase):
             f"pipeline={getattr(model_config, 'architecture', 'unknown')}/"
             f"{getattr(model_config, 'algorithm', 'unknown')}, request_id={request_id}"
         )
+        artifacts = {}
+        primary_artifact = None
         audio_sample_rate: Optional[int] = None
         rollout_audio: Any = None
-        if isinstance(diffusion_output, tuple | list):
+        if artifact_header is not None:
+            primary_artifact = artifact_header["primary"]
+            artifacts = artifacts_from_fields(
+                {
+                    ARTIFACT_SPECS: artifact_header["specs"],
+                    PRIMARY_ARTIFACT: primary_artifact,
+                    **{ARTIFACT_PREFIX + name: tensor for name, tensor in diffusion_output.items()},
+                },
+                context=context,
+            )
+            validate_artifacts(
+                artifacts.items(),
+                {name: artifact.spec for name, artifact in artifacts.items()},
+                primary=primary_artifact,
+                context=context,
+                requested=sampling_params.get(
+                    "requested_outputs", (sampling_params.get("extra_args") or {}).get("requested_outputs")
+                ),
+            )
+            preview_name = artifact_header.get("preview")
+            if preview_name is not None and (
+                preview_name not in artifacts
+                or artifacts[preview_name].spec.representation != "decoded"
+                or artifacts[preview_name].spec.modality not in ("image", "video")
+            ):
+                raise ValueError(f"{context}: preview artifact={preview_name!r} must name decoded visual media")
+            primary = artifacts[primary_artifact]
+            expected_representation = "latent" if output_type == "latent" else "decoded"
+            if primary.spec.representation != expected_representation:
+                raise ValueError(
+                    f"{context}, artifact={primary_artifact!r}: expected {expected_representation}, got {primary.spec}"
+                )
+            if io_spec is not None and primary.spec.modality != io_spec.primary.modality:
+                raise ValueError(f"{context}: primary artifact modality conflicts with pipeline declaration")
+            diffusion_output = primary.data
+            if artifact_header.get("audio") is not None:
+                audio_artifact = select_artifact(
+                    artifacts, name=artifact_header["audio"], modality="audio", representation="decoded"
+                )
+                rollout_audio = audio_artifact.data
+                audio_sample_rate = audio_artifact.spec.sample_rate
+        elif isinstance(diffusion_output, dict):
+            if len(diffusion_output) != 1:
+                raise ValueError(f"{context}: multiple legacy media keys require named artifacts")
+            diffusion_output = next(iter(diffusion_output.values()))
+        if not artifacts and isinstance(diffusion_output, tuple | list):
             expected_streams = 1 + len(io_spec.auxiliary) if io_spec is not None else None
             if len(diffusion_output) not in (1, 2) or (
                 expected_streams is not None and len(diffusion_output) != expected_streams
@@ -249,7 +325,9 @@ class DiffusionStrategy(OmniStrategyBase):
             diffusion_output = diffusion_output[0]
             if io_spec is not None and io_spec.auxiliary:
                 audio_sample_rate = io_spec.auxiliary[0].sample_rate
-        if output_type == "latent":
+        if artifacts:
+            pass  # The adapter has normalized decoded media; native latents retain dtype/layout.
+        elif output_type == "latent":
             diffusion_output = torch.as_tensor(diffusion_output).float()
         else:
             if isinstance(diffusion_output, np.ndarray):
@@ -273,8 +351,18 @@ class DiffusionStrategy(OmniStrategyBase):
                 if key in extra_fields:
                     raise ValueError(f"Duplicate rollout metadata field: {key}")
                 extra_fields[key] = _maybe_unbatch(value)
+        if artifacts:
+            kind = artifacts[primary_artifact].spec.modality
+            if extra_fields.get("media_kind", kind) != kind:
+                raise ValueError(f"{context}: media_kind conflicts with primary artifact")
+            extra_fields["media_kind"] = kind
+            if rollout_audio is not None:
+                if "audio" in extra_fields and not torch.equal(torch.as_tensor(extra_fields["audio"]), rollout_audio):
+                    raise ValueError(f"{context}: audio metadata conflicts with named audio artifact")
+                if extra_fields.get("audio_sample_rate", audio_sample_rate) != audio_sample_rate:
+                    raise ValueError(f"{context}: audio_sample_rate conflicts with named audio artifact")
         if rollout_audio is not None:
-            extra_fields["audio"] = _maybe_unbatch(rollout_audio)
+            extra_fields["audio"] = rollout_audio if artifacts else _maybe_unbatch(rollout_audio)
             # The audio sample rate is declared by the adapter's DiffusionIOSpec
             # (or provided at runtime through rollout metadata); no model-specific
             # default lives in this shared strategy.
@@ -301,6 +389,9 @@ class DiffusionStrategy(OmniStrategyBase):
         num_preempted = self._extract_num_preempted(req_output)
 
         return DiffusionOutput(
+            artifacts=artifacts,
+            primary_artifact=primary_artifact,
+            preview_artifact=artifact_header.get("preview") if artifact_header else None,
             diffusion_output=diffusion_output,
             log_probs=log_probs,
             stop_reason=stop_reason,

--- a/verl_omni/workers/rollout/vllm_rollout/vllm_omni_diffusion_strategy.py
+++ b/verl_omni/workers/rollout/vllm_rollout/vllm_omni_diffusion_strategy.py
@@ -18,7 +18,6 @@ from typing import Any, Optional
 
 import numpy as np
 import torch
-import torchvision.transforms as T
 from verl.utils.import_utils import import_external_libs
 from vllm_omni.inputs.data import OmniDiffusionSamplingParams
 from vllm_omni.lora.request import LoRARequest
@@ -29,6 +28,7 @@ from verl_omni.pipelines.rollout_artifacts import (
     ARTIFACT_SPECS,
     PRIMARY_ARTIFACT,
     artifacts_from_fields,
+    requested_artifact_names,
     select_artifact,
     validate_artifacts,
 )
@@ -49,18 +49,11 @@ def _diffusion_output_type(sampling_params: dict[str, Any]) -> str:
     output_type = sampling_params.get("output_type")
     if output_type is None:
         output_type = (sampling_params.get("extra_args") or {}).get("output_type")
-    return output_type or "image"
-
-
-def _pixel_output_to_uint8(output: torch.Tensor) -> torch.Tensor:
-    """Quantize a rollout pixel tensor from float ``[0, 1]`` to uint8 once."""
-    if output.dtype == torch.uint8:
-        return output
-    output = output.detach().to(dtype=torch.float32, copy=True)
-    if not bool(torch.isfinite(output).all()):
-        raise ValueError("Pixel rollout output must contain only finite values")
-    output = output.clamp_(0, 1)
-    return output.mul_(255).round_().to(dtype=torch.uint8)
+    if output_type is None:
+        return "image"
+    if not isinstance(output_type, str) or output_type not in ("image", "pt", "np", "pil", "both", "latent"):
+        raise ValueError(f"Unsupported diffusion output_type: {output_type!r}")
+    return output_type
 
 
 def _rollout_metadata_groups(multimodal_output: Any) -> tuple[Mapping[str, Any], ...]:
@@ -77,15 +70,18 @@ def _rollout_metadata_groups(multimodal_output: Any) -> tuple[Mapping[str, Any],
     return tuple(groups)
 
 
-def _maybe_unbatch(value: Any) -> Any:
-    if value is None:
-        return None
-    if isinstance(value, torch.Tensor):
-        return value[0] if value.dim() > 0 else value
-    if isinstance(value, np.ndarray):
-        return value[0] if value.ndim > 0 else value
+def _unbatch_training_field(value: Any, *, context: str, name: str) -> Any:
+    """Training groups declare B-leading tensors/lists; the RPC returns exactly one sample."""
+    if isinstance(value, torch.Tensor | np.ndarray):
+        if value.ndim == 0:
+            return value
+        if value.shape[0] != 1:
+            raise ValueError(f"{context}, field={name!r}: expected batch size 1, got shape={tuple(value.shape)}")
+        return value[0]
     if isinstance(value, list | tuple):
-        return value[0] if value else None
+        if len(value) != 1:
+            raise ValueError(f"{context}, field={name!r}: expected one batched item, got {len(value)}")
+        return value[0]
     return value
 
 
@@ -100,9 +96,6 @@ class DiffusionStrategy(OmniStrategyBase):
 
     rollout_config_cls = DiffusionRolloutConfig
     model_config_cls = DiffusionModelConfig
-
-    def post_init(self, cuda_visible_devices: str) -> None:
-        self.server._to_tensor = T.PILToTensor()
 
     def worker_extension_cls(self, device_type: str) -> str:
         if device_type == "npu":
@@ -159,6 +152,7 @@ class DiffusionStrategy(OmniStrategyBase):
         if not isinstance(explicit_extra, Mapping):
             raise TypeError("Diffusion sampling extra_args must be a mapping")
         extra_args: dict[str, Any] = dict(explicit_extra)
+        _diffusion_output_type(sampling_params)
         for key, value in sampling_params.items():
             if key == "extra_args":
                 continue
@@ -170,6 +164,11 @@ class DiffusionStrategy(OmniStrategyBase):
                 sampling_kwargs[key] = value
             else:
                 extra_args[key] = value
+        requested = requested_artifact_names(extra_args.get("requested_outputs"), context="diffusion request")
+        if requested:
+            io_spec = self._diffusion_io_spec()
+            if io_spec is not None and (unknown := set(requested) - io_spec.artifacts.keys()):
+                raise ValueError(f"Diffusion request asks for undeclared artifacts: {sorted(unknown)}")
         sampling_kwargs["extra_args"] = extra_args
         if lora_request is not None:
             sampling_kwargs["lora_request"] = lora_request
@@ -196,12 +195,7 @@ class DiffusionStrategy(OmniStrategyBase):
         )
 
     def _diffusion_io_spec(self) -> Optional[DiffusionIOSpec]:
-        """Resolve the adapter-declared media I/O spec for the active pipeline.
-
-        The spec declares primary modality and the optional joint audio stream's
-        sample rate. The current transport fixes audio at tuple position 1. Returns
-        ``None`` when the pipeline (or a bare test server) declares no spec.
-        """
+        """Resolve the adapter's available named artifacts, independent of engine wire layout."""
         model_config = getattr(self.server, "model_config", None)
         if model_config is None:
             return None
@@ -213,23 +207,73 @@ class DiffusionStrategy(OmniStrategyBase):
 
     def process_output(self, final_res: Any, params: Any, sampling_params: dict[str, Any]) -> DiffusionOutput:
         output_type = _diffusion_output_type(sampling_params)
+        req_output = getattr(final_res, "request_output", None) or final_res
+        request_id = getattr(req_output, "request_id", getattr(final_res, "request_id", "unknown"))
+        model_config = getattr(self.server, "model_config", None)
+        context = (
+            f"pipeline={getattr(model_config, 'architecture', 'unknown')}/"
+            f"{getattr(model_config, 'algorithm', 'unknown')}, request_id={request_id}"
+        )
         multimodal = getattr(final_res, "multimodal_output", None)
         metadata = multimodal.get("metadata", {}) if isinstance(multimodal, Mapping) else {}
         artifact_header = metadata.get("media_artifacts") if isinstance(metadata, Mapping) else None
         artifact_payload = None
         if artifact_header is not None:
-            if not isinstance(artifact_header, Mapping) or not {"primary", "specs"} <= artifact_header.keys():
+            if (
+                not isinstance(artifact_header, Mapping)
+                or not {"primary", "specs", "preview", "audio"} <= artifact_header.keys()
+            ):
                 raise ValueError(
                     f"request_id={getattr(final_res, 'request_id', 'unknown')}: invalid media_artifacts header"
                 )
-            if len(final_res.images) == 1:
-                artifact_payload = final_res.images[0]
-            elif not final_res.images:
-                artifact_payload = multimodal.get("audio")
-            if not isinstance(artifact_payload, Mapping):
-                raise ValueError(
-                    f"request_id={getattr(final_res, 'request_id', 'unknown')}: expected one named artifact payload"
-                )
+            artifact_payload = {}
+            sources = []
+            specs = artifact_header["specs"]
+            if not isinstance(specs, Mapping) or artifact_header["primary"] not in specs:
+                raise ValueError(f"{context}: invalid named artifact declarations/primary")
+            for key, value in multimodal.items():
+                if key in {"metadata", "audio_sample_rate", "fps", "trajectory"}:
+                    continue
+                if key in ("image", "video", "audio") and isinstance(value, Mapping | list):
+                    if isinstance(value, list):
+                        if len(value) != 1:
+                            raise ValueError(f"{context}: expected one named artifact payload")
+                        value = value[0]
+                    if not isinstance(value, Mapping):
+                        raise ValueError(f"{context}: invalid named {key} payload")
+                    sources.append(value)
+                elif key in specs:
+                    sources.append({key: value})
+                else:
+                    raise ValueError(f"{context}: undeclared multimodal output {key!r}")
+            images = final_res.images or []
+            if images:
+                if len(images) != 1:
+                    raise ValueError(f"{context}: expected one named artifact payload")
+                image_payload = images[0]
+                if not isinstance(image_payload, Mapping):
+                    primary = artifact_header["primary"]
+                    expected_kind = specs[primary]["modality"]
+                    if getattr(final_res, "final_output_type", None) != expected_kind:
+                        raise ValueError(
+                            f"{context}: images fallback requires explicit final_output_type={expected_kind}"
+                        )
+                    image_payload = {primary: image_payload}
+                sources.append(image_payload)
+            for source in sources:
+                for name, tensor in source.items():
+                    if not isinstance(name, str):
+                        raise ValueError(f"{context}: artifact names must be strings, got {name!r}")
+                    if name in artifact_payload and (
+                        getattr(artifact_payload[name], "dtype", None) != getattr(tensor, "dtype", None)
+                        or not _alias_values_match(artifact_payload[name], tensor)
+                    ):
+                        raise ValueError(f"{context}: conflicting artifact={name!r} in multimodal_output and images")
+                    artifact_payload[name] = tensor
+            if not artifact_payload:
+                raise ValueError(f"{context}: expected one named artifact payload")
+        if artifact_header is None and isinstance(multimodal, Mapping) and multimodal.keys() - {"metadata"}:
+            raise ValueError(f"{context}: named media_artifacts declaration required")
         if artifact_header is None and (final_res is None or not final_res.images):
             finish_reason = "abort"
             if final_res is not None:
@@ -253,15 +297,12 @@ class DiffusionStrategy(OmniStrategyBase):
                 extra_fields={"global_steps": self.server.global_steps},
             )
 
-        diffusion_output = artifact_payload if artifact_header is not None else final_res.images[0]
+        if artifact_header is None:
+            raise ValueError(
+                f"{context}: named media_artifacts declaration required; legacy tensor/tuple output is unsupported"
+            )
+        diffusion_output = artifact_payload
         io_spec = self._diffusion_io_spec()
-        req_output = getattr(final_res, "request_output", None) or final_res
-        request_id = getattr(req_output, "request_id", getattr(final_res, "request_id", "unknown"))
-        model_config = getattr(self.server, "model_config", None)
-        context = (
-            f"pipeline={getattr(model_config, 'architecture', 'unknown')}/"
-            f"{getattr(model_config, 'algorithm', 'unknown')}, request_id={request_id}"
-        )
         artifacts = {}
         primary_artifact = None
         audio_sample_rate: Optional[int] = None
@@ -298,8 +339,18 @@ class DiffusionStrategy(OmniStrategyBase):
                 raise ValueError(
                     f"{context}, artifact={primary_artifact!r}: expected {expected_representation}, got {primary.spec}"
                 )
-            if io_spec is not None and primary.spec.modality != io_spec.primary.modality:
-                raise ValueError(f"{context}: primary artifact modality conflicts with pipeline declaration")
+            if io_spec is not None:
+                for name, artifact in artifacts.items():
+                    expected = io_spec.artifacts.get(name)
+                    if expected is None:
+                        raise ValueError(f"{context}: undeclared artifact={name!r}")
+                    actual = artifact.spec
+                    if (actual.modality, actual.representation, actual.layout) != (
+                        expected.modality,
+                        expected.representation,
+                        expected.layout,
+                    ) or (expected.sample_rate is not None and actual.sample_rate != expected.sample_rate):
+                        raise ValueError(f"{context}, artifact={name!r}: expected {expected}, got {actual}")
             diffusion_output = primary.data
             if artifact_header.get("audio") is not None:
                 audio_artifact = select_artifact(
@@ -307,50 +358,28 @@ class DiffusionStrategy(OmniStrategyBase):
                 )
                 rollout_audio = audio_artifact.data
                 audio_sample_rate = audio_artifact.spec.sample_rate
-        elif isinstance(diffusion_output, dict):
-            if len(diffusion_output) != 1:
-                raise ValueError(f"{context}: multiple legacy media keys require named artifacts")
-            diffusion_output = next(iter(diffusion_output.values()))
-        if not artifacts and isinstance(diffusion_output, tuple | list):
-            expected_streams = 1 + len(io_spec.auxiliary) if io_spec is not None else None
-            if len(diffusion_output) not in (1, 2) or (
-                expected_streams is not None and len(diffusion_output) != expected_streams
-            ):
-                raise ValueError(
-                    f"Unsupported diffusion media tuple ({context}): expected "
-                    f"{expected_streams if expected_streams is not None else '1 or 2'} streams, "
-                    f"got {len(diffusion_output)}"
-                )
-            rollout_audio = diffusion_output[1] if len(diffusion_output) > 1 else None
-            diffusion_output = diffusion_output[0]
-            if io_spec is not None and io_spec.auxiliary:
-                audio_sample_rate = io_spec.auxiliary[0].sample_rate
-        if artifacts:
-            pass  # The adapter has normalized decoded media; native latents retain dtype/layout.
-        elif output_type == "latent":
-            diffusion_output = torch.as_tensor(diffusion_output).float()
-        else:
-            if isinstance(diffusion_output, np.ndarray):
-                diffusion_output = torch.from_numpy(diffusion_output)
-            elif not isinstance(diffusion_output, torch.Tensor):
-                diffusion_output = self.server._to_tensor(diffusion_output)
-            diffusion_output = _pixel_output_to_uint8(diffusion_output)
 
         if sampling_params.get("logprobs", False):
-            log_probs = _maybe_unbatch(final_res.trajectory_log_probs)
+            log_probs = _unbatch_training_field(
+                final_res.trajectory_log_probs, context=context, name="trajectory_log_probs"
+            )
         else:
             log_probs = None
 
         extra_fields: dict[str, Any] = {"global_steps": self.server.global_steps}
         if final_res.trajectory_latents is not None:
-            extra_fields["all_latents"] = _maybe_unbatch(final_res.trajectory_latents)
+            extra_fields["all_latents"] = _unbatch_training_field(
+                final_res.trajectory_latents, context=context, name="trajectory_latents"
+            )
         if final_res.trajectory_timesteps is not None:
-            extra_fields["all_timesteps"] = _maybe_unbatch(final_res.trajectory_timesteps)
+            extra_fields["all_timesteps"] = _unbatch_training_field(
+                final_res.trajectory_timesteps, context=context, name="trajectory_timesteps"
+            )
         for metadata_group in _rollout_metadata_groups(final_res.multimodal_output):
             for key, value in metadata_group.items():
                 if key in extra_fields:
                     raise ValueError(f"Duplicate rollout metadata field: {key}")
-                extra_fields[key] = _maybe_unbatch(value)
+                extra_fields[key] = _unbatch_training_field(value, context=context, name=key)
         if artifacts:
             kind = artifacts[primary_artifact].spec.modality
             if extra_fields.get("media_kind", kind) != kind:
@@ -362,21 +391,8 @@ class DiffusionStrategy(OmniStrategyBase):
                 if extra_fields.get("audio_sample_rate", audio_sample_rate) != audio_sample_rate:
                     raise ValueError(f"{context}: audio_sample_rate conflicts with named audio artifact")
         if rollout_audio is not None:
-            extra_fields["audio"] = rollout_audio if artifacts else _maybe_unbatch(rollout_audio)
-            # The audio sample rate is declared by the adapter's DiffusionIOSpec
-            # (or provided at runtime through rollout metadata); no model-specific
-            # default lives in this shared strategy.
-            if audio_sample_rate is not None:
-                extra_fields.setdefault("audio_sample_rate", audio_sample_rate)
-        # Surface the adapter-declared primary media kind so downstream consumers
-        # read the modality instead of inferring it from the response tensor rank.
-        if io_spec is not None:
-            runtime_kind = extra_fields.get("media_kind")
-            if runtime_kind is not None and runtime_kind != io_spec.primary.modality:
-                raise ValueError(
-                    f"Conflicting media_kind ({context}): expected {io_spec.primary.modality!r}, got {runtime_kind!r}"
-                )
-            extra_fields["media_kind"] = io_spec.primary.modality
+            extra_fields["audio"] = rollout_audio
+            extra_fields["audio_sample_rate"] = audio_sample_rate
 
         if hasattr(req_output, "outputs") and req_output.outputs:
             finish_reason = req_output.outputs[0].finish_reason or "stop"
@@ -391,7 +407,7 @@ class DiffusionStrategy(OmniStrategyBase):
         return DiffusionOutput(
             artifacts=artifacts,
             primary_artifact=primary_artifact,
-            preview_artifact=artifact_header.get("preview") if artifact_header else None,
+            preview_artifact=artifact_header["preview"],
             diffusion_output=diffusion_output,
             log_probs=log_probs,
             stop_reason=stop_reason,

--- a/verl_omni/workers/rollout/vllm_rollout/vllm_omni_diffusion_strategy.py
+++ b/verl_omni/workers/rollout/vllm_rollout/vllm_omni_diffusion_strategy.py
@@ -20,7 +20,7 @@ import numpy as np
 import torch
 import torchvision.transforms as T
 from verl.utils.import_utils import import_external_libs
-from vllm_omni.inputs.data import OmniCustomPrompt, OmniDiffusionSamplingParams
+from vllm_omni.inputs.data import OmniDiffusionSamplingParams
 from vllm_omni.lora.request import LoRARequest
 
 from verl_omni.pipelines.model_base import VllmOmniPipelineBase
@@ -138,34 +138,13 @@ class DiffusionStrategy(OmniStrategyBase):
         request: OmniRolloutRequest,
         sampling_params: dict[str, Any],
         lora_request: Optional[LoRARequest],
-    ) -> tuple[OmniCustomPrompt, list[Any]]:
-        prompt_ids = request.prompt.token_ids
-        prompt_mask = request.prompt.mask
-        negative_prompt_ids = request.prompt.negative_token_ids
-        extra_prompt_ids = request.prompt.extra_token_ids
-        negative_extra_prompt_ids = request.prompt.negative_extra_token_ids
-        mm_processor_kwargs = request.prompt.mm_processor_kwargs
-        multi_modal_data = request.multi_modal_data()
-
+    ) -> tuple[dict[str, Any], list[Any]]:
         default_params_list = self.server.engine.default_sampling_params_list
-
-        custom_prompt: OmniCustomPrompt = {"prompt_token_ids": prompt_ids}
-        if prompt_mask is not None:
-            custom_prompt["prompt_mask"] = prompt_mask
+        custom_prompt = dict(request.to_diffusion_prompt())
         if len(default_params_list) > 1:
+            # The initial AR stage uses vLLM token preprocessing, not OmniCustomPrompt.
+            custom_prompt["prompt_token_ids"] = custom_prompt.pop("prompt_ids")
             custom_prompt["modalities"] = ["image"]
-        if negative_prompt_ids is not None:
-            custom_prompt["negative_prompt_ids"] = negative_prompt_ids
-        if extra_prompt_ids is not None:
-            custom_prompt["extra_prompt_ids"] = extra_prompt_ids
-        if negative_extra_prompt_ids is not None:
-            custom_prompt["negative_extra_prompt_ids"] = negative_extra_prompt_ids
-        if multi_modal_data:
-            custom_prompt["multi_modal_data"] = multi_modal_data
-            custom_prompt["extra_args"] = {"multi_modal_data": multi_modal_data}
-        if mm_processor_kwargs:
-            # Reference fps / sampling_rate must reach the pipeline (mirrors ARStrategy).
-            custom_prompt["mm_processor_kwargs"] = mm_processor_kwargs
 
         sampling_kwargs: dict[str, Any] = {}
         extra_args: dict[str, Any] = {}

--- a/verl_omni/workers/rollout/vllm_rollout/vllm_omni_diffusion_strategy.py
+++ b/verl_omni/workers/rollout/vllm_rollout/vllm_omni_diffusion_strategy.py
@@ -202,9 +202,8 @@ class DiffusionStrategy(OmniStrategyBase):
     def _diffusion_io_spec(self) -> Optional[DiffusionIOSpec]:
         """Resolve the adapter-declared media I/O spec for the active pipeline.
 
-        The spec lets a diffusion adapter declare its auxiliary media streams
-        (e.g. joint audio and its sample rate) so this strategy does not have to
-        hard-code model-specific tuple positions or sample rates. Returns
+        The spec declares primary modality and the optional joint audio stream's
+        sample rate. The current transport fixes audio at tuple position 1. Returns
         ``None`` when the pipeline (or a bare test server) declares no spec.
         """
         model_config = getattr(self.server, "model_config", None)
@@ -248,15 +247,29 @@ class DiffusionStrategy(OmniStrategyBase):
                     diffusion_output = diffusion_output[key]
                     break
         io_spec = self._diffusion_io_spec()
+        req_output = getattr(final_res, "request_output", None) or final_res
+        request_id = getattr(req_output, "request_id", getattr(final_res, "request_id", "unknown"))
+        model_config = getattr(self.server, "model_config", None)
+        context = (
+            f"pipeline={getattr(model_config, 'architecture', 'unknown')}/"
+            f"{getattr(model_config, 'algorithm', 'unknown')}, request_id={request_id}"
+        )
         audio_sample_rate: Optional[int] = None
         rollout_audio: Any = None
         if isinstance(diffusion_output, tuple | list):
+            expected_streams = 1 + len(io_spec.auxiliary) if io_spec is not None else None
+            if len(diffusion_output) not in (1, 2) or (
+                expected_streams is not None and len(diffusion_output) != expected_streams
+            ):
+                raise ValueError(
+                    f"Unsupported diffusion media tuple ({context}): expected "
+                    f"{expected_streams if expected_streams is not None else '1 or 2'} streams, "
+                    f"got {len(diffusion_output)}"
+                )
             rollout_audio = diffusion_output[1] if len(diffusion_output) > 1 else None
             diffusion_output = diffusion_output[0]
-            if io_spec is not None:
-                audio_spec = next((spec for spec in io_spec.auxiliary if spec.modality == "audio"), None)
-                if audio_spec is not None:
-                    audio_sample_rate = audio_spec.sample_rate
+            if io_spec is not None and io_spec.auxiliary:
+                audio_sample_rate = io_spec.auxiliary[0].sample_rate
         if output_type == "latent":
             diffusion_output = torch.as_tensor(diffusion_output).float()
         else:
@@ -291,9 +304,13 @@ class DiffusionStrategy(OmniStrategyBase):
         # Surface the adapter-declared primary media kind so downstream consumers
         # read the modality instead of inferring it from the response tensor rank.
         if io_spec is not None:
-            extra_fields.setdefault("media_kind", io_spec.primary.modality)
+            runtime_kind = extra_fields.get("media_kind")
+            if runtime_kind is not None and runtime_kind != io_spec.primary.modality:
+                raise ValueError(
+                    f"Conflicting media_kind ({context}): expected {io_spec.primary.modality!r}, got {runtime_kind!r}"
+                )
+            extra_fields["media_kind"] = io_spec.primary.modality
 
-        req_output = getattr(final_res, "request_output", None) or final_res
         if hasattr(req_output, "outputs") and req_output.outputs:
             finish_reason = req_output.outputs[0].finish_reason or "stop"
         elif hasattr(req_output, "finish_reason"):


### PR DESCRIPTION
## Summary

Carry named media artifacts from diffusion adapters through rollout, reward scoring and export. Declare each artifact's modality, representation and layout rather than inferring its meaning from tensor shape or tuple position.

Part 6 of RFC #403: merged #480 → #481 → #556 → **#557**.

- **Stack parent:** #556 at `6eb8db3`.
- **Tested head:** `05998d0`.
- **PR6 review range:** `6eb8db3..05998d0`.

The GitHub base remains `main`, so the displayed diff also includes #481/#556 until they merge. The implementation covers the in-tree adapters, but **this remains a draft: GPU acceptance of the current rebased head and remaining migration work are not complete.**

## Changes

### Named artifacts and explicit layouts

- Keep `DiffusionIOSpec` and the existing **`MediaSpec`** name/import in `verl_omni.pipelines.rollout_media`. Replace positional `primary`/`auxiliary` declarations with an `artifacts` mapping whose specs declare modality, representation and layout. The tensor's dtype is authoritative.
- Normalize decoded media at the adapter boundary:

  | Media | Canonical layout | Dtype |
  | --- | --- | --- |
  | Image | `CHW` | `uint8` |
  | Video | `TCHW` | `uint8` |
  | Audio | `CT` | Floating point |

- Preserve latent dtype and explicitly declared native or packed sampler layouts. Final latents remain separate from saved trajectories and algorithm/replay tensors; packed sampler data is not relabelled as VAE-native data.
- Migrate Qwen image/edit/DPO/NFT/dual/mix, SD3, **FLUX DanceGRPO**, Boogu, Wan, LTX, MiniMax H3 NFT/FlowGRPO and Bagel.

### Transport, consumers and failure policy

- Preserve named tensors through the pinned formatter. Merge complementary `multimodal_output` and `images` sources, reject conflicting values/dtypes, and reject unlabelled legacy tensor/tuple results.
- Carry artifacts, selectors and pipeline/request context through ordinary and TransferQueue paths. `responses` remains an explicit primary projection, validated by both reward managers rather than reinterpreted from global configuration.
- Route CLAP, ImageBind, latent HTTP scoring, pixel/frame rewards, V0/V1 dumps and W&B through explicit media contracts. For example, SD3 latent scoring selects the named `CHW` latent instead of testing whether a dimension equals 16.
- Add `pipeline.requested_outputs` to rollout/model/validation configs. Packed requests retain the union of all requests' requirements. A latent primary can coexist with a decoded preview; an intentionally absent preview skips logging, while a missing requested artifact fails.
- Use emitted FPS and decoder sample rates, including fractional video FPS and LTX BWE's 48000 Hz audio. Export has no implicit FPS fallback.
- Keep schema, selection and primary-projection failures synchronous and fatal, even for optional sub-rewards. Export/encoding/W&B failures remain best-effort. V1 bounds pending dumps and copies only retained media instead of holding full-batch storage through row views.

### Adapter integration fixes

- **Qwen Image Edit:** distinguish raw token-native images from the engine's resized conditioning views; they are not conflicting aliases. Honor the requested `output_type`.
- **Qwen step execution and LTX:** execute decoder warmup but discard media for the reserved dummy request. Pinned warmup NaNs or missing serving metadata do not become serving artifacts; nonfinite pixels in real requests still fail.
- **LTX:** pass the phase recipe's sampler to the pinned forward context.
- **FLUX:** declare packed `LC` clean predictions and decoded `CHW` previews, preserve separate trajectories, and decode a preview when any request in the batch needs one. This fixes the adapter introduced by newer `main` without weakening validation.

These adapter repairs do not patch installed engine packages or shared model weights. The rebase retains #553's upstream merged-LoRA work and explicitly preserves the implementation/review changes originally carried by merge commits `beb2498` and `9971959`.

## Breaking changes and compatibility

Out-of-tree diffusion adapters must migrate their declarations and emit named artifacts. Unlabelled legacy outputs and ambiguous consumer inputs now fail. Keeping the `MediaSpec` name does **not** preserve its old constructor signature.

The public Ray keyword API, AR strategy/lifecycle behavior and algorithm-owned training tensor keys are unchanged. Compatibility projections such as `responses` remain. `requested_outputs` guarantees artifact availability; it is not an exclusive output filter or a universal selective-decoding/transfer API.

Contract and migration details: [`diffusion_media_artifacts.md`](https://github.com/NancyFyong/verl-omni/blob/05998d0c56228e1bd6338dd869fbb337eb1e2d74/docs/contributing/diffusion_media_artifacts.md) and the diffusion integration guide.

## Validation

### Current head: local CPU and static checks

**2195 passed, 7 skipped, 31 warnings** at `05998d0`, after replaying
onto #556 `6eb8db3` and #481 `3c82cf0` (current upstream `main` `0971c25`).

Coverage includes real upstream postprocessors/formatter, native dtype/storage
preservation, explicit decoded layouts, request splitting and preview unions, step
hooks, ordinary/TQ transport, reward projection checks, error provenance,
optional-reward fail-fast behavior, bounded dump storage and MP4/W&B encoding.
FLUX tests use pinned pack/unpack functions with mocked encoders, denoising and
VAE decode. The rebase follow-up also covers absent previews, strict declared
rank validation, legacy response compatibility, canonical visual scorer inputs,
and V1 dump queue ownership.

<details>
<summary>Command, environment and check details</summary>

Pinned environment: verl `fefb080`, vllm-omni `ded893462` (0.28), vllm 0.28.

```bash
printf '[pytest]
python_files = *_on_cpu.py
' > pytest.ini
PYTHONPATH="$PWD" TORCH_COMPILE_DISABLE=1 TORCHINDUCTOR_DISABLE=1 \
  OMP_NUM_THREADS=1 python -m pytest -q --asyncio-mode=auto tests/
# 2195 passed, 7 skipped, 31 warnings
```

Ruff check/format, mypy, changed-file pre-commit hooks, compileall and whitespace
checks passed. mypy uses the repository's permissive configuration, so it is
limited evidence. The repository-wide pre-commit launcher remains incompatible
with this host Git version; the affected-file hook invocation passed.

Full-suite evidence: `/dockerdata/rfc403-rebase-pr556-557-20260917/pr557-third-full.log`.

</details>

### Current GPU evidence: tiny-random direct-engine smoke

The current #557 descendant `05998d0` contains #556 head `6eb8db3` unchanged.
A clean checkout ran `AsyncOmni` directly (no Ray cluster) on three shared H20
GPUs with `CUDA_VISIBLE_DEVICES=4,5,6`; no unrelated task was stopped.

| Path | Current result |
| --- | --- |
| Qwen Image FlowGRPO | **Passed** on GPU 4 with two requests. Engine admission logged `waiting=2, max_batch=2`; both request IDs appear in each producer context. It produced two `uint8` CHW 64×64 PNG previews plus LC latent artifacts. |
| Qwen Image NFT step execution | **Passed** on GPU 5 with two requests and `step_execution=True`; each request completed with a unique producer context and a `bfloat16` LC latent plus `uint8` CHW preview. |
| MiniMax H3 FlowGRPO T2VA | **Passed** on GPU 6 using the existing isolated compatible tiny VAE fixture. It generated TCHW `uint8` video, CT `float32` audio, native video/audio latents, and an H.264 384×256/24fps MP4 with AAC 32kHz stereo. |

The smoke checker was copied into the evidence directory and supplied two current
rollout defaults (`tensor_model_parallel_size=1`, `text_encoder_tp_size=1`) plus
the declared preview FPS to match upstream interfaces. It did **not** modify PR
source. The H3 fixture adds only the previously documented tiny-VAE compatibility
attribute; neither fixture is a full-weight acceptance test.

Evidence: `/dockerdata/rfc403-pr5-gpu-20260918/` (`final-results-summary.json`,
`h3-flow-compatible/ffprobe.json`, logs, runner and `harness-compat.patch`).

**Still pending:** FLUX (no local tiny checkpoint), SD3 multi-encoder IDs, AR or
multi-stage entrance GPU coverage, V1/TransferQueue training, full-weight model
acceptance, quality/convergence, and hosted CI on these rewritten heads.

### Historical GPU evidence: recorded September 7 snapshots

**The historical runs below do not validate the current rebased `05998d0` head.** The current limited direct-engine smoke is documented above. Historical runs were serial on shared GPUs without stopping unrelated tasks; checkpoints, execution modes and source hashes are recorded per case.

| Path | Recorded result |
| --- | --- |
| VAE layout probes | Nine passed: Qwen, SD3, Boogu, Wan, LTX video/audio, H3 video/audio and Bagel. H3 video used the real 2.6B-parameter VAE. Bagel checkpoint provenance remains unverified. |
| Qwen FlowGRPO / DPO / NFT | Request and step execution passed; FlowGRPO also passed packed two-request execution with both IDs in producer context. Tiny-checkpoint/dummy-pipeline limitations apply to the relevant cases. |
| Qwen dual / mix | Advertised single-request paths passed; no packed-batch acceptance is claimed. |
| SD3 / Boogu | Two-request packed forwards passed, including SD3's separate encoder-ID maps. |
| Wan / LTX-2.3 | Video generation, named outputs and export passed; LTX retained native video/audio layouts and 48000 Hz decoded audio. |
| H3 FlowGRPO | Tiny-fixture T2VA engine generation, latent primary and audiovisual export passed. |
| H3 NFT V0 / V1-TQ | Tiny-fixture runs completed one training step with CLAP/ImageBind and audiovisual export. The final V1/TQ run exported H.264 384×256 at 24 fps with AAC 32000 Hz stereo. |
| Bagel | Single-stage engine generation passed with the tiny DiT/LLM fixture and its VAE. |
| Qwen Image Edit | Conditioned tiny-fixture LoRA training completed an actor update, weight sync and capped JPEG export with latent primary plus preview. |
| FLUX | **Pending:** no real VAE or rollout GPU acceptance. |

These establish the recorded layout/interface/plumbing behavior, **not model quality, convergence or every conditioning/parallelism combination**. Tiny/dummy-pipeline checks do not establish full-weight pipeline acceptance. Final validation metrics were `None` in the H3 and image-edit training smokes; image edit also emitted a microbatch `ratio_std` NaN warning.

<details>
<summary>Reproduction entrypoints and evidence locations</summary>

The added tools require local checkpoints and model-specific deployment settings:

```bash
# Sequential VAE probes on one GPU; JSON maps case names to checkpoints.
python tests/special_e2e/check_diffusion_vae_layouts.py \
  --models-json <paths.json> --output <report.json>

# Engine → adapter → formatter → reward selection → export.
python tests/special_e2e/check_named_diffusion_rollout.py \
  --model <qwen-checkpoint> --architecture QwenImagePipeline --algorithm flow_grpo \
  --num-requests 2 --require-request-batch --output-dir <output>
# Add --step-execution for step mode; see the guide for tokenizer/deployment arguments.
```

Local evidence is under `/dockerdata/rfc403-complete-20260907/`, including `verified-matrix.json`, `vae-layouts.json`, media probes and per-snapshot source hashes. The final H3 V1/TQ run matched `beb2498`'s production source hash:

```text
d91c75a363f59c2c61e215170be705759b1e8120c3da56a067cededdeb8b17ea
```

That hash identifies the historical tested source, not the current head. Earlier-snapshot engine results retain their own source/fixture scope.

</details>

**Pending:** hosted CPU CI and GPU acceptance on the current head, real FLUX GPU coverage, broader conditioning/parallelism and queue-pressure stress coverage, compatibility-projection removal, and human review. Only `drop_label` has run on this head.

## Non-duplication and disclosure

The recorded #403/comment review and open-PR searches for `403 in:body`, wire/media artifacts and LTX sampler work found no competing named-output migration. #480/#481/#556 are the intended lower slices. Upstream #553 was preserved rather than reimplemented.

AI assistance (Pi coding agent / OpenAI Codex) was used. The human submitter reviewed every changed line and authorized this update; the validation above was run before push.
