### PR TITLE
[doc, ci] feat: add project governance and path-based CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -33,13 +33,13 @@
 /verl_omni/workers/ @zhtmike
 
 # Rollout and agent loop (overrides workers/rollout)
-/verl_omni/agent_loop/ @knlnguyen1802 @Sky-Trigger @NancyFyong
-/verl_omni/workers/rollout/ @knlnguyen1802 @Sky-Trigger @NancyFyong
-/verl_omni/utils/vllm_omni/ @knlnguyen1802 @Sky-Trigger @NancyFyong
+/verl_omni/agent_loop/ @knlnguyen1802 @Sky-Trigger @NancyFyong @ZihaoW123
+/verl_omni/workers/rollout/ @knlnguyen1802 @Sky-Trigger @NancyFyong @ZihaoW123
+/verl_omni/utils/vllm_omni/ @knlnguyen1802 @Sky-Trigger @NancyFyong @ZihaoW123
 
 # Reward system
-/verl_omni/reward_loop/ @ruihanglix @chenyingshu @Sky-Trigger
-/verl_omni/utils/reward_score/ @ruihanglix @chenyingshu @Sky-Trigger
+/verl_omni/reward_loop/ @ruihanglix @chenyingshu @Sky-Trigger @ZihaoW123
+/verl_omni/utils/reward_score/ @ruihanglix @chenyingshu @Sky-Trigger @ZihaoW123
 
 # Pipeline and model adaptation
-/verl_omni/pipelines/ @chenyingshu @NancyFyong
+/verl_omni/pipelines/ @chenyingshu @NancyFyong @ZihaoW123

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,7 +30,7 @@
 /verl_omni/trainer/ @chenyingshu @NancyFyong
 
 # Workers and training engines (FSDP/VeOmni, actor/ref, LoRA, checkpointing)
-/verl_omni/workers/ @cr-gao @zhtmike
+/verl_omni/workers/ @zhtmike
 
 # Rollout and agent loop (overrides workers/rollout)
 /verl_omni/agent_loop/ @knlnguyen1802 @Sky-Trigger @NancyFyong

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,7 +12,7 @@
 # Being listed here does not grant committer status or merge rights.
 
 # Default owner for unmatched paths
-* @samithuang
+* @samithuang @zhtmike
 
 # Tests, CI, packaging, environment, and documentation
 /.github/ @wtomin

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,19 +1,45 @@
 # CODEOWNERS for verl-project/verl-omni
 #
-# Syntax: <pattern> <owner1> [<owner2> ...]
-# - The LAST matching pattern for a given file wins.
-# - Owners must have write access to the repo.
-# - See https://docs.github.com/articles/about-code-owners
+# Used to automatically request PR reviewers.
+# Format: <pattern> @username [@username ...]
+# See https://docs.github.com/articles/about-code-owners
+#
+# Derived from the module table in docs/community/governance.md.
+# When updating ownership, update governance.md first, then the matching
+# rule here.
+#
+# Last-match-wins: more specific rules must come AFTER broader ones.
+# Being listed here does not grant committer status or merge rights.
 
-# Default owner for everything in the repo
-*                @samithuang
+# Default owner for unmatched paths
+* @samithuang
 
-/verl_omni/      @zhtmike @wtomin @knlnguyen1802 @AndyZhou952 @samithuang
-/examples/       @knlnguyen1802
+# Tests, CI, packaging, environment, and documentation
+/.github/ @wtomin
+/docker/ @wtomin
+/tests/ @wtomin
+/docs/ @wtomin
+/scripts/ @wtomin
+/.agents/ @wtomin
 
-/docker/         @wtomin
-/tests/          @wtomin
+# Datasets and examples
+/examples/ @chenyingshu @NancyFyong
+/verl_omni/utils/dataset/ @chenyingshu @NancyFyong
 
-# Documentation
-/docs/           @AndyZhou952
-*.md             @samithuang
+# Trainer and algorithm core
+/verl_omni/trainer/ @chenyingshu @NancyFyong
+
+# Workers and training engines (FSDP/VeOmni, actor/ref, LoRA, checkpointing)
+/verl_omni/workers/ @cr-gao @zhtmike
+
+# Rollout and agent loop (overrides workers/rollout)
+/verl_omni/agent_loop/ @knlnguyen1802 @Sky-Trigger @NancyFyong
+/verl_omni/workers/rollout/ @knlnguyen1802 @Sky-Trigger @NancyFyong
+/verl_omni/utils/vllm_omni/ @knlnguyen1802 @Sky-Trigger @NancyFyong
+
+# Reward system
+/verl_omni/reward_loop/ @ruihanglix @chenyingshu @Sky-Trigger
+/verl_omni/utils/reward_score/ @ruihanglix @chenyingshu @Sky-Trigger
+
+# Pipeline and model adaptation
+/verl_omni/pipelines/ @chenyingshu @NancyFyong

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,10 +27,10 @@
 /verl_omni/utils/dataset/ @chenyingshu @NancyFyong
 
 # Trainer and algorithm core
-/verl_omni/trainer/ @chenyingshu @NancyFyong
+/verl_omni/trainer/ @chenyingshu @NancyFyong @WenzheWang
 
 # Workers and training engines (FSDP/VeOmni, actor/ref, LoRA, checkpointing)
-/verl_omni/workers/ @zhtmike
+/verl_omni/workers/ @cr-gao @zhtmike
 
 # Rollout and agent loop (overrides workers/rollout)
 /verl_omni/agent_loop/ @knlnguyen1802 @Sky-Trigger @NancyFyong @ZihaoW123
@@ -42,4 +42,4 @@
 /verl_omni/utils/reward_score/ @ruihanglix @chenyingshu @Sky-Trigger @ZihaoW123
 
 # Pipeline and model adaptation
-/verl_omni/pipelines/ @chenyingshu @NancyFyong @ZihaoW123
+/verl_omni/pipelines/ @chenyingshu @NancyFyong @ZihaoW123 @knlnguyen1802

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,6 +97,10 @@ Additional guides:
 - [CI/CD Layers](docs/contributing/ci_cd.md)
 - [Common Pitfalls](docs/contributing/common_pitfalls.md)
 
+## Governance
+
+Project roles, module ownership, and the committer nomination process are documented in [`docs/community/governance.md`](docs/community/governance.md). Path-based reviewer routing lives in [`.github/CODEOWNERS`](.github/CODEOWNERS).
+
 ## Pull Requests & Code Reviews
 
 Thanks for submitting a PR! To streamline reviews:

--- a/docs/community/governance.md
+++ b/docs/community/governance.md
@@ -33,10 +33,12 @@ Committers have write access and merge rights. They typically have deep expertis
 
 - [@AndyZhou952](https://github.com/AndyZhou952) (Jingan Zhou): Trainer and algorithm core; Diffusion Models
 - [@chenyingshu](https://github.com/chenyingshu) (Susan, Yingshu Chen): Trainer and algorithm core; Reward system; Pipeline and model adaptation; Datasets and examples
-- [@knlnguyen1802](https://github.com/knlnguyen1802) (Long): Rollout and agent loop
+- [@cr-gao](https://github.com/cr-gao) (Chenrui Gao): Workers and training engines
+- [@knlnguyen1802](https://github.com/knlnguyen1802) (Long Nguyen): Rollout and agent loop; Pipeline and model adaptation
 - [@NancyFyong](https://github.com/NancyFyong) (Zhiyong Feng): Trainer and algorithm core; Rollout and agent loop; Pipeline and model adaptation; Datasets and examples
 - [@ruihanglix](https://github.com/ruihanglix) (Ruihang Li): Reward system
 - [@Sky-Trigger](https://github.com/Sky-Trigger) (Mengbo Wang): Rollout and agent loop; Reward system
+- [@WenzheWang](https://github.com/WenzheWang) (Wenzhe Wang): Trainer and algorithm core
 - [@wtomin](https://github.com/wtomin) (Didan DENG): Tests and CI; Packaging and environment; Documentation
 - [@ZihaoW123](https://github.com/ZihaoW123) (Zihao Wang): Rollout and agent loop; Reward system; Pipeline and model adaptation
 - [@zhtmike](https://github.com/zhtmike) (Cheung Ka Wai): Workers and training engines
@@ -47,11 +49,11 @@ Directory rules cover the whole tree unless a more specific path below overrides
 
 | Path | Committers |
 | --- | --- |
-| `verl_omni/trainer/` | [@chenyingshu](https://github.com/chenyingshu), [@NancyFyong](https://github.com/NancyFyong) |
-| `verl_omni/workers/` | [@zhtmike](https://github.com/zhtmike) |
+| `verl_omni/trainer/` | [@chenyingshu](https://github.com/chenyingshu), [@NancyFyong](https://github.com/NancyFyong), [@WenzheWang](https://github.com/WenzheWang) |
+| `verl_omni/workers/` | [@cr-gao](https://github.com/cr-gao), [@zhtmike](https://github.com/zhtmike) |
 | `verl_omni/agent_loop/` <br> `verl_omni/workers/rollout/` <br> `verl_omni/utils/vllm_omni/` | [@knlnguyen1802](https://github.com/knlnguyen1802), [@Sky-Trigger](https://github.com/Sky-Trigger), [@NancyFyong](https://github.com/NancyFyong), [@ZihaoW123](https://github.com/ZihaoW123) |
 | `verl_omni/reward_loop/` <br> `verl_omni/utils/reward_score/` | [@ruihanglix](https://github.com/ruihanglix), [@chenyingshu](https://github.com/chenyingshu), [@Sky-Trigger](https://github.com/Sky-Trigger), [@ZihaoW123](https://github.com/ZihaoW123) |
-| `verl_omni/pipelines/` | [@chenyingshu](https://github.com/chenyingshu), [@NancyFyong](https://github.com/NancyFyong), [@ZihaoW123](https://github.com/ZihaoW123) |
+| `verl_omni/pipelines/` | [@chenyingshu](https://github.com/chenyingshu), [@NancyFyong](https://github.com/NancyFyong), [@ZihaoW123](https://github.com/ZihaoW123), [@knlnguyen1802](https://github.com/knlnguyen1802) |
 | `verl_omni/utils/dataset/` <br> `examples/` | [@chenyingshu](https://github.com/chenyingshu), [@NancyFyong](https://github.com/NancyFyong) |
 | `tests/` <br> `.github/` <br> `scripts/` <br> `docker/` <br> `docs/` <br> `.agents/` | [@wtomin](https://github.com/wtomin) |
 

--- a/docs/community/governance.md
+++ b/docs/community/governance.md
@@ -38,6 +38,7 @@ Committers have write access and merge rights. They typically have deep expertis
 - [@ruihanglix](https://github.com/ruihanglix) (Ruihang Li): Reward system
 - [@Sky-Trigger](https://github.com/Sky-Trigger) (Mengbo Wang): Rollout and agent loop; Reward system
 - [@wtomin](https://github.com/wtomin) (Didan DENG): Tests and CI; Packaging and environment; Documentation
+- [@ZihaoW123](https://github.com/ZihaoW123) (Zihao Wang): Rollout and agent loop; Reward system; Pipeline and model adaptation
 - [@zhtmike](https://github.com/zhtmike) (Cheung Ka Wai): Workers and training engines
 
 ### Path Ownership
@@ -48,9 +49,9 @@ Directory rules cover the whole tree unless a more specific path below overrides
 | --- | --- |
 | `verl_omni/trainer/` | [@chenyingshu](https://github.com/chenyingshu), [@NancyFyong](https://github.com/NancyFyong) |
 | `verl_omni/workers/` | [@zhtmike](https://github.com/zhtmike) |
-| `verl_omni/agent_loop/` <br> `verl_omni/workers/rollout/` <br> `verl_omni/utils/vllm_omni/` | [@knlnguyen1802](https://github.com/knlnguyen1802), [@Sky-Trigger](https://github.com/Sky-Trigger), [@NancyFyong](https://github.com/NancyFyong) |
-| `verl_omni/reward_loop/` <br> `verl_omni/utils/reward_score/` | [@ruihanglix](https://github.com/ruihanglix), [@chenyingshu](https://github.com/chenyingshu), [@Sky-Trigger](https://github.com/Sky-Trigger) |
-| `verl_omni/pipelines/` | [@chenyingshu](https://github.com/chenyingshu), [@NancyFyong](https://github.com/NancyFyong) |
+| `verl_omni/agent_loop/` <br> `verl_omni/workers/rollout/` <br> `verl_omni/utils/vllm_omni/` | [@knlnguyen1802](https://github.com/knlnguyen1802), [@Sky-Trigger](https://github.com/Sky-Trigger), [@NancyFyong](https://github.com/NancyFyong), [@ZihaoW123](https://github.com/ZihaoW123) |
+| `verl_omni/reward_loop/` <br> `verl_omni/utils/reward_score/` | [@ruihanglix](https://github.com/ruihanglix), [@chenyingshu](https://github.com/chenyingshu), [@Sky-Trigger](https://github.com/Sky-Trigger), [@ZihaoW123](https://github.com/ZihaoW123) |
+| `verl_omni/pipelines/` | [@chenyingshu](https://github.com/chenyingshu), [@NancyFyong](https://github.com/NancyFyong), [@ZihaoW123](https://github.com/ZihaoW123) |
 | `verl_omni/utils/dataset/` <br> `examples/` | [@chenyingshu](https://github.com/chenyingshu), [@NancyFyong](https://github.com/NancyFyong) |
 | `tests/` <br> `.github/` <br> `scripts/` <br> `docker/` <br> `docs/` <br> `.agents/` | [@wtomin](https://github.com/wtomin) |
 

--- a/docs/community/governance.md
+++ b/docs/community/governance.md
@@ -26,6 +26,7 @@ VeRL-Omni aims to be an easy, fast, and stable RL training framework for diffusi
 Lead maintainers are responsible for the overall direction and strategy of the project:
 
 - [@samithuang](https://github.com/samithuang) (Yongxiang Huang)
+- [@wuxibin89](https://github.com/wuxibin89) (Xibin Wu)
 
 ### Active Committers
 

--- a/docs/community/governance.md
+++ b/docs/community/governance.md
@@ -33,7 +33,6 @@ Committers have write access and merge rights. They typically have deep expertis
 
 - [@AndyZhou952](https://github.com/AndyZhou952) (Jingan Zhou): Trainer and algorithm core; Diffusion Models
 - [@chenyingshu](https://github.com/chenyingshu) (Susan, Yingshu Chen): Trainer and algorithm core; Reward system; Pipeline and model adaptation; Datasets and examples
-- [@cr-gao](https://github.com/cr-gao) (Chenrui Gao): Workers and training engines
 - [@knlnguyen1802](https://github.com/knlnguyen1802) (Long): Rollout and agent loop
 - [@NancyFyong](https://github.com/NancyFyong) (Zhiyong Feng): Trainer and algorithm core; Rollout and agent loop; Pipeline and model adaptation; Datasets and examples
 - [@ruihanglix](https://github.com/ruihanglix) (Ruihang Li): Reward system
@@ -48,7 +47,7 @@ Directory rules cover the whole tree unless a more specific path below overrides
 | Path | Committers |
 | --- | --- |
 | `verl_omni/trainer/` | [@chenyingshu](https://github.com/chenyingshu), [@NancyFyong](https://github.com/NancyFyong) |
-| `verl_omni/workers/` | [@cr-gao](https://github.com/cr-gao), [@zhtmike](https://github.com/zhtmike) |
+| `verl_omni/workers/` | [@zhtmike](https://github.com/zhtmike) |
 | `verl_omni/agent_loop/` <br> `verl_omni/workers/rollout/` <br> `verl_omni/utils/vllm_omni/` | [@knlnguyen1802](https://github.com/knlnguyen1802), [@Sky-Trigger](https://github.com/Sky-Trigger), [@NancyFyong](https://github.com/NancyFyong) |
 | `verl_omni/reward_loop/` <br> `verl_omni/utils/reward_score/` | [@ruihanglix](https://github.com/ruihanglix), [@chenyingshu](https://github.com/chenyingshu), [@Sky-Trigger](https://github.com/Sky-Trigger) |
 | `verl_omni/pipelines/` | [@chenyingshu](https://github.com/chenyingshu), [@NancyFyong](https://github.com/NancyFyong) |

--- a/docs/community/governance.md
+++ b/docs/community/governance.md
@@ -1,0 +1,68 @@
+# Governance
+
+VeRL-Omni is an open-source project. Committer status is earned through contribution, maintenance, and stewardship — not purchased or assigned by company affiliation.
+
+## Values
+
+VeRL-Omni aims to be an easy, fast, and stable RL training framework for diffusion and omni-modality models.
+
+### Design Values
+
+1. **Top performance**: Training and rollout throughput are first-class. We monitor overheads, overlap reward with generation, and publish recipes and benchmarks. We never leave performance on the table.
+2. **Ease of use**: VeRL-Omni must be simple to install, configure, and run. We provide clear documentation, Hydra configs, example recipes, helpful error messages, and reproducible end-to-end training paths. Many users fork our code or study it deeply, so we keep it readable and modular.
+3. **Wide coverage**: VeRL-Omni supports frontier diffusion, unified multimodal, and omni-modality models, plus high-performance accelerators. We make it easy to add new models, algorithms, rewards, and hardware backends.
+4. **Production ready**: VeRL-Omni is used for long-running RL jobs. Training must be stable, observable, and operable — with clear logs, metrics, and checkpointing.
+5. **Extensibility**: VeRL-Omni cannot cover every use case in-tree. We design pipelines, trainers, workers, and reward loops so they can be forked, composed, and customized.
+
+### Collaboration Values
+
+1. **Tightly Knit and Fast-Moving**: Our maintainer team is aligned on vision, philosophy, and roadmap. We work closely to unblock each other and move quickly.
+2. **Individual Merit**: No one buys their way into governance. Committer status belongs to individuals, not companies. We reward contribution, maintenance, and project stewardship.
+
+## Project Maintainers
+
+### Lead Maintainers
+
+Lead maintainers are responsible for the overall direction and strategy of the project:
+
+- [@samithuang](https://github.com/samithuang) (Yongxiang Huang)
+
+### Active Committers
+
+Committers have write access and merge rights. They typically have deep expertise in specific areas of this project and shepherd the community contributions:
+
+- [@AndyZhou952](https://github.com/AndyZhou952) (Jingan Zhou): Trainer and algorithm core; Diffusion Models
+- [@chenyingshu](https://github.com/chenyingshu) (Susan, Yingshu Chen): Trainer and algorithm core; Reward system; Pipeline and model adaptation; Datasets and examples
+- [@cr-gao](https://github.com/cr-gao) (Chenrui Gao): Workers and training engines
+- [@knlnguyen1802](https://github.com/knlnguyen1802) (Long): Rollout and agent loop
+- [@NancyFyong](https://github.com/NancyFyong) (Zhiyong Feng): Trainer and algorithm core; Rollout and agent loop; Pipeline and model adaptation; Datasets and examples
+- [@ruihanglix](https://github.com/ruihanglix) (Ruihang Li): Reward system
+- [@Sky-Trigger](https://github.com/Sky-Trigger) (Mengbo Wang): Rollout and agent loop; Reward system
+- [@wtomin](https://github.com/wtomin) (Didan DENG): Tests and CI; Packaging and environment; Documentation
+- [@zhtmike](https://github.com/zhtmike) (Cheung Ka Wai): Workers and training engines
+
+### Path Ownership
+
+Directory rules cover the whole tree unless a more specific path below overrides them.
+
+| Path | Committers |
+| --- | --- |
+| `verl_omni/trainer/` | [@chenyingshu](https://github.com/chenyingshu), [@NancyFyong](https://github.com/NancyFyong) |
+| `verl_omni/workers/` | [@cr-gao](https://github.com/cr-gao), [@zhtmike](https://github.com/zhtmike) |
+| `verl_omni/agent_loop/` <br> `verl_omni/workers/rollout/` <br> `verl_omni/utils/vllm_omni/` | [@knlnguyen1802](https://github.com/knlnguyen1802), [@Sky-Trigger](https://github.com/Sky-Trigger), [@NancyFyong](https://github.com/NancyFyong) |
+| `verl_omni/reward_loop/` <br> `verl_omni/utils/reward_score/` | [@ruihanglix](https://github.com/ruihanglix), [@chenyingshu](https://github.com/chenyingshu), [@Sky-Trigger](https://github.com/Sky-Trigger) |
+| `verl_omni/pipelines/` | [@chenyingshu](https://github.com/chenyingshu), [@NancyFyong](https://github.com/NancyFyong) |
+| `verl_omni/utils/dataset/` <br> `examples/` | [@chenyingshu](https://github.com/chenyingshu), [@NancyFyong](https://github.com/NancyFyong) |
+| `tests/` <br> `.github/` <br> `scripts/` <br> `docker/` <br> `docs/` <br> `.agents/` | [@wtomin](https://github.com/wtomin) |
+
+`verl_omni/workers/rollout/` overrides `verl_omni/workers/` for reviewer routing. Unlisted paths fall back to the default owner in [`.github/CODEOWNERS`](https://github.com/verl-project/verl-omni/blob/main/.github/CODEOWNERS).
+
+## Reviewer Routing
+
+For path-based reviewer routing, consult [`.github/CODEOWNERS`](https://github.com/verl-project/verl-omni/blob/main/.github/CODEOWNERS). The path table above is the source of truth for subsystem boundaries.
+
+`CODEOWNERS` is operational routing metadata, not a governance or approval policy. Being listed does not grant committer status or merge rights, and it does not mean every listed reviewer must approve a change. The maintainer roster above is authoritative for project roles and merge rights.
+
+## Committer Nomination Process
+
+Every month, any active committer can nominate new committer(s) to the project. Up to **two new committers** will be admitted per month based on the quality and impact of their contributions.

--- a/docs/index.md
+++ b/docs/index.md
@@ -119,6 +119,13 @@ api/utils.rst
 
 ```{toctree}
 :maxdepth: 1
+:caption: Community
+
+community/governance.md
+```
+
+```{toctree}
+:maxdepth: 1
 :caption: Developer Guide
 
 contributing/editing-agent-instructions.md

--- a/docs/index.md
+++ b/docs/index.md
@@ -119,13 +119,6 @@ api/utils.rst
 
 ```{toctree}
 :maxdepth: 1
-:caption: Community
-
-community/governance.md
-```
-
-```{toctree}
-:maxdepth: 1
 :caption: Developer Guide
 
 contributing/editing-agent-instructions.md


### PR DESCRIPTION
### What does this PR do?

Publish a VeRL-Omni governance page (values, lead/active committers, path ownership, nomination process) and replace the coarse `.github/CODEOWNERS` map with directory-level reviewer routing that matches that table. Link the page from the docs toctree and CONTRIBUTING.md.

`CODEOWNERS` remains routing metadata only: listing someone does not grant merge rights. Default unmatched paths stay `@samithuang` and `@zhtmike`. `verl_omni/workers/rollout/` overrides `verl_omni/workers/`.

### Design & Code Changes

- Add `docs/community/governance.md` and register it under a Community toctree in `docs/index.md`.
- Point `CONTRIBUTING.md` at governance + CODEOWNERS.
- Expand `.github/CODEOWNERS` to the path table (trainer, workers, rollout/agent_loop, reward, pipelines, dataset/examples, tests/CI/docs/docker/scripts).

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update the documentation.
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl-omni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: governance/CODEOWNERS are documentation and reviewer-routing files; CI cannot usefully assert GitHub org membership or merge rights.

