### PR TITLE
[cfg, recipe, doc, tests] fix: default diffusion packing knobs to avoid VAE OOM

### DIFF
--- a/docs/contributing/integrating_a_diffusion_model.md
+++ b/docs/contributing/integrating_a_diffusion_model.md
@@ -506,6 +506,10 @@ and
    output with `split_diffusion_output_by_request` when the input was a
    `DiffusionRequestBatch`.
 
+Yaml defaults (`max_num_seqs=8`, `engine_kwargs.vllm_omni.request_batch_max_wait_ms=10`)
+are chosen so a new recipe can omit these knobs without VAE-decode OOM on
+large image models. Raise `max_num_seqs` only when the model can take more.
+
 For launch knobs and measured speedups, see
 [`rollout_batching.md`](../start/rollout_batching.md).
 

--- a/docs/examples/config.md
+++ b/docs/examples/config.md
@@ -303,12 +303,12 @@ actor_rollout_ref:
 - `actor_rollout_ref.rollout.seed`: Base seed for deterministic training rollout RNG. Per-step base is `seed + global_step - 1`; `null` disables seeding.
 - `actor_rollout_ref.rollout.rollout_attn_backend`: vLLM-Omni diffusion attention backend. One of `FLASH_ATTN`, `FLASH_ATTN_HUB`, `FLASH_ATTN_3_HUB`, `TORCH_SDPA`. Must match `model.attn_backend` (default `FLASH_ATTN_3_HUB` ↔ `_flash_3_varlen_hub`).
 - `actor_rollout_ref.rollout.step_execution`: When `true`, run the registered pipeline in step-execution (continuous / stepwise batching) mode. See {doc}`../start/rollout_batching`.
-- `actor_rollout_ref.rollout.max_num_seqs`: Max concurrent sequences in the engine; also the request-level batching capacity knob.
+- `actor_rollout_ref.rollout.max_num_seqs`: Max concurrent sequences in the engine; also the request-level batching capacity knob. Default `8` to avoid VAE-decode OOM on large image models; raise per-recipe when the model can take more.
 - `actor_rollout_ref.rollout.gpu_memory_utilization`: Fraction of GPU memory for the vLLM-Omni cache.
 - `actor_rollout_ref.rollout.calculate_log_probs`: Log rollout log-probs for debugging.
 - `actor_rollout_ref.rollout.rollout_adapter`: Named adapter for generation: `default` or `old`.
 - `actor_rollout_ref.rollout.agent.default_agent_loop`: Default `diffusion_single_turn_agent`.
-- `actor_rollout_ref.rollout.engine_kwargs.vllm_omni`: Extra vLLM-Omni engine kwargs (dict).
+- `actor_rollout_ref.rollout.engine_kwargs.vllm_omni`: Extra vLLM-Omni engine kwargs (dict). Default includes `request_batch_max_wait_ms: 10` for request-level packing admission.
 
 ### `trainer` — diffusion-only dump / video knobs
 

--- a/docs/start/rollout_batching.md
+++ b/docs/start/rollout_batching.md
@@ -39,12 +39,14 @@ Do not enable both modes at once.
 
 | Recipe | Default mode |
 |---|---|
-| Qwen-Image FlowGRPO baselines (`run_qwen_image_ocr.sh`, `run_qwen_image_ocr_lora.sh`) | Step-wise (`step_execution=true`, `max_num_seqs=256`) |
+| Qwen-Image FlowGRPO baseline (`run_qwen_image_ocr.sh`) | Step-wise (`step_execution=true`, `max_num_seqs` aligned with log-prob micro-batch) |
+| Qwen-Image FlowGRPO LoRA (`run_qwen_image_ocr_lora.sh`) | Request-level (`step_execution=false`, yaml default `max_num_seqs=8`, `wait_ms=10`) |
 | SD3.5 FlowGRPO (`run_sd35_medium_ocr_lora.sh`) | Request-level (`step_execution=false`, `max_num_seqs=256`, `wait_ms=10`) |
 
-Other `run_qwen_image_ocr*.sh` launchers do not all set these overrides.
-Inspect the selected launcher before assuming that step-wise batching is
-enabled.
+Remaining Qwen-Image request-level launchers inherit the yaml defaults
+(`max_num_seqs=8`, `request_batch_max_wait_ms=10`) and can still override
+them with `MAX_NUM_SEQS` / `REQUEST_BATCH_MAX_WAIT_MS`. Inspect the selected
+launcher before assuming that step-wise batching is enabled.
 
 On Qwen-Image FlowGRPO e2e LoRA (32×16, 512²) the two modes were essentially
 tied (~106–108s gen). SD3.5 currently has request-level support only.
@@ -109,8 +111,8 @@ actor_rollout_ref.rollout.step_execution=false
 | Knob | Meaning |
 |---|---|
 | `step_execution=false` | Required (yaml default). |
-| `max_num_seqs` | Max requests packed per forward. Engine default is effectively serial (`1`) unless raised. |
-| `request_batch_max_wait_ms` | Optional admission wait before the first schedule of a wave. Default `0`; `10` is enough for typical training bursts. |
+| `max_num_seqs` | Max requests packed per forward. Yaml default is `8` (safe for large image models); pipelines without `supports_request_batch` are clamped to `1`. Raise per-recipe when the model can take more. |
+| `request_batch_max_wait_ms` | Optional admission wait before the first schedule of a wave. Yaml default `10`; `0` disables the wait. |
 
 Override with `MAX_NUM_SEQS` / `REQUEST_BATCH_MAX_WAIT_MS` in the example
 scripts, or Hydra as above.

--- a/examples/diffusionnft_trainer/qwen_image/run_qwen_image_ocr_lora.sh
+++ b/examples/diffusionnft_trainer/qwen_image/run_qwen_image_ocr_lora.sh
@@ -63,7 +63,7 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.rollout.pipeline.max_sequence_length=256 \
     actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=40 \
     +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.max_num_seqs=${MAX_NUM_SEQS} \
-    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
+    ++actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
     actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=32 \
     algorithm.trainer_type=direct_preference \
     algorithm.sample_source=online \

--- a/examples/diffusionnft_trainer/qwen_image/run_qwen_image_ocr_lora.sh
+++ b/examples/diffusionnft_trainer/qwen_image/run_qwen_image_ocr_lora.sh
@@ -18,6 +18,9 @@ IMAGE_RESOLUTION=512
 
 ENGINE=vllm_omni
 REWARD_ENGINE=vllm
+# Request-level packing (mutually exclusive with step-wise continuous batching).
+MAX_NUM_SEQS=${MAX_NUM_SEQS:-8}
+REQUEST_BATCH_MAX_WAIT_MS=${REQUEST_BATCH_MAX_WAIT_MS:-10}
 
 
 python3 -m verl_omni.trainer.main_diffusion \
@@ -59,6 +62,8 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.rollout.pipeline.width=$IMAGE_RESOLUTION \
     actor_rollout_ref.rollout.pipeline.max_sequence_length=256 \
     actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=40 \
+    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.max_num_seqs=${MAX_NUM_SEQS} \
+    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
     actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=32 \
     algorithm.trainer_type=direct_preference \
     algorithm.sample_source=online \

--- a/examples/diffusionnft_trainer/qwen_image/run_qwen_image_ocr_lora_npu.sh
+++ b/examples/diffusionnft_trainer/qwen_image/run_qwen_image_ocr_lora_npu.sh
@@ -66,7 +66,7 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.rollout.pipeline.max_sequence_length=256 \
     actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=40 \
     +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.max_num_seqs=${MAX_NUM_SEQS} \
-    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
+    ++actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
     actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=32 \
     algorithm.trainer_type=direct_preference \
     algorithm.sample_source=online \

--- a/examples/diffusionnft_trainer/qwen_image/run_qwen_image_ocr_lora_npu.sh
+++ b/examples/diffusionnft_trainer/qwen_image/run_qwen_image_ocr_lora_npu.sh
@@ -19,6 +19,9 @@ IMAGE_RESOLUTION=512
 
 ENGINE=vllm_omni
 REWARD_ENGINE=vllm
+# Request-level packing (mutually exclusive with step-wise continuous batching).
+MAX_NUM_SEQS=${MAX_NUM_SEQS:-8}
+REQUEST_BATCH_MAX_WAIT_MS=${REQUEST_BATCH_MAX_WAIT_MS:-10}
 
 
 python3 -m verl_omni.trainer.main_diffusion \
@@ -62,6 +65,8 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.rollout.pipeline.width=$IMAGE_RESOLUTION \
     actor_rollout_ref.rollout.pipeline.max_sequence_length=256 \
     actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=40 \
+    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.max_num_seqs=${MAX_NUM_SEQS} \
+    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
     actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=32 \
     algorithm.trainer_type=direct_preference \
     algorithm.sample_source=online \

--- a/examples/dpo_trainer/qwen_image/run_qwen_image_online_dpo_lora.sh
+++ b/examples/dpo_trainer/qwen_image/run_qwen_image_online_dpo_lora.sh
@@ -17,6 +17,9 @@ REWARD_TP=4
 
 ENGINE=vllm_omni
 REWARD_ENGINE=vllm
+# Request-level packing (mutually exclusive with step-wise continuous batching).
+MAX_NUM_SEQS=${MAX_NUM_SEQS:-8}
+REQUEST_BATCH_MAX_WAIT_MS=${REQUEST_BATCH_MAX_WAIT_MS:-10}
 
 python3 -m verl_omni.trainer.main_diffusion \
     algorithm.trainer_type=direct_preference \
@@ -53,6 +56,8 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.rollout.pipeline.true_cfg_scale=1.0 \
     actor_rollout_ref.rollout.pipeline.max_sequence_length=256 \
     actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=50 \
+    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.max_num_seqs=${MAX_NUM_SEQS} \
+    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
     actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=8 \
     reward.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / REWARD_TP)) \
     reward.reward_model.enable=True \

--- a/examples/dpo_trainer/qwen_image/run_qwen_image_online_dpo_lora.sh
+++ b/examples/dpo_trainer/qwen_image/run_qwen_image_online_dpo_lora.sh
@@ -57,7 +57,7 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.rollout.pipeline.max_sequence_length=256 \
     actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=50 \
     +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.max_num_seqs=${MAX_NUM_SEQS} \
-    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
+    ++actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
     actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=8 \
     reward.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / REWARD_TP)) \
     reward.reward_model.enable=True \

--- a/examples/dpo_trainer/qwen_image/run_qwen_image_online_dpo_lora_npu.sh
+++ b/examples/dpo_trainer/qwen_image/run_qwen_image_online_dpo_lora_npu.sh
@@ -60,7 +60,7 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.rollout.pipeline.max_sequence_length=256 \
     actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=50 \
     +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.max_num_seqs=${MAX_NUM_SEQS} \
-    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
+    ++actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
     actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=4 \
     reward.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / REWARD_TP)) \
     reward.reward_model.enable=True \

--- a/examples/dpo_trainer/qwen_image/run_qwen_image_online_dpo_lora_npu.sh
+++ b/examples/dpo_trainer/qwen_image/run_qwen_image_online_dpo_lora_npu.sh
@@ -18,6 +18,9 @@ REWARD_TP=4
 
 ENGINE=vllm_omni
 REWARD_ENGINE=vllm
+# Request-level packing (mutually exclusive with step-wise continuous batching).
+MAX_NUM_SEQS=${MAX_NUM_SEQS:-8}
+REQUEST_BATCH_MAX_WAIT_MS=${REQUEST_BATCH_MAX_WAIT_MS:-10}
 
 python3 -m verl_omni.trainer.main_diffusion \
     algorithm.trainer_type=direct_preference \
@@ -56,6 +59,8 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.rollout.pipeline.true_cfg_scale=1.0 \
     actor_rollout_ref.rollout.pipeline.max_sequence_length=256 \
     actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=50 \
+    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.max_num_seqs=${MAX_NUM_SEQS} \
+    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
     actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=4 \
     reward.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / REWARD_TP)) \
     reward.reward_model.enable=True \

--- a/examples/dpo_trainer/qwen_image/run_qwen_image_online_dpo_lora_v1.sh
+++ b/examples/dpo_trainer/qwen_image/run_qwen_image_online_dpo_lora_v1.sh
@@ -68,7 +68,7 @@ python3 -m verl_omni.trainer.main_diffusion_v1 \
     actor_rollout_ref.rollout.pipeline.max_sequence_length=256 \
     actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=50 \
     +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.max_num_seqs=${MAX_NUM_SEQS} \
-    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
+    ++actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
     actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=8 \
     reward.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / REWARD_TP)) \
     reward.reward_model.enable=True \

--- a/examples/dpo_trainer/qwen_image/run_qwen_image_online_dpo_lora_v1.sh
+++ b/examples/dpo_trainer/qwen_image/run_qwen_image_online_dpo_lora_v1.sh
@@ -28,6 +28,9 @@ REWARD_TP=4
 
 ENGINE=vllm_omni
 REWARD_ENGINE=vllm
+# Request-level packing (mutually exclusive with step-wise continuous batching).
+MAX_NUM_SEQS=${MAX_NUM_SEQS:-8}
+REQUEST_BATCH_MAX_WAIT_MS=${REQUEST_BATCH_MAX_WAIT_MS:-10}
 
 python3 -m verl_omni.trainer.main_diffusion_v1 \
     algorithm.trainer_type=direct_preference \
@@ -64,6 +67,8 @@ python3 -m verl_omni.trainer.main_diffusion_v1 \
     actor_rollout_ref.rollout.pipeline.true_cfg_scale=1.0 \
     actor_rollout_ref.rollout.pipeline.max_sequence_length=256 \
     actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=50 \
+    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.max_num_seqs=${MAX_NUM_SEQS} \
+    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
     actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=8 \
     reward.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / REWARD_TP)) \
     reward.reward_model.enable=True \

--- a/examples/flowdppo_trainer/qwen_image/run_qwen_image_ocr_lora.sh
+++ b/examples/flowdppo_trainer/qwen_image/run_qwen_image_ocr_lora.sh
@@ -58,7 +58,7 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=50 \
     actor_rollout_ref.rollout.val_kwargs.algo.noise_level=0.0 \
     +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.max_num_seqs=${MAX_NUM_SEQS} \
-    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
+    ++actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
     actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=32 \
     reward.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / REWARD_TP)) \
     reward.reward_model.enable=True \

--- a/examples/flowdppo_trainer/qwen_image/run_qwen_image_ocr_lora.sh
+++ b/examples/flowdppo_trainer/qwen_image/run_qwen_image_ocr_lora.sh
@@ -17,6 +17,9 @@ REWARD_TP=4
 
 ENGINE=vllm_omni
 REWARD_ENGINE=vllm
+# Request-level packing (mutually exclusive with step-wise continuous batching).
+MAX_NUM_SEQS=${MAX_NUM_SEQS:-8}
+REQUEST_BATCH_MAX_WAIT_MS=${REQUEST_BATCH_MAX_WAIT_MS:-10}
 
 
 python3 -m verl_omni.trainer.main_diffusion \
@@ -54,6 +57,8 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.rollout.algo.sde_window_range="[0,5]" \
     actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=50 \
     actor_rollout_ref.rollout.val_kwargs.algo.noise_level=0.0 \
+    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.max_num_seqs=${MAX_NUM_SEQS} \
+    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
     actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=32 \
     reward.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / REWARD_TP)) \
     reward.reward_model.enable=True \

--- a/examples/flowgrpo_trainer/boogu_image/run_boogu_image_ocr_lora.sh
+++ b/examples/flowgrpo_trainer/boogu_image/run_boogu_image_ocr_lora.sh
@@ -96,7 +96,7 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.actor.fsdp_config.model_dtype=bfloat16 \
     actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=${MAX_NUM_SEQS} \
     +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.max_num_seqs=${MAX_NUM_SEQS} \
-    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
+    ++actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
     actor_rollout_ref.rollout.tensor_model_parallel_size=$ROLLOUT_TP \
     actor_rollout_ref.rollout.name=$ENGINE \
     actor_rollout_ref.rollout.n=16 \

--- a/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_fsdp2_64cards.sh
+++ b/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_fsdp2_64cards.sh
@@ -59,7 +59,7 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=50 \
     actor_rollout_ref.rollout.val_kwargs.algo.noise_level=0.0 \
     +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.max_num_seqs=${MAX_NUM_SEQS} \
-    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
+    ++actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
     actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=32 \
     reward.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / REWARD_TP)) \
     reward.reward_model.enable=True \

--- a/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_fsdp2_64cards.sh
+++ b/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_fsdp2_64cards.sh
@@ -20,6 +20,9 @@ IMAGE_RESOLUTION=512
 
 ENGINE=vllm_omni
 REWARD_ENGINE=vllm
+# Request-level packing (mutually exclusive with step-wise continuous batching).
+MAX_NUM_SEQS=${MAX_NUM_SEQS:-8}
+REQUEST_BATCH_MAX_WAIT_MS=${REQUEST_BATCH_MAX_WAIT_MS:-10}
 
 python3 -m verl_omni.trainer.main_diffusion \
     algorithm.adv_estimator=flow_grpo \
@@ -55,6 +58,8 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.rollout.algo.sde_window_range="[0,5]" \
     actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=50 \
     actor_rollout_ref.rollout.val_kwargs.algo.noise_level=0.0 \
+    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.max_num_seqs=${MAX_NUM_SEQS} \
+    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
     actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=32 \
     reward.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / REWARD_TP)) \
     reward.reward_model.enable=True \

--- a/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_h200_mfu_optimized.sh
+++ b/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_h200_mfu_optimized.sh
@@ -23,6 +23,9 @@ IMAGE_RESOLUTION=512
 
 ENGINE=vllm_omni
 REWARD_ENGINE=vllm
+# Request-level packing (mutually exclusive with step-wise continuous batching).
+MAX_NUM_SEQS=${MAX_NUM_SEQS:-8}
+REQUEST_BATCH_MAX_WAIT_MS=${REQUEST_BATCH_MAX_WAIT_MS:-10}
 
 
 python3 -m verl_omni.trainer.main_diffusion \
@@ -58,6 +61,8 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.rollout.algo.sde_window_range="[0,5]" \
     actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=50 \
     actor_rollout_ref.rollout.val_kwargs.algo.noise_level=0.0 \
+    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.max_num_seqs=${MAX_NUM_SEQS} \
+    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
     actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=32 \
     reward.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / REWARD_TP)) \
     reward.reward_model.enable=True \

--- a/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_h200_mfu_optimized.sh
+++ b/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_h200_mfu_optimized.sh
@@ -62,7 +62,7 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=50 \
     actor_rollout_ref.rollout.val_kwargs.algo.noise_level=0.0 \
     +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.max_num_seqs=${MAX_NUM_SEQS} \
-    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
+    ++actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
     actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=32 \
     reward.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / REWARD_TP)) \
     reward.reward_model.enable=True \

--- a/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_lora.sh
+++ b/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_lora.sh
@@ -59,7 +59,7 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=50 \
     actor_rollout_ref.rollout.val_kwargs.algo.noise_level=0.0 \
     +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.max_num_seqs=${MAX_NUM_SEQS} \
-    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
+    ++actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
     actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=32 \
     reward.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / REWARD_TP)) \
     reward.reward_model.enable=True \

--- a/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_lora_async_reward.sh
+++ b/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_lora_async_reward.sh
@@ -56,7 +56,7 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=50 \
     actor_rollout_ref.rollout.val_kwargs.algo.noise_level=0.0 \
     +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.max_num_seqs=${MAX_NUM_SEQS} \
-    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
+    ++actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
     actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=32 \
     reward.num_workers=$((NUM_GPUS_REWARD / REWARD_TP)) \
     reward.reward_model.enable=True \

--- a/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_lora_async_reward.sh
+++ b/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_lora_async_reward.sh
@@ -18,6 +18,9 @@ REWARD_TP=1
 
 ENGINE=vllm_omni
 REWARD_ENGINE=vllm
+# Request-level packing (mutually exclusive with step-wise continuous batching).
+MAX_NUM_SEQS=${MAX_NUM_SEQS:-8}
+REQUEST_BATCH_MAX_WAIT_MS=${REQUEST_BATCH_MAX_WAIT_MS:-10}
 
 
 python3 -m verl_omni.trainer.main_diffusion \
@@ -52,6 +55,8 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.rollout.algo.sde_window_range="[0,5]" \
     actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=50 \
     actor_rollout_ref.rollout.val_kwargs.algo.noise_level=0.0 \
+    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.max_num_seqs=${MAX_NUM_SEQS} \
+    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
     actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=32 \
     reward.num_workers=$((NUM_GPUS_REWARD / REWARD_TP)) \
     reward.reward_model.enable=True \

--- a/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_lora_fsdp2_fa3.sh
+++ b/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_lora_fsdp2_fa3.sh
@@ -56,7 +56,7 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=50 \
     actor_rollout_ref.rollout.val_kwargs.algo.noise_level=0.0 \
     +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.max_num_seqs=${MAX_NUM_SEQS} \
-    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
+    ++actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
     actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=32 \
     reward.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / REWARD_TP)) \
     reward.reward_model.enable=True \

--- a/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_lora_fsdp2_fa3.sh
+++ b/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_lora_fsdp2_fa3.sh
@@ -17,6 +17,9 @@ REWARD_TP=4
 
 ENGINE=vllm_omni
 REWARD_ENGINE=vllm
+# Request-level packing (mutually exclusive with step-wise continuous batching).
+MAX_NUM_SEQS=${MAX_NUM_SEQS:-8}
+REQUEST_BATCH_MAX_WAIT_MS=${REQUEST_BATCH_MAX_WAIT_MS:-10}
 
 
 python3 -m verl_omni.trainer.main_diffusion \
@@ -52,6 +55,8 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.rollout.algo.sde_window_range="[0,5]" \
     actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=50 \
     actor_rollout_ref.rollout.val_kwargs.algo.noise_level=0.0 \
+    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.max_num_seqs=${MAX_NUM_SEQS} \
+    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
     actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=32 \
     reward.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / REWARD_TP)) \
     reward.reward_model.enable=True \

--- a/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_lora_multi_node.sh
+++ b/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_lora_multi_node.sh
@@ -26,6 +26,9 @@ REWARD_TP=4
 
 ENGINE=vllm_omni
 REWARD_ENGINE=vllm
+# Request-level packing (mutually exclusive with step-wise continuous batching).
+MAX_NUM_SEQS=${MAX_NUM_SEQS:-8}
+REQUEST_BATCH_MAX_WAIT_MS=${REQUEST_BATCH_MAX_WAIT_MS:-10}
 
 # ---- Batch sizing ------------------------------------------------------------
 # Single-node baseline (run_qwen_image_ocr_lora.sh): 4 GPUs, train_batch=32,
@@ -83,6 +86,8 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.rollout.algo.sde_window_range="[0,5]" \
     actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=50 \
     actor_rollout_ref.rollout.val_kwargs.algo.noise_level=0.0 \
+    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.max_num_seqs=${MAX_NUM_SEQS} \
+    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
     actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=32 \
     reward.num_workers=$((TOTAL_GPUS / REWARD_TP)) \
     reward.reward_model.enable=True \

--- a/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_lora_multi_node.sh
+++ b/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_lora_multi_node.sh
@@ -87,7 +87,7 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=50 \
     actor_rollout_ref.rollout.val_kwargs.algo.noise_level=0.0 \
     +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.max_num_seqs=${MAX_NUM_SEQS} \
-    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
+    ++actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
     actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=32 \
     reward.num_workers=$((TOTAL_GPUS / REWARD_TP)) \
     reward.reward_model.enable=True \

--- a/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_lora_npu.sh
+++ b/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_lora_npu.sh
@@ -26,6 +26,9 @@ REWARD_TP=4
 
 ENGINE=vllm_omni
 REWARD_ENGINE=vllm
+# Request-level packing (mutually exclusive with step-wise continuous batching).
+MAX_NUM_SEQS=${MAX_NUM_SEQS:-8}
+REQUEST_BATCH_MAX_WAIT_MS=${REQUEST_BATCH_MAX_WAIT_MS:-10}
 
 python3 -m verl_omni.trainer.main_diffusion \
     trainer.device=npu \
@@ -63,6 +66,8 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.rollout.algo.sde_window_range="[0,5]" \
     actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=50 \
     actor_rollout_ref.rollout.val_kwargs.algo.noise_level=0.0 \
+    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.max_num_seqs=${MAX_NUM_SEQS} \
+    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
     actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=32 \
     reward.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / REWARD_TP)) \
     reward.reward_model.enable=True \

--- a/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_lora_npu.sh
+++ b/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_lora_npu.sh
@@ -67,7 +67,7 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=50 \
     actor_rollout_ref.rollout.val_kwargs.algo.noise_level=0.0 \
     +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.max_num_seqs=${MAX_NUM_SEQS} \
-    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
+    ++actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
     actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=32 \
     reward.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / REWARD_TP)) \
     reward.reward_model.enable=True \

--- a/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_lora_rollout_corr.sh
+++ b/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_lora_rollout_corr.sh
@@ -75,7 +75,7 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=50 \
     actor_rollout_ref.rollout.val_kwargs.algo.noise_level=0.0 \
     +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.max_num_seqs=${MAX_NUM_SEQS} \
-    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
+    ++actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
     actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=32 \
     reward.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / REWARD_TP)) \
     reward.reward_model.enable=True \

--- a/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_lora_rollout_corr.sh
+++ b/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_lora_rollout_corr.sh
@@ -31,6 +31,9 @@ REWARD_TP=4
 
 ENGINE=vllm_omni
 REWARD_ENGINE=vllm
+# Request-level packing (mutually exclusive with step-wise continuous batching).
+MAX_NUM_SEQS=${MAX_NUM_SEQS:-8}
+REQUEST_BATCH_MAX_WAIT_MS=${REQUEST_BATCH_MAX_WAIT_MS:-10}
 
 
 python3 -m verl_omni.trainer.main_diffusion \
@@ -71,6 +74,8 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.rollout.algo.sde_window_range="[0,5]" \
     actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=50 \
     actor_rollout_ref.rollout.val_kwargs.algo.noise_level=0.0 \
+    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.max_num_seqs=${MAX_NUM_SEQS} \
+    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
     actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=32 \
     reward.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / REWARD_TP)) \
     reward.reward_model.enable=True \

--- a/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_lora_sp2.sh
+++ b/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_lora_sp2.sh
@@ -18,6 +18,9 @@ REWARD_TP=4
 
 ENGINE=vllm_omni
 REWARD_ENGINE=vllm
+# Request-level packing (mutually exclusive with step-wise continuous batching).
+MAX_NUM_SEQS=${MAX_NUM_SEQS:-8}
+REQUEST_BATCH_MAX_WAIT_MS=${REQUEST_BATCH_MAX_WAIT_MS:-10}
 
 # Match actor native backend with vLLM-Omni rollout SDPA backend.
 export DIFFUSION_ATTENTION_BACKEND=TORCH_SDPA
@@ -57,6 +60,8 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.rollout.algo.sde_window_range="[0,5]" \
     actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=50 \
     actor_rollout_ref.rollout.val_kwargs.algo.noise_level=0.0 \
+    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.max_num_seqs=${MAX_NUM_SEQS} \
+    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
     actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=32 \
     reward.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / REWARD_TP)) \
     reward.reward_model.enable=True \

--- a/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_lora_sp2.sh
+++ b/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_lora_sp2.sh
@@ -61,7 +61,7 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=50 \
     actor_rollout_ref.rollout.val_kwargs.algo.noise_level=0.0 \
     +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.max_num_seqs=${MAX_NUM_SEQS} \
-    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
+    ++actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
     actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=32 \
     reward.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / REWARD_TP)) \
     reward.reward_model.enable=True \

--- a/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_multi_reward.sh
+++ b/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_multi_reward.sh
@@ -77,7 +77,7 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=50 \
     actor_rollout_ref.rollout.val_kwargs.algo.noise_level=0.0 \
     +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.max_num_seqs=${MAX_NUM_SEQS} \
-    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
+    ++actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
     actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=32 \
     reward.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / REWARD_TP)) \
     reward.reward_model.enable=True \

--- a/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_multi_reward.sh
+++ b/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_multi_reward.sh
@@ -19,6 +19,9 @@ IMAGE_RESOLUTION=512
 
 ENGINE=vllm_omni
 REWARD_ENGINE=vllm
+# Request-level packing (mutually exclusive with step-wise continuous batching).
+MAX_NUM_SEQS=${MAX_NUM_SEQS:-8}
+REQUEST_BATCH_MAX_WAIT_MS=${REQUEST_BATCH_MAX_WAIT_MS:-10}
 
 script_path=$(readlink -f "$0")
 script_name=$(basename "$script_path" .sh)
@@ -73,6 +76,8 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.rollout.algo.sde_window_range="[0,5]" \
     actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=50 \
     actor_rollout_ref.rollout.val_kwargs.algo.noise_level=0.0 \
+    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.max_num_seqs=${MAX_NUM_SEQS} \
+    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
     actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=32 \
     reward.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / REWARD_TP)) \
     reward.reward_model.enable=True \

--- a/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_npu.sh
+++ b/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_npu.sh
@@ -25,6 +25,9 @@ IMAGE_RESOLUTION=512
 
 ENGINE=vllm_omni
 REWARD_ENGINE=vllm
+# Request-level packing (mutually exclusive with step-wise continuous batching).
+MAX_NUM_SEQS=${MAX_NUM_SEQS:-8}
+REQUEST_BATCH_MAX_WAIT_MS=${REQUEST_BATCH_MAX_WAIT_MS:-10}
 
 
 python3 -m verl_omni.trainer.main_diffusion \
@@ -62,6 +65,8 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.rollout.algo.sde_window_range="[0,5]" \
     actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=50 \
     actor_rollout_ref.rollout.val_kwargs.algo.noise_level=0.0 \
+    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.max_num_seqs=${MAX_NUM_SEQS} \
+    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
     actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=32 \
     reward.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / REWARD_TP)) \
     reward.reward_model.enable=True \

--- a/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_npu.sh
+++ b/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_npu.sh
@@ -66,7 +66,7 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=50 \
     actor_rollout_ref.rollout.val_kwargs.algo.noise_level=0.0 \
     +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.max_num_seqs=${MAX_NUM_SEQS} \
-    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
+    ++actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
     actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=32 \
     reward.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / REWARD_TP)) \
     reward.reward_model.enable=True \

--- a/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_reward_server.sh
+++ b/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_reward_server.sh
@@ -20,6 +20,9 @@ ROLLOUT_TP=1
 IMAGE_RESOLUTION=512
 
 ENGINE=vllm_omni
+# Request-level packing (mutually exclusive with step-wise continuous batching).
+MAX_NUM_SEQS=${MAX_NUM_SEQS:-8}
+REQUEST_BATCH_MAX_WAIT_MS=${REQUEST_BATCH_MAX_WAIT_MS:-10}
 
 script_path=$(readlink -f "$0")
 script_name=$(basename "$script_path" .sh)
@@ -74,6 +77,8 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.rollout.algo.sde_window_range="[0,5]" \
     actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=50 \
     actor_rollout_ref.rollout.val_kwargs.algo.noise_level=0.0 \
+    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.max_num_seqs=${MAX_NUM_SEQS} \
+    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
     actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=32 \
     reward.reward_model.enable=False \
     reward.custom_reward_function.path=pkg://verl_omni.reward_loop.reward_manager.multi \

--- a/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_reward_server.sh
+++ b/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_reward_server.sh
@@ -78,7 +78,7 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=50 \
     actor_rollout_ref.rollout.val_kwargs.algo.noise_level=0.0 \
     +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.max_num_seqs=${MAX_NUM_SEQS} \
-    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
+    ++actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
     actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=32 \
     reward.reward_model.enable=False \
     reward.custom_reward_function.path=pkg://verl_omni.reward_loop.reward_manager.multi \

--- a/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_veomni.sh
+++ b/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_veomni.sh
@@ -75,7 +75,7 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=50 \
     actor_rollout_ref.rollout.val_kwargs.algo.noise_level=0.0 \
     +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.max_num_seqs=${MAX_NUM_SEQS} \
-    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
+    ++actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
     actor_rollout_ref.ref.veomni_config.strategy=$TRAINER_BACKEND \
     actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=32 \
     reward.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / REWARD_TP)) \

--- a/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_veomni.sh
+++ b/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_veomni.sh
@@ -33,6 +33,9 @@ IMAGE_RESOLUTION=512
 ENGINE=vllm_omni
 REWARD_ENGINE=vllm
 TRAINER_BACKEND=veomni
+# Request-level packing (mutually exclusive with step-wise continuous batching).
+MAX_NUM_SEQS=${MAX_NUM_SEQS:-8}
+REQUEST_BATCH_MAX_WAIT_MS=${REQUEST_BATCH_MAX_WAIT_MS:-10}
 
 
 python3 -m verl_omni.trainer.main_diffusion \
@@ -71,6 +74,8 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.rollout.algo.sde_window_range="[0,5]" \
     actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=50 \
     actor_rollout_ref.rollout.val_kwargs.algo.noise_level=0.0 \
+    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.max_num_seqs=${MAX_NUM_SEQS} \
+    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
     actor_rollout_ref.ref.veomni_config.strategy=$TRAINER_BACKEND \
     actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=32 \
     reward.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / REWARD_TP)) \

--- a/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_veomni_64cards.sh
+++ b/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_veomni_64cards.sh
@@ -75,7 +75,7 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=50 \
     actor_rollout_ref.rollout.val_kwargs.algo.noise_level=0.0 \
     +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.max_num_seqs=${MAX_NUM_SEQS} \
-    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
+    ++actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
     actor_rollout_ref.ref.veomni_config.strategy=$TRAINER_BACKEND \
     actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=32 \
     reward.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / REWARD_TP)) \

--- a/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_veomni_64cards.sh
+++ b/examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_veomni_64cards.sh
@@ -33,6 +33,9 @@ IMAGE_RESOLUTION=512
 ENGINE=vllm_omni
 REWARD_ENGINE=vllm
 TRAINER_BACKEND=veomni
+# Request-level packing (mutually exclusive with step-wise continuous batching).
+MAX_NUM_SEQS=${MAX_NUM_SEQS:-8}
+REQUEST_BATCH_MAX_WAIT_MS=${REQUEST_BATCH_MAX_WAIT_MS:-10}
 
 
 python3 -m verl_omni.trainer.main_diffusion \
@@ -71,6 +74,8 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.rollout.algo.sde_window_range="[0,5]" \
     actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=50 \
     actor_rollout_ref.rollout.val_kwargs.algo.noise_level=0.0 \
+    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.max_num_seqs=${MAX_NUM_SEQS} \
+    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
     actor_rollout_ref.ref.veomni_config.strategy=$TRAINER_BACKEND \
     actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=32 \
     reward.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / REWARD_TP)) \

--- a/examples/grpoguard_trainer/qwen_image/run_qwen_image_ocr_lora.sh
+++ b/examples/grpoguard_trainer/qwen_image/run_qwen_image_ocr_lora.sh
@@ -58,7 +58,7 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=50 \
     actor_rollout_ref.rollout.val_kwargs.algo.noise_level=0.0 \
     +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.max_num_seqs=${MAX_NUM_SEQS} \
-    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
+    ++actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
     actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=32 \
     reward.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / REWARD_TP)) \
     reward.reward_model.enable=True \

--- a/examples/grpoguard_trainer/qwen_image/run_qwen_image_ocr_lora.sh
+++ b/examples/grpoguard_trainer/qwen_image/run_qwen_image_ocr_lora.sh
@@ -17,6 +17,9 @@ REWARD_TP=4
 
 ENGINE=vllm_omni
 REWARD_ENGINE=vllm
+# Request-level packing (mutually exclusive with step-wise continuous batching).
+MAX_NUM_SEQS=${MAX_NUM_SEQS:-8}
+REQUEST_BATCH_MAX_WAIT_MS=${REQUEST_BATCH_MAX_WAIT_MS:-10}
 
 
 python3 -m verl_omni.trainer.main_diffusion \
@@ -54,6 +57,8 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.rollout.algo.sde_window_range="[0,5]" \
     actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=50 \
     actor_rollout_ref.rollout.val_kwargs.algo.noise_level=0.0 \
+    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.max_num_seqs=${MAX_NUM_SEQS} \
+    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
     actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=32 \
     reward.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / REWARD_TP)) \
     reward.reward_model.enable=True \

--- a/examples/grpoguard_trainer/qwen_image/run_qwen_image_ocr_lora_npu.sh
+++ b/examples/grpoguard_trainer/qwen_image/run_qwen_image_ocr_lora_npu.sh
@@ -64,7 +64,7 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=50 \
     actor_rollout_ref.rollout.val_kwargs.algo.noise_level=0.0 \
     +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.max_num_seqs=${MAX_NUM_SEQS} \
-    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
+    ++actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
     actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=32 \
     actor_rollout_ref.rollout.rollout_attn_backend=TORCH_SDPA \
     reward.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / REWARD_TP)) \

--- a/examples/grpoguard_trainer/qwen_image/run_qwen_image_ocr_lora_npu.sh
+++ b/examples/grpoguard_trainer/qwen_image/run_qwen_image_ocr_lora_npu.sh
@@ -21,6 +21,9 @@ REWARD_TP=4
 
 ENGINE=vllm_omni
 REWARD_ENGINE=vllm
+# Request-level packing (mutually exclusive with step-wise continuous batching).
+MAX_NUM_SEQS=${MAX_NUM_SEQS:-8}
+REQUEST_BATCH_MAX_WAIT_MS=${REQUEST_BATCH_MAX_WAIT_MS:-10}
 
 
 python3 -m verl_omni.trainer.main_diffusion \
@@ -60,6 +63,8 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.rollout.algo.sde_window_range="[0,5]" \
     actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=50 \
     actor_rollout_ref.rollout.val_kwargs.algo.noise_level=0.0 \
+    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.max_num_seqs=${MAX_NUM_SEQS} \
+    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
     actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=32 \
     actor_rollout_ref.rollout.rollout_attn_backend=TORCH_SDPA \
     reward.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / REWARD_TP)) \

--- a/examples/mixgrpo_trainer/qwen_image/run_qwen_image_ocr_lora_mixgrpo.sh
+++ b/examples/mixgrpo_trainer/qwen_image/run_qwen_image_ocr_lora_mixgrpo.sh
@@ -63,7 +63,7 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=50 \
     actor_rollout_ref.rollout.val_kwargs.algo.noise_level=0.0 \
     +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.max_num_seqs=${MAX_NUM_SEQS} \
-    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
+    ++actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
     actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=32 \
     reward.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / REWARD_TP)) \
     reward.reward_model.enable=True \

--- a/examples/mixgrpo_trainer/qwen_image/run_qwen_image_ocr_lora_mixgrpo.sh
+++ b/examples/mixgrpo_trainer/qwen_image/run_qwen_image_ocr_lora_mixgrpo.sh
@@ -21,6 +21,9 @@ REWARD_TP=4
 
 ENGINE=vllm_omni
 REWARD_ENGINE=vllm
+# Request-level packing (mutually exclusive with step-wise continuous batching).
+MAX_NUM_SEQS=${MAX_NUM_SEQS:-8}
+REQUEST_BATCH_MAX_WAIT_MS=${REQUEST_BATCH_MAX_WAIT_MS:-10}
 
 
 python3 -m verl_omni.trainer.main_diffusion \
@@ -59,6 +62,8 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.rollout.algo.sde_type="sde" \
     actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=50 \
     actor_rollout_ref.rollout.val_kwargs.algo.noise_level=0.0 \
+    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.max_num_seqs=${MAX_NUM_SEQS} \
+    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
     actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=32 \
     reward.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / REWARD_TP)) \
     reward.reward_model.enable=True \

--- a/examples/mixgrpo_trainer/qwen_image/run_qwen_image_ocr_lora_mixgrpo_npu.sh
+++ b/examples/mixgrpo_trainer/qwen_image/run_qwen_image_ocr_lora_mixgrpo_npu.sh
@@ -25,6 +25,9 @@ REWARD_TP=4
 
 ENGINE=vllm_omni
 REWARD_ENGINE=vllm
+# Request-level packing (mutually exclusive with step-wise continuous batching).
+MAX_NUM_SEQS=${MAX_NUM_SEQS:-8}
+REQUEST_BATCH_MAX_WAIT_MS=${REQUEST_BATCH_MAX_WAIT_MS:-10}
 
 
 python3 -m verl_omni.trainer.main_diffusion \
@@ -66,6 +69,8 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.rollout.algo.sde_type="sde" \
     actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=50 \
     actor_rollout_ref.rollout.val_kwargs.algo.noise_level=0.0 \
+    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.max_num_seqs=${MAX_NUM_SEQS} \
+    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
     actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=32 \
     reward.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / REWARD_TP)) \
     reward.reward_model.enable=True \

--- a/examples/mixgrpo_trainer/qwen_image/run_qwen_image_ocr_lora_mixgrpo_npu.sh
+++ b/examples/mixgrpo_trainer/qwen_image/run_qwen_image_ocr_lora_mixgrpo_npu.sh
@@ -70,7 +70,7 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=50 \
     actor_rollout_ref.rollout.val_kwargs.algo.noise_level=0.0 \
     +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.max_num_seqs=${MAX_NUM_SEQS} \
-    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
+    ++actor_rollout_ref.rollout.engine_kwargs.vllm_omni.request_batch_max_wait_ms=${REQUEST_BATCH_MAX_WAIT_MS} \
     actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=32 \
     reward.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / REWARD_TP)) \
     reward.reward_model.enable=True \

--- a/tests/workers/config/test_diffusion_config_on_cpu.py
+++ b/tests/workers/config/test_diffusion_config_on_cpu.py
@@ -209,6 +209,10 @@ class TestDiffusionRolloutConfig:
         cfg = DiffusionRolloutConfig(name="vllm_omni")
         assert cfg.text_encoder_tp_size == 1
 
+    def test_request_level_packing_defaults(self):
+        cfg = DiffusionRolloutConfig(name="vllm_omni")
+        assert cfg.max_num_seqs == 8
+
     def test_text_encoder_tp_size_equal_to_tp_is_allowed(self):
         cfg = DiffusionRolloutConfig(name="vllm_omni", tensor_model_parallel_size=4, text_encoder_tp_size=4)
         assert cfg.text_encoder_tp_size == 4

--- a/verl_omni/trainer/config/_generated_diffusion_trainer.yaml
+++ b/verl_omni/trainer/config/_generated_diffusion_trainer.yaml
@@ -195,7 +195,7 @@ actor_rollout_ref:
     pipeline_model_parallel_size: 1
     max_num_batched_tokens: 8192
     max_model_len: null
-    max_num_seqs: 1024
+    max_num_seqs: 8
     step_execution: false
     enable_chunked_prefill: true
     enable_prefix_caching: true
@@ -212,7 +212,8 @@ actor_rollout_ref:
       _target_: verl.workers.config.MultiTurnConfig
       enable: false
     engine_kwargs:
-      vllm_omni: {}
+      vllm_omni:
+        request_batch_max_wait_ms: 10
     enable_prompt_embed_cache: false
     prompt_embed_cache_size: 32
     enable_prompt_embed_cache_routing_affinity: false

--- a/verl_omni/trainer/config/_generated_diffusion_veomni_trainer.yaml
+++ b/verl_omni/trainer/config/_generated_diffusion_veomni_trainer.yaml
@@ -236,7 +236,7 @@ actor_rollout_ref:
     pipeline_model_parallel_size: 1
     max_num_batched_tokens: 8192
     max_model_len: null
-    max_num_seqs: 1024
+    max_num_seqs: 8
     step_execution: false
     enable_chunked_prefill: true
     enable_prefix_caching: true
@@ -253,7 +253,8 @@ actor_rollout_ref:
       _target_: verl.workers.config.MultiTurnConfig
       enable: false
     engine_kwargs:
-      vllm_omni: {}
+      vllm_omni:
+        request_batch_max_wait_ms: 10
     enable_prompt_embed_cache: false
     prompt_embed_cache_size: 32
     enable_prompt_embed_cache_routing_affinity: false

--- a/verl_omni/trainer/config/diffusion/rollout/diffusion_rollout.yaml
+++ b/verl_omni/trainer/config/diffusion/rollout/diffusion_rollout.yaml
@@ -77,8 +77,11 @@ max_num_batched_tokens: 8192
 # max length for rollout
 max_model_len: null
 
-# max length of sequences
-max_num_seqs: 1024
+# Max concurrent sequences in the vLLM-Omni engine. Also the request-level packing
+# cap; 8 avoids VAE-decode OOM on large image models. Pipelines without
+# request-level support are clamped to 1. Raise per-recipe when the model can
+# take more (e.g. SD3.5 request-level 256, step-wise Qwen-Image 32).
+max_num_seqs: 8
 
 # When True, the vLLM-Omni engine runs the registered pipeline in
 # step-execution mode.
@@ -132,7 +135,11 @@ multi_turn:
 engine_kwargs:
 
   # vllm-omni engine config
-  vllm_omni: {}
+  vllm_omni:
+
+    # Admission wait (ms) before the first schedule of a request-level packing wave.
+    # 10 covers typical training bursts; ignored when request-level packing is unused.
+    request_batch_max_wait_ms: 10
 
 # Reuse text-encoder outputs for repeated diffusion prompts.
 enable_prompt_embed_cache: false

--- a/verl_omni/workers/config/diffusion/rollout.py
+++ b/verl_omni/workers/config/diffusion/rollout.py
@@ -161,7 +161,10 @@ class DiffusionRolloutConfig(BaseConfig):
     val_kwargs: DiffusionSamplingConfig = field(default_factory=DiffusionSamplingConfig)
 
     max_model_len: Optional[int] = None
-    max_num_seqs: int = 1024
+    # Request-level packing cap (and step-wise concurrency). 8 avoids VAE-decode
+    # OOM on large image models; pipelines without request-level support are
+    # clamped to 1 at engine init. Raise per-recipe when the model can take more.
+    max_num_seqs: int = 8
 
     # When True, the vLLM-Omni engine runs the registered pipeline in
     # step-execution mode.


### PR DESCRIPTION
## Summary
- Default diffusion request-level packing to `max_num_seqs=8` and `engine_kwargs.vllm_omni.request_batch_max_wait_ms=10` so new recipes inherit a safe cap without copying these knobs.
- Prevents vLLM-Omni VAE-decode CUDA OOM on 80GB GPUs when recipes previously inherited yaml `max_num_seqs=1024`.
- Qwen-Image request-level recipes still set `MAX_NUM_SEQS` / `REQUEST_BATCH_MAX_WAIT_MS` for env overrides. The step-wise baseline (`run_qwen_image_ocr.sh`) is unchanged.
- Pipelines without request-level support are still clamped to `max_num_seqs=1` at engine init.

## Test plan
- [ ] Rerun `run_qwen_image_ocr_lora_async_reward.sh` on 5x 80GB GPUs and confirm rollout generation no longer OOM during VAE decode.
- [ ] Confirm Hydra logs show `max_num_seqs=8` (and `request_batch_max_wait_ms=10`) on a representative FlowGRPO / DPO / DiffusionNFT Qwen-Image recipe that does not override packing.
- [ ] Override `MAX_NUM_SEQS=1` still works if a tighter memory budget is needed.

Made with [Cursor](https://cursor.com)
