### PR TITLE
[rollout] fix: derive TQ rollout seeds from global prompt index

### DIFF
--- a/tests/agent_loop/test_diffusion_agent_loop_correctness_on_cpu.py
+++ b/tests/agent_loop/test_diffusion_agent_loop_correctness_on_cpu.py
@@ -18,7 +18,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 import torch
-from tensordict import TensorDict
+from tensordict import NonTensorData, NonTensorStack, TensorDict
 from verl.experimental.agent_loop.agent_loop import AgentLoopMetrics
 from verl.protocol import DataProto
 from verl.utils import tensordict_utils as tu
@@ -32,6 +32,7 @@ from verl_omni.agent_loop.diffusion_agent_loop import (
 )
 from verl_omni.agent_loop.diffusion_agent_loop_tq import DiffusionAgentLoopWorkerTQ
 from verl_omni.agent_loop.single_turn_agent_loop import DiffusionSingleTurnAgentLoop
+from verl_omni.agent_loop.utils import maybe_per_rollout_seeds
 from verl_omni.trainer.diffusion.v1 import tq_utils
 
 
@@ -259,6 +260,49 @@ def test_tq_batch_restores_non_tensor_trajectory_metadata(monkeypatch):
 
     assert data.non_tensor_batch["img_shapes"].tolist() == img_shapes
     assert tu.get(data.to_tensordict(), "img_shapes") == img_shapes
+
+
+@pytest.mark.asyncio
+async def test_tq_rollout_seeds_are_global_across_worker_chunks(monkeypatch):
+    num_prompts, num_workers, n = 48, 4, 16
+    rollout_base_seed = 42
+    batch = TensorDict(
+        {
+            "index": torch.arange(num_prompts),
+            "uid": NonTensorStack(*(NonTensorData(str(i)) for i in range(num_prompts))),
+            "global_steps": NonTensorData(1),
+            "rollout_seed": NonTensorData(rollout_base_seed),
+        },
+        batch_size=num_prompts,
+    )
+    monkeypatch.setattr(diffusion_agent_loop_tq.tq, "async_kv_put", AsyncMock())
+    worker_cls = DiffusionAgentLoopWorkerTQ.__ray_metadata__.modified_class
+    seeds_by_rollout = {}
+
+    async def capture_rollout(sampling_params, *, uid, session_id, **kwargs):
+        seeds_by_rollout[int(uid) * n + session_id] = sampling_params["seed"]
+
+    for chunk in batch.chunk(num_workers):
+        assert len(chunk) == 12
+        worker = object.__new__(worker_cls)
+        worker.rollout_config = SimpleNamespace(
+            pipeline=None,
+            algo=None,
+            calculate_log_probs=False,
+            agent=SimpleNamespace(default_agent_loop="diffusion_single_turn_agent"),
+            n=n,
+        )
+        worker.background_tasks = set()
+        worker._run_agent_loop = capture_rollout
+        await worker.generate_sequences(chunk)
+        await asyncio.gather(*worker.background_tasks)
+
+    assert len(seeds_by_rollout) == num_prompts * n
+    seeds = [seeds_by_rollout[i] for i in range(num_prompts * n)]
+    assert len(set(seeds)) == num_prompts * n
+    assert seeds == maybe_per_rollout_seeds(
+        {"rollout_seed": rollout_base_seed}, num_prompts * n, range(num_prompts * n)
+    )
 
 
 @pytest.mark.asyncio

--- a/verl_omni/agent_loop/diffusion_agent_loop_tq.py
+++ b/verl_omni/agent_loop/diffusion_agent_loop_tq.py
@@ -98,7 +98,8 @@ class DiffusionAgentLoopWorkerTQ(DiffusionAgentLoopWorker):
                     prompt,
                     sampling_params,
                     trajectory=trajectory_info[i],
-                    sample_index=i,
+                    # Use the global prompt index so worker chunks cannot reuse rollout seeds.
+                    sample_index=int(index[i]),
                     rollout_base_seed=rollout_base_seed,
                 )
             )


### PR DESCRIPTION
## Summary

Fixes #561.

The v1 TQ agent-loop worker derived per-rollout RNG seeds from the **chunk-local** prompt index (`sample_index`, 0-11 per worker) instead of the **global** prompt index (0-47), unlike the v0 path. With 48 prompts chunked 12/12/12/12 across 4 workers, this caused 4 different prompts (one per worker, at the same chunk-local position) to receive identical seeds every step, producing identical noise realizations across their rollout groups. This is a structural, deterministic corruption of rollout noise that inflates policy-gradient variance and destabilizes GRPO training.

Fix: `verl_omni/agent_loop/diffusion_agent_loop_tq.py` now derives `sample_index` from the batch's global `index` field (already available in scope) instead of the loop-local `i`, matching v0's convention in `diffusion_agent_loop.py` / `maybe_per_rollout_seeds`.

## AI assistance disclosure

This PR was AI-assisted: **Claude** (Claude Code) diagnosed/scoped the fix from the issue and orchestrated the work, and **OpenAI Codex** wrote the production diff and the regression test. Per this repo's contribution policy, a human submitter (me) will review every changed line and confirm the reasoning before this leaves draft status.

**This PR stays in draft until I (the human submitter) have personally reviewed every changed line end-to-end and am prepared to defend the change. I will mark it "ready for review" only after that pass — not before.**

## Test plan

Ran the regression test (and the two other `seed`/`tq`-matched tests in the same file) on a Modal GPU container (A10G, CUDA 13.0, Ubuntu 22.04), installing the actual pinned dependency stack per `docs/start/install.md`:
- `uv pip install -e ".[gpu]" --torch-backend=auto`
- `uv pip install "vllm-omni @ git+https://github.com/vllm-project/vllm-omni.git@ded8934626aaad1a3e816c3a1d9d742efc012d93"` (the exact commit pinned in `.github/vllm_omni_pin.txt`, and the same commit cited in the issue's root-cause analysis)
- `uv pip install -e ".[train,dev]"`

Command:
```
.venv/bin/python -m pytest -q --asyncio-mode=auto \
  tests/agent_loop/test_diffusion_agent_loop_correctness_on_cpu.py -k "seed or tq" -v
```

Result:
```
tests/agent_loop/test_diffusion_agent_loop_correctness_on_cpu.py ...     [100%]
3 passed, 18 deselected, 20 warnings in 34.43s
```

The new test, `test_tq_rollout_seeds_are_global_across_worker_chunks`, simulates the exact 48-prompt / 4-worker / 12-per-chunk scenario from #561, asserts all `48 * 16 = 768` derived seeds are distinct, and asserts they match `maybe_per_rollout_seeds` (v0's derivation) exactly. It fails against the pre-fix code (chunk-local seeding collapses to 192 distinct values) and passes after the fix.

Earlier attempts to run this on CPU-only environments failed for environment reasons unrelated to the fix (missing `vllm_omni`, then a missing CUDA runtime lib for `torchcodec`'s import chain) — the GPU container above was used specifically to get a clean, representative result against the repo's real dependency graph.

I have not run the full test suite (blocked in some earlier CPU-only attempts by an unrelated `datasets`/`pyarrow` incompatibility, not investigated further since out of scope for this fix).