### PR TITLE
[doc] chore: drop author-local HTML comments from install docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,6 @@
 # Welcome to VeRL-Omni's documentation!
 
-<!-- 2026-09-02, tianqi, add NPU install page to Getting Started toctree -->
-Last updated: 09/02/2026
-<!-- end -->
+Last updated: 09/09/2026
 
 [VeRL-Omni](https://github.com/verl-project/verl-omni) is a general RL training framework focused on multimodal generative models, built on top of [verl](https://github.com/verl-project/verl). It originated from the multi-modal generation RL effort in `verl`, and now has a dedicated home so it can evolve in a more focused way.
 
@@ -24,7 +22,6 @@ VeRL-Omni targets RL post-training for three families of generative models:
 
 See {doc}`start/models` for the full model catalogue and which algorithms run on each model.
 
-<!-- 2026-09-02, tianqi, list NPU install next to GPU install in Getting Started -->
 ```{toctree}
 :maxdepth: 2
 :caption: Getting Started
@@ -36,7 +33,6 @@ start/flowgrpo_quickstart.md
 start/multi_node_training.md
 start/metrics.md
 ```
-<!-- end -->
 
 ```{toctree}
 :maxdepth: 1

--- a/docs/start/flowgrpo_quickstart_npu.md
+++ b/docs/start/flowgrpo_quickstart_npu.md
@@ -1,8 +1,6 @@
 # Quickstart: FlowGRPO training on Qwen-Image OCR dataset with Ascend NPU
 
-<!-- 2026-09-02, tianqi, point NPU quickstart install link at install_npu.md -->
-Last updated: 09/02/2026
-<!-- end -->
+Last updated: 09/09/2026
 
 Post-train a diffusion image generation model with FlowGRPO on Atlas 800T A2.
 
@@ -16,9 +14,7 @@ Prepare an Atlas 800T A2 server with 8 NPUs, and install the necessary software 
 
 1. Install CANN by following the [Ascend CANN installation guide](https://www.hiascend.com/document/detail/zh/CANNCommunityEdition/900/softwareinst/instg/instg_0003.html?OS=openEuler&InstallType=local).
 
-<!-- 2026-09-02, tianqi, point NPU quickstart at the NPU install page -->
 2. Install VeRL-Omni and its dependencies as described in the [NPU installation guide](install_npu.md).
-<!-- end -->
 
 3. Install the FlowGRPO-specific reward dependency:
 

--- a/docs/start/install.md
+++ b/docs/start/install.md
@@ -1,7 +1,6 @@
-<!-- 2026-09-06, tianqi, resolve merge conflicts with main: keep GPU-only page; take Python>=3.11, vllm 0.28 extras, and FA fail-fast from main -->
 # Installation
 
-Last updated: 09/07/2026
+Last updated: 09/09/2026
 
 For Ascend NPU, see the {doc}`NPU installation guide <install_npu>`.
 
@@ -228,4 +227,3 @@ The script launches `python3 -m verl_omni.trainer.main_diffusion` with FlowGRPO 
 ```bash
 checkpoints/flow_grpo/qwen_image_ocr_lora
 ```
-<!-- end -->

--- a/docs/start/install_npu.md
+++ b/docs/start/install_npu.md
@@ -1,16 +1,13 @@
-<!-- 2026-09-06, tianqi, sync NPU install page with main: Python>=3.11 and vllm 0.28 after merge -->
 # Installation (NPU)
 
-Last updated: 09/07/2026
+Last updated: 09/09/2026
 
 For NVIDIA GPU, see the {doc}`GPU installation guide <install>`.
 
 ## Requirements
 
-<!-- 2026-09-06, tianqi, bump NPU Python requirement to >=3.11 to match main -->
 * **Python**: Version >= 3.11
 * **CANN**: Version == 9.1.0
-<!-- end -->
 
 ## Install
 
@@ -28,12 +25,10 @@ source .venv/bin/activate
 
 2. Install the platform backend
 
-<!-- 2026-09-06, tianqi, bump NPU vllm pin to 0.28.0 to match main / pyproject gpu extra -->
 ```bash
 uv pip install vllm==0.28.0
 uv pip install "vllm-ascend @ git+https://github.com/vllm-project/vllm-ascend.git@$(cat .github/vllm_ascend_pin.txt)"
 ```
-<!-- end -->
 
 3. Install vLLM-Omni and VeRL-Omni
 
@@ -55,14 +50,12 @@ This installs `vllm-omni`, then `verl` and `verl-omni`.
 
 ### Extras
 
-<!-- 2026-09-06, tianqi, bump NPU extras table vllm-omni to 0.28.0rc1 to match pyproject.toml -->
 | Extra       | Adds                                                          | When                     |
 | ----------- | ------------------------------------------------------------- | ------------------------ |
 | `vllm-omni` | `vllm-omni==0.28.0rc1`                                        | Optional PyPI baseline only; CI/docs use the git pin above |
 | `train`     | `verl` @ [`.github/verl_pin.txt`](../../.github/verl_pin.txt) | RL training              |
 | `dev`       | `pytest`, `pre-commit`, `Levenshtein`, …                      | Local development / CI   |
 | `ocr`       | `Levenshtein`                                                 | OCR reward (FlowGRPO)    |
-<!-- end -->
 
 The CUDA `gpu` extra (`vllm`, `kernels`, `liger-kernel`) is not used on NPU. NPU recipes override the attention backend with `actor_rollout_ref.model.attn_backend=_native_npu`.
 
@@ -291,4 +284,3 @@ The script launches `python3 -m verl_omni.trainer.main_diffusion` with FlowGRPO 
 ```bash
 checkpoints/flow_grpo/qwen_image_ocr_lora
 ```
-<!-- end -->


### PR DESCRIPTION
### What does this PR do?

Follow-up to #515: remove author-local HTML markers (`<!-- YYYY-MM-DD, tianqi, ... -->` / `<!-- end -->`) that shipped with the GPU/NPU install split. They are not meant for upstream docs. Install steps are unchanged.

### Checklist Before Starting

- [x] Search for similar PRs:
  - https://github.com/verl-project/verl-omni/pulls?q=is%3Apr+is%3Aopen+515+in%3Abody
  - https://github.com/verl-project/verl-omni/pulls?q=is%3Apr+is%3Aopen+install+HTML+comment
  - No open PR strips these comments. Related merged work: #515.
- [x] Title: `[doc] chore: drop author-local HTML comments from install docs`

### Test

Docs-only. No new CI, no training.

- Comment-only deletion in `docs/index.md`, `docs/start/install.md`, `docs/start/install_npu.md`, and `docs/start/flowgrpo_quickstart_npu.md`.
- `Last updated` bumped to 09/09/2026 on the touched pages.

### API and Usage Example

No API change.

### Design & Code Changes

- Drop the personal HTML comment wrappers left from #515.
- Do not change GPU/NPU install instructions, extras, or pins.

### Checklist Before Submitting

- [x] Read the Contribute Guide
- [x] Docs-only comment deletion; no Python/CI files
- [x] Add / Update the documentation
- [x] No new unit/e2e CI: documentation comment cleanup only