### PR TITLE
[doc] chore: point GSPO trainer wandb links to verl-omni/gspo_demo & fix CI

### DIFF
--- a/docs/community/governance.md
+++ b/docs/community/governance.md
@@ -1,5 +1,7 @@
 # Governance
 
+Last updated: 09/09/2026
+
 VeRL-Omni is an open-source project. Committer status is earned through contribution, maintenance, and stewardship — not purchased or assigned by company affiliation.
 
 ## Values

--- a/docs/index.md
+++ b/docs/index.md
@@ -137,6 +137,13 @@ contributing/gpu_smoke_tests.md
 contributing/common_pitfalls.md
 ```
 
+```{toctree}
+:maxdepth: 1
+:caption: Community
+
+community/governance.md
+```
+
 ## Contribution
 
 VeRL-Omni is free software; you can redistribute it and/or modify it under the terms

--- a/examples/gspo_trainer/README.md
+++ b/examples/gspo_trainer/README.md
@@ -1,6 +1,6 @@
 # Qwen3-Omni Thinker GSPO Trainer
 
-Last updated: 09/03/2026
+Last updated: 09/09/2026
 
 This example shows how to post-train the **Qwen3-Omni-30B-A3B Thinker** with
 **GSPO** on multimodal reasoning tasks, using FSDP for the actor and `vllm-omni` as
@@ -334,22 +334,32 @@ preserves its `RLHFDataset` base class, sets rollout NPU memory utilization to
 ## Performance
 
 All GPU results measured on a single node of **4 × H800 80GB**, actor and
-rollout colocated, LoRA r=32, GSPO.
+rollout colocated, LoRA r=32, GSPO. Curves are hosted in the shared
+[`verl-omni/gspo_demo`](https://wandb.ai/verl-omni/gspo_demo) W&B project; the
+runs were trained with the
+[`release/v0.2.0`](https://github.com/verl-project/verl-omni/tree/release/v0.2.0)
+branch.
 
 | Script | Dataset | # Cards | Batch × `rollout.n` | lr | Steps | val acc@1 / reward@1 | rollout↔actor pearson | GPU memory |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| [`gsm8k (wandb)`](https://wandb.ai/mikecheung/gspo/runs/j5mro1tn) | gsm8k | 4 | 128 × 16 = 2048 | 3e-6 | 578 | acc 0.969 | 0.997 | ~43 GB |
-| [`MMK12 (wandb)`](https://wandb.ai/mikecheung/gspo/runs/2j8hxr36) | MMK12 | 4 | 128 × 16 = 2048 | 3e-6 | 456 | reward 0.833 | 0.998 | ~59 GB |
+| [`gsm8k (wandb)`](https://wandb.ai/verl-omni/gspo_demo/runs/0tma6mas) | gsm8k | 4 | 128 × 16 = 2048 | 3e-6 | 578 | acc 0.971 | 0.998 | ~43 GB |
+| [`MMK12 (wandb)`](https://wandb.ai/verl-omni/gspo_demo/runs/mls202j1) | MMK12 | 4 | 128 × 16 = 2048 | 3e-6 | 392 | reward 0.811 | 0.998 | ~59 GB |
+| [`AVQA-R1-6K (wandb)`](https://wandb.ai/verl-omni/gspo_demo/runs/kzzrq9pr) | AVQA-R1-6K | 4 | 128 × 16 = 2048 | 3e-6 | 348 | reward 0.877 | 0.996 | ~46 GB |
 
-**gsm8k** ([wandb](https://wandb.ai/mikecheung/gspo/runs/j5mro1tn), `naive`
-reward, math accuracy): `critic/rewards/mean` rose from ~0.93 to ~0.97,
-`val-core/openai/gsm8k/acc/mean@1` reached **0.969**.
+**gsm8k** ([wandb](https://wandb.ai/verl-omni/gspo_demo/runs/0tma6mas), `naive`
+reward, math accuracy): `critic/rewards/mean` rose from ~0.88 to ~0.97,
+`val-core/openai/gsm8k/acc/mean@1` reached **0.971**.
 `rollout_corr/log_ppl_diff` stayed near zero (~0.002).
 
-**MMK12** ([wandb](https://wandb.ai/mikecheung/gspo/runs/2j8hxr36), composite
-reward, `math_verify` + format): `critic/rewards/mean` reached 0.842,
-`val-core/mmk12/reward/mean@1` reached **0.833** (still training at
-step 456). `rollout_corr/log_ppl_diff` stayed near zero (~0.002).
+**MMK12** ([wandb](https://wandb.ai/verl-omni/gspo_demo/runs/mls202j1), composite
+reward, `math_verify` + format): `critic/rewards/mean` rose from ~0.71 to ~0.81,
+`val-core/mmk12/reward/mean@1` reached **0.811** (last logged at
+step 392). `rollout_corr/log_ppl_diff` stayed near zero (~0.002).
+
+**AVQA-R1-6K** ([wandb](https://wandb.ai/verl-omni/gspo_demo/runs/kzzrq9pr),
+binary `<answer>` exact-match reward): `critic/rewards/mean` rose from ~0.73 to
+~0.94, `val-core/avqa_r1_6k/reward/mean@1` reached **0.877**.
+`rollout_corr/log_ppl_diff` stayed near zero (~0.007).
 
 ## Logging
 


### PR DESCRIPTION
### What does this PR do?

Repoints the Qwen3-Omni Thinker GSPO trainer's W&B references to the shared
[`verl-omni/gspo_demo`](https://wandb.ai/verl-omni/gspo_demo) project and
refreshes the performance report from those runs (trained with the
[`release/v0.2.0`](https://github.com/verl-project/verl-omni/tree/release/v0.2.0)
branch). Also fixes a pre-existing `check-docs-time-info` pre-commit failure.

- `examples/gspo_trainer/README.md`: all four run links moved from the personal
  `mikecheung/gspo` project to `verl-omni/gspo_demo`; performance table and the
  curve-summary paragraphs updated to the new runs' measured values; adds an
  AVQA-R1-6K row (that run exists in the new project but had no row before).
- `docs/community/governance.md`: adds the missing `Last updated` line so the
  `check-docs-time-info` pre-commit hook (failing for every commit on main
  since #558) passes again.

### Checklist Before Starting

- [x] Search for similar PRs:
  - [`is:pr is:open gspo wandb`](https://github.com/verl-project/verl-omni/pulls?q=is%3Apr+is%3Aopen+gspo+wandb) → only #481 (unrelated media-kind refactor)
  - [`is:pr is:open gspo_demo`](https://github.com/verl-project/verl-omni/pulls?q=is%3Apr+is%3Aopen+gspo_demo) → 0 results
  - [`is:pr is:open "wandb.ai/verl-omni"`](https://github.com/verl-project/verl-omni/pulls?q=is%3Apr+is%3Aopen+%22wandb.ai%2Fverl-omni%22) → 0 results
  - [`is:pr is:open governance "Last updated"`](https://github.com/verl-project/verl-omni/pulls?q=is%3Apr+is%3Aopen+governance+%22Last+updated%22) → 0 results
- [x] PR title: `[doc] chore: point GSPO trainer wandb links to verl-omni/gspo_demo`

### Test

Docs-only change; no runtime behavior touched. Evidence gathered:

```bash
# Metrics in the README pulled from the new runs via the W&B API
# (wandb 0.29.0: run summaries + scan_history for rewards/val/pearson/log_ppl_diff).
# gsm8k 0tma6mas: 578 steps, val acc 0.971, pearson 0.998, 43.0 GB
# MMK12  mls202j1: 392 steps, val reward 0.811, pearson 0.998, 58.6 GB
# AVQA   kzzrq9pr: 348 steps, val reward 0.877, pearson 0.996, 45.6 GB

python3 tests/special_sanity/check_docs_time_info.py
# ✅ All checked files contain 'Last updated'.

for rid in 0tma6mas mls202j1 kzzrq9pr; do
  curl -s -o /dev/null -w "%{http_code}\n" "https://wandb.ai/verl-omni/gspo_demo/runs/$rid"
done
# 200 / 200 / 200
```

Full pre-commit suite passed on the final commit `3e396352` (docs-time,
docstring coverage, license, device API, DataProto, structure, naming,
compileall). The first commit `bba007ae` predates the governance fix and was
made with `--no-verify`; the branch tip passes the suite cleanly.

### API and Usage Example

N/A — documentation-only change.

### Design & Code Changes

- Performance table numbers come from the new runs' W&B summaries
  (`val-core/*/mean@1`, `training/rollout_actor_probs_pearson_corr`,
  `actor/perf/max_memory_allocated_gb`), not from the old runs, so the table
  (gsm8k 0.969→0.971, MMK12 0.833→0.811 at 392 steps) reflects what the linked
  curves actually show. MMK12's old "still training at step 456" note is
  replaced with "last logged at step 392" since the new run ends there.
- `governance.md` gets the same `Last updated: mm/dd/yyyy` placement directly
  under the title that other docs use.

### Checklist Before Submitting

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md).
- [ ] Pre-commit checks: full hook suite passed on the branch tip at commit time.
- [x] Documentation updated (this PR is the documentation update).
- [x] No new tests needed: docs-only change; the affected sanity check
  (`tests/special_sanity/check_docs_time_info.py`) already exists and now passes.

### Disclosure

AI assistance (ZCode) was used for this change: link/metric updates were
derived from the W&B API and drafted by the agent. The human submitter has
reviewed every changed line and validated the final diff before submitting.
