### PR TITLE
[trainer, cfg, tests, doc] feat: hybrid rollout switching for diffusion v1 separate-async

### DIFF
--- a/docs/start/diffusion_v1.md
+++ b/docs/start/diffusion_v1.md
@@ -1,6 +1,6 @@
 # Diffusion V1 training
 
-Last updated: 09/01/2026
+Last updated: 09/10/2026
 
 This guide runs the diffusion V1 trainer in synchronous or separate-asynchronous
 mode using the provided Stable Diffusion 3.5 Medium FlowGRPO OCR recipes.
@@ -150,6 +150,47 @@ bash examples/flowgrpo_trainer/sd35/run_sd35_medium_ocr_lora_v1_separate_async.s
 requires `num_warmup_batches=0`; set it to `false` to retain rollout/training
 overlap.
 
+### Hybrid rollout switching
+
+The colocated rollout replicas share GPUs with the actor. By default they are
+lent to generation only during warmup and validation: they start in rollout
+mode after initialization, and the first training step reclaims them
+(aborts their in-flight requests, sleeps them, and removes them from the
+load balancer) before any actor update. Validation lends them out again and
+the next step reclaims them.
+
+Enable dynamic switching so the trainer also lends them to the next step's
+generation whenever the replay buffer is short:
+
+```bash
+trainer.v1.separate_async.sync_compatible=false \
+trainer.v1.separate_async.hybrid_rollout.enable_switch=true \
+bash examples/flowgrpo_trainer/sd35/run_sd35_medium_ocr_lora_v1_separate_async.sh
+```
+
+At the end of a step, the trainer syncs the standalone replicas as usual and
+then estimates how many prompt groups the next step still misses. If the
+expected wait exceeds the recent cost of a switch round trip, it installs the
+new actor weights into the colocated replicas, resumes them, and registers them
+with the standalone load balancer. The next step submits its prompts, waits
+until `switch_threshold_ratio * train_batch_size` groups (at least one
+mini-batch) are sampleable, and reclaims the replicas. Aborted diffusion
+samples are retried as whole samples on the remaining replicas. Switching
+happens at most once per step; `adaptive_switch_threshold` raises the
+threshold after sustained sampling waits and lowers it after calm steps.
+
+`enable_switch=true` requires `sync_compatible=false` and
+`actor_rollout_ref.rollout.disaggregation.enabled=false`. The remaining
+knobs follow the upstream `HybridRolloutSwitchConfig` defaults:
+`switch_threshold_ratio`, `adaptive_switch_threshold`,
+`switch_threshold_step_up`, `switch_threshold_step_down`,
+`switch_threshold_release_steps`, and `switch_cost_window_size`.
+
+Logged metrics: `timing_s/switch_wait`, `timing_s/switch_to_rollout`,
+`timing_s/switch_to_trainer`, `separate_async/switch/*`, and
+`separate_async/decision/*`. Throughput metrics normalize by the total of
+actor and standalone rollout GPUs.
+
 ## Important settings
 
 - `trainer.use_v1=true` selects the V1 trainer instead of the legacy diffusion
@@ -157,6 +198,9 @@ overlap.
 - `trainer.v1.trainer_mode` selects `sync` or `separate_async`.
 - `trainer.v1.separate_async.parameter_sync_step` controls the number of local
   actor updates per rollout-weight synchronization cycle.
+- `trainer.v1.separate_async.hybrid_rollout.enable_switch` lends the colocated
+  rollout replicas to generation between steps when the replay buffer is
+  short.
 - `actor_rollout_ref.rollout.agent.num_workers` controls the rollout worker
   count.
 - `trainer.v1.sampler.drop_incomplete_groups=true` evicts a training prompt

--- a/tests/trainer/diffusion/test_v1_hybrid_rollout_switch_on_cpu.py
+++ b/tests/trainer/diffusion/test_v1_hybrid_rollout_switch_on_cpu.py
@@ -1,0 +1,660 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU tests for the diffusion ``separate_async`` once-per-step hybrid rollout switching.
+
+The hybrid replicas share GPUs with the actor. Lending them to generation costs a
+naive weight sync plus a resume, and reclaiming them costs an abort plus a sleep.
+These tests pin one round trip per global step and the diffusion-specific order:
+hybrid replicas join the balancer only after the naive sync has resumed them.
+"""
+
+from contextlib import contextmanager
+from types import SimpleNamespace
+
+import pytest
+from omegaconf import OmegaConf
+from transfer_queue import KVBatchMeta
+from verl.trainer.config import HybridRolloutSwitchConfig
+from verl.utils.config import omega_conf_to_dataclass
+
+import verl_omni.trainer.diffusion.v1.trainer_separate_async as trainer_module
+from verl_omni.trainer.diffusion.v1.trainer_base import PolicyGradientDiffusionTrainerV1
+from verl_omni.trainer.diffusion.v1.trainer_separate_async import (
+    HybridEngineMode,
+    PolicyGradientDiffusionTrainerV1SeparateAsync,
+)
+
+
+class _RecordingCheckpointManager:
+    def __init__(self, name: str, events: list[str]):
+        self.name = name
+        self.events = events
+        self.update_calls: list[int] = []
+        self.resume_calls = 0
+        self.abort_calls = 0
+        self.sleep_calls = 0
+        self.wake_calls = 0
+
+    def update_weights(self, global_steps: int):
+        self.events.append(f"{self.name}_update")
+        self.update_calls.append(global_steps)
+        return {}
+
+    def resume_generation_replicas(self):
+        self.events.append(f"{self.name}_resume")
+        self.resume_calls += 1
+
+    def abort_replicas(self):
+        self.events.append(f"{self.name}_abort")
+        self.abort_calls += 1
+
+    def sleep_replicas(self):
+        self.events.append(f"{self.name}_sleep")
+        self.sleep_calls += 1
+
+    def wake_up_replicas(self):
+        self.events.append(f"{self.name}_wake")
+        self.wake_calls += 1
+
+
+class _RecordingReplayBuffer:
+    poll_interval = 1.0
+
+    def __init__(self, eviction_metrics: dict | None = None, sampleable_count: int = 0):
+        self.wait_calls: list[int] = []
+        self.count_calls = 0
+        self.eviction_metrics = eviction_metrics or {}
+        self.sampleable_count = sampleable_count
+
+    def wait_for_sampleable(self, global_steps: int, partition_id: str, target_count: int) -> tuple[set[str], dict]:
+        del global_steps, partition_id
+        self.wait_calls.append(target_count)
+        return set(), dict(self.eviction_metrics)
+
+    def get_sampleable_count(self, global_steps: int, partition_id: str) -> int:
+        del global_steps, partition_id
+        self.count_calls += 1
+        return self.sampleable_count
+
+
+def _trainer(
+    *,
+    enable_switch: bool = True,
+    switch_threshold_ratio: float = 0.25,
+    adaptive_switch_threshold: bool = False,
+    train_batch_size: int = 64,
+    parameter_sync_step: int = 4,
+    global_steps: int = 1,
+    total_training_steps: int = 3,
+    eviction_metrics: dict | None = None,
+    sampleable_count: int = 0,
+) -> PolicyGradientDiffusionTrainerV1SeparateAsync:
+    trainer = object.__new__(PolicyGradientDiffusionTrainerV1SeparateAsync)
+    trainer.config = OmegaConf.create(
+        {
+            "data": {"train_batch_size": train_batch_size},
+            "trainer": {"nnodes": 2, "n_gpus_per_node": 8},
+            "actor_rollout_ref": {
+                "rollout": {
+                    "nnodes": 2,
+                    "n_gpus_per_node": 8,
+                    "disaggregation": {"enabled": False},
+                }
+            },
+        }
+    )
+    trainer.parameter_sync_step = parameter_sync_step
+    trainer.sync_compatible = False
+    trainer._standalone_paused = False
+    trainer.global_steps = global_steps
+    trainer.total_training_steps = total_training_steps
+    trainer.timing_raw = {}
+    trainer.current_mode = HybridEngineMode.ROLLOUT
+    trainer.replay_buffer = _RecordingReplayBuffer(eviction_metrics, sampleable_count)
+    trainer.events: list[str] = []
+    trainer.checkpoint_manager = _RecordingCheckpointManager("hybrid", trainer.events)
+    trainer.standalone_checkpoint_manager = _RecordingCheckpointManager("standalone", trainer.events)
+    trainer.balancer_calls: list[str] = []
+
+    def add_replicas():
+        trainer.events.append("add")
+        trainer.balancer_calls.append("add")
+
+    def remove_replicas():
+        trainer.events.append("remove")
+        trainer.balancer_calls.append("remove")
+
+    def clear_sticky():
+        trainer.events.append("clear")
+        trainer.balancer_calls.append("clear")
+        return {"cleared_entries": 7}
+
+    trainer.add_replicas_to_balancer = add_replicas
+    trainer.remove_replicas_from_balancer = remove_replicas
+    trainer.clear_sticky_cache = clear_sticky
+    trainer.hybrid_rollout_config = HybridRolloutSwitchConfig(
+        enable_switch=enable_switch,
+        switch_threshold_ratio=switch_threshold_ratio,
+        adaptive_switch_threshold=adaptive_switch_threshold,
+        switch_threshold_step_up=0.05,
+        switch_threshold_step_down=0.025,
+        switch_threshold_release_steps=2,
+        switch_cost_window_size=3,
+    )
+    if enable_switch:
+        trainer._init_hybrid_rollout_state()
+    return trainer
+
+
+def _construct_trainer(
+    monkeypatch,
+    *,
+    replay_buffer,
+    enable_switch: bool = True,
+    disaggregation: bool = False,
+    sync_compatible: bool = False,
+):
+    config = OmegaConf.create(
+        {
+            "data": {"train_batch_size": 64},
+            "actor_rollout_ref": {
+                "actor": {"ppo_mini_batch_size": 16},
+                "rollout": {
+                    "nnodes": 1,
+                    "n_gpus_per_node": 8,
+                    "checkpoint_engine": {"backend": "nccl"},
+                    "disaggregation": {"enabled": disaggregation},
+                },
+            },
+            "trainer": {
+                "nnodes": 1,
+                "n_gpus_per_node": 8,
+                "v1": {
+                    "separate_async": {
+                        "parameter_sync_step": 4,
+                        "num_warmup_batches": 0,
+                        "sync_compatible": sync_compatible,
+                        "hybrid_rollout": {
+                            "_target_": "verl.trainer.config.HybridRolloutSwitchConfig",
+                            "enable_switch": enable_switch,
+                        },
+                    }
+                },
+            },
+        }
+    )
+
+    def mock_base_init(trainer, trainer_config):
+        trainer.config = trainer_config
+        trainer.replay_buffer = replay_buffer
+
+    monkeypatch.setattr(PolicyGradientDiffusionTrainerV1, "__init__", mock_base_init)
+    return PolicyGradientDiffusionTrainerV1SeparateAsync(config)
+
+
+def _run_step(trainer: PolicyGradientDiffusionTrainerV1SeparateAsync, *, sample_wait_seconds: float) -> None:
+    """Drive one global step's hooks, with the mini-batches blocked for the given total."""
+    trainer.on_step_begin()
+    trainer._wait_for_sampleable_and_switch()
+    trainer._step_sample_wait_seconds = sample_wait_seconds
+    trainer.on_step_end()
+
+
+def test_hybrid_rollout_switch_config_target_instantiates_dataclass():
+    config = OmegaConf.create(
+        {
+            "_target_": "verl.trainer.config.HybridRolloutSwitchConfig",
+            "switch_threshold_ratio": 0.25,
+        }
+    )
+
+    switch_config = omega_conf_to_dataclass(config)
+
+    assert isinstance(switch_config, HybridRolloutSwitchConfig)
+    assert switch_config.switch_threshold_ratio == 0.25
+
+
+def test_diffusion_trainer_yaml_declares_upstream_hybrid_rollout_defaults():
+    from hydra import compose, initialize_config_module
+
+    with initialize_config_module(config_module="verl_omni.trainer.config", version_base=None):
+        config = compose(
+            config_name="diffusion_trainer",
+            overrides=["trainer.v1.separate_async.hybrid_rollout.enable_switch=true"],
+        )
+
+    switch_config = omega_conf_to_dataclass(config.trainer.v1.separate_async.hybrid_rollout)
+
+    assert isinstance(switch_config, HybridRolloutSwitchConfig)
+    assert switch_config.enable_switch is True
+    defaults = HybridRolloutSwitchConfig()
+    for field in (
+        "switch_threshold_ratio",
+        "adaptive_switch_threshold",
+        "switch_threshold_step_up",
+        "switch_threshold_step_down",
+        "switch_threshold_release_steps",
+        "switch_cost_window_size",
+    ):
+        assert getattr(switch_config, field) == getattr(defaults, field), field
+
+
+def test_setup_leaves_hybrid_in_rollout_mode_and_registered(monkeypatch):
+    trainer = object.__new__(PolicyGradientDiffusionTrainerV1SeparateAsync)
+    events: list[str] = []
+    trainer.config = OmegaConf.create(
+        {
+            "actor_rollout_ref": {"rollout": {"checkpoint_engine": {"backend": "nccl"}}},
+            "trainer": {"v1": {"separate_async": {"sync_compatible": False}}},
+        }
+    )
+    trainer.llm_server_manager = SimpleNamespace(rollout_replicas=[object()])
+    trainer.actor_rollout_wg = object()
+    monkeypatch.setattr(PolicyGradientDiffusionTrainerV1, "_setup", lambda self: events.append("base_setup"))
+    monkeypatch.setattr(trainer_module, "omega_conf_to_dataclass", lambda cfg: SimpleNamespace(**cfg))
+    monkeypatch.setattr(
+        trainer_module.LLMServerManager,
+        "create",
+        staticmethod(lambda **kwargs: SimpleNamespace(start_rank=kwargs["start_rank"], get_replicas=lambda: [])),
+    )
+    monkeypatch.setattr(
+        trainer_module,
+        "OmniCheckpointEngineManager",
+        lambda **kwargs: SimpleNamespace(backend=kwargs["config"].backend),
+    )
+    trainer.add_replicas_to_balancer = lambda: events.append("add")
+
+    trainer._setup()
+
+    assert events == ["base_setup", "add"]
+    assert trainer.current_mode == HybridEngineMode.ROLLOUT
+    assert trainer.standalone_server_manager.start_rank == 1
+    assert not hasattr(trainer, "_colocated_slept")
+
+
+def test_disabled_switch_first_step_reclaims_hybrid_without_waiting():
+    trainer = _trainer(enable_switch=False)
+
+    trainer.on_step_begin()
+
+    assert trainer.current_mode == HybridEngineMode.TRAINER
+    assert trainer.events == ["remove", "hybrid_abort", "hybrid_sleep"]
+    assert trainer.replay_buffer.wait_calls == []
+    assert trainer.replay_buffer.count_calls == 0
+    assert trainer.timing_raw["switch_to_trainer"] >= 0.0
+    assert "switch_wait" not in trainer.timing_raw
+    assert trainer._wait_for_sampleable_and_switch() == {}
+
+    trainer.on_step_end()
+    assert trainer.current_mode == HybridEngineMode.TRAINER
+    assert trainer.checkpoint_manager.update_calls == []
+    assert trainer._pending_sync_metrics == {}
+
+    trainer.on_step_begin()
+    assert trainer.checkpoint_manager.sleep_calls == 1
+
+
+def test_step_lends_the_engine_out_and_reclaims_it_exactly_once():
+    trainer = _trainer()
+    trainer.current_mode = HybridEngineMode.TRAINER
+
+    # Weight sync ends the previous step by lending the engine to the next one's generation.
+    trainer.on_step_end()
+    assert trainer.current_mode == HybridEngineMode.ROLLOUT
+    assert trainer.standalone_checkpoint_manager.update_calls == [1]
+    assert trainer.checkpoint_manager.update_calls == [1]
+    assert trainer.checkpoint_manager.resume_calls == 1
+    assert trainer.checkpoint_manager.wake_calls == 0
+    # Hybrid replicas join the balancer only after the naive sync has resumed them.
+    assert trainer.events == ["standalone_update", "hybrid_update", "hybrid_resume", "add", "clear"]
+    assert trainer.timing_raw["switch_to_rollout"] >= 0.0
+    assert len(trainer._to_rollout_costs) == 1
+    assert "separate_async/decision/per_sample_time_seconds" not in trainer._pending_sync_metrics
+    assert "separate_async/decision/effective_switch_cost_seconds" not in trainer._pending_sync_metrics
+
+    trainer.on_step_begin()
+    trainer._wait_for_sampleable_and_switch()
+    assert trainer.current_mode == HybridEngineMode.TRAINER
+    assert trainer.replay_buffer.wait_calls == [16]
+    assert trainer.checkpoint_manager.abort_calls == 1
+    assert trainer.checkpoint_manager.sleep_calls == 1
+    assert trainer.balancer_calls == ["add", "clear", "remove"]
+    assert trainer.timing_raw["switch_to_trainer"] >= 0.0
+    assert len(trainer._to_trainer_costs) == 1
+
+    # Later mini-batches run through the sample hooks, which must not switch again.
+    for _ in range(3):
+        trainer.on_sample_begin()
+        trainer.on_sample_end()
+    assert trainer.checkpoint_manager.sleep_calls == 1
+    assert trainer.balancer_calls == ["add", "clear", "remove"]
+
+
+def test_switch_to_rollout_timing_covers_sync_resume_and_registration(monkeypatch):
+    @contextmanager
+    def recording_timer(name, timing_raw, **_kwargs):
+        yield
+        timing_raw[name] = timing_raw.get(name, 0.0) + 1.0
+
+    monkeypatch.setattr(trainer_module, "marked_timer", recording_timer)
+    trainer = _trainer()
+    trainer.current_mode = HybridEngineMode.TRAINER
+
+    trainer.on_step_end()
+
+    assert trainer.timing_raw["switch_to_rollout"] == 1.0
+    assert trainer.timing_raw["update_weights"] == 1.0
+    assert trainer._to_rollout_costs[0] >= 0.0
+
+
+def test_step_begin_reclaims_hybrid_before_submission_when_inventory_is_ready():
+    trainer = _trainer(sampleable_count=16)
+
+    trainer.on_step_begin()
+
+    assert trainer.current_mode == HybridEngineMode.TRAINER
+    assert trainer.replay_buffer.count_calls == 1
+    assert trainer.replay_buffer.wait_calls == []
+    assert trainer.checkpoint_manager.abort_calls == 1
+    assert trainer.checkpoint_manager.sleep_calls == 1
+    assert trainer.timing_raw["switch_wait"] == 0.0
+    assert trainer.timing_raw["switch_to_trainer"] >= 0.0
+    assert trainer._wait_for_sampleable_and_switch() == {}
+
+
+def test_wait_for_sampleable_is_a_noop_once_the_engine_is_training():
+    trainer = _trainer()
+    trainer.current_mode = HybridEngineMode.TRAINER
+
+    assert trainer._wait_for_sampleable_and_switch() == {}
+    assert trainer.replay_buffer.wait_calls == []
+    assert trainer.balancer_calls == []
+
+
+def test_prepare_step_submits_prompts_before_the_blocking_wait():
+    metrics = {"training/off_policy/evicted_samples": 3}
+    trainer = _trainer(eviction_metrics=metrics)
+    trainer._add_batch_to_generate = lambda: trainer.events.append("feed")
+
+    trainer.on_step_begin()
+    assert trainer.prepare_step() == metrics
+    assert trainer.events == ["feed", "remove", "hybrid_abort", "hybrid_sleep"]
+    assert trainer.timing_raw["feed"] >= 0.0
+    assert trainer.timing_raw["switch_wait"] >= 0.0
+
+
+def test_base_step_merges_prepare_metrics_into_the_step():
+    trainer = object.__new__(PolicyGradientDiffusionTrainerV1SeparateAsync)
+    trainer.config = OmegaConf.create({"data": {"train_batch_size": 4}})
+    trainer.parameter_sync_step = 2
+    trainer.sync_compatible = False
+    trainer.timing_raw = {}
+    events = []
+    trainer.prepare_step = lambda: (events.append("prepare"), {"training/rollout_failure/evicted_groups": 2})[1]
+
+    def step_once(iter_metrics, timing_raw, sample_batch_size):
+        del timing_raw, sample_batch_size
+        events.append(f"train_{trainer.local_trigger_step}")
+        iter_metrics["training/rollout_failure/evicted_groups"] = 1
+        return KVBatchMeta(partition_id="train", keys=[f"s-{trainer.local_trigger_step}"], tags=[{}])
+
+    trainer._step_once = step_once
+    metrics = {}
+    PolicyGradientDiffusionTrainerV1.step(trainer, metrics, trainer.timing_raw)
+
+    assert events == ["prepare", "train_0", "train_1"]
+    assert metrics["training/rollout_failure/evicted_groups"] == 4
+
+
+def test_last_step_does_not_lend_the_engine_out():
+    trainer = _trainer(global_steps=3, total_training_steps=3)
+    trainer.current_mode = HybridEngineMode.TRAINER
+
+    trainer.on_step_end()
+
+    assert trainer.current_mode == HybridEngineMode.TRAINER
+    assert trainer.standalone_checkpoint_manager.update_calls == [3]
+    assert trainer.checkpoint_manager.update_calls == []
+
+
+def test_inventory_gate_skips_lending_when_the_target_is_already_buffered():
+    trainer = _trainer(sampleable_count=16)
+    trainer.current_mode = HybridEngineMode.TRAINER
+
+    trainer.on_step_begin()
+    trainer.on_step_end()
+
+    assert trainer.checkpoint_manager.update_calls == []
+    assert trainer.balancer_calls == []
+    assert trainer.timing_raw["switch_wait"] == 0.0
+    assert trainer._pending_sync_metrics["separate_async/decision/remaining"] == 0.0
+    assert trainer._pending_sync_metrics["separate_async/decision/should_switch_to_rollout"] == 0.0
+
+
+def test_cost_gate_skips_lending_when_the_remaining_work_is_cheaper_to_fill_on_standalone():
+    trainer = _trainer(sampleable_count=15)
+    trainer.current_mode = HybridEngineMode.TRAINER
+    trainer._wait_seconds = 2.0
+    trainer._wait_samples = 1
+    trainer._to_rollout_costs.append(3.0)
+    trainer._to_trainer_costs.append(4.0)
+
+    trainer.on_step_end()
+
+    assert trainer.checkpoint_manager.update_calls == []
+    assert trainer._scaling_factor == 2.0
+    assert trainer._pending_sync_metrics["separate_async/decision/remaining"] == 1.0
+    assert trainer._pending_sync_metrics["separate_async/decision/per_sample_time_seconds"] == 2.0
+    assert trainer._pending_sync_metrics["separate_async/decision/effective_switch_cost_seconds"] == 7.0
+    # benefit = remaining * per_sample_time * (1 - 1/scaling_factor) = 1 * 2.0 * 0.5 = 1.0 < 7.0
+    assert trainer._pending_sync_metrics["separate_async/decision/should_switch_to_rollout"] == 0.0
+
+
+def test_cost_gate_lends_when_the_remaining_work_is_more_expensive_than_the_switch():
+    trainer = _trainer(sampleable_count=15)
+    trainer.current_mode = HybridEngineMode.TRAINER
+    trainer._wait_seconds = 16.0
+    trainer._wait_samples = 1
+    trainer._to_rollout_costs.append(3.0)
+    trainer._to_trainer_costs.append(4.0)
+
+    trainer.on_step_end()
+
+    assert trainer.checkpoint_manager.update_calls == [1]
+    assert trainer._pending_sync_metrics["separate_async/decision/should_switch_to_rollout"] == 1.0
+
+
+def test_switch_cost_window_forgets_cold_start():
+    trainer = _trainer()
+    trainer._to_rollout_costs.extend([100.0, 2.0, 4.0, 6.0])
+    trainer._to_trainer_costs.extend([50.0, 1.0, 3.0, 5.0])
+
+    assert trainer._effective_switch_cost() == pytest.approx(7.0)
+
+
+@pytest.mark.parametrize(
+    ("ratio", "parameter_sync_step", "expected"),
+    [
+        (0.5, 4, 32),
+        (1.0, 4, 64),
+        (0.01, 4, 16),
+        (0.25, 1, 64),
+    ],
+)
+def test_threshold_is_clamped_to_between_one_mini_batch_and_the_batch(ratio, parameter_sync_step, expected):
+    trainer = _trainer(switch_threshold_ratio=ratio, parameter_sync_step=parameter_sync_step)
+
+    assert trainer._switch_threshold() == expected
+
+
+@pytest.mark.parametrize("ratio", [0.0, -0.1, 1.5])
+def test_switching_rejects_a_ratio_outside_the_unit_interval(ratio):
+    with pytest.raises(ValueError, match="switch_threshold_ratio"):
+        _trainer(switch_threshold_ratio=ratio)
+
+
+def test_switching_rejects_a_replay_buffer_that_cannot_report_depth(monkeypatch):
+    with pytest.raises(TypeError, match="wait_for_sampleable"):
+        _construct_trainer(monkeypatch, replay_buffer=SimpleNamespace())
+
+
+def test_switching_rejects_rollout_disaggregation(monkeypatch):
+    with pytest.raises(ValueError, match="does not support rollout disaggregation"):
+        _construct_trainer(monkeypatch, replay_buffer=_RecordingReplayBuffer(), disaggregation=True)
+
+
+def test_switching_rejects_sync_compatible(monkeypatch):
+    with pytest.raises(AssertionError, match="sync_compatible"):
+        _construct_trainer(monkeypatch, replay_buffer=_RecordingReplayBuffer(), sync_compatible=True)
+
+
+def test_disabled_switching_skips_custom_replay_buffer_validation(monkeypatch):
+    trainer = _construct_trainer(monkeypatch, replay_buffer=SimpleNamespace(), enable_switch=False)
+
+    assert trainer.hybrid_rollout_config.enable_switch is False
+    assert not hasattr(trainer, "_to_rollout_costs")
+
+
+def test_enabled_switching_initializes_policy_state(monkeypatch):
+    trainer = _construct_trainer(monkeypatch, replay_buffer=_RecordingReplayBuffer())
+
+    assert trainer.hybrid_rollout_config.enable_switch is True
+    assert trainer._scaling_factor == 2.0
+    assert trainer._to_rollout_costs.maxlen == 3
+
+
+def test_validation_lends_the_engine_and_leaves_it_for_the_next_step():
+    trainer = _trainer(enable_switch=False)
+    trainer.current_mode = HybridEngineMode.TRAINER
+
+    trainer.on_validate_begin()
+    assert trainer.current_mode == HybridEngineMode.ROLLOUT
+    assert trainer.events == ["hybrid_update", "hybrid_resume", "add"]
+    assert trainer.checkpoint_manager.wake_calls == 0
+
+    trainer.on_validate_end()
+    assert trainer.current_mode == HybridEngineMode.ROLLOUT
+    assert trainer.events == ["hybrid_update", "hybrid_resume", "add"]
+
+    trainer.on_step_begin()
+    assert trainer.current_mode == HybridEngineMode.TRAINER
+    assert trainer.events[3:] == ["remove", "hybrid_abort", "hybrid_sleep"]
+
+
+def test_validation_does_not_switch_when_already_in_rollout_mode():
+    trainer = _trainer(enable_switch=False)
+
+    trainer.on_validate_begin()
+
+    assert trainer.events == []
+    assert trainer.current_mode == HybridEngineMode.ROLLOUT
+
+
+def test_switch_failures_propagate_without_marking_the_new_mode():
+    trainer = _trainer()
+
+    def failing_sleep():
+        raise RuntimeError("sleep failed")
+
+    trainer.checkpoint_manager.sleep_replicas = failing_sleep
+    with pytest.raises(RuntimeError, match="sleep failed"):
+        trainer.switch_to_trainer()
+    assert trainer.current_mode == HybridEngineMode.ROLLOUT
+
+    trainer = _trainer()
+    trainer.current_mode = HybridEngineMode.TRAINER
+
+    def failing_update(global_steps):
+        raise RuntimeError("sync failed")
+
+    trainer.checkpoint_manager.update_weights = failing_update
+    with pytest.raises(RuntimeError, match="sync failed"):
+        trainer.switch_to_rollout()
+    assert trainer.current_mode == HybridEngineMode.TRAINER
+    assert trainer.balancer_calls == []
+
+
+def test_step_end_metrics_are_consumed_once():
+    trainer = _trainer(sampleable_count=16)
+    trainer.current_mode = HybridEngineMode.TRAINER
+    trainer.standalone_checkpoint_manager.update_weights = lambda global_steps: {"sync/changed_ratio": 0.5}
+
+    trainer.on_step_begin()
+    trainer.on_step_end()
+    metrics = trainer._consume_sync_metrics()
+
+    assert metrics["sync/changed_ratio"] == 0.5
+    assert metrics["separate_async/switch/threshold_ratio"] == 0.25
+    assert trainer._consume_sync_metrics() == {}
+
+
+def test_throughput_gpus_include_standalone_rollout():
+    trainer = _trainer()
+    trainer.resource_pool_manager = SimpleNamespace(get_n_gpus=lambda: 16)
+
+    assert trainer._get_n_gpus_for_throughput() == 32
+    assert PolicyGradientDiffusionTrainerV1._get_n_gpus_for_throughput(trainer) == 16
+
+
+def test_adaptive_threshold_increases_after_trainer_idle():
+    trainer = _trainer(adaptive_switch_threshold=True, switch_threshold_ratio=0.5)
+
+    ratios = []
+    for _ in range(3):
+        _run_step(trainer, sample_wait_seconds=2.0)
+        ratios.append(trainer._switch_threshold_ratio)
+
+    assert ratios == pytest.approx([0.5, 0.55, 0.6])
+
+
+def test_adaptive_threshold_decreases_after_calm_release_interval():
+    trainer = _trainer(adaptive_switch_threshold=True, switch_threshold_ratio=0.5)
+
+    ratios = []
+    for _ in range(4):
+        _run_step(trainer, sample_wait_seconds=0.0)
+        ratios.append(trainer._switch_threshold_ratio)
+
+    assert ratios == pytest.approx([0.5, 0.475, 0.45, 0.425])
+
+
+def test_threshold_direction_change_resets_hysteresis():
+    trainer = _trainer(adaptive_switch_threshold=True, switch_threshold_ratio=0.5)
+
+    for _ in range(3):
+        _run_step(trainer, sample_wait_seconds=0.0)
+    _run_step(trainer, sample_wait_seconds=2.0)
+    _run_step(trainer, sample_wait_seconds=0.0)
+
+    assert trainer._switch_threshold_ratio == pytest.approx(0.45)
+
+
+def test_alternating_idle_and_calm_does_not_move_threshold():
+    trainer = _trainer(adaptive_switch_threshold=True, switch_threshold_ratio=0.5)
+
+    for sample_wait_seconds in [2.0, 0.0] * 4:
+        _run_step(trainer, sample_wait_seconds=sample_wait_seconds)
+
+    assert trainer._switch_threshold_ratio == pytest.approx(0.5)
+
+
+def test_trainer_idle_is_reported():
+    trainer = _trainer(switch_threshold_ratio=0.5)
+
+    _run_step(trainer, sample_wait_seconds=2.0)
+
+    assert trainer._pending_sync_metrics["separate_async/switch/idle"] == 1.0
+    assert trainer._step_threshold == 32
+    assert trainer._step_sample_wait_seconds == pytest.approx(2.0)
+    assert trainer._switch_threshold_ratio == pytest.approx(0.5)

--- a/tests/trainer/diffusion/test_v1_parameter_sync_on_cpu.py
+++ b/tests/trainer/diffusion/test_v1_parameter_sync_on_cpu.py
@@ -21,10 +21,12 @@ from omegaconf import OmegaConf
 from transfer_queue import KVBatchMeta
 from verl import DataProto
 from verl.experimental.separation.engine_workers import DetachActorWorker
+from verl.trainer.config import HybridRolloutSwitchConfig
 from verl.trainer.ppo.v1.replay_buffer import ReplayBufferAsync
 
 from verl_omni.trainer.diffusion.v1.trainer_base import PolicyGradientDiffusionTrainerV1
 from verl_omni.trainer.diffusion.v1.trainer_separate_async import (
+    HybridEngineMode,
     PolicyGradientDiffusionTrainerV1SeparateAsync,
 )
 from verl_omni.workers import detach_actor_worker as detach_actor_worker_module
@@ -49,6 +51,7 @@ def _separate_async_config(*, train_batch_size=8, ppo_mini_batch_size=2, paramet
                         "parameter_sync_step": parameter_sync_step,
                         "num_warmup_batches": 0,
                         "sync_compatible": True,
+                        "hybrid_rollout": {"_target_": "verl.trainer.config.HybridRolloutSwitchConfig"},
                     },
                 }
             },
@@ -57,8 +60,13 @@ def _separate_async_config(*, train_batch_size=8, ppo_mini_batch_size=2, paramet
 
 
 def test_separate_async_validates_parameter_sync_batches(monkeypatch):
-    monkeypatch.setattr(PolicyGradientDiffusionTrainerV1, "__init__", lambda self, config: None)
-    PolicyGradientDiffusionTrainerV1SeparateAsync(_separate_async_config())
+    def base_init(self, config):
+        self.config = config
+        self.replay_buffer = None
+
+    monkeypatch.setattr(PolicyGradientDiffusionTrainerV1, "__init__", base_init)
+    trainer = PolicyGradientDiffusionTrainerV1SeparateAsync(_separate_async_config())
+    assert trainer.hybrid_rollout_config.enable_switch is False
 
     invalid_configs = [
         (_separate_async_config(train_batch_size=7), r"parameter_sync_step \* ppo_mini_batch_size"),
@@ -103,6 +111,8 @@ def test_base_step_samples_one_mini_batch_per_local_update():
     trainer.config = OmegaConf.create({"data": {"train_batch_size": 8}})
     trainer.parameter_sync_step = 4
     trainer.sync_compatible = False
+    trainer.timing_raw = {}
+    trainer.current_mode = HybridEngineMode.TRAINER
     sample_sizes = []
     local_steps = []
 
@@ -177,6 +187,8 @@ def test_sync_compatible_prefetches_all_local_batches_before_training():
     trainer.config = OmegaConf.create({"data": {"train_batch_size": 4}})
     trainer.parameter_sync_step = 2
     trainer.sync_compatible = True
+    trainer.timing_raw = {}
+    trainer.current_mode = HybridEngineMode.TRAINER
     events = []
     trainer._add_batch_to_generate = lambda: events.append("feed")
     trainer.on_sample_begin = lambda: events.append("sample_begin")
@@ -253,6 +265,7 @@ def test_on_step_end_syncs_every_outer_step():
     events = []
     trainer.global_steps = 1
     trainer.timing_raw = {}
+    trainer.hybrid_rollout_config = HybridRolloutSwitchConfig(enable_switch=False)
     trainer.standalone_checkpoint_manager = SimpleNamespace(
         update_weights=lambda global_steps: events.append(("sync", global_steps))
     )

--- a/tests/workers/test_checkpoint_engine_on_cpu.py
+++ b/tests/workers/test_checkpoint_engine_on_cpu.py
@@ -50,3 +50,20 @@ def test_lora_probe_propagates_genuine_actor_failure():
 
     with pytest.raises(RuntimeError, match="actor RPC failed"):
         manager._fetch_actor_lora_peft_config()
+
+
+@pytest.mark.parametrize("backend", ["naive", "nccl"])
+def test_update_weights_returns_parent_sync_metrics(monkeypatch, backend):
+    from verl.checkpoint_engine import CheckpointEngineManager
+
+    expected = {"sync/changed_ratio": 0.5}
+
+    async def parent_update_weights(self, global_steps=None):
+        return expected
+
+    monkeypatch.setattr(CheckpointEngineManager, "update_weights", parent_update_weights)
+    manager = _manager_with_actor(object())
+    manager.backend = backend
+    manager.replicas = []
+
+    assert manager.update_weights(global_steps=1) is expected

--- a/verl_omni/trainer/config/_generated_diffusion_trainer.yaml
+++ b/verl_omni/trainer/config/_generated_diffusion_trainer.yaml
@@ -562,6 +562,15 @@ trainer:
       num_warmup_batches: 1
       parameter_sync_step: 4
       sync_compatible: false
+      hybrid_rollout:
+        _target_: verl.trainer.config.HybridRolloutSwitchConfig
+        enable_switch: false
+        switch_threshold_ratio: 0.4
+        adaptive_switch_threshold: true
+        switch_threshold_step_up: 0.05
+        switch_threshold_step_down: 0.03
+        switch_threshold_release_steps: 2
+        switch_cost_window_size: 3
     sampler:
       max_off_policy_threshold: 8
       max_off_policy_strategy: drop

--- a/verl_omni/trainer/config/_generated_diffusion_veomni_trainer.yaml
+++ b/verl_omni/trainer/config/_generated_diffusion_veomni_trainer.yaml
@@ -602,6 +602,15 @@ trainer:
       num_warmup_batches: 1
       parameter_sync_step: 4
       sync_compatible: false
+      hybrid_rollout:
+        _target_: verl.trainer.config.HybridRolloutSwitchConfig
+        enable_switch: false
+        switch_threshold_ratio: 0.4
+        adaptive_switch_threshold: true
+        switch_threshold_step_up: 0.05
+        switch_threshold_step_down: 0.03
+        switch_threshold_release_steps: 2
+        switch_cost_window_size: 3
     sampler:
       max_off_policy_threshold: 8
       max_off_policy_strategy: drop

--- a/verl_omni/trainer/config/diffusion_trainer.yaml
+++ b/verl_omni/trainer/config/diffusion_trainer.yaml
@@ -253,6 +253,33 @@ trainer:
       # Pause standalone rollout during actor update, resume after weight sync.
       sync_compatible: false
 
+      # Lend idle hybrid trainer GPUs to rollout. Requires sync_compatible=false.
+      hybrid_rollout:
+
+        # Target dataclass for this configuration
+        _target_: verl.trainer.config.HybridRolloutSwitchConfig
+
+        # Global toggle to allow the trainer to switch to rollout mode to reduce idle.
+        enable_switch: false
+
+        # Fraction of train_batch_size that must be sampleable before the rollout replicas are reclaimed.
+        switch_threshold_ratio: 0.4
+
+        # Automatically adapt the threshold to reduce trainer starvation when enable_switch is True.
+        adaptive_switch_threshold: true
+
+        # Fraction added to switch_threshold_ratio after sustained trainer idle.
+        switch_threshold_step_up: 0.05
+
+        # Fraction subtracted from switch_threshold_ratio after a sustained calm period.
+        switch_threshold_step_down: 0.03
+
+        # Consecutive idle/calm steps required before ratio adjusts in that direction.
+        switch_threshold_release_steps: 2
+
+        # Window size for calculating average switch cost.
+        switch_cost_window_size: 3
+
     # Replay buffer sampling strategy.
     sampler:
 

--- a/verl_omni/trainer/diffusion/v1/trainer_base.py
+++ b/verl_omni/trainer/diffusion/v1/trainer_base.py
@@ -240,6 +240,7 @@ class PolicyGradientDiffusionTrainerV1(ABC):
                     with marked_timer("save_checkpoint", self.timing_raw, color="green"):
                         self._save_checkpoint()
                 self.on_step_end()
+                metrics.update(self._consume_sync_metrics())
 
             if self.config.trainer.test_freq > 0 and (
                 is_last_step or self.global_steps % self.config.trainer.test_freq == 0
@@ -285,8 +286,7 @@ class PolicyGradientDiffusionTrainerV1(ABC):
         )
         sample_batch_size = train_batch_size // self.parameter_sync_step
 
-        with marked_timer("feed", timing_raw):
-            self._add_batch_to_generate()
+        prepare_metrics = self.prepare_step()
 
         metrics_aggregator = MetricsAggregator()
         metrics_aggregator.aggregation_rules["sum"].extend(
@@ -297,6 +297,8 @@ class PolicyGradientDiffusionTrainerV1(ABC):
                 "training/rollout_failure/refill_rounds",
             ]
         )
+        if prepare_metrics:
+            metrics_aggregator.add_step_metrics(prepare_metrics)
         prefetched_batches = None
         if self._should_prefetch_local_batches():
             prefetched_batches = []
@@ -327,6 +329,12 @@ class PolicyGradientDiffusionTrainerV1(ABC):
 
         metrics.update(metrics_aggregator.get_aggregated_metrics())
         return KVBatchMeta(partition_id=combined_partition_id, keys=combined_keys, tags=combined_tags)
+
+    def prepare_step(self) -> dict:
+        """Submit this step's prompt batch before any mini-batch is sampled."""
+        with marked_timer("feed", self.timing_raw):
+            self._add_batch_to_generate()
+        return {}
 
     def _step_once(self, metrics: dict, timing_raw: dict, sample_batch_size: int) -> KVBatchMeta:
         """Sample one mini-batch from the replay buffer and run the diffusion PG pipeline."""
@@ -610,10 +618,20 @@ class PolicyGradientDiffusionTrainerV1(ABC):
         """Called at the end of each training step."""
         return
 
+    def _consume_sync_metrics(self) -> dict:
+        """Weight-sync stats stashed by ``on_step_end``, merged into this step's logged metrics."""
+        metrics = getattr(self, "_pending_sync_metrics", None) or {}
+        self._pending_sync_metrics = {}
+        return metrics
+
     @abstractmethod
     def on_sample_end(self):
         """Called after sampling a batch from the replay buffer."""
         return
+
+    def _get_n_gpus_for_throughput(self) -> int:
+        """Return the total number of GPUs used for throughput normalization."""
+        return self.resource_pool_manager.get_n_gpus()
 
     def release_rollout_cache_for_weight_sync(self) -> None:
         """No-op for pure diffusion models (no KV cache)."""
@@ -1502,7 +1520,7 @@ class PolicyGradientDiffusionTrainerV1(ABC):
         data = diffusion_tq_batch_to_dataproto(batch_meta, pad_token_id=self.tokenizer.pad_token_id or 0)
         metrics.update({"training/global_step": global_steps, "training/epoch": epoch})
         metrics.update(compute_data_metrics_diffusion(batch=data))
-        n_gpus = self.resource_pool_manager.get_n_gpus()
+        n_gpus = self._get_n_gpus_for_throughput()
         num_images = (
             data.batch["advantages"].shape[0]
             if "advantages" in data.batch

--- a/verl_omni/trainer/diffusion/v1/trainer_separate_async.py
+++ b/verl_omni/trainer/diffusion/v1/trainer_separate_async.py
@@ -26,6 +26,13 @@ hook semantics, adapted to verl-omni diffusion rollout:
 3. Weight synchronization from actor to standalone rollout uses a non-naive
    checkpoint backend (nccl/nixl/mooncake/...); the colocated rollout still uses
    the naive in-place backend.
+4. Hybrid rollout switching (``separate_async.hybrid_rollout.enable_switch``)
+   lends the colocated replicas to generation at the end of a step when the
+   replay buffer is short for the next one, and reclaims them once enough
+   prompt groups are sampleable. The switch policy is ported method by method
+   from the upstream trainer. Unlike upstream, colocated replicas join the
+   load balancer only after the naive sync has resumed them, because the
+   vLLM-Omni engine rejects requests while any sleeping tag is set.
 
 Diffusion-specific compute (reward, old/ref log-prob, Flow-GRPO advantage,
 actor update, metrics, dumping) lives in ``PolicyGradientDiffusionTrainerV1``;
@@ -35,6 +42,8 @@ wiring.
 
 import logging
 import os
+import time
+from collections import deque
 from enum import Enum
 
 import ray
@@ -42,6 +51,7 @@ from omegaconf import DictConfig
 from transfer_queue import KVBatchMeta
 from verl import DataProto
 from verl.checkpoint_engine import CheckpointEngineManager
+from verl.trainer.config import HybridRolloutSwitchConfig
 from verl.trainer.ppo.utils import Role
 from verl.utils.config import omega_conf_to_dataclass
 from verl.utils.debug import marked_timer
@@ -70,19 +80,24 @@ class PolicyGradientDiffusionTrainerV1SeparateAsync(PolicyGradientDiffusionTrain
 
     Hook behavior:
 
+    - ``_setup``: colocated replicas start in rollout mode and registered with
+      the standalone load balancer, so warmup and validation use both pools.
     - ``on_init_end``: update weights on both the standalone and colocated
       checkpoint managers.
     - ``on_train_begin``: enqueue ``num_warmup_batches`` prompt batches.
-    - ``on_validate_begin``: switch to rollout mode if currently training.
-    - ``on_sample_begin``: switch to rollout mode if training and the switch
-      strategy says so.
-    - ``on_sample_end``: switch to trainer mode (abort + sleep colocated
-      replicas, remove them from the standalone load balancer). When
-      ``sync_compatible`` is True, also pause the standalone rollout.
+    - ``on_step_begin``: reclaim the colocated replicas (abort + sleep, remove
+      from the balancer) when switching is disabled or the replay buffer already
+      holds the switch threshold; otherwise ``prepare_step`` submits this step's
+      prompts and waits for the threshold before reclaiming.
+    - ``on_validate_begin``: switch to rollout mode if currently training; the
+      next ``on_step_begin`` reclaims.
+    - ``on_sample_begin`` / ``on_sample_end``: record replay-buffer shortfall
+      and wait time. When ``sync_compatible`` is True, ``on_sample_end`` also
+      pauses the standalone rollout.
     - ``on_step_end``: after ``parameter_sync_step`` local actor updates, push
-      actor weights into the standalone rollout replicas. Colocated replicas
-      stay slept during training (they share GPUs with the actor) and are only
-      synced at init and when switching to rollout mode. When
+      actor weights into the standalone rollout replicas. With switching
+      enabled, lend the colocated replicas to the next step's generation when
+      the estimated benefit exceeds the recent switch cost. When
       ``sync_compatible`` is True, resume standalone generation after weight
       sync.
     """
@@ -113,11 +128,51 @@ class PolicyGradientDiffusionTrainerV1SeparateAsync(PolicyGradientDiffusionTrain
         ), "sync_compatible=True requires num_warmup_batches=0"
 
         super().__init__(config)
+        self.hybrid_rollout_config: HybridRolloutSwitchConfig = omega_conf_to_dataclass(
+            self.config.trainer.v1.separate_async.hybrid_rollout
+        )
+        if self.hybrid_rollout_config.enable_switch:
+            assert not separate_async_config.get("sync_compatible", False), (
+                "trainer.v1.separate_async.hybrid_rollout.enable_switch requires sync_compatible=false"
+            )
+            rollout_cfg = self.config.get("actor_rollout_ref", {}).get("rollout", {})
+            disaggregation_cfg = rollout_cfg.get("disaggregation", {})
+            if bool(disaggregation_cfg.get("enabled", False)):
+                raise ValueError(
+                    "trainer.v1.separate_async.hybrid_rollout.enable_switch does not support rollout disaggregation: "
+                    "step-boundary redistribution relies on paused replicas queueing new requests"
+                )
+            required_methods = ("wait_for_sampleable", "get_sampleable_count")
+            if any(not hasattr(self.replay_buffer, method) for method in required_methods):
+                raise TypeError(
+                    f"{type(self.replay_buffer).__name__} must implement {required_methods} when "
+                    "trainer.v1.separate_async.hybrid_rollout.enable_switch=True"
+                )
+            self._init_hybrid_rollout_state()
 
     def _init_resource_pool_mgr(self):
         super()._init_resource_pool_mgr()
         role = Role.ActorRolloutRef if Role.ActorRolloutRef in self.role_worker_mapping else Role.ActorRollout
         self.role_worker_mapping[role] = ray.remote(DiffusionDetachActorWorker)
+
+    def _init_hybrid_rollout_state(self) -> None:
+        config = self.hybrid_rollout_config
+        self._switch_threshold_ratio = config.switch_threshold_ratio
+        self._idle_steps = 0
+        self._calm_steps = 0
+        self._step_sample_wait_seconds = 0.0
+        self._step_wait_samples = 0
+        self._sample_start = time.perf_counter()
+        self._step_threshold = 0
+        self._wait_seconds = 0.0
+        self._wait_samples = 0
+        self._to_rollout_costs: deque[float] = deque(maxlen=config.switch_cost_window_size)
+        self._to_trainer_costs: deque[float] = deque(maxlen=config.switch_cost_window_size)
+        rollout_cfg = self.config.get("actor_rollout_ref", {}).get("rollout", {})
+        trainer_cfg = self.config.trainer
+        hybrid_gpus = trainer_cfg.nnodes * trainer_cfg.n_gpus_per_node
+        standalone_gpus = rollout_cfg.nnodes * rollout_cfg.n_gpus_per_node
+        self._scaling_factor = (hybrid_gpus + standalone_gpus) / standalone_gpus
 
     def _compute_old_log_prob(self, data: DataProto) -> DataProto:
         """Compute every local update's proximal log-probs with cycle-start weights."""
@@ -205,9 +260,6 @@ class PolicyGradientDiffusionTrainerV1SeparateAsync(PolicyGradientDiffusionTrain
             replicas=self.standalone_server_manager.get_replicas(),
         )
 
-        self.current_mode = HybridEngineMode.TRAINER
-        self._colocated_slept = False
-
         self.sync_compatible = self.config.trainer.v1.separate_async.get("sync_compatible", False)
         self._standalone_paused = False
         if self.sync_compatible:
@@ -216,17 +268,16 @@ class PolicyGradientDiffusionTrainerV1SeparateAsync(PolicyGradientDiffusionTrain
                 "generation during actor training (sync-mode parity)."
             )
 
+        # hybrid engine is in rollout mode after initialization
+        self.current_mode = HybridEngineMode.ROLLOUT
+        self.add_replicas_to_balancer()
+
     def get_llm_client(self):
         """Get the diffusion whole-sample-retry client backed by the standalone rollout."""
         return self.standalone_server_manager.get_client(client_cls=DiffusionWholeSampleRetryLLMServerClient)
 
     def on_init_end(self):
         # Push actor weights into both standalone and colocated rollout replicas.
-        logger.warning(
-            "LORA_SYNC_PROOF separate_async on_init_end: sending weights to BOTH "
-            "standalone and colocated checkpoint managers (global_steps=%s)",
-            self.global_steps,
-        )
         self.standalone_checkpoint_manager.update_weights(self.global_steps)
         self.checkpoint_manager.update_weights(self.global_steps)
 
@@ -237,49 +288,173 @@ class PolicyGradientDiffusionTrainerV1SeparateAsync(PolicyGradientDiffusionTrain
         logger.info(f"Added {num_warmup_batches} warmup batches to the agent loop manager")
 
     def on_validate_begin(self):
-        if self.current_mode == HybridEngineMode.TRAINER and self._colocated_slept:
+        if self.current_mode == HybridEngineMode.TRAINER:
             logger.info("Switching hybrid engine to rollout mode for validation")
             self.switch_to_rollout()
-        else:
-            logger.info(
-                "Skipping colocated rollout switch for validation "
-                "(colocated replicas never slept; using standalone replicas only)"
-            )
         if self.sync_compatible and self._standalone_paused:
             # Validation uses the standalone rollout via get_llm_client(), so
             # make sure it is resumed if it was paused for actor training.
             self._resume_standalone_generation()
 
-    def on_validate_end(self):
-        if self.current_mode == HybridEngineMode.ROLLOUT:
-            logger.info("Switching hybrid engine back to trainer mode after validation")
+    def on_step_begin(self):
+        self._step_sample_wait_seconds = 0.0
+        self._step_wait_samples = 0
+        self._step_threshold = 0
+        if self.hybrid_rollout_config.enable_switch:
+            self.timing_raw["switch_wait"] = 0.0
+        if self.current_mode != HybridEngineMode.ROLLOUT:
+            return
+        if not self.hybrid_rollout_config.enable_switch:
+            self._timed_switch_to_trainer()
+            return
+
+        self._step_threshold = self._switch_threshold()
+        sampleable_count = self.replay_buffer.get_sampleable_count(self.global_steps, "train")
+        if sampleable_count >= self._step_threshold:
+            self._timed_switch_to_trainer()
+
+    def _timed_switch_to_trainer(self) -> None:
+        """Switch Hybrid back to training and record the full remove/abort/sleep cost."""
+        switch_start = time.perf_counter()
+        with marked_timer("switch_to_trainer", self.timing_raw, color="cyan"):
             self.switch_to_trainer()
+        if self.hybrid_rollout_config.enable_switch:
+            self._to_trainer_costs.append(time.perf_counter() - switch_start)
 
     def on_sample_begin(self):
-        if self.current_mode == HybridEngineMode.TRAINER and self.should_switch_to_rollout():
-            logger.info("Switching hybrid engine to rollout mode for generation")
-            self.switch_to_rollout()
+        if self.hybrid_rollout_config.enable_switch:
+            sampleable = self.replay_buffer.get_sampleable_count(self.global_steps, "train")
+            mini_batch_size = self.config.data.train_batch_size // self.parameter_sync_step
+            self._step_wait_samples += max(0, mini_batch_size - sampleable)
+        self._sample_start = time.perf_counter()
 
     def on_sample_end(self):
-        if self.current_mode == HybridEngineMode.ROLLOUT:
-            logger.info("Switching hybrid engine to trainer mode for training")
-            self.switch_to_trainer()
+        self._step_sample_wait_seconds += time.perf_counter() - self._sample_start
         if self.sync_compatible and not self._standalone_paused:
             self._pause_standalone_generation()
 
-    def on_step_end(self):
-        with marked_timer("update_weights", self.timing_raw, color="red"):
-            logger.warning(
-                "LORA_SYNC_PROOF separate_async on_step_end: sending weights to "
-                "STANDALONE checkpoint manager (global_steps=%s)",
-                self.global_steps,
+    def prepare_step(self) -> dict:
+        metrics = super().prepare_step()
+        metrics.update(self._wait_for_sampleable_and_switch())
+        return metrics
+
+    def _wait_for_sampleable_and_switch(self) -> dict:
+        if self.current_mode != HybridEngineMode.ROLLOUT:
+            return {}
+
+        logger.info(f"Lending hybrid engine to generation until {self._step_threshold} groups are sampleable")
+        with marked_timer("switch_wait", self.timing_raw, color="yellow"):
+            _, eviction_metrics = self.replay_buffer.wait_for_sampleable(
+                self.global_steps, "train", self._step_threshold
             )
-            self.standalone_checkpoint_manager.update_weights(self.global_steps)
+        self._timed_switch_to_trainer()
+        return eviction_metrics
+
+    def _switch_threshold(self) -> int:
+        """Sampleable prompts before switching to trainer, floored at one mini-batch."""
+        train_batch_size = self.config.data.train_batch_size
+        mini_batch_size = train_batch_size // self.parameter_sync_step
+        target = round(self._switch_threshold_ratio * train_batch_size)
+        return min(max(target, mini_batch_size), train_batch_size)
+
+    def _step_had_idle(self) -> bool:
+        """Whether waiting for sampleable prompts."""
+        poll_interval = getattr(self.replay_buffer, "poll_interval", 2.0)
+        return self._step_sample_wait_seconds > poll_interval
+
+    def _adapt_switch_threshold(self, had_idle: bool) -> None:
+        config = self.hybrid_rollout_config
+        if had_idle:
+            self._calm_steps = 0
+            self._idle_steps = min(self._idle_steps + 1, config.switch_threshold_release_steps)
+            if self._idle_steps < config.switch_threshold_release_steps:
+                return
+            self._switch_threshold_ratio = min(1.0, self._switch_threshold_ratio + config.switch_threshold_step_up)
+            return
+
+        self._idle_steps = 0
+        self._calm_steps = min(self._calm_steps + 1, config.switch_threshold_release_steps)
+        if self._calm_steps < config.switch_threshold_release_steps:
+            return
+        min_ratio = 1.0 / self.parameter_sync_step
+        self._switch_threshold_ratio = max(min_ratio, self._switch_threshold_ratio - config.switch_threshold_step_down)
+
+    def _effective_switch_cost(self) -> float | None:
+        if not self._to_rollout_costs or not self._to_trainer_costs:
+            return None
+        return sum(self._to_rollout_costs) / len(self._to_rollout_costs) + sum(self._to_trainer_costs) / len(
+            self._to_trainer_costs
+        )
+
+    def on_step_end(self):
+        config = self.hybrid_rollout_config
+        should_switch = False
+        decision_metrics: dict[str, float] = {}
+        if config.enable_switch:
+            ratio_used = self._switch_threshold_ratio
+            had_idle = self._step_had_idle()
+            if self._step_wait_samples > 0 and self._step_sample_wait_seconds > 0:
+                self._wait_seconds += self._step_sample_wait_seconds
+                self._wait_samples += self._step_wait_samples
+            if config.adaptive_switch_threshold:
+                self._adapt_switch_threshold(had_idle)
+
+            decision_threshold = self._switch_threshold()
+            sampleable_count = self.replay_buffer.get_sampleable_count(self.global_steps + 1, "train")
+            remaining = max(0, decision_threshold - sampleable_count)
+            per_sample_time = self._wait_seconds / self._wait_samples if self._wait_samples > 0 else None
+            effective_switch_cost = self._effective_switch_cost()
+            benefit = (
+                remaining * per_sample_time * (1.0 - 1.0 / self._scaling_factor)
+                if per_sample_time is not None
+                else None
+            )
+            should_switch = (
+                self.global_steps < self.total_training_steps
+                and remaining > 0
+                and (benefit is None or effective_switch_cost is None or benefit > effective_switch_cost)
+            )
+            decision_metrics = {
+                "separate_async/switch/threshold_ratio": ratio_used,
+                "separate_async/switch/wait_samples": float(self._step_wait_samples),
+                "separate_async/switch/idle": float(had_idle),
+                "separate_async/decision/sampleable_count": float(sampleable_count),
+                "separate_async/decision/remaining": float(remaining),
+                "separate_async/decision/should_switch_to_rollout": float(should_switch),
+            }
+            if per_sample_time is not None:
+                decision_metrics["separate_async/decision/per_sample_time_seconds"] = per_sample_time
+            if effective_switch_cost is not None:
+                decision_metrics["separate_async/decision/effective_switch_cost_seconds"] = effective_switch_cost
+
+        with marked_timer("update_weights", self.timing_raw, color="red"):
+            self._pending_sync_metrics = dict(
+                self.standalone_checkpoint_manager.update_weights(self.global_steps) or {}
+            )
             if self.sync_compatible and self._standalone_paused:
                 # Sync-compatible mode: resume standalone generation after the
                 # actor update + weight sync so the next generate phase uses
                 # fresh weights, exactly like sync mode waking colocated replicas.
                 self._resume_standalone_generation()
+
+        if config.enable_switch:
+            self._pending_sync_metrics.update(decision_metrics)
+
+            if should_switch:
+                switch_start = time.perf_counter()
+                with marked_timer("switch_to_rollout", self.timing_raw, color="cyan"):
+                    logger.info("Switching hybrid engine to rollout mode for the next step")
+                    self.switch_to_rollout()
+                    self.clear_sticky_cache()
+                self._to_rollout_costs.append(time.perf_counter() - switch_start)
+
+    def _get_n_gpus_for_throughput(self) -> int:
+        """Include standalone rollout GPUs in the throughput denominator."""
+        trainer_gpus = self.resource_pool_manager.get_n_gpus()
+        rollout_gpus = (
+            self.config.actor_rollout_ref.rollout.n_gpus_per_node * self.config.actor_rollout_ref.rollout.nnodes
+        )
+        return trainer_gpus + rollout_gpus
 
     def _pause_standalone_generation(self):
         """Stop the standalone rollout from accepting/serving new requests.
@@ -316,21 +491,23 @@ class PolicyGradientDiffusionTrainerV1SeparateAsync(PolicyGradientDiffusionTrain
         self._standalone_paused = False
 
     def switch_to_rollout(self):
-        # Wake colocated replicas (their weights were offloaded by sleep),
-        # sync fresh actor weights, and let them serve generation again.
-        self.checkpoint_manager.wake_up_replicas()
-        self._colocated_slept = False
+        """Install committed weights and make Hybrid replicas available for generation.
+
+        The naive update resumes the slept replicas' weights and cache before
+        installing the actor weights, so no frontend wake-up is needed. The
+        replicas are registered with the balancer only after that, because the
+        engine rejects requests while any sleeping tag is set.
+        """
         self.checkpoint_manager.update_weights(self.global_steps)
         self.checkpoint_manager.resume_generation_replicas()
         self.add_replicas_to_balancer()
         self.current_mode = HybridEngineMode.ROLLOUT
 
     def switch_to_trainer(self):
-        # Remove colocated replicas from the balancer and free their memory for training.
+        """Stop routing to Hybrid, abort partial requests, and return its GPU memory to training."""
         self.remove_replicas_from_balancer()
         self.checkpoint_manager.abort_replicas()
         self.checkpoint_manager.sleep_replicas()
-        self._colocated_slept = True
         self.current_mode = HybridEngineMode.TRAINER
 
     def add_replicas_to_balancer(self):
@@ -344,6 +521,6 @@ class PolicyGradientDiffusionTrainerV1SeparateAsync(PolicyGradientDiffusionTrain
         global_load_balancer = self.standalone_server_manager.global_load_balancer
         ray.get(global_load_balancer.remove_servers.remote(self.llm_server_manager.server_addresses))
 
-    def should_switch_to_rollout(self):
-        # TODO: implement a switch strategy based on replay buffer state / switch overhead.
-        return False
+    def clear_sticky_cache(self) -> dict:
+        global_load_balancer = self.standalone_server_manager.global_load_balancer
+        return ray.get(global_load_balancer.clear_sticky_cache.remote())

--- a/verl_omni/workers/checkpoint_engine.py
+++ b/verl_omni/workers/checkpoint_engine.py
@@ -31,7 +31,7 @@ class OmniCheckpointEngineManager(CheckpointEngineManager):
             peft_config = self._fetch_actor_lora_peft_config()
             self._lora_peft_config = peft_config
             await self._push_lora_peft_config_to_replicas(peft_config)
-        await super().update_weights(global_steps=global_steps)
+        return await super().update_weights(global_steps=global_steps)
 
     async def _push_lora_peft_config_to_replicas(self, peft_config: dict | None) -> None:
         """Fetch ``peft_config`` from the actor (collective-free) and stash it


### PR DESCRIPTION
### What

Ports verl's hybrid rollout switching (verl#7373, in the pinned verl `fefb0802`) into `PolicyGradientDiffusionTrainerV1SeparateAsync`: when the replay buffer is short for the next step, the colocated (hybrid) replicas are lent to generation at step end and reclaimed once `switch_threshold_ratio * train_batch_size` groups are sampleable. It helps when the trainer/rollout GPU split is fixed and the rollout side is the bottleneck (the trainer waits on `timing_s/gen` with the switch off); it does nothing useful when training is the bottleneck.

Off by default. Enable with
```bash
SYNC_COMPATIBLE=false bash examples/flowgrpo_trainer/sd35/run_sd35_medium_ocr_lora_v1_separate_async.sh \
    trainer.v1.separate_async.hybrid_rollout.enable_switch=true
```
`enable_switch` requires `sync_compatible=false` and `rollout.disaggregation.enabled=false`; the remaining knobs follow upstream `HybridRolloutSwitchConfig`.

Default-path change (switch off): the hybrid replicas start in rollout mode and registered with the balancer after init, and are reclaimed (removed from the balancer, aborted, slept) before the warmup batches are fed. Before, `_setup` marked them TRAINER while the init sync had already woken them, so they held rollout memory without serving requests. Validation still lends them and the next step reclaims them.

Diffusion-specific differences from upstream, pinned by CPU tests:
- The lend decision runs after the standalone weight sync: the standalone batch in flight at step end lands during the sync, and deciding before it lent against a phantom gap.
- Hybrid replicas join the balancer only after the naive sync has resumed them; vLLM-Omni's `AsyncOmni.generate()` rejects requests while a sleeping tag is set, so upstream's "register early, requests queue" does not hold.

Also: `prepare_step` / `_consume_sync_metrics` / `_get_n_gpus_for_throughput` on the diffusion base trainer (upstream parity).

### Not a duplicate

`gh pr list --state open --search` for `hybrid_rollout OR enable_switch`, `hybrid switch`, `separate_async hybrid`: no open PR touches this (#560 is the GC knob). #470 only edits `on_init_end`; #380 is the Omni separate-async trainer. Tracks the re-diff item in #445.

### Tests

CPU, on the GPU box at the pins (verl `fefb0802`, vllm `0.28.0`, vllm-omni `ded8934`):
```
pytest --asyncio-mode=auto tests/workers/rollout/rollout_vllm/test_vllm_omni_async_server_lifecycle_on_cpu.py \
  tests/trainer/diffusion/ tests/workers/test_checkpoint_engine_on_cpu.py tests/workers/rollout/**/*_on_cpu.py \
  tests/utils/test_rl_insight_on_cpu.py
# 429 passed on 9f4d791 (the later commits remove the two checkpoint-manager return tests and edit docs only). New: tests/trainer/diffusion/test_v1_hybrid_rollout_switch_on_cpu.py (35 test functions, ported from
# verl's test_separate_async_step_switch_on_cpu.py plus the diffusion ordering / init / validation / warmup-feed
# cases).
```
CI on `4f108c5` (`ready-for-ci`): `cpu_unit_tests` 1153 passed, `gpu_smoke`, `sanity`, `doc`, `pre-commit`, `type_coverage_check`, `secrets_scan`, `check_pr_title` all green.

In-flight lifecycle, 4× RTX PRO 6000 (96 GB), tiny random SD3 FlowGRPO with generation slowed (3000 denoising steps, 1024²) so every reclaim meets in-flight work:
- 1 hybrid + 1 standalone, switch on, 4 steps: 3 lend→reclaim round trips, reclaims aborted 11/11/8/7 in-flight requests, `switch_to_trainer` 1.1–6.5 s (waits for the executing batch), `switch_to_rollout` 1.7 s, all aborted samples retried whole; no errors.
- 2 hybrid + 2 standalone (FSDP, 2 actor ranks), switch on, 5 steps: 4 reclaims + 3 lends, both ranks abort/sleep/sync together, 0 NCCL/collective errors, `switch_to_trainer` 0.75–6.96 s, `switch_to_rollout` 1.76–1.85 s.
- Probe (per-process event logs): in the measured runs no hybrid execution overlapped actor training on the actor GPUs; each hybrid sleep ACK reports the rollout memory freed (2 MiB tiny model, 15.85 GiB SD3.5-M, 21.24 GiB Wan2.2-5B).

SD3.5-Medium OCR LoRA (`run_sd35_medium_ocr_lora_v1_separate_async.sh`, recipe settings: 384², 10 denoising steps, 2 hybrid + 1 standalone + 1 reward, `train_batch_size=16`, `parameter_sync_step=4`, n=8), 20 steps per run, steps 6–20 measured, all within one hour on the same box. Training is the bottleneck here, so the switch must not regress:

| arm | `timing_s/step` median (min–max) | `gen` wait median | hung requests | lends in steps 6–20 |
|---|---|---|---|---|
| `main` 298eb0c (no PR) | 24.46 (23.55–25.17) | 0.067 s | 0 | – |
| this PR, switch off, 2 runs | 24.26 (23.67–25.54), 25.35 (24.05–26.33) | 0.060 s | 0, 0 | – |
| this PR, switch on | 24.69 (23.58–25.63) | 0.064 s | 0 | 0 / 15 |

Step time is set by the actor phases in all arms and the PR heads sit inside the OFF pair's own 1.1 s spread; the post-sync decision sees 12–16 of 16 groups and lends nothing; rewards 0.11–0.13 → 0.20–0.31 in every run.

Wan2.2-TI2V-5B T2V DanceGRPO (`examples/dancegrpo_trainer/wan22/run_wan22_5b_t2v_hpsv3_v1.sh` run in `separate_async` mode; the first video run of v1 separate-async). Three arms × 20 steps, steps 4–20 measured (17 steps, 2176 training videos), one run per arm, consecutive on the same box; an earlier 8-step pair of the two 2+1 arms gave the same −19 %. With 2 hybrid + 1 standalone the geometry is rollout-bound: the standalone executes one request at a time (2.9 s per 9-frame 704×1280 video, ≈ 376 s per 128) against ≈ 250 s of training.

| | OFF, 2 hybrid + 1 standalone | ON, 2 hybrid + 1 standalone | OFF, 2 hybrid + 2 standalone |
|---|---|---|---|
| `timing_s/step` median (min–max) | 377.9 (336.0–418.8) | 307.8 (275.2–355.8) | 250.4 (241.6–252.8) |
| total step time, 17 steps | 6406 s | 5252 s (−18 %) | 4251 s (−34 %) |
| videos/s (2176 videos / total step time) | 0.340 | 0.414 (+22 %) | 0.512 |
| videos/s/GPU (3 / 3 / 4 GPUs) | 0.113 | 0.138 | 0.128 |
| sampling wait per step (`gen` + `switch_wait`), median / total | 130.4 s / 2200 s | 52.2 s / 882 s | 0.1 s / 2 s |
| lends / reclaims | 0 / 1 | 17 / 18 (every decision from step 3) | 0 / 1 |
| `switch_to_rollout` / `switch_to_trainer` | – | 9.1 s (naive sync of the 5B weights + resume) / 3.3 s | – |
| hybrid share: request attempts / completed deliveries | – | 39 % / 19 % (497 of 2616) | – |
| aborted attempts, retried whole (hybrid reclaims / standalone step-end syncs) | – / 2065 | 1838 / 1522 | – / 0 |
| `critic/rewards/mean`, steps 4–20 | 0.674 | 0.690 | 0.681 |
| full run wall, 20 steps incl. startup | 7898 s | 6511 s | 5420 s |

No obvious reward degradation in these short runs; every hybrid sleep frees 21.24 GiB; 0 hung requests, 0 errors in all arms. Reading: at a fixed 3-GPU budget the switch recovers about half of the trainer's idle time (−18 % time, +22 % throughput); a second rollout GPU removes the wait entirely and is faster in total, while the switch keeps ≈ 8 % higher throughput per GPU. The switch is not a substitute for sizing the rollout pool.

![Wan2.2 reward curves](https://raw.githubusercontent.com/cr-gao/verl-omni/assets/v1-hybrid-switch/wan_ab20_reward.png)

<details>
<summary>Wan2.2 reproduction command, deviations from the recipe, per-step rewards</summary>

```bash
TRAIN_BATCH_SIZE=16 MODEL_NAME=<Wan2.2-TI2V-5B-Diffusers> CUSTOM_REWARD_MODEL_PATH=<HPSv3/HPSv3.safetensors> \
bash examples/dancegrpo_trainer/wan22/run_wan22_5b_t2v_hpsv3_v1.sh \
    trainer.v1.trainer_mode=separate_async trainer.n_gpus_per_node=2 \
    actor_rollout_ref.rollout.nnodes=1 actor_rollout_ref.rollout.n_gpus_per_node=1 \
    actor_rollout_ref.rollout.agent.num_workers=2 actor_rollout_ref.rollout.mode=async \
    actor_rollout_ref.rollout.calculate_log_probs=True actor_rollout_ref.rollout.checkpoint_engine.backend=nccl \
    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.max_num_seqs=1 \
    actor_rollout_ref.actor.ppo_mini_batch_size=4 \
    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=2 actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=2 \
    trainer.v1.separate_async.num_warmup_batches=1 trainer.v1.separate_async.parameter_sync_step=4 \
    trainer.v1.separate_async.sync_compatible=false \
    trainer.v1.sampler.max_off_policy_threshold=8 trainer.v1.sampler.max_off_policy_strategy=drop \
    trainer.val_before_train=False trainer.test_freq=-1 trainer.save_freq=-1 trainer.total_training_steps=20 \
    trainer.v1.separate_async.hybrid_rollout.enable_switch=true   # false for the OFF arms; the 2+2 arm sets rollout.n_gpus_per_node=2
```
Deviations from the recipe: 8 colocated GPUs (sync) → 2 hybrid + 1 standalone `separate_async`; `train_batch_size` 64 → 16; `ppo_mini_batch_size` 16 → 4; `log_prob_micro_batch_size_per_gpu` 16 → 2; `max_num_seqs` explicit 1 (the Wan2.2 DanceGRPO adapter executes one request per batch); validation and checkpoints off. Unchanged: n=8, 704×1280, `num_frames=8` (9 frames after the adapter's VAE rounding), 10 denoising steps, `ppo_micro_batch_size_per_gpu=4`, full fine-tune with parameter/optimizer offload, HPSv3 as the custom reward function in the reward loop (it lands on the first actor GPU), prompts from `wan22_hpsv3.py` on the README's `Hao7/video_prompts`. AutoDL blocks `pidfd_getfd`, so the runs used a small platform plugin that forces the shm path for the naive sync. Adaptive `threshold_ratio` over the ON run (steps 1–20): 0.40 0.40 0.37 0.34 0.34 0.39 0.39 0.39 0.39 0.39 0.39 0.36 0.36 0.41 0.46 0.46 0.43 0.40 0.40 0.45.

Per-step `critic/rewards/mean`:

| step | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20 |
|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
| OFF 2+1 | 0.611 | 0.749 | 0.655 | 0.650 | 0.740 | 0.579 | 0.659 | 0.719 | 0.705 | 0.652 | 0.669 | 0.693 | 0.578 | 0.713 | 0.677 | 0.772 | 0.646 |
| ON 2+1 | 0.622 | 0.750 | 0.673 | 0.692 | 0.747 | 0.523 | 0.732 | 0.758 | 0.679 | 0.695 | 0.645 | 0.673 | 0.632 | 0.730 | 0.697 | 0.786 | 0.702 |
| OFF 2+2 | 0.627 | 0.763 | 0.659 | 0.649 | 0.742 | 0.591 | 0.658 | 0.721 | 0.715 | 0.657 | 0.677 | 0.700 | 0.583 | 0.722 | 0.687 | 0.776 | 0.658 |

</details>

### Known limits

- Default off; enable only when `timing_s/gen` is clearly > 0 with the switch off.
- In rollout-bound runs the standalone step-end sync still waits for the executing batch and aborts its in-flight requests, which are retried as whole samples (the abort counts above); the switch does not change that path.
- Lending a 5B model costs a ≈ 9 s naive weight sync per lend; the cost gate accounts for it from the observed switch history.
- The `ENABLE_SWITCH=1` smoke knob is not wired into the CI matrix.

AI assistance (Claude Code) was used; every changed line was reviewed and the tests above were run by the submitter.


