### PR TITLE
[docker, doc] feat: add ROCm Dockerfile and installation guide

### DIFF
--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -1,0 +1,115 @@
+# verl-omni AMD GPU (ROCm) image — dependency versions aligned with docs/start/install_rocm.md
+#
+# Build (from repo root):
+#   docker build -f docker/Dockerfile.rocm -t verl-omni:rocm .
+#
+# Build for a single architecture — much faster (gfx950 = MI350X, gfx942 = MI300X):
+#   docker build -f docker/Dockerfile.rocm -t verl-omni:rocm \
+#     --build-arg PYTORCH_ROCM_ARCH=gfx950 .
+#
+# Override pinned versions (defaults match pyproject.toml extras):
+#   docker build -f docker/Dockerfile.rocm -t verl-omni:rocm \
+#     --build-arg VLLM_VERSION=v0.28.0 \
+#     --build-arg VERL_GIT_REF=fefb080262e1c015a0ea05f958822a6a512dc795 .
+#
+# Run:
+#   docker run --device=/dev/kfd --device=/dev/dri --group-add video \
+#     --security-opt seccomp=unconfined --shm-size=16g -it verl-omni:rocm
+
+# Base provides torch 2.12 + ROCm 7.14, a vLLM checkout at /workspace/vllm, and hipcc.
+ARG BASE_IMAGE=verlai/verl:rocm7.14_torch2.12_release_0724
+ARG VLLM_VERSION=v0.28.0
+# Default: read from .github/verl_pin.txt at build time (override with VERL_GIT_REF).
+ARG VERL_GIT_REF=
+
+FROM ${BASE_IMAGE}
+
+ARG VLLM_VERSION
+ARG VERL_GIT_REF
+ARG PYTORCH_ROCM_ARCH="gfx942;gfx950"  # both current CDNA generations; narrow to halve build time
+
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+
+# Step 1 — vLLM from source: PyPI publishes no ROCm wheels. Runs before any pip
+# install so the build environment stays the one the base image validated.
+# --force because base images may carry local tags that would clobber; the tag
+# itself is required since setuptools_scm derives the wheel version from it.
+RUN cd /workspace/vllm \
+ && git fetch --depth=1 --force origin \
+      "refs/tags/${VLLM_VERSION}:refs/tags/${VLLM_VERSION}" \
+ && git worktree add /workspace/vllm-src "${VLLM_VERSION}" \
+ && cd /workspace/vllm-src \
+ && VLLM_TARGET_DEVICE=rocm \
+    PYTORCH_ROCM_ARCH="${PYTORCH_ROCM_ARCH}" \
+    ROCM_AMDGPU_TARGETS="${PYTORCH_ROCM_ARCH}" \
+    GPU_ARCHS="${PYTORCH_ROCM_ARCH}" \
+    CMAKE_BUILD_PARALLEL_LEVEL="${MAX_JOBS:-32}" \
+    pip wheel . --no-deps --no-build-isolation -w /tmp/vllm-wheel \
+ && pip uninstall -y vllm \
+ && pip install --no-deps /tmp/vllm-wheel/vllm-*.whl \
+ && cd / \
+ && rm -rf /tmp/vllm-wheel /workspace/vllm-src \
+ && git -C /workspace/vllm worktree prune \
+ && python3 -c "import vllm; print('vllm', vllm.__version__)"
+
+# Step 2 — pin the accelerator packages. AMD's torch build is not on PyPI, so any
+# resolver that "upgrades" it silently swaps in a CUDA wheel; fail loudly instead.
+RUN python3 - > /opt/rocm-constraints.txt <<'PY'
+from importlib.metadata import version, PackageNotFoundError
+for pkg in ("torch", "torchvision", "torchaudio", "vllm"):
+    try:
+        print(f"{pkg}=={version(pkg)}")
+    except PackageNotFoundError:
+        pass
+PY
+ENV PIP_CONSTRAINT=/opt/rocm-constraints.txt
+
+WORKDIR /workspace/verl-omni
+
+COPY pyproject.toml setup.py README.md ./
+COPY .github/verl_pin.txt .github/vllm_omni_pin.txt ./.github/
+COPY verl_omni ./verl_omni
+
+# Step 3 — vllm-omni at the git pin, --no-deps so its vllm==0.28.0 requirement does
+# not pull the CUDA wheel over the ROCm build. The rest are the runtime imports
+# --no-deps therefore skips; see install_rocm.md for what is deliberately omitted.
+RUN VLLM_OMNI_REF="$(tr -d '[:space:]' < .github/vllm_omni_pin.txt)" \
+ && echo "Installing vllm-omni@${VLLM_OMNI_REF}" \
+ && pip install --no-deps \
+      "vllm-omni @ git+https://github.com/vllm-project/vllm-omni.git@${VLLM_OMNI_REF}" \
+ && pip install --no-deps \
+      aenum==3.1.16 \
+      janus \
+      torchsde \
+      x-transformers \
+      cache-dit==1.5.0 \
+      onnxruntime \
+      prettytable \
+      gguf \
+      kernels==0.14.1 \
+ && pip install kernels-data  # not optional: kernels loads it via an entry point
+
+# Step 4 — corrections the ROCm base needs.
+RUN pip install --no-deps diffusers==0.40.0 \
+ && pip install --no-deps -U "torchao>=0.16.0"  # peft >=0.19 rejects torchao <0.16
+
+# Step 5 — verl at the pin: the base ships 0.9.0.dev0, whose agent loop reads a
+# data.continuous_token key the diffusion trainer config does not define.
+RUN VERL_REF="${VERL_GIT_REF:-$(tr -d '[:space:]' < .github/verl_pin.txt)}" \
+ && echo "Installing verl@${VERL_REF}" \
+ && pip install --no-deps --force-reinstall \
+      "verl @ git+https://github.com/verl-project/verl.git@${VERL_REF}"
+
+# Step 6 — verl-omni, plus the core dependencies the ROCm base lacks.
+RUN pip install --no-deps -e . \
+ && pip install "imageio[ffmpeg]>=2.37.2" latex2sympy2_extended math_verify
+
+# Device-independent checks only. vllm_omni / verl_omni pull in vLLM's cumem
+# allocator, which asserts the GPU runtime is loaded — impossible without a
+# device, so they are verified at container start; see install_rocm.md.
+RUN python3 -c "import torch; print('torch', torch.__version__, '| HIP', torch.version.hip)" \
+ && python3 -c "import vllm; print('vllm', vllm.__version__)" \
+ && python3 -c "import verl; print('verl', verl.__version__)" \
+ && python3 -c "from importlib.metadata import version; print('vllm-omni', version('vllm-omni'))"
+
+CMD ["/bin/bash"]

--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -87,7 +87,7 @@ RUN VLLM_OMNI_REF="$(tr -d '[:space:]' < .github/vllm_omni_pin.txt)" \
       prettytable \
       gguf \
       kernels==0.14.1 \
- && pip install kernels-data  # not optional: kernels loads it via an entry point
+      kernels-data==0.16.1  # not optional: kernels loads it via an entry point
 
 # Step 4 — corrections the ROCm base needs.
 RUN pip install --no-deps diffusers==0.40.0 \

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,7 @@ See {doc}`start/models` for the full model catalogue and which algorithms run on
 
 start/install.md
 start/install_npu.md
+start/install_rocm.md
 start/models.md
 start/flowgrpo_quickstart.md
 start/multi_node_training.md

--- a/docs/start/install.md
+++ b/docs/start/install.md
@@ -2,7 +2,7 @@
 
 Last updated: 09/09/2026
 
-For Ascend NPU, see the {doc}`NPU installation guide <install_npu>`.
+For Ascend NPU, see the {doc}`NPU installation guide <install_npu>`. For AMD GPU, see the {doc}`ROCm installation guide <install_rocm>`.
 
 ## Requirements
 

--- a/docs/start/install_npu.md
+++ b/docs/start/install_npu.md
@@ -2,7 +2,7 @@
 
 Last updated: 09/09/2026
 
-For NVIDIA GPU, see the {doc}`GPU installation guide <install>`.
+For NVIDIA GPU, see the {doc}`GPU installation guide <install>`. For AMD GPU, see the {doc}`ROCm installation guide <install_rocm>`.
 
 ## Requirements
 

--- a/docs/start/install_rocm.md
+++ b/docs/start/install_rocm.md
@@ -41,13 +41,15 @@ Build context is controlled by the repo-root [`.dockerignore`](https://github.co
 
 ## Optional Dependencies
 
-The image installs the core stack only. Add these inside the container as needed:
+The base image already provides `qwen-vl-utils` for vision-language training and
+`pytest`, `pytest-cov`, `pytest-asyncio`, and `pre-commit` for development, and
+the build adds `math-verify` and `latex2sympy2_extended`. Only these need
+installing inside the container:
 
-| Extra               | Install                                                        | When needed                             |
-| ------------------- | -------------------------------------------------------------- | --------------------------------------- |
-| OCR reward          | `pip install Levenshtein`                                       | FlowGRPO training with OCR-based reward |
-| Multimodal training | `pip install qwen-vl-utils math-verify`                         | Vision-language training (e.g. MMK12)   |
-| Dev tools           | `pip install pytest pytest-cov pytest-asyncio pre-commit py-spy` | Linting and unit tests                  |
+| Extra      | Install                     | When needed                             |
+| ---------- | --------------------------- | --------------------------------------- |
+| OCR reward | `pip install Levenshtein`   | FlowGRPO training with OCR-based reward |
+| Profiling  | `pip install py-spy`        | Sampling profiler for stack traces      |
 
 `PIP_CONSTRAINT` is baked into the image, so these cannot pull a CUDA `torch` over the ROCm build.
 

--- a/docs/start/install_rocm.md
+++ b/docs/start/install_rocm.md
@@ -1,0 +1,216 @@
+# Installation (ROCm)
+
+Last updated: 09/10/2026
+
+For NVIDIA GPU, see the {doc}`GPU installation guide <install>`. For Ascend NPU, see the {doc}`NPU installation guide <install_npu>`.
+
+## Requirements
+
+* **Python**: Version >= 3.11
+* **ROCm**: Version >= 7.0
+* **GPU**: CDNA3 (`gfx942`, MI300X / MI325X) or CDNA4 (`gfx950`, MI350X / MI355X)
+
+## Install
+
+On ROCm the Docker image is the supported path; there is no bare-metal `pip` install.
+
+```bash
+git clone https://github.com/verl-project/verl-omni.git
+cd verl-omni
+docker build -f docker/Dockerfile.rocm -t verl-omni:rocm .
+```
+
+Compiling vLLM dominates the build. It defaults to both current CDNA
+generations; narrowing it to your card roughly halves the time:
+
+```bash
+docker build -f docker/Dockerfile.rocm -t verl-omni:rocm \
+  --build-arg PYTORCH_ROCM_ARCH=gfx950 .
+```
+
+Build context is controlled by the repo-root [`.dockerignore`](https://github.com/verl-project/verl-omni/blob/main/.dockerignore); keep large local folders such as `.venv`, `data/`, and `checkpoints/` out of the context.
+
+### Build arguments
+
+| Argument            | Default                                        | Purpose                                     |
+| ------------------- | ---------------------------------------------- | ------------------------------------------- |
+| `BASE_IMAGE`        | `verlai/verl:rocm7.14_torch2.12_release_0724`  | ROCm PyTorch stack, vLLM checkout, hipcc    |
+| `PYTORCH_ROCM_ARCH` | `gfx942;gfx950`                                | GPU architectures to compile vLLM kernels for |
+| `VLLM_VERSION`      | `v0.28.0`                                      | vLLM tag built from source                  |
+| `VERL_GIT_REF`      | [`.github/verl_pin.txt`](../../.github/verl_pin.txt) | verl commit to install                |
+
+## Optional Dependencies
+
+The image installs the core stack only. Add these inside the container as needed:
+
+| Extra               | Install                                                        | When needed                             |
+| ------------------- | -------------------------------------------------------------- | --------------------------------------- |
+| OCR reward          | `pip install Levenshtein`                                       | FlowGRPO training with OCR-based reward |
+| Multimodal training | `pip install qwen-vl-utils math-verify`                         | Vision-language training (e.g. MMK12)   |
+| Dev tools           | `pip install pytest pytest-cov pytest-asyncio pre-commit py-spy` | Linting and unit tests                  |
+
+`PIP_CONSTRAINT` is baked into the image, so these cannot pull a CUDA `torch` over the ROCm build.
+
+## Run
+
+```bash
+docker run -it --rm \
+  --network host \
+  --ipc host \
+  --device=/dev/kfd \
+  --device=/dev/dri \
+  --group-add video \
+  --security-opt seccomp=unconfined \
+  --shm-size=16g \
+  -w /workspace/verl-omni \
+  verl-omni:rocm \
+  bash
+```
+
+* **`/dev/kfd`** — the AMD compute driver interface; without it the HIP runtime cannot initialise.
+* **`/dev/dri`** — render nodes for the individual GPUs.
+* **`--group-add video`** — grants the container user access to those device nodes.
+* **`--security-opt seccomp=unconfined`** — required for the userspace memory mapping the HIP allocator performs.
+* **`--ipc host`** and **`--shm-size`** — avoid shared-memory limits during rollout.
+
+## Post-Installation Verification
+
+The image verifies `torch`, `vllm`, `verl`, and `vllm-omni` at build time, but
+only the checks that do not touch a device. Importing `vllm_omni` or `verl_omni`
+pulls in vLLM's cumem allocator (`vllm.device_allocator.cumem`), which asserts
+that the GPU runtime library is loaded into the process — it is not until torch
+has opened a device, so these cannot be checked during `docker build`. Run the
+full set inside the container:
+
+```bash
+rocm-smi
+python -c "import torch; print('torch', torch.__version__, '| HIP', torch.version.hip, '| GPU', torch.cuda.is_available())"
+python -c "import vllm; print('vllm', vllm.__version__)"
+python -c "from importlib.metadata import version; import vllm_omni; print('vllm-omni', version('vllm-omni'))"
+python -c "import verl; print('verl', verl.__version__)"
+python -c "import verl_omni; print('VeRL-Omni ready')"
+```
+
+## Attention backend
+
+Diffusion recipes default to FlashAttention 3
+(`attn_backend=_flash_3_varlen_hub`), and the `kernels-community` hub repos
+publish no ROCm build variant — the run fails at model init with
+`FileNotFoundError: Cannot find a build variant for this system`. Nothing warns
+first: `fa_available()` only checks that `kernels` is importable. Every
+diffusion recipe on ROCm needs both overrides:
+
+```bash
+actor_rollout_ref.model.attn_backend=native \
+actor_rollout_ref.rollout.rollout_attn_backend=TORCH_SDPA
+```
+
+Both are required together; `validate_attention_consistency` rejects a
+mismatched pair. Omni recipes (`main_omni`) are unaffected — they select
+attention via `attn_implementation`, which defaults to `flash_attention_2` and
+works on ROCm using the base image's `flash_attn` build.
+
+## Notes on the image
+
+A few choices in `Dockerfile.rocm` differ from
+[`docker/Dockerfile.cuda`](https://github.com/verl-project/verl-omni/blob/main/docker/Dockerfile.cuda)
+and are worth knowing before you modify it.
+
+**vLLM is compiled from source, before anything else is installed.** There are
+no ROCm wheels on PyPI, so `pip install vllm==0.28.0` cannot work. Building it
+first keeps the compile environment identical to the one the base image
+validated — notably, installing `kernels` without `kernels-data` registers a
+setuptools entry point that breaks every subsequent source build in the image.
+
+**The accelerator packages are constrained image-wide.** After vLLM is built,
+the installed versions of `torch`, `torchvision`, `torchaudio`, and `vllm` are
+frozen into `/opt/rocm-constraints.txt` and exported as `PIP_CONSTRAINT`. AMD's
+torch build is not on PyPI, so any resolver that decides to upgrade it would
+replace it with a CUDA wheel and silently break the image; the constraint turns
+that into a hard failure instead.
+
+**`vllm-omni` is installed with `--no-deps`**, because its `vllm==0.28.0`
+requirement would otherwise pull the CUDA wheel over the ROCm build. Its
+runtime imports are therefore installed explicitly. Three of its dependencies
+are deliberately omitted: `openai-whisper` and `cosmos-guardrail` serve audio
+and video-safety paths the diffusion recipes do not use, and `fa3-fwd` is
+CUDA-only FlashAttention 3.
+
+**Two dependency corrections are applied** that the ROCm base needs:
+`diffusers` is raised to 0.40.0 (0.33.1 references `FLAX_WEIGHTS_NAME`, removed
+in transformers v5), and `torchao` to >=0.16.0 (`peft` >=0.19 raises
+`ImportError` when an older torchao is present, even though these recipes never
+use torchao quantization).
+
+**`verl` is reinstalled at the repo pin.** The base image ships 0.9.0.dev0,
+whose agent loop reads a `data.continuous_token` key the diffusion trainer
+config does not define.
+
+## Build Your Own Docker Image
+
+* AMD GPU (ROCm) Dockerfile: [`docker/Dockerfile.rocm`](https://github.com/verl-project/verl-omni/blob/main/docker/Dockerfile.rocm)
+
+NVIDIA GPU images are documented in the {doc}`GPU installation guide <install>`, and Ascend NPU images in the {doc}`NPU installation guide <install_npu>`.
+
+## Example: Qwen-Image FlowGRPO training in Docker
+
+This walkthrough uses the OCR dataset and
+`examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_lora.sh`. It needs 8
+GPUs — 4 for actor and rollout, 4 for the reward model.
+
+### 1. Launch the interactive container
+
+Use the `docker run` command from [Run](#run) above.
+
+### 2. Prepare the OCR dataset inside the container
+
+```bash
+export WORKSPACE=${WORKSPACE:-$HOME}
+mkdir -p $WORKSPACE/data/ocr
+
+# Obtain raw train.txt / test.txt from the Flow-GRPO repo:
+# https://github.com/yifan123/flow_grpo/tree/main/dataset/ocr
+# Place them under $WORKSPACE/data/ocr/, then preprocess:
+
+python3 examples/flowgrpo_trainer/data_process/qwenimage_ocr.py \
+  --input_dir $WORKSPACE/data/ocr \
+  --output_dir $WORKSPACE/data/ocr/qwen_image
+```
+
+`Qwen/Qwen-Image` and the `Qwen/Qwen3-VL-8B-Instruct` reward model are fetched
+from the Hub on first use; pre-download them with `hf download` to keep the
+first step from timing out.
+
+### 3. Optional: Set W&B credentials
+
+```bash
+export WANDB_API_KEY=<your_wandb_api_key>
+```
+
+Without a key the run aborts at logger init with
+`wandb.errors.UsageError: No API key configured`. To run without W&B, append
+`trainer.logger=[console]`.
+
+### 4. Run FlowGRPO training
+
+ROCm requires the native/SDPA attention pair described in
+[Attention backend](#attention-backend); the script forwards extra Hydra
+overrides, so append them to the command:
+
+```bash
+bash examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_lora.sh \
+  actor_rollout_ref.model.attn_backend=native \
+  actor_rollout_ref.rollout.rollout_attn_backend=TORCH_SDPA
+```
+
+Without those two overrides the run fails during model init with
+`FileNotFoundError: Cannot find a build variant for this system in
+kernels-community/flash-attn3`.
+
+The script launches `python3 -m verl_omni.trainer.main_diffusion` with FlowGRPO
++ `vllm_omni` rollout and OCR reward (`compute_score_ocr`). Checkpoints are
+written to:
+
+```bash
+checkpoints/flow_grpo/qwen_image_ocr_lora
+```


### PR DESCRIPTION
### What does this PR do?

Adds AMD GPU (ROCm) support: a `docker/Dockerfile.rocm` image for Instinct MI300X/MI350X, and a `docs/start/install_rocm.md` guide alongside the existing CUDA and Ascend NPU install pages.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `vllm_omni`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `diffusion`, `omni`, `tests`, `docker`
  - If this PR involves multiple modules, separate them with `,` like `[diffusion, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][diffusion, fsdp] feat: new rollout scheduler`

### Test

 ```bash
  bash examples/flowgrpo_trainer/qwen_image/run_qwen_image_ocr_lora.sh \
    actor_rollout_ref.model.attn_backend=native \
    actor_rollout_ref.rollout.rollout_attn_backend=TORCH_SDPA \
    trainer.total_training_steps=2
 ```
  Completes successfully (exit 0): 2 training steps at ~380 s/step,
  critic/rewards/mean: 0.765, throughput 0.334 img/s.


### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x]  Read the [Contribute Guide](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md).
- [x]  Apply [pre-commit checks](https://github.com/verl-project/verl-omni/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update the documentation.
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl-omni/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
