### PR TITLE
[doc] chore: add slides badge next to Slack in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <a href="https://deepwiki.com/verl-project/verl-omni"><img src="https://devin.ai/assets/deepwiki-badge.png" alt="Ask DeepWiki.com" style="height:20px;"></a>
 [![Docs](https://img.shields.io/badge/docs-Read%20the%20Docs-8A2BE2)](https://verl-omni.readthedocs.io/en/latest/index.html)
-[![License](https://img.shields.io/badge/license-Apache%202.0-blue)](./LICENSE) <a href="docs/assets/WeChat.jpg"><img src="https://img.shields.io/badge/微信-green?logo=wechat"></a> <a href="https://join.slack.com/t/verl-project/shared_invite/zt-47rq3rljo-PMM7921PnFVf67be0tqYJg"><img src="https://img.shields.io/badge/Slack-verl-blueviolet?logo=slack"></a>
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue)](./LICENSE) <a href="docs/assets/WeChat.jpg"><img src="https://img.shields.io/badge/微信-green?logo=wechat"></a> <a href="https://join.slack.com/t/verl-project/shared_invite/zt-47rq3rljo-PMM7921PnFVf67be0tqYJg"><img src="https://img.shields.io/badge/Slack-verl-blueviolet?logo=slack"></a> <a href="https://drive.google.com/file/d/1EGVFZdvRgSBymMlZa62FObbzEhMoLA0F/view?usp=sharing"><img src="https://img.shields.io/badge/Slides-verl--omni-orange?logo=google-drive&logoColor=white"></a>
 
 </div>
 


### PR DESCRIPTION
### What does this PR do?

Add a header **Slides** badge next to Slack on the main README, linking to https://drive.google.com/file/d/1EGVFZdvRgSBymMlZa62FObbzEhMoLA0F/view?usp=sharing

This keeps the deck visible on the badge row instead of only in the News list (which still points at an older meetup deck).

### Checklist Before Starting

- [x] Search for similar PRs: https://github.com/verl-project/verl-omni/pulls?q=is%3Apr+is%3Aopen+slides and https://github.com/verl-project/verl-omni/pulls?q=is%3Apr+is%3Aopen+README+slack. Web search of open PRs did not turn up a duplicate header-slides change.
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

README-only change. Verified the badge sits on the WeChat/Slack row and the Drive URL matches `verl-omni slides 202608.pdf`. No unit tests: documentation link only.

### API and Usage Example

N/A (docs-only).

### Design & Code Changes

- README.md: append a Google Drive Slides shield after the Slack badge.

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] Single README line; no config regeneration.
- [x] Documentation updated.
- [x] Unit/e2e tests not applicable.

### AI assistance / accountability

AI assistance (Cursor) was used for this change. A human submitter has reviewed every changed line.