### PR TITLE
[diffusion] fix: align Qwen-Image-Edit image tokens and features

### DIFF
--- a/tests/pipelines/test_qwen_image_edit_on_cpu.py
+++ b/tests/pipelines/test_qwen_image_edit_on_cpu.py
@@ -29,6 +29,7 @@ from verl_omni.pipelines.model_base import DiffusionModelBase
 from verl_omni.pipelines.qwen_image_edit_flow_grpo.diffusers_training_adapter import QwenImageEditPlusFlowGRPO
 from verl_omni.pipelines.qwen_image_edit_flow_grpo.vllm_omni_rollout_adapter import (
     QwenImageEditPlusPipelineWithLogProb,
+    _condition_images_for_prompt_encoding,
     _use_true_cfg,
     _validate_condition_image_sizes,
 )
@@ -193,6 +194,28 @@ def test_prompt_encoding_requires_condition_images():
             torch.tensor([1]),
             condition_images=None,
         )
+
+
+def test_prompt_encoding_prefers_raw_image_over_preprocessed_alias():
+    raw_image = torch.zeros(3, 8, 8)
+    resized_image = torch.ones(3, 4, 4)
+    payload = {
+        "multi_modal_data": {"image": [raw_image]},
+        "additional_information": {"condition_images": [resized_image]},
+    }
+
+    result = _condition_images_for_prompt_encoding(payload)
+    assert len(result) == 1
+    assert result[0] is raw_image
+
+
+def test_prompt_encoding_falls_back_to_preprocessed_image():
+    resized_image = torch.ones(3, 4, 4)
+    payload = {"additional_information": {"condition_images": [resized_image]}}
+
+    result = _condition_images_for_prompt_encoding(payload)
+    assert len(result) == 1
+    assert result[0] is resized_image
 
 
 def test_condition_images_require_fixed_square_latents():

--- a/verl_omni/pipelines/qwen_image_edit_flow_grpo/vllm_omni_rollout_adapter.py
+++ b/verl_omni/pipelines/qwen_image_edit_flow_grpo/vllm_omni_rollout_adapter.py
@@ -112,6 +112,17 @@ def _validate_condition_image_sizes(condition_images, vae_image_sizes, target_si
         )
 
 
+def _condition_images_for_prompt_encoding(custom_prompt: dict) -> list[Any]:
+    """Use the raw image that was used to build the pre-tokenized prompt."""
+    raw_payload = {
+        key: custom_prompt[key] for key in ("images", "image", "multi_modal_data", "extra_args") if key in custom_prompt
+    }
+    raw_images = condition_images_from_payload(raw_payload)
+    if raw_images:
+        return raw_images
+    return condition_images_from_payload(custom_prompt)
+
+
 @VllmOmniPipelineBase.register("QwenImageEditPlusPipeline", algorithm="flow_grpo")
 class QwenImageEditPlusPipelineWithLogProb(QwenImageTokenIdPromptMixin, QwenImageEditPlusPipeline):
     """Qwen-Image-Edit-Plus rollout pipeline for FlowGRPO."""
@@ -368,7 +379,9 @@ class QwenImageEditPlusPipelineWithLogProb(QwenImageTokenIdPromptMixin, QwenImag
 
         # Condition images are parsed from the rollout request payload; the prompt
         # itself is read from custom_prompt below.
-        condition_images = condition_images_from_payload(custom_prompt) if isinstance(custom_prompt, dict) else None
+        condition_images = (
+            _condition_images_for_prompt_encoding(custom_prompt) if isinstance(custom_prompt, dict) else None
+        )
         if not condition_images:
             raise ValueError("Qwen-Image-Edit requires at least one condition image")
 


### PR DESCRIPTION
## Summary

- Prefer the raw condition image used to build pre-tokenized Qwen-Image-Edit prompts.
- Fall back to the vLLM-Omni preprocessed condition image when no raw image is present.
- Add regression coverage for both selection paths.

## Problem

vLLM-Omni retains the raw image in multi_modal_data.image and also stores a derived resized image in additional_information.condition_images. Treating these values as equivalent aliases raises a conflict. Selecting only the resized image instead can make the existing image placeholder tokens disagree with the visual features (for example, 324 tokens versus 196 features).

This change keeps strict validation between raw input aliases while excluding the derived resized alias from prompt encoding whenever the raw image is available.

## Tests

- python3 -m pytest tests/pipelines/test_qwen_image_edit_on_cpu.py tests/pipelines/test_rollout_request_on_cpu.py -q (42 passed)
- ruff check on the changed files
- ruff format --check on the changed files
- git diff --check