### PR TITLE
[rollout, recipe, tests, doc] fix: preserve diffusion text-encoder TP

### DIFF
--- a/docs/examples/config.md
+++ b/docs/examples/config.md
@@ -1,6 +1,6 @@
 # Config Explanation
 
-Last updated: 09/01/2026
+Last updated: 09/12/2026
 
 VeRL-Omni builds on [verl](https://github.com/verl-project/verl) and reuses the
 same Hydra config surface for shared RL trainer fields (`data`, FSDP actor /
@@ -232,6 +232,28 @@ VeOmni engine path (`strategy=veomni`) adds `veomni_config` / VeOmni optimizer f
 ### `actor_rollout_ref.rollout` — `DiffusionRolloutConfig`
 
 Diffusion-specific blocks sit under `pipeline`, `algo`, and `val_kwargs`. Several engine knobs are shared with verl vLLM rollout but have diffusion defaults.
+
+#### Text-encoder tensor parallelism
+
+`actor_rollout_ref.rollout.text_encoder_tp_size` (default `1`) controls encoder
+sharding for supporting diffusion pipelines. Use `1` or
+`actor_rollout_ref.rollout.tensor_model_parallel_size`; intermediate subgroups
+are rejected for the pinned backend. MiniMax-H3 supports ETP 1/2/4/8.
+
+```bash
+actor_rollout_ref.rollout.tensor_model_parallel_size=4 \
+actor_rollout_ref.rollout.text_encoder_tp_size=4
+```
+
+NFT and FlowGRPO share this path. The field reaches the fused engine's
+`OmniDiffusionConfig.parallel_config.text_encoder_tp_size`; it is independent
+of CPU/layerwise offload. H3 launchers default `TEXT_ENCODER_TP` to `ROLLOUT_TP`.
+
+The legacy `+actor_rollout_ref.rollout.engine_kwargs.vllm_omni.text_encoder_tp_size`
+override is still accepted and overrides the typed default of `1`. Conflicting
+non-default typed and legacy values raise an error. If an explicit
+`parallel_config` provides ETP, it must agree with any requested override;
+otherwise its value is preserved. Prefer the typed field without `+`.
 
 #### Pipeline — `DiffusionPipelineConfig`
 

--- a/examples/diffusionnft_trainer/minimax_h3/README.md
+++ b/examples/diffusionnft_trainer/minimax_h3/README.md
@@ -1,6 +1,6 @@
 # MiniMax H3 T2VA, FL2VA, and Ref2VA DiffusionNFT
 
-Last updated: 09/04/2026
+Last updated: 09/12/2026
 
 These recipes train rank-64 MiniMax H3 LoRA adapters with online DiffusionNFT
 for text-to-audio-video (T2VA), first-frame image-to-audio-video (FL2VA), and
@@ -184,6 +184,23 @@ python3 examples/diffusionnft_trainer/minimax_h3/build_fl2va_jsonl.py \
   training at e.g. 288x464 (same ~1:1.61 aspect) works directly.
 
 ## Launch
+
+### Text-encoder tensor parallelism
+
+All H3 NFT launchers use `TEXT_ENCODER_TP=${TEXT_ENCODER_TP:-$ROLLOUT_TP}`,
+forwarded as `actor_rollout_ref.rollout.text_encoder_tp_size` (without `+`).
+For example, `ROLLOUT_TP=4 TEXT_ENCODER_TP=4` shards the encoder across all four
+DiT ranks; `TEXT_ENCODER_TP=1` keeps it unsharded. With the pinned backend, use
+ETP=1 or ETP=rollout TP, not an intermediate subgroup; H3 supports ETP 1/2/4/8.
+This applies to T2VA, FL2VA, and Ref2VA and is independent of CPU/layerwise offload.
+
+The legacy `+actor_rollout_ref.rollout.engine_kwargs.vllm_omni.text_encoder_tp_size`
+override remains supported. Prefer the typed field and do not set conflicting
+values through both paths. The fix for [#563](https://github.com/verl-project/verl-omni/issues/563)
+retains ETP through CLI conversion into the fused diffusion engine's parallel
+config; a CLI argument alone was not evidence that the encoder was sharded.
+
+### T2VA
 
 ```bash
 export MODEL_PATH=/path/to/MiniMax-H3

--- a/examples/diffusionnft_trainer/minimax_h3/run_minimax_h3_fl2va_lora.sh
+++ b/examples/diffusionnft_trainer/minimax_h3/run_minimax_h3_fl2va_lora.sh
@@ -16,6 +16,7 @@ fi
 
 N_GPUS=${N_GPUS:-8}
 ROLLOUT_TP=${ROLLOUT_TP:-4}
+TEXT_ENCODER_TP=${TEXT_ENCODER_TP:-$ROLLOUT_TP}
 ROLLOUT_N=${ROLLOUT_N:-16}
 HEIGHT=${HEIGHT:-288}
 WIDTH=${WIDTH:-448}
@@ -98,6 +99,7 @@ python3 -m verl_omni.trainer.main_diffusion \
   actor_rollout_ref.rollout.rollout_attn_backend="$ROLLOUT_ATTN_BACKEND" \
   actor_rollout_ref.rollout.rollout_adapter=old \
   actor_rollout_ref.rollout.tensor_model_parallel_size="$ROLLOUT_TP" \
+  actor_rollout_ref.rollout.text_encoder_tp_size="$TEXT_ENCODER_TP" \
   actor_rollout_ref.rollout.n="$ROLLOUT_N" \
   actor_rollout_ref.rollout.seed=42 \
   actor_rollout_ref.rollout.agent.num_workers=$((N_GPUS / ROLLOUT_TP)) \

--- a/examples/diffusionnft_trainer/minimax_h3/run_minimax_h3_ref2va_lora.sh
+++ b/examples/diffusionnft_trainer/minimax_h3/run_minimax_h3_ref2va_lora.sh
@@ -102,7 +102,7 @@ python3 -m verl_omni.trainer.main_diffusion \
   actor_rollout_ref.rollout.rollout_attn_backend="$ROLLOUT_ATTN_BACKEND" \
   actor_rollout_ref.rollout.rollout_adapter=old \
   actor_rollout_ref.rollout.tensor_model_parallel_size="$ROLLOUT_TP" \
-  +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.text_encoder_tp_size="$TEXT_ENCODER_TP" \
+  actor_rollout_ref.rollout.text_encoder_tp_size="$TEXT_ENCODER_TP" \
   actor_rollout_ref.rollout.n="$ROLLOUT_N" \
   actor_rollout_ref.rollout.seed=42 \
   actor_rollout_ref.rollout.agent.num_workers=$((N_GPUS / ROLLOUT_TP)) \

--- a/examples/diffusionnft_trainer/minimax_h3/run_minimax_h3_t2va_lora.sh
+++ b/examples/diffusionnft_trainer/minimax_h3/run_minimax_h3_t2va_lora.sh
@@ -9,6 +9,7 @@ MODEL_PATH=${MODEL_PATH:-}
 DATA_DIR=${DATA_DIR:-$WORKSPACE/data/vid_prompt/verl_omni}
 NUM_GPUS=${NUM_GPUS:-8}
 ROLLOUT_TP=${ROLLOUT_TP:-2}
+TEXT_ENCODER_TP=${TEXT_ENCODER_TP:-$ROLLOUT_TP}
 ROLLOUT_N=${ROLLOUT_N:-16}
 TOTAL_TRAINING_STEPS=${TOTAL_TRAINING_STEPS:-1000}
 HEIGHT=${HEIGHT:-256}
@@ -105,6 +106,7 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.rollout.max_num_seqs=1 \
     actor_rollout_ref.rollout.rollout_attn_backend=$ROLLOUT_ATTN_BACKEND \
     actor_rollout_ref.rollout.tensor_model_parallel_size=$ROLLOUT_TP \
+    actor_rollout_ref.rollout.text_encoder_tp_size=$TEXT_ENCODER_TP \
     actor_rollout_ref.rollout.n=$ROLLOUT_N \
     actor_rollout_ref.rollout.seed=42 \
     actor_rollout_ref.rollout.agent.num_workers=$((NUM_GPUS / ROLLOUT_TP)) \

--- a/examples/flowgrpo_trainer/minimax_h3/README.md
+++ b/examples/flowgrpo_trainer/minimax_h3/README.md
@@ -1,6 +1,6 @@
 # MiniMax H3 T2VA, FL2VA, and Ref2VA FlowGRPO
 
-Last updated: 09/02/2026
+Last updated: 09/12/2026
 
 These recipes train `MiniMaxAI/MiniMax-H3` LoRA adapters with FlowGRPO for
 text-to-audio-video (T2VA), first-frame image-to-audio-video (FL2VA), and
@@ -295,9 +295,20 @@ and Actor micro-batch 1. It enables layerwise rollout offload and FSDP2 Actor
 parameter/optimizer offload because reference presentations can be much longer
 than T2VA prompts.
 
-`NUM_GPUS` must be divisible by `ROLLOUT_TP`. `TEXT_ENCODER_TP` cannot exceed
-`ROLLOUT_TP`; H3 supports text-encoder TP sizes 1, 2, 4, and 8. The recipe uses
-an Actor micro-batch of 1 because samples with different packed
+`NUM_GPUS` must be divisible by `ROLLOUT_TP`. `TEXT_ENCODER_TP` defaults to
+`ROLLOUT_TP` and is forwarded as `actor_rollout_ref.rollout.text_encoder_tp_size`
+(without `+`), using the same diffusion engine path as NFT. With the pinned
+backend, ETP must be 1 or equal to rollout TP; H3 supports ETP 1/2/4/8.
+For example, `ROLLOUT_TP=4 TEXT_ENCODER_TP=4` shards the encoder across all four
+DiT ranks, while `TEXT_ENCODER_TP=1` disables encoder sharding. ETP is independent
+of CPU/layerwise offload. This applies to the GPU, V1 sync, and NPU launchers.
+
+The legacy `+actor_rollout_ref.rollout.engine_kwargs.vllm_omni.text_encoder_tp_size`
+override remains supported; conflicting values fail at startup. The fix for
+[#563](https://github.com/verl-project/verl-omni/issues/563) preserves ETP through
+CLI conversion into the fused diffusion engine's parallel config.
+
+The recipe uses an Actor micro-batch of 1 because samples with different packed
 video/audio/text layouts cannot share one H3 forward. A larger micro-batch is
 valid only when every sample has the same packed layout.
 

--- a/examples/flowgrpo_trainer/minimax_h3/run_minimax_h3_fl2va_lora.sh
+++ b/examples/flowgrpo_trainer/minimax_h3/run_minimax_h3_fl2va_lora.sh
@@ -79,7 +79,7 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.rollout.name=vllm_omni \
     actor_rollout_ref.rollout.rollout_attn_backend=FLASH_ATTN_3_HUB \
     actor_rollout_ref.rollout.tensor_model_parallel_size=$ROLLOUT_TP \
-    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.text_encoder_tp_size=$TEXT_ENCODER_TP \
+    actor_rollout_ref.rollout.text_encoder_tp_size=$TEXT_ENCODER_TP \
     actor_rollout_ref.rollout.n=8 \
     actor_rollout_ref.rollout.seed=42 \
     actor_rollout_ref.rollout.agent.num_workers=$((NUM_GPUS / ROLLOUT_TP)) \

--- a/examples/flowgrpo_trainer/minimax_h3/run_minimax_h3_fl2va_lora_v1.sh
+++ b/examples/flowgrpo_trainer/minimax_h3/run_minimax_h3_fl2va_lora_v1.sh
@@ -88,7 +88,7 @@ python3 -m verl_omni.trainer.main_diffusion_v1 \
     actor_rollout_ref.rollout.name=vllm_omni \
     actor_rollout_ref.rollout.rollout_attn_backend=FLASH_ATTN_3_HUB \
     actor_rollout_ref.rollout.tensor_model_parallel_size=$ROLLOUT_TP \
-    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.text_encoder_tp_size=$TEXT_ENCODER_TP \
+    actor_rollout_ref.rollout.text_encoder_tp_size=$TEXT_ENCODER_TP \
     actor_rollout_ref.rollout.n=8 \
     actor_rollout_ref.rollout.seed=42 \
     actor_rollout_ref.rollout.agent.num_workers=$((NUM_GPUS / ROLLOUT_TP)) \

--- a/examples/flowgrpo_trainer/minimax_h3/run_minimax_h3_ref2va_lora.sh
+++ b/examples/flowgrpo_trainer/minimax_h3/run_minimax_h3_ref2va_lora.sh
@@ -100,7 +100,7 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.rollout.max_num_seqs=1 \
     actor_rollout_ref.rollout.rollout_attn_backend="$ROLLOUT_ATTN_BACKEND" \
     actor_rollout_ref.rollout.tensor_model_parallel_size="$ROLLOUT_TP" \
-    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.text_encoder_tp_size="$TEXT_ENCODER_TP" \
+    actor_rollout_ref.rollout.text_encoder_tp_size="$TEXT_ENCODER_TP" \
     +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.enable_layerwise_offload=True \
     actor_rollout_ref.rollout.n="$ROLLOUT_N" \
     actor_rollout_ref.rollout.seed=42 \

--- a/examples/flowgrpo_trainer/minimax_h3/run_minimax_h3_t2va_lora.sh
+++ b/examples/flowgrpo_trainer/minimax_h3/run_minimax_h3_t2va_lora.sh
@@ -79,7 +79,7 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.rollout.name=vllm_omni \
     actor_rollout_ref.rollout.rollout_attn_backend=FLASH_ATTN_3_HUB \
     actor_rollout_ref.rollout.tensor_model_parallel_size=$ROLLOUT_TP \
-    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.text_encoder_tp_size=$TEXT_ENCODER_TP \
+    actor_rollout_ref.rollout.text_encoder_tp_size=$TEXT_ENCODER_TP \
     actor_rollout_ref.rollout.n=8 \
     actor_rollout_ref.rollout.seed=42 \
     actor_rollout_ref.rollout.agent.num_workers=$((NUM_GPUS / ROLLOUT_TP)) \

--- a/examples/flowgrpo_trainer/minimax_h3/run_minimax_h3_t2va_lora_npu.sh
+++ b/examples/flowgrpo_trainer/minimax_h3/run_minimax_h3_t2va_lora_npu.sh
@@ -89,7 +89,7 @@ python3 -m verl_omni.trainer.main_diffusion \
     actor_rollout_ref.rollout.tensor_model_parallel_size=$ROLLOUT_TP \
     actor_rollout_ref.rollout.max_num_seqs=1 \
     actor_rollout_ref.rollout.layered_summon=True \
-    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.text_encoder_tp_size=$TEXT_ENCODER_TP \
+    actor_rollout_ref.rollout.text_encoder_tp_size=$TEXT_ENCODER_TP \
     actor_rollout_ref.rollout.n=8 \
     actor_rollout_ref.rollout.seed=42 \
     actor_rollout_ref.rollout.agent.num_workers=$((NUM_GPUS / ROLLOUT_TP)) \

--- a/examples/flowgrpo_trainer/minimax_h3/run_minimax_h3_t2va_lora_v1.sh
+++ b/examples/flowgrpo_trainer/minimax_h3/run_minimax_h3_t2va_lora_v1.sh
@@ -88,7 +88,7 @@ python3 -m verl_omni.trainer.main_diffusion_v1 \
     actor_rollout_ref.rollout.name=vllm_omni \
     actor_rollout_ref.rollout.rollout_attn_backend=FLASH_ATTN_3_HUB \
     actor_rollout_ref.rollout.tensor_model_parallel_size=$ROLLOUT_TP \
-    +actor_rollout_ref.rollout.engine_kwargs.vllm_omni.text_encoder_tp_size=$TEXT_ENCODER_TP \
+    actor_rollout_ref.rollout.text_encoder_tp_size=$TEXT_ENCODER_TP \
     actor_rollout_ref.rollout.n=8 \
     actor_rollout_ref.rollout.seed=42 \
     actor_rollout_ref.rollout.agent.num_workers=$((NUM_GPUS / ROLLOUT_TP)) \

--- a/tests/special_e2e/run_flowgrpo_minimax_h3_tiny.py
+++ b/tests/special_e2e/run_flowgrpo_minimax_h3_tiny.py
@@ -237,8 +237,7 @@ def _hydra_overrides(
         "actor_rollout_ref.rollout.val_kwargs.pipeline.true_cfg_scale=1.0",
         "+actor_rollout_ref.rollout.val_kwargs.pipeline.output_type=pt",
         "actor_rollout_ref.rollout.val_kwargs.algo.noise_level=0.0",
-        # vLLM-Omni engine kwargs: the field is top-level, not parallel_config.
-        f"+actor_rollout_ref.rollout.engine_kwargs.vllm_omni.text_encoder_tp_size={text_encoder_tp}",
+        f"actor_rollout_ref.rollout.text_encoder_tp_size={text_encoder_tp}",
         f"actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu={micro_bsz_per_gpu}",
         # reward: local stub only; no CLAP, ImageBind, or reward-model weights.
         "reward.num_workers=1",

--- a/tests/workers/rollout/rollout_vllm/test_diffusion_text_encoder_tp_on_cpu.py
+++ b/tests/workers/rollout/rollout_vllm/test_diffusion_text_encoder_tp_on_cpu.py
@@ -1,0 +1,127 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Exercise the fused diffusion ETP path without starting workers or loading weights."""
+
+import os
+from argparse import Namespace
+from dataclasses import asdict
+from types import SimpleNamespace
+
+import pytest
+from vllm_omni.diffusion.data import DiffusionParallelConfig, OmniDiffusionConfig
+from vllm_omni.engine.arg_utils import OmniEngineArgs
+from vllm_omni.engine.async_omni_engine import AsyncOmniEngine
+
+from verl_omni.workers.config import DiffusionRolloutConfig
+from verl_omni.workers.rollout.vllm_rollout import vllm_omni_async_server as server_module
+from verl_omni.workers.rollout.vllm_rollout import vllm_omni_diffusion_strategy as strategy_module
+
+
+def _prepare(monkeypatch, *, algorithm="diffusion_nft", typed=1, cli=None, parallel=None):
+    monkeypatch.setattr(strategy_module, "import_external_libs", lambda _: None)
+    monkeypatch.setattr(strategy_module.VllmOmniPipelineBase, "get_pipeline_path", lambda **_: "test.Pipeline")
+    monkeypatch.setattr(
+        strategy_module.VllmOmniPipelineBase, "get_class", lambda **_: SimpleNamespace(supports_request_batch=True)
+    )
+    config = DiffusionRolloutConfig(tensor_model_parallel_size=4, text_encoder_tp_size=typed)
+    server = SimpleNamespace(
+        config=config, model_config=SimpleNamespace(architecture="MiniMaxH3Pipeline", algorithm=algorithm)
+    )
+    args = Namespace(tensor_parallel_size=4, text_encoder_tp_size=cli)
+    engine_args = asdict(OmniEngineArgs.from_cli_args(args))
+    if parallel is not None:
+        engine_args["parallel_config"] = parallel
+    strategy_module.DiffusionStrategy(server).prepare_engine_args(engine_args, args)
+    return engine_args
+
+
+@pytest.mark.parametrize("algorithm", ["diffusion_nft", "flow_grpo"])
+@pytest.mark.parametrize("typed,cli,expected", [(1, None, 1), (4, None, 4), (1, 4, 4), (4, 4, 4), (1, 1, 1)])
+def test_text_encoder_tp_reaches_fused_diffusion_config(monkeypatch, algorithm, typed, cli, expected):
+    engine_args = _prepare(monkeypatch, algorithm=algorithm, typed=typed, cli=cli)
+    stages = AsyncOmniEngine._create_default_diffusion_stage_cfg(engine_args)
+    parallel = stages[0]["engine_args"]["parallel_config"]
+    od_config = OmniDiffusionConfig(parallel_config=parallel)
+    assert od_config.parallel_config.tensor_parallel_size == 4
+    assert od_config.parallel_config.text_encoder_tp_size == expected
+
+
+@pytest.mark.parametrize("cli", [0, 2, 8])
+def test_legacy_cli_rejects_invalid_encoder_groups(monkeypatch, cli):
+    with pytest.raises(ValueError, match="text_encoder_tp_size"):
+        _prepare(monkeypatch, cli=cli)
+
+
+def test_conflicting_typed_and_legacy_etp_fails(monkeypatch):
+    with pytest.raises(ValueError, match="Conflicting text_encoder_tp_size"):
+        _prepare(monkeypatch, typed=4, cli=1)
+
+
+@pytest.mark.parametrize("as_object", [False, True])
+def test_explicit_parallel_config_keeps_etp_and_other_fields(monkeypatch, as_object):
+    parallel = {"tensor_parallel_size": 4, "text_encoder_tp_size": 4, "ring_degree": 2}
+    if as_object:
+        parallel = DiffusionParallelConfig.from_dict(parallel)
+    engine_args = _prepare(monkeypatch, parallel=parallel)
+    stages = AsyncOmniEngine._create_default_diffusion_stage_cfg(engine_args)
+    od_config = OmniDiffusionConfig(parallel_config=stages[0]["engine_args"]["parallel_config"])
+    assert od_config.parallel_config.text_encoder_tp_size == 4
+    assert od_config.parallel_config.ring_degree == 2
+
+
+def test_missing_nested_etp_is_filled_without_mutating_input(monkeypatch):
+    parallel = {"tensor_parallel_size": 4, "ring_degree": 2}
+    engine_args = _prepare(monkeypatch, typed=4, parallel=parallel)
+    stages = AsyncOmniEngine._create_default_diffusion_stage_cfg(engine_args)
+    assert stages[0]["engine_args"]["parallel_config"].text_encoder_tp_size == 4
+    assert "text_encoder_tp_size" not in parallel
+
+
+def test_conflicting_parallel_config_fails(monkeypatch):
+    with pytest.raises(ValueError, match="Conflicting text_encoder_tp_size"):
+        _prepare(monkeypatch, typed=4, parallel={"tensor_parallel_size": 4, "text_encoder_tp_size": 1})
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("algorithm", ["diffusion_nft", "flow_grpo"])
+@pytest.mark.parametrize("typed,cli", [(4, None), (1, 4)])
+async def test_run_server_preserves_etp_at_engine_boundary(monkeypatch, algorithm, typed, cli):
+    monkeypatch.setattr(strategy_module, "import_external_libs", lambda _: None)
+    monkeypatch.setattr(strategy_module.VllmOmniPipelineBase, "get_pipeline_path", lambda **_: None)
+    monkeypatch.setattr(server_module, "get_non_ephemeral_free_port", lambda *_: 12345)
+    monkeypatch.setattr(os, "environ", dict(os.environ))
+    server = SimpleNamespace(
+        config=DiffusionRolloutConfig(tensor_model_parallel_size=4, text_encoder_tp_size=typed),
+        model_config=SimpleNamespace(architecture="MiniMaxH3Pipeline", algorithm=algorithm),
+    )
+    server._generate_strategy = strategy_module.DiffusionStrategy(server)
+    captured = {}
+
+    class EngineBoundaryReached(Exception):
+        pass
+
+    def capture_engine(**kwargs):
+        captured.update(kwargs)
+        raise EngineBoundaryReached
+
+    monkeypatch.setattr(server_module, "AsyncOmni", capture_engine)
+    with pytest.raises(EngineBoundaryReached):
+        await server_module.vLLMOmniHttpServer.run_server(
+            server, Namespace(tensor_parallel_size=4, text_encoder_tp_size=cli)
+        )
+    stages = AsyncOmniEngine._create_default_diffusion_stage_cfg(captured)
+    od_config = OmniDiffusionConfig(parallel_config=stages[0]["engine_args"]["parallel_config"])
+    assert od_config.parallel_config.tensor_parallel_size == 4
+    assert od_config.parallel_config.text_encoder_tp_size == 4

--- a/tests/workers/rollout/rollout_vllm/test_vllm_omni_strategy_on_cpu.py
+++ b/tests/workers/rollout/rollout_vllm/test_vllm_omni_strategy_on_cpu.py
@@ -725,6 +725,8 @@ def test_diffusion_strategy_preserves_engine_argument_preparation(monkeypatch):
     server = SimpleNamespace(
         config=SimpleNamespace(
             external_lib=["extension"],
+            tensor_model_parallel_size=4,
+            text_encoder_tp_size=1,
             step_execution=False,
             enable_prompt_embed_cache=True,
             prompt_embed_cache_size=16,
@@ -739,6 +741,7 @@ def test_diffusion_strategy_preserves_engine_argument_preparation(monkeypatch):
     assert imported == [["extension"]]
     assert engine_args == {
         "max_num_seqs": 1,
+        "text_encoder_tp_size": 1,
         "enable_dummy_pipeline": True,
         "custom_pipeline_args": {"pipeline_class": "package.Adapter"},
         "enable_prompt_embed_cache": True,

--- a/verl_omni/workers/rollout/vllm_rollout/vllm_omni_diffusion_strategy.py
+++ b/verl_omni/workers/rollout/vllm_rollout/vllm_omni_diffusion_strategy.py
@@ -14,6 +14,7 @@
 import logging
 from argparse import Namespace
 from collections.abc import Mapping
+from dataclasses import asdict
 from typing import Any, Optional
 
 import numpy as np
@@ -102,6 +103,34 @@ class DiffusionStrategy(OmniStrategyBase):
         return _GPU_WORKER_EXTENSION
 
     def prepare_engine_args(self, engine_args: dict[str, Any], args: Namespace) -> None:
+        # The pinned OmniEngineArgs drops the CLI-only text_encoder_tp_size field.
+        text_encoder_tp = self.server.config.text_encoder_tp_size
+        cli_text_encoder_tp = getattr(args, "text_encoder_tp_size", None)
+        if cli_text_encoder_tp is not None:
+            if text_encoder_tp not in (1, cli_text_encoder_tp):
+                raise ValueError("Conflicting text_encoder_tp_size in rollout config and engine_kwargs.")
+            text_encoder_tp = cli_text_encoder_tp
+
+        parallel_config = engine_args.get("parallel_config")
+        tp_size = self.server.config.tensor_model_parallel_size
+        if parallel_config is not None:
+            parallel_config = dict(parallel_config) if isinstance(parallel_config, Mapping) else asdict(parallel_config)
+            nested_text_encoder_tp = parallel_config.get("text_encoder_tp_size")
+            if nested_text_encoder_tp is not None:
+                if nested_text_encoder_tp != text_encoder_tp and (
+                    cli_text_encoder_tp is not None or text_encoder_tp != 1
+                ):
+                    raise ValueError("Conflicting text_encoder_tp_size in rollout/engine_kwargs and parallel_config.")
+                text_encoder_tp = nested_text_encoder_tp
+            tp_size = parallel_config.get("tensor_parallel_size", tp_size)
+
+        if text_encoder_tp < 1 or text_encoder_tp not in (1, tp_size):
+            raise ValueError(f"text_encoder_tp_size must be 1 or equal to tensor parallel size ({tp_size}).")
+        engine_args["text_encoder_tp_size"] = text_encoder_tp
+        if parallel_config is not None:
+            parallel_config["text_encoder_tp_size"] = text_encoder_tp
+            engine_args["parallel_config"] = parallel_config
+
         import_external_libs(self.server.config.external_lib)
 
         pipeline_path = VllmOmniPipelineBase.get_pipeline_path(


### PR DESCRIPTION
### What does this PR do?

Fix silent loss of MiniMax-H3 text-encoder tensor parallelism (ETP) in the shared diffusion rollout path used by both DiffusionNFT and FlowGRPO.

Related to the ETP bug reported in #563; this does not claim to resolve the separate reward/convergence discussion there.

The pinned vLLM-Omni CLI accepts `text_encoder_tp_size`, but `OmniEngineArgs.from_cli_args` filters it out because it is not a declared engine/orchestrator field. The fused diffusion engine then defaults to ETP=1. This PR restores the value after CLI conversion, without switching to the AR strategy or adding an environment-variable patch.

The upstream bug is filed as [vllm-omni#7564](https://github.com/vllm-project/vllm-omni/issues/7564). The downstream compatibility shim is tracked by [verl-omni#445](https://github.com/verl-project/verl-omni/issues/445) and should be removed after the upstream fix enters the pin.

### Checklist Before Starting

- [x] Searched for duplicates: [#563 references](https://github.com/verl-project/verl-omni/pulls?q=is%3Apr+is%3Aopen+563+in%3Abody), [text_encoder_tp](https://github.com/verl-project/verl-omni/pulls?q=is%3Apr+is%3Aopen+text_encoder_tp), and text-encoder parallelism keywords. Read #563 and its comments; no matching open fix PR found.
- [x] PR title follows the validated format.

### Test

**CPU routing and regression tests: 98 passed.**

```bash
python -m pytest -q --asyncio-mode=auto \
  tests/workers/rollout/rollout_vllm/test_diffusion_text_encoder_tp_on_cpu.py \
  tests/workers/rollout/rollout_vllm/test_vllm_omni_strategy_on_cpu.py \
  tests/workers/rollout/rollout_vllm/test_vllm_omni_run_server_engine_args_on_cpu.py \
  tests/workers/rollout/rollout_vllm/test_vllm_omni_deploy_config_on_cpu.py \
  tests/workers/config/test_diffusion_config_on_cpu.py
```

Before the fix, the routing regression reproduced requested TP=4/ETP=4 becoming ETP=1. Tests now cover the real CLI conversion and `run_server` boundary through default-stage construction to `OmniDiffusionConfig.parallel_config`, legacy overrides, conflicts, invalid groups, and explicit parallel configurations.

**Tiny-model GPU validation: both passed.** Two H20 GPUs, TP=2/ETP=2, T2VA, 160×288, 97 frames, four inference steps:

| Algorithm | Training | Exit code |
| --- | --- | --- |
| FlowGRPO | 2/2 steps, actor update and weight sync | 0 |
| DiffusionNFT | 2/2 steps, actor update and weight sync | 0 |

Both ranks had encoder group size 2 and embedding shards `[256,32]` from the full `[512,32]` table. Each shard matched its checkpoint slice exactly; each rank completed 16 real encoding calls in each run. This checks actual sharding, not just a config print.

These runs used a local diagnostic harness around the existing tiny runner's `_hydra_overrides`, with NFT-specific overrides for the second run (`python <local-harness>/run.py flowgrpo` / `nft`). The harness and instrumentation are not included in this PR. They use the existing tiny text-width workaround and lightweight VAE/reward fixtures; instrumentation asserts ETP but never assigns it. Tested with vLLM-Omni `0.28.0rc2.dev68+gded893462`, vLLM `0.28.0`, and torch `2.13.0+cu129`.

Also verified:
- All nine H3 launchers pass `bash -n`; 18 stubbed argument-capture checks passed for default ETP=TP and explicit ETP=1.
- All 12 pre-commit hooks passed, including generated-config verification. Full-repository checks used an explicit `git ls-files` list because the local Git lacks the `--deduplicate` flag required by `pre-commit --all-files`.
- The broader rollout CPU suite timed out after 600 seconds: **not counted as passing**. Production-weight memory savings, FL2VA/Ref2VA GPU runs, V1, and NPU execution were not revalidated here.

### API and Usage Example

Use the existing typed field, without `+`:

```bash
actor_rollout_ref.rollout.tensor_model_parallel_size=4 \
actor_rollout_ref.rollout.text_encoder_tp_size=4
```

H3 launchers now consistently forward `TEXT_ENCODER_TP`, defaulting to `ROLLOUT_TP`. The NFT T2VA and FL2VA launchers previously omitted ETP and therefore ran with ETP=1; this is an intentional recipe-default change to full-TP sharding. Set `TEXT_ENCODER_TP=1` to preserve the previous unsharded behavior. The pinned backend accepts only ETP=1 or exactly the configured rollout TP; intermediate subgroups are rejected. ETP is independent of CPU/layerwise offload.

The legacy `+actor_rollout_ref.rollout.engine_kwargs.vllm_omni.text_encoder_tp_size` remains accepted. It overrides the typed default of 1; conflicting non-default typed values fail rather than being silently discarded.

### Design & Code Changes

- Restore and validate ETP in `DiffusionStrategy.prepare_engine_args`, shared by NFT and FlowGRPO.
- Preserve explicit mapping/dataclass parallel configurations and unrelated fields, reject conflicting ETP values, and avoid mutating the input configuration.
- Update nine H3 launchers, the tiny FlowGRPO runner, and configuration/recipe documentation to use the typed field.
- Add diffusion-specific routing regression coverage; leave AR strategy behavior unchanged.

### Checklist Before Submitting

- [x] Read the contribution guide.
- [x] Run pre-commit checks across all tracked files (explicit-file workaround described above).
- [x] Update documentation.
- [x] Add CPU regression tests under the existing `*_on_cpu.py` discovery convention; GPU validation was manual, not added to CI.
- [x] Human submitter has reviewed every changed line and rerun the relevant tests before requesting review.

AI assistance was used for this change.

