### PR TITLE
[recipe, tests, doc] feat: add Qwen-Image DiffusionNFT V1 sync recipe

### DIFF
--- a/examples/diffusionnft_trainer/README.md
+++ b/examples/diffusionnft_trainer/README.md
@@ -1,6 +1,6 @@
 # DiffusionNFT Trainer
 
-Last updated: 09/10/2026
+Last updated: 09/12/2026
 
 This example shows how to post-train `Qwen-Image` with DiffusionNFT on an OCR-style image generation task using `vllm-omni` rollout and a visual generative reward model (`Qwen3-VL-8B-Instruct` in this example).
 
@@ -83,6 +83,35 @@ Launch the example from the repository root:
 bash examples/diffusionnft_trainer/qwen_image/run_qwen_image_ocr_lora.sh
 ```
 
+### NVIDIA GPU: V1 sync
+
+The V1 counterpart uses TransferQueue and ReplayBuffer with the synchronous
+trainer. Launch it from the repository root with the same prepared data and
+model dependencies:
+
+```bash
+bash examples/diffusionnft_trainer/qwen_image/run_qwen_image_ocr_lora_v1.sh
+```
+
+It selects `verl_omni.trainer.main_diffusion_v1`, `trainer.use_v1=true`, and
+`trainer.v1.trainer_mode=sync`. Its experiment name is `qwen_image_ocr_lora_v1`.
+The model, reward model, four-GPU layout, optimizer, and NFT settings match the
+V0 recipe: train the `default` adapter, sample with `old`, disable rollout
+log-probabilities, and refresh `old` every two steps using
+`delayed_linear_to_0_999`. This schedule starts with copies and begins EMA
+updates after step 75.
+
+Hydra overrides are forwarded in the same way as in V0. For a configuration
+check without launching training:
+
+```bash
+bash examples/diffusionnft_trainer/qwen_image/run_qwen_image_ocr_lora_v1.sh --cfg job --resolve
+```
+
+Keep the V0 entrypoint for matched comparisons. The performance table below
+reports the existing V0 measurements; it does not establish V1 convergence or
+throughput. A tiny-checkpoint smoke also does not reproduce the full OCR setup.
+
 ### NPU
 
 For Huawei Ascend NPUs, use the NPU-optimized script:
@@ -111,7 +140,7 @@ The script runs `python3 -m verl_omni.trainer.main_diffusion` with DiffusionNFT-
 - `actor_rollout_ref.model.policy_state_adapters='["default","old"]'`
 - `actor_rollout_ref.rollout.calculate_log_probs=False`
 - `actor_rollout_ref.rollout.rollout_adapter=old`
-- `actor_rollout_ref.rollout.n=24`
+- `actor_rollout_ref.rollout.n=16`
 - `algorithm.timestep_fraction=1.0`
 - `algorithm.old_policy_decay_schedule=delayed_linear_to_0_999`
 - `algorithm.old_policy_update_interval=2`

--- a/examples/diffusionnft_trainer/qwen_image/run_qwen_image_ocr_lora_v1.sh
+++ b/examples/diffusionnft_trainer/qwen_image/run_qwen_image_ocr_lora_v1.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Qwen-Image DiffusionNFT LoRA RL, V1 sync trainer and vllm_omni rollout.
+# Keep the V0 NFT adapters, loss, and old-policy schedule for comparison.
+set -x
+
+# Set WORKSPACE to any writable directory; defaults to $HOME
+WORKSPACE=${WORKSPACE:-$HOME}
+
+ocr_train_path=$WORKSPACE/data/ocr/train.parquet
+ocr_test_path=$WORKSPACE/data/ocr/test.parquet
+
+model_name=Qwen/Qwen-Image
+reward_model_name=Qwen/Qwen3-VL-8B-Instruct
+reward_function_path=verl_omni/utils/reward_score/genrm_ocr.py
+
+NUM_GPUS_ACTOR_ROLLOUT_REWARD=4
+ROLLOUT_TP=1
+REWARD_TP=4
+IMAGE_RESOLUTION=512
+
+ENGINE=vllm_omni
+REWARD_ENGINE=vllm
+
+
+python3 -m verl_omni.trainer.main_diffusion_v1 \
+    data.train_files=$ocr_train_path \
+    data.val_files=$ocr_test_path \
+    data.train_max_samples=7200 \
+    data.train_batch_size=24 \
+    data.max_prompt_length=256 \
+    actor_rollout_ref.model.algorithm=diffusion_nft \
+    actor_rollout_ref.model.model_type=diffusion_nft_model \
+    actor_rollout_ref.model.path=$model_name \
+    actor_rollout_ref.model.lora_rank=64 \
+    actor_rollout_ref.model.lora_alpha=128 \
+    actor_rollout_ref.model.policy_state_adapters='["default","old"]' \
+    actor_rollout_ref.model.target_modules="['to_q','to_k','to_v','to_out.0','add_q_proj','add_k_proj','add_v_proj','to_add_out','img_mlp.net.0.proj','img_mlp.net.2','txt_mlp.net.0.proj','txt_mlp.net.2']" \
+    actor_rollout_ref.actor.optim.lr=3e-4 \
+    actor_rollout_ref.actor.optim.weight_decay=0.0001 \
+    actor_rollout_ref.actor.ppo_mini_batch_size=12 \
+    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=12 \
+    actor_rollout_ref.actor.diffusion_loss.loss_mode=diffusion_nft \
+    actor_rollout_ref.actor.diffusion_loss.clip_ratio=1e-5 \
+    actor_rollout_ref.actor.diffusion_loss.mix_beta=0.1 \
+    actor_rollout_ref.actor.diffusion_loss.ref_kl_coef=0.0001 \
+    actor_rollout_ref.actor.diffusion_loss.adv_clip_max=5.0 \
+    actor_rollout_ref.actor.fsdp_config.param_offload=True \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=True \
+    actor_rollout_ref.actor.fsdp_config.model_dtype=bfloat16 \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=$ROLLOUT_TP \
+    actor_rollout_ref.rollout.name=$ENGINE \
+    actor_rollout_ref.rollout.n=16 \
+    actor_rollout_ref.rollout.agent.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / ROLLOUT_TP)) \
+    actor_rollout_ref.rollout.load_format=safetensors \
+    actor_rollout_ref.rollout.layered_summon=True \
+    actor_rollout_ref.rollout.calculate_log_probs=False \
+    actor_rollout_ref.rollout.rollout_adapter=old \
+    actor_rollout_ref.rollout.pipeline.num_inference_steps=10 \
+    actor_rollout_ref.rollout.pipeline.true_cfg_scale=1.0 \
+    actor_rollout_ref.rollout.pipeline.height=$IMAGE_RESOLUTION \
+    actor_rollout_ref.rollout.pipeline.width=$IMAGE_RESOLUTION \
+    actor_rollout_ref.rollout.pipeline.max_sequence_length=256 \
+    actor_rollout_ref.rollout.val_kwargs.pipeline.num_inference_steps=40 \
+    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=32 \
+    algorithm.trainer_type=direct_preference \
+    algorithm.sample_source=online \
+    algorithm.timestep_fraction=1.0 \
+    algorithm.old_policy_decay_schedule=delayed_linear_to_0_999 \
+    algorithm.old_policy_update_interval=2 \
+    algorithm.adv_mode=continuous \
+    reward.num_workers=$((NUM_GPUS_ACTOR_ROLLOUT_REWARD / REWARD_TP)) \
+    reward.reward_model.enable=True \
+    reward.reward_model.model_path=$reward_model_name \
+    reward.reward_model.rollout.name=$REWARD_ENGINE \
+    reward.reward_model.rollout.tensor_model_parallel_size=$REWARD_TP \
+    reward.custom_reward_function.path=$reward_function_path \
+    reward.custom_reward_function.name=compute_score_ocr \
+    trainer.logger='["console", "wandb"]' \
+    trainer.project_name=diffusion_nft \
+    trainer.experiment_name=qwen_image_ocr_lora_v1 \
+    trainer.log_val_generations=8 \
+    trainer.val_before_train=False \
+    trainer.n_gpus_per_node=$NUM_GPUS_ACTOR_ROLLOUT_REWARD \
+    trainer.nnodes=1 \
+    trainer.save_freq=60 \
+    trainer.test_freq=20 \
+    trainer.total_epochs=1 \
+    trainer.total_training_steps=300 \
+    trainer.use_v1=true \
+    trainer.v1.trainer_mode=sync "$@"

--- a/tests/trainer/diffusion/test_v1_diffusionnft_on_cpu.py
+++ b/tests/trainer/diffusion/test_v1_diffusionnft_on_cpu.py
@@ -1,0 +1,145 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""NFT V1 wiring: preserve sample associations and refresh the rollout adapter."""
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+from hydra import compose, initialize_config_dir
+from transfer_queue import KVBatchMeta
+from verl import DataProto
+
+import verl_omni
+
+
+def make_nft_trainer():
+    from verl_omni.trainer.diffusion.v1.trainer_sync import PolicyGradientDiffusionTrainerV1Sync
+
+    config_dir = Path(verl_omni.__file__).parent / "trainer/config"
+    with initialize_config_dir(config_dir=str(config_dir), version_base=None):
+        config = compose(
+            config_name="diffusion_trainer",
+            overrides=[
+                "trainer.use_v1=true",
+                "trainer.v1.trainer_mode=sync",
+                "algorithm.trainer_type=direct_preference",
+                "algorithm.sample_source=online",
+                "algorithm.old_policy_update_interval=2",
+                "algorithm.old_policy_decay_schedule=delayed_linear_to_0_999",
+                "algorithm.timestep_fraction=1.0",
+                "actor_rollout_ref.model.algorithm=diffusion_nft",
+                "actor_rollout_ref.model.model_type=diffusion_nft_model",
+                'actor_rollout_ref.model.policy_state_adapters=["default","old"]',
+                "actor_rollout_ref.actor.diffusion_loss.loss_mode=diffusion_nft",
+                "actor_rollout_ref.rollout.rollout_adapter=old",
+                "actor_rollout_ref.rollout.calculate_log_probs=false",
+            ],
+        )
+    return PolicyGradientDiffusionTrainerV1Sync(config)
+
+
+def test_nft_initializes_old_adapter_before_first_weight_sync(monkeypatch):
+    trainer = make_nft_trainer()
+    events = []
+    trainer.actor_rollout_wg = MagicMock()
+    trainer.actor_rollout_wg.copy_adapter.side_effect = lambda **kwargs: events.append("copy")
+    trainer.checkpoint_manager = SimpleNamespace(update_weights=lambda step: events.append("sync"))
+    monkeypatch.setattr(trainer, "_setup", lambda: None)
+
+    trainer.init()
+
+    trainer.actor_rollout_wg.copy_adapter.assert_called_once_with(source="default", target="old")
+    assert events == ["copy", "sync"]
+
+
+@pytest.mark.parametrize("step,refresh", [(1, None), (2, "copy"), (76, "ema")])
+def test_nft_tq_rows_and_old_policy_schedule(monkeypatch, step, refresh):
+    trainer = make_nft_trainer()
+    trainer.global_steps = step
+    trainer.timing_raw = {}
+    trainer.tokenizer = SimpleNamespace(pad_token_id=0)
+    trainer.reward_loop_manager = SimpleNamespace(reward_loop_worker_handles=object())
+    trainer.actor_rollout_wg = MagicMock()
+    events = []
+    trainer.actor_rollout_wg.copy_adapter.side_effect = lambda **kwargs: events.append("copy")
+    trainer.actor_rollout_wg.ema_update_adapter.side_effect = lambda **kwargs: events.append("ema")
+    trainer.checkpoint_manager = SimpleNamespace(update_weights=lambda step: events.append("sync"))
+
+    # Interleave prompt groups so grouping cannot accidentally rely on row adjacency.
+    keys = ["p0_0_0", "p1_0_0", "p0_1_0", "p1_1_0"]
+    uids = ["p0", "p1", "p0", "p1"]
+    latents = torch.arange(16, dtype=torch.float32).reshape(4, 1, 2, 2)
+    timesteps = torch.tensor([[900, 600, 300]]).repeat(4, 1)
+    rewards = torch.tensor([[1.0], [0.2], [0.0], [0.8]])
+    rollout = {
+        "uid": uids,
+        "sample_id": keys,
+        "latents_clean": latents,
+        "train_timesteps": timesteps,
+        "rm_scores": rewards,
+    }
+    read = MagicMock(return_value=rollout)
+    write = MagicMock()
+    monkeypatch.setattr("verl_omni.trainer.diffusion.v1.tq_utils.tq.kv_batch_get", read)
+    monkeypatch.setattr("verl_omni.trainer.diffusion.v1.tq_utils.tq.kv_batch_put", write)
+
+    def forbidden(*args, **kwargs):
+        pytest.fail("NFT must use final latents without PPO log-probs or trainer-side DPO reference inference")
+
+    monkeypatch.setattr(trainer, "_compute_old_log_prob", forbidden)
+    monkeypatch.setattr(trainer, "_compute_ref_noise_pred", forbidden)
+    captured = {}
+
+    def update(data):
+        events.append("actor")
+        captured["data"] = data
+        return DataProto.from_single_dict(data={}, meta_info={"metrics": {"actor/nft_loss": 0.1}})
+
+    monkeypatch.setattr(trainer, "_update_actor", update)
+    meta = KVBatchMeta(partition_id="train", keys=keys, tags=[{"is_padding": False}] * 4)
+    metrics = {}
+
+    assert trainer._train_sampled_batch(metrics, {}, meta) is meta
+    trainer.on_step_end()
+
+    read.assert_called_once_with(keys=keys, partition_id="train")
+    sent = captured["data"]
+    assert list(sent.non_tensor_batch["uid"]) == uids
+    assert list(sent.non_tensor_batch["sample_id"]) == keys
+    torch.testing.assert_close(sent.batch["latents_clean"], latents)
+    torch.testing.assert_close(sent.batch["train_timesteps"].sort(dim=1).values, timesteps.sort(dim=1).values)
+    torch.testing.assert_close(sent.batch["sample_level_scores"], rewards)
+    assert sent.batch["reward_prob"].shape == (4, 3)
+    assert (sent.batch["reward_prob"][[0, 3]] > 0.5).all()
+    assert (sent.batch["reward_prob"][[1, 2]] < 0.5).all()
+    assert "old_log_probs" not in sent.batch
+    assert "ref_noise_pred" not in sent.batch
+    assert write.call_args.kwargs["keys"] == keys
+    torch.testing.assert_close(write.call_args.kwargs["fields"]["sample_level_scores"], rewards)
+    assert metrics["old_policy/update_applied"] == float(refresh is not None)
+    assert events == ["actor", *([refresh] if refresh else []), "sync"]
+    if refresh == "copy":
+        trainer.actor_rollout_wg.copy_adapter.assert_called_once_with(source="default", target="old")
+        trainer.actor_rollout_wg.ema_update_adapter.assert_not_called()
+    elif refresh == "ema":
+        trainer.actor_rollout_wg.ema_update_adapter.assert_called_once_with(
+            source="default", target="old", decay=pytest.approx(0.0075)
+        )
+        trainer.actor_rollout_wg.copy_adapter.assert_not_called()
+    else:
+        trainer.actor_rollout_wg.copy_adapter.assert_not_called()
+        trainer.actor_rollout_wg.ema_update_adapter.assert_not_called()


### PR DESCRIPTION
### What does this PR do?

Adds the Qwen-Image + DiffusionNFT OCR recipe on V1 `sync`, as claimed in #389. The new entrypoint selects `main_diffusion_v1`, `trainer.use_v1=true`, and `trainer.v1.trainer_mode=sync`, and uses a separate experiment name. It preserves the V0 model, adapters, NFT loss, optimizer, rollout settings, and old-policy update schedule.

The change contains the recipe, documentation, and four CPU cases covering interleaved TransferQueue sample associations and old-policy copy/EMA ordering. Trainer implementations are unchanged. MiniMax H3 and asynchronous modes are outside this PR.

This draft now includes a resumed full-model V1 checkpoint chain reaching global step 100, reward/timing figures, and run logs. The September 16 V0 short-run chain now includes a successful step-3 restore → step-4 update, saved checkpoint, and final validation over all 32 prompts, with exit code 0. The prior OOM continuation and its checkpoint audit remain separately documented. A controlled matched V0/V1 performance comparison and full pre-commit validation remain outstanding.

### Checklist Before Starting

- [x] Checked #389 and its ownership confirmation, [open PRs referencing #389](https://github.com/verl-project/verl-omni/pulls?q=is%3Apr+is%3Aopen+389+in%3Abody), and [open NFT PRs](https://github.com/verl-project/verl-omni/pulls?q=is%3Apr+is%3Aopen+NFT) on September 12. No duplicate Qwen-Image / DiffusionNFT / V1 sync recipe was found. The BOOGU adapter and other algorithm migrations cover different paths.
- [x] Used the repository PR title format.

### Test

**Completed V1 training to global step 100 (September 15 update).**

The two-L20 run `ocr-v1-100-12` resumed from global step 23 and completed all 77 subsequent training steps (1,232 training images), final validation, and the `global_step_100` checkpoint. The process exited with code 0 at 13:08 UTC on September 15. This is a resumed run; it is not an uninterrupted run from step 0, and it is not concatenated with the separate historical 48-step series below.

![Qwen-Image V1 training and validation reward](https://raw.githubusercontent.com/0z5a/verl-omni/49d770867be29c1cc4d66f3e2401125ed70d48e1/examples/diffusionnft_trainer/qwen_image/results/20260915-l20-v1/reward_curve.png)

| Validation global step | Mean OCR reward (32 prompts) |
| --- | --- |
| 23 (after restore) | 0.4986821790 |
| 40 | 0.5800898186 |
| 60 | 0.8906557611 |
| 80 | 0.8364970256 |
| 100 | **0.9247436151** |

Final training reward is 0.9739583731. All 77 logged actor losses and gradient norms are finite, and all gradient norms are positive. The final held-out reward is the highest of these evaluations, but one 32-prompt evaluation series does not establish statistical convergence or V0 parity.

![V1 per-step timing breakdown](https://raw.githubusercontent.com/0z5a/verl-omni/49d770867be29c1cc4d66f3e2401125ed70d48e1/examples/diffusionnft_trainer/qwen_image/results/20260915-l20-v1/step_timing.png)

Observed step p50/p95 were 1,352.846/2,683.093 seconds, including checkpoint saves and excluding validation. Final validation took an additional 3,085.640 seconds. The host was shared and later steps were slower; **a matched full-model V0 timing comparison remains outstanding**.

The run used the historical pinned runtime base with FSDP2/offload overrides and a local bounded ZMQ transfer/cleanup repair, rather than a GPU rerun of the PR head. The full log preserves runtime startup patches and the FSDP2 view/pre-backward-hook warning. Details and limits are recorded in the report.

Evidence: [report and configuration](https://github.com/0z5a/verl-omni/blob/49d770867be29c1cc4d66f3e2401125ed70d48e1/examples/diffusionnft_trainer/qwen_image/results/20260915-l20-v1/README.md), [readable driver log](https://github.com/0z5a/verl-omni/blob/49d770867be29c1cc4d66f3e2401125ed70d48e1/examples/diffusionnft_trainer/qwen_image/results/20260915-l20-v1/driver.log), [original log (gzip)](https://github.com/0z5a/verl-omni/blob/49d770867be29c1cc4d66f3e2401125ed70d48e1/examples/diffusionnft_trainer/qwen_image/results/20260915-l20-v1/driver.log.gz), [training CSV](https://github.com/0z5a/verl-omni/blob/49d770867be29c1cc4d66f3e2401125ed70d48e1/examples/diffusionnft_trainer/qwen_image/results/20260915-l20-v1/train_metrics.csv), [validation CSV](https://github.com/0z5a/verl-omni/blob/49d770867be29c1cc4d66f3e2401125ed70d48e1/examples/diffusionnft_trainer/qwen_image/results/20260915-l20-v1/validation_metrics.csv), [launch/exit manifest](https://github.com/0z5a/verl-omni/blob/49d770867be29c1cc4d66f3e2401125ed70d48e1/examples/diffusionnft_trainer/qwen_image/results/20260915-l20-v1/launch.json), [checkpoint completion manifest](https://github.com/0z5a/verl-omni/blob/49d770867be29c1cc4d66f3e2401125ed70d48e1/examples/diffusionnft_trainer/qwen_image/results/20260915-l20-v1/checkpoint_manifest.json), and [SHA-256 checksums](https://github.com/0z5a/verl-omni/blob/49d770867be29c1cc4d66f3e2401125ed70d48e1/examples/diffusionnft_trainer/qwen_image/results/20260915-l20-v1/SHA256SUMS).

Attachment validation: contiguous steps 24–100, five validation records, finite losses/positive finite gradients, matching launch records, successful exit, final checkpoint manifest, original-log checksum against the server, CSV/figure consistency, gzip integrity and `git diff --cached --check` passed. Pre-commit on the results files passed the documentation, license, structure, naming, device/DataProto, and compile checks; Python lint/type hooks had no applicable files. Configuration generation could not run locally because `omegaconf` was missing, so this is not a full pre-commit pass. The final checkpoint has not been reloaded in a new process.

**Checkpoint-chain audit and matched V0 short-run attempt (September 16 update).**

The server-side V1 evidence reaches global step 100 through four checkpoint-linked processes, not one uninterrupted process:

| Process | Logged training steps | Resume boundary |
| --- | --- | --- |
| `ocr-v1-pilot-05` | 1–4 | fresh start |
| `ocr-v1-100-10` | 5–13 | restored step 4 |
| `ocr-v1-100-11` | 14–22 | restored step 13; produced the recovered step-23 checkpoint |
| `ocr-v1-100-12` | 24–100 | restored step 23 |

Across the chain, per-step training metrics exist for 99 steps: 1–22 and 24–100. Step 23 has a checkpoint and a post-restore validation record, but no recoverable training-metric line. Therefore the attached reward curve above intentionally shows the clean final process (steps 24–100) plus validation at restored step 23; it should not be read as a gap-free 100-point training curve.

The matched full-model V0 short run `ocr-v0-matched-4` used the same two-L20 workload and was configured for four steps. It exited with code 1 during `val_before_train`, before any training step or metric record. The immediate error was `FileNotFoundError` for the configured relative custom reward module path (`verl_omni/utils/reward_score/genrm_ocr.py`) inside the reward-loop worker. Consequently there is no V0 curve or valid V0/V1 timing comparison from this attempt; the subsequent rerun resolved the reward module path as described below.


**Matched V0 rerun and step-4 checkpoint recovery (September 16).**

The two-L20 run `ocr-v0-matched-4-rerun-01` logged steps 1–3, was interrupted by a jk01 reboot, then explicitly restored `global_step_3` and executed the fourth actor update. Both model shards, optimizer shards, extra-state files, and dataloader state were saved before final validation. All seven required files (44,258,265,612 bytes) passed a full streaming archive CRC scan. The existing checkpoint commit helper flushed the saved files and atomically wrote `COMPLETED.json` and the latest-step pointer (4), without deleting step 3. The checkpoint remains on jk01; no model weights are uploaded.

Final validation failed with Ray host-memory OOM (481.35 / 503.49 GB, above the 95% threshold; seven workers killed), and the resumed process exited with code 1. Step-4 training metrics were not emitted because validation failed before the logging boundary. This establishes a saved, byte-verified training checkpoint, **not a passed E2E test, successful checkpoint reload, or completed matched V0/V1 comparison**. The historical pinned runtime and workload limits still apply.

Evidence: [report and available metrics](https://github.com/0z5a/verl-omni/blob/18fea99b973699c368ec218bf28de9660f0546ff/examples/diffusionnft_trainer/qwen_image/results/20260916-l20-v0/README.md), [training/restore/save/OOM events](https://github.com/0z5a/verl-omni/blob/18fea99b973699c368ec218bf28de9660f0546ff/examples/diffusionnft_trainer/qwen_image/results/20260916-l20-v0/events.log), [checkpoint completion manifest](https://github.com/0z5a/verl-omni/blob/18fea99b973699c368ec218bf28de9660f0546ff/examples/diffusionnft_trainer/qwen_image/results/20260916-l20-v0/checkpoint_manifest.json), [full CRC recovery audit](https://github.com/0z5a/verl-omni/blob/18fea99b973699c368ec218bf28de9660f0546ff/examples/diffusionnft_trainer/qwen_image/results/20260916-l20-v0/checkpoint_verification.json), [initial launch](https://github.com/0z5a/verl-omni/blob/18fea99b973699c368ec218bf28de9660f0546ff/examples/diffusionnft_trainer/qwen_image/results/20260916-l20-v0/run_initial.sh), [step-3 resume launch](https://github.com/0z5a/verl-omni/blob/18fea99b973699c368ec218bf28de9660f0546ff/examples/diffusionnft_trainer/qwen_image/results/20260916-l20-v0/run_resume.sh), and [original driver-log checksums](https://github.com/0z5a/verl-omni/blob/18fea99b973699c368ec218bf28de9660f0546ff/examples/diffusionnft_trainer/qwen_image/results/20260916-l20-v0/source_log_checksums.txt).

**Successful V0 step-4 retry (September 16, 18:49 UTC+08:00).**

The new isolated process `ocr-v0-step4-retry-02` restored both model/optimizer ranks from step 3, executed step 4, saved a new checkpoint, and completed final validation with **exit code 0**. Validation used eight batches of 4, retaining all 32 prompts and 40 inference steps; training settings were unchanged. Steps 1–3 remain the earlier process's records, so this is a checkpoint-linked short run, not an uninterrupted four-step process.

| Step-4 observation | Value |
| --- | --- |
| Mean training OCR reward | 0.4381944537 |
| Actor loss | 9.6961450577 |
| Gradient norm | 0.0149230957 |
| Final validation OCR reward (32 prompts) | 0.4738139388 |
| Step seconds, excluding validation | 1525.858503 |
| Final validation seconds | 3109.227755 |

The new checkpoint files and latest-step pointer (4) are present, but this new checkpoint has not been fully CRC-scanned or reloaded. The previous failed continuation's CRC audit applies only to its own checkpoint. Full logs retain the FSDP2 warning and post-success worker-shutdown messages. The historical pinned-runtime limitation still applies, and controlled V0/V1 timing/parity and submission-base pre-commit remain unverified.

Evidence: [report](https://github.com/0z5a/verl-omni/blob/15c6e048e8e5ecd1fd44542b55f80bb19615ac4c/examples/diffusionnft_trainer/qwen_image/results/20260916-l20-v0-success/README.md), [complete readable driver log](https://github.com/0z5a/verl-omni/blob/15c6e048e8e5ecd1fd44542b55f80bb19615ac4c/examples/diffusionnft_trainer/qwen_image/results/20260916-l20-v0-success/driver.log), [exact launch](https://github.com/0z5a/verl-omni/blob/15c6e048e8e5ecd1fd44542b55f80bb19615ac4c/examples/diffusionnft_trainer/qwen_image/results/20260916-l20-v0-success/run.sh), [precise step-4 metrics](https://github.com/0z5a/verl-omni/blob/15c6e048e8e5ecd1fd44542b55f80bb19615ac4c/examples/diffusionnft_trainer/qwen_image/results/20260916-l20-v0-success/metrics.json), [exit code](https://github.com/0z5a/verl-omni/blob/15c6e048e8e5ecd1fd44542b55f80bb19615ac4c/examples/diffusionnft_trainer/qwen_image/results/20260916-l20-v0-success/exit_code.txt), and [original server-log checksum](https://github.com/0z5a/verl-omni/blob/15c6e048e8e5ecd1fd44542b55f80bb19615ac4c/examples/diffusionnft_trainer/qwen_image/results/20260916-l20-v0-success/source_log_checksums.txt).

**Submission checks.** The candidate is based on `f863ecc3a52c1744ff6c4c37110e73dfac869666`. The recipe and new CPU test are byte-identical to the earlier tested candidate; the README preserves intervening upstream documentation changes.

Shell syntax and V1 Hydra configuration resolution passed. The three CPU test files passed all 38 cases on the submission base (25.78 seconds). Full pre-commit passed on the original GPU-smoke base. On this newer submission base, full pre-commit could not complete because bootstrapping the Ruff hook environment stalled while fetching its Git dependency. That isolated check was stopped; full pre-commit on the submission base remains unverified.

```bash
bash -n examples/diffusionnft_trainer/qwen_image/run_qwen_image_ocr_lora_v1.sh
bash examples/diffusionnft_trainer/qwen_image/run_qwen_image_ocr_lora_v1.sh --cfg job --resolve
python -m pytest -q \
  tests/trainer/diffusion/test_v1_diffusionnft_on_cpu.py \
  tests/trainer/diffusion/test_v1_direct_preference_on_cpu.py \
  tests/trainer/diffusion/test_diffusion_core_algos_on_cpu.py
pre-commit run --all-files --show-diff-on-failure --color=never
```

**Matched tiny-model GPU smoke (historical).** Both actual V0/V1 entrypoints ran on 2 × RTX A4000 16 GiB, with a random tiny Qwen-Image checkpoint, BF16 LoRA, FSDP1, 256×256 images, four inference steps, and real JPEG compressibility reward. Model/data hashes, seed, optimizer, and per-step workload matched: 16 synthetic prompts, batch 4, two images per prompt.

| Observation | V0 | V1 sync |
| --- | --- | --- |
| Trainer steps / optimizer updates / images | 4 / 8 / 32 | 4 / 8 / 32 |
| Old-policy copies verified in saved tensors | Steps 2 and 4 | Steps 2 and 4 |
| Resume step 2 → 4 | Passed | Passed |
| Resume step 4 → 6 across epoch boundary | Incomplete: exit 0 with no new steps | Passed |
| Observed step p50 / p95 (seconds) | 5.432 / 12.121 | 7.160 / 14.423 |

Gradients were finite and nonzero, trainable adapters changed, and optimizer state was finite. Percentiles use four samples including startup/checkpoint effects. V1 was slower in this tiny setting; these timings are not a speedup claim. GPU smoke covered the copy phase; the CPU cases also cover the EMA call at step 76. Odd-step restore and equivalence to uninterrupted training have not been established.

**Full pretrained Qwen-Image + Qwen3-VL OCR (historical).** A two-L20 run used FSDP2, BF16 LoRA rank 64 / alpha 128, parameter/optimizer CPU offload, distributed layerwise rollout offload, rollout TP=2, reward TP=2, batch 4 with 4 images per prompt, mini-batch 2, per-GPU micro-batch 1, 512×512 images, 10 training inference steps and 40 validation inference steps. The data seed was 42 and validation used 32 samples. These explicit resource overrides differ from the unchanged four-GPU recipe defaults.

A four-step pilot completed and saved a two-rank checkpoint. Checkpoint inspection found optimizer step count 8, finite optimizer state, updated LoRA-B parameters, and exact `default`/`old` equality after the step-4 copy.

A separate fresh V1 run then completed **48 trainer steps / 768 training images**, with finite loss and nonzero finite gradients throughout:

| Validation step | Mean OCR reward (32 samples) |
| --- | --- |
| 0 | 0.4446610437 |
| 20 | 0.5999353810 |
| 40 | 0.7239540718 |

Observed step p50 was 848.056 seconds. The next step failed with Ray `ActorDiedError` / `SYSTEM_ERROR`; that message alone does not establish the cause. The run did not reach its first scheduled checkpoint at step 50. The recoverable checkpoint remains the separate four-step pilot. Later restore attempts are not appended to this 48-step series.

The validation reward increased in this short V1 run, but it does not establish convergence, a V0/V1 comparison, or a performance improvement. The initial September 16 V0 attempts failed, but the subsequent step-4 retry completed training, checkpoint save, and final validation with exit code 0, as described above. It is a resumed short run, not a convergence or performance-parity result.

<details>
<summary>All 48 completed training steps (CSV)</summary>

```csv
step,train_reward_mean,actor_loss,grad_norm,step_seconds
1,0.19653798639774323,10.321502685546875,0.027191162109375,946.6801988639636
2,0.5041666626930237,9.099244117736816,0.02264404296875,911.9385507580009
3,0.3298611342906952,9.746775150299072,0.02911376953125,847.0525124740088
4,0.35555556416511536,9.866251468658447,0.03564453125,849.0312528249924
5,0.338203489780426,9.491130828857422,0.025146484375,924.4033691970399
6,0.4764880836009979,9.169525146484375,0.02734375,852.069711641001
7,0.4216157793998718,9.388191223144531,0.0325927734375,845.2555281100213
8,0.369995653629303,8.513345718383789,0.02655029296875,848.9819393830257
9,0.3766714334487915,9.549010753631592,0.084228515625,906.9040434120107
10,0.4459379017353058,9.14697790145874,0.037353515625,849.0296463959967
11,0.6143973469734192,9.147148132324219,0.03125,907.6086580720148
12,0.8693453073501587,8.452064514160156,0.03662109375,849.8123479710193
13,0.66796875,8.911321640014648,0.08233642578125,845.2422665969934
14,0.40008997917175293,8.551613330841064,0.041259765625,848.9590728530311
15,0.616995096206665,9.219841957092285,0.016845703125,907.6945233030128
16,0.6200892925262451,8.728306293487549,0.0177001953125,907.8083360799938
17,0.46252506971359253,9.101420402526855,0.06494140625,905.0229989679647
18,0.5471813678741455,8.220696449279785,0.03839111328125,847.7491623180103
19,0.6309782266616821,7.124449253082275,0.040771484375,905.5688144409796
20,0.9855769276618958,8.928157329559326,0.03033447265625,848.1612841929891
21,0.8668301105499268,8.261890411376953,0.052001953125,844.2371624920052
22,0.5482887029647827,7.896247625350952,0.03399658203125,907.3337256460218
23,0.5151785612106323,9.02426528930664,0.03125,844.2907920780126
24,0.7037613391876221,8.56229567527771,0.34246826171875,909.0492681699689
25,0.7798763513565063,7.96213436126709,0.076416015625,844.6677434929879
26,0.5245726704597473,9.343113422393799,0.0303955078125,909.9170463170158
27,0.763084888458252,8.9430570602417,0.039459228515625,844.9152039280161
28,0.5385950803756714,9.420668125152588,0.02215576171875,847.8668849549722
29,0.7423611283302307,7.955366611480713,0.021392822265625,844.8149644570076
30,0.669093132019043,8.676432132720947,0.0413818359375,848.0857935079839
31,0.894437849521637,7.760059833526611,0.02813720703125,844.924576357007
32,0.9215686321258545,6.784919261932373,0.04962158203125,847.5368546730024
33,0.5576298832893372,9.208049774169922,0.074462890625,845.3216621489846
34,0.7394230961799622,8.525253295898438,0.012176513671875,910.4761516889557
35,0.9135416746139526,8.07149052619934,0.0323486328125,904.4477290509967
36,0.844951868057251,8.794344425201416,0.03631591796875,847.4248839339707
37,0.5587536692619324,7.8327672481536865,0.13037109375,906.8620429640287
38,0.5936478972434998,7.683271646499634,0.02276611328125,909.6357109439559
39,0.6024109125137329,7.7764198780059814,0.0400390625,844.7810804360197
40,0.6883658170700073,7.713846206665039,0.0283203125,847.5617043959792
41,0.6624053716659546,7.500312805175781,0.02490234375,845.2848878179793
42,0.625,8.302261352539062,0.012908935546875,847.8679097919958
43,0.7049019932746887,6.587801456451416,0.0523681640625,845.5788572569727
44,0.7007085680961609,8.035511016845703,0.01959228515625,847.6203836909845
45,0.6670039892196655,8.151184558868408,0.02008056640625,844.5709117320366
46,0.822148323059082,8.098725080490112,0.02801513671875,848.0255196689977
47,0.882138729095459,8.299121141433716,0.0831298828125,841.5484184430097
48,0.8365384340286255,7.549904823303223,0.020721435546875,845.1773334350437
```

</details>

<details>
<summary>Historical experiment provenance</summary>

- GPU experiments used verl-omni base `c0c88fc88a7d85367a5a4dfcee9f01346e71dda5` with the candidate recipe and recorded experiment-runner overrides, verl core `fefb080262e1c015a0ea05f958822a6a512dc795`, and vllm-omni `ded8934626aaad1a3e816c3a1d9d742efc012d93`. They are not GPU measurements of the newer submission base.
- Experiment runner SHA-256: `0308eeb2c5cad8cc89a1c044e2754ffa2cac7f30db01c2fb30967f15cebeaf1b`; recipe SHA-256: `e0a2f29f99825ffeb02544cd4041408649ceb85e1767a42143db657dbce18756`.
- Raw OCR data came from Flow-GRPO revision `879042cf5707f8b90daa98d147d7deac2317c5da`.
- Qwen-Image revision: `75e0b4be04f60ec59a75f475837eced720f823b6`.
- Qwen3-VL-8B-Instruct revision: `0c351dd01ed87e9c1b53cbc748cba10e6187ff3b`.
- Processed OCR train parquet SHA-256: `c03aefde40cbb4f0504ec8e36c345335f269539b888c9dc1a59564bb61876705` (19,653 rows; recipe uses up to 7,200).
- Processed OCR test parquet SHA-256: `7a253ba1873ea3c6cee6d43a6e59b7f600eb624d705d98e91e0010b893a38dba` (1,018 rows; this run validates 32).
- Four-step pilot metrics SHA-256: `5c239e5ec05b2222ea82059b032731fc122028a47faa7eb9531ee82df29e356a`.
- Separate 48-step run metrics SHA-256: `828cdb0a579e182e707a6cc021a72549dafc75d8db55720b8e5ca8a757724307`.
- V0/V1 resolved configurations were compared: differences were limited to trainer selection and experiment/output paths. The configuration check is not a completed V0 experiment.

</details>

### API and Usage Example

After preparing the existing OCR data and model dependencies:

```bash
bash examples/diffusionnft_trainer/qwen_image/run_qwen_image_ocr_lora_v1.sh
```

Normal Hydra overrides are forwarded. The V0 entrypoint remains available for matched comparisons. The README's existing performance table is explicitly identified as V0 evidence.

### Checklist Before Submitting

- [x] Read the contribution guide.
- [ ] Complete pre-commit on the submission base.
- [x] Update documentation.
- [x] Add four CPU cases under the existing CPU CI test discovery pattern.
- [x] Attach the completed resumed V1 run through global step 100, with reward/timing plots and logs.
- [ ] Complete a successful matched full-model V0 timing comparison and remaining review checks before marking ready for review.
